### PR TITLE
Fixed bug in handling of a 32-bit execve on a 64-bit program

### DIFF
--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -642,44 +642,17 @@ static void decode_execve( struct pfs_process *p, INT64_T entering, INT64_T sysc
 	char *scratch_avail = scratch_addr;
 
 	if(args[0]==0) {
-		debug(D_PROCESS,"execve: %s executing ",p->name);
+		debug(D_PROCESS,"execve: %s complete in 64 bit mode",p->name);
+		debug(D_PSTREE,"%d exec %s",p->pid,p->new_logical_name);
+
 		p->state = PFS_PROCESS_STATE_USER;
+		p->completing_execve = 0;
+
 	} else if(entering) {
 		char path[PFS_PATH_MAX];
 		char firstline[PFS_PATH_MAX];
 
 		tracer_copy_in_string(p->tracer,path,POINTER(args[0]),sizeof(path));
-
-        /* debug arguments/environment */
-		{
-			int argc = 0, n = 0;
-			debug(D_SYSCALL,"execve(");
-			debug(D_SYSCALL,"\t%s,",path);
-			debug(D_SYSCALL,"\t[");
-			while (1) {
-				char arg[4096];
-				char *argp;
-				tracer_copy_in(p->tracer, &argp, ((char **)args[1])+argc, sizeof(argp));
-				if (argp == NULL) break;
-				tracer_copy_in_string(p->tracer, arg, argp, sizeof(arg));
-				arg[4096-1] = '\0';
-				debug(D_SYSCALL,"\t\"%s\",",arg);
-				argc++;
-			}
-			debug(D_SYSCALL,"\t],");
-			debug(D_SYSCALL,"\t[");
-			while (1) {
-				char var[4096];
-				char *varp;
-				tracer_copy_in(p->tracer, &varp, ((char **)args[2])+n, sizeof(varp));
-				if (varp == NULL) break;
-				tracer_copy_in_string(p->tracer, var, varp, sizeof(var));
-				var[4096-1] = '\0';
-				debug(D_SYSCALL,"\t\"%s\",",var);
-				n++;
-			}
-			debug(D_SYSCALL,"\t])");
-        }
 
 		p->new_logical_name[0] = 0;
 		p->new_physical_name[0] = 0;
@@ -809,30 +782,45 @@ static void decode_execve( struct pfs_process *p, INT64_T entering, INT64_T sysc
 
 			/* set the new program name to the logical name */
 			args[0] = (INT64_T) scratch_addr;
+
+			/* up to three arguments (args[0-2]) were modified. */
 			tracer_args_set(p->tracer,p->syscall,args,3);
 		}
+
 		if (pfs_ldso_path) {
 			redirect_ldso(p, pfs_ldso_path, args, scratch_avail);
 		}
-		debug(D_PROCESS,"execve: %s attempting",p->new_logical_name);
+
+		/* This forces the next call to return to decode_execve, see comment at top of decode_syscall */
+		p->completing_execve = 1;
+
+		debug(D_PROCESS,"execve: %s about to start",p->new_logical_name);
 	} else {
 		INT64_T actual_result;
 		tracer_result_get(p->tracer,&actual_result);
+
 		if(actual_result==0) {
-			debug(D_PROCESS,"execve: %s working",p->new_logical_name);
+			debug(D_PROCESS,"execve: %s succeeded in 64 bit mode",p->new_logical_name);
 			strcpy(p->name,p->new_logical_name);
+
 			/* after a successful exec, signal handlers are reset */
 			memset(p->signal_interruptible,0,sizeof(p->signal_interruptible));
+
 			/* and certain files in the file table are closed */
 			p->table->close_on_exec();
+
 			/* and our knowledge of the address space is gone. */
 			p->heap_address = 0;
 			p->break_address = 0;
-			debug(D_PSTREE,"%d exec %s",p->pid,p->new_logical_name);
-		} else if(p->new_logical_name[0]) {
-			debug(D_PROCESS,"execve: %s failed",p->new_logical_name);
-			debug(D_PROCESS,"execve: restoring scratch area");
-			tracer_copy_out(p->tracer,p->scratch_data,scratch_addr,scratch_size);
+		} else {
+			/* If we did not succeed and we are not entering, then the exec must have failed. */
+
+			debug(D_PROCESS,"execve: %s failed: %s",p->new_logical_name,strerror(-actual_result));
+			debug(D_PROCESS,"execve: restoring scratch area at %x",scratch_addr);
+			
+			tracer_copy_out(p->tracer,p->scratch_data,(void*)scratch_addr,scratch_size);
+
+			p->completing_execve = 0;
 		}
 	}
 }
@@ -949,6 +937,21 @@ static void decode_syscall( struct pfs_process *p, INT64_T entering )
 		p->state = PFS_PROCESS_STATE_KERNEL;
 		p->syscall_dummy = 0;
 		tracer_args_get(p->tracer,&p->syscall,p->syscall_args);
+
+		/*
+		SYSCALL_execve has a different value in 32 and 64 bit modes.
+		When an execve forces a switch between execution modes, the
+		old system call number is retained, even though the mode has
+		changed.  So, we must explicitly check for this condition
+		and fix up the system call number to end up in the right code.
+		*/
+
+		if(p->completing_execve) {
+			p->syscall = SYSCALL64_execve;
+			p->completing_execve = 0;
+		}
+
+
 		debug(D_SYSCALL,"%s",tracer_syscall_name(p->tracer,p->syscall));
 		p->syscall_original = p->syscall;
 		pfs_syscall_count++;
@@ -2553,6 +2556,7 @@ static void decode_syscall( struct pfs_process *p, INT64_T entering )
 				if(p->syscall_result==0) {
 					if(p->syscall_args[0]!=0) {
 						p->break_address = p->syscall_args[0];
+						debug(D_PROCESS,"break address: %x",p->break_address);
 					}
 				}
 			}

--- a/parrot/src/pfs_process.cc
+++ b/parrot/src/pfs_process.cc
@@ -145,6 +145,7 @@ struct pfs_process * pfs_process_create( pid_t pid, pid_t actual_ppid, pid_t not
 	child->nsyscalls = 0;
 	child->heap_address = 0;
 	child->break_address = 0;
+	child->completing_execve = 0;
 
 	actual_parent = pfs_process_lookup(actual_ppid);
 
@@ -534,6 +535,7 @@ PTRINT_T pfs_process_heap_address( struct pfs_process *p )
 
 	while(fgets(line,sizeof(line),file)) {
 		debug(D_PROCESS,"line: %s",line);
+
 		fields = sscanf(line, "%" SCNxPTR "-%" SCNxPTR " %s %" SCNxPTR "%d:%d %d",
 			&start,&end,flagstring,&offset,&major,&minor,&inode);
 

--- a/parrot/src/pfs_process.h
+++ b/parrot/src/pfs_process.h
@@ -58,6 +58,7 @@ struct pfs_process {
 	INT64_T syscall_args_changed;
 	INT64_T actual_result;
 
+	int completing_execve;
 	int did_stream_warning;
 	int diverted_length;
 	int signal_interruptible[256];


### PR DESCRIPTION
This fixes a bug reported by Stefan Kluth when using ATLAS
software via CVMFS.
