### PR TITLE
Low Disk Space in Worker

### DIFF
--- a/dttools/src/work_queue_worker.c
+++ b/dttools/src/work_queue_worker.c
@@ -1485,8 +1485,7 @@ int main(int argc, char *argv[])
 			}
 			break;
 		case 'z':
-			disk_avail_threshold = string_metric_parse(optarg);
-			disk_avail_threshold *= 1024 * 1024; //convert MB to Bytes.
+			disk_avail_threshold = atoll(optarg) * MEGA;
 			break;
 		case 'A':
 			free(arch_name); //free the arch string obtained from uname


### PR DESCRIPTION
More aggressive handling of out-of-disk condition by checking every five seconds in the main work_queue_worker loop.  This will help the CRC with full disk problems on Condor.
