### PR TITLE
Added cvmfs option try_local_filesystem.

### DIFF
--- a/doc/parrot.html
+++ b/doc/parrot.html
@@ -397,7 +397,8 @@ mirrored in multiple locations and accessed via groups of
 load-balanced web proxies, with fail-over between groups.
 
 <p>The CVMFS repositories hosted by the <a
-href=http://cernvm.cern.ch/>CernVM project</a> are enabled by default.
+href=http://cernvm.cern.ch/>CernVM project</a> and by
+Open Science Grid (OASIS) are enabled by default.
 To access a different repository, it is necessary to configure parrot
 to know how to access the repository.  This may be done with the
 <tt>-r</tt> option or with the <tt>PARROT_CVMFS_REPO</tt> environment
@@ -456,6 +457,7 @@ to the proxy used by parrot, if any.
 <tr><td><b>repo_name=NAME</b>         <td>Unique name of the mounted repository; default is the name used for this configuration entry
 <tr><td><b>mountpoint=PATH</b>        <td>Path to root of repository; default is /cvmfs/repo_name
 <tr><td><b>blacklist=FILE</b>         <td>Local blacklist for invalid certificates.  Has precedence over the whitelist.
+<tr><td><b>try_local_filesystem</b>   <td>If this cvmfs repository is mounted on the local filesystem, use that instead of Parrot's CVMFS client.
 </table>
 
 <p>Setting the CVMFS configuration overrides the default
@@ -467,6 +469,13 @@ configuration string.  Example:
 <pre>
 parrot_run -r '&lt;default-repositories&gt; my.repo:url=http://cvmfs.server.edu/cvmfs/my.repo.edu' ...
 </pre>
+
+<p><nobr><tt>&lt;default-repositories&gt;</tt></nobr> should
+come first, because it contains a catch-all clause
+<nobr><tt>*:try_local_filesystem</tt></nobr> that matches anything that
+isn't caught by later entries.  This clause allows access to locally
+mounted CVMFS repositories that Parrot is not configured to access
+internally.
 
 <p>The configuration of the default repositories may be modified by
 specifying additional options using the syntax

--- a/parrot/src/pfs_service_cvmfs.cc
+++ b/parrot/src/pfs_service_cvmfs.cc
@@ -40,7 +40,7 @@ static struct cvmfs_filesystem *cvmfs_active_filesystem = 0;
 #define CERN_KEY_PLACEHOLDER "<BUILTIN-cern.ch.pub>"
 #define OASIS_KEY_PLACEHOLDER "<BUILTIN-opensciencegrid.org.pub>"
 
-static const char *default_cvmfs_repo = "*.cern.ch:pubkey=" CERN_KEY_PLACEHOLDER ",url=http://cvmfs-stratum-one.cern.ch/opt/*;http://cernvmfs.gridpp.rl.ac.uk/opt/*;http://cvmfs.racf.bnl.gov/opt/* *.opensciencegrid.org:pubkey=" OASIS_KEY_PLACEHOLDER ",url=http://oasis-replica.opensciencegrid.org:8000/cvmfs/*;http://cvmfs.fnal.gov:8000/cvmfs/*;http://cvmfs.racf.bnl.gov:8000/cvmfs/*";
+static const char *default_cvmfs_repo = "*:try_local_filesystem *.cern.ch:pubkey=" CERN_KEY_PLACEHOLDER ",url=http://cvmfs-stratum-one.cern.ch/opt/*;http://cernvmfs.gridpp.rl.ac.uk/opt/*;http://cvmfs.racf.bnl.gov/opt/* *.opensciencegrid.org:pubkey=" OASIS_KEY_PLACEHOLDER ",url=http://oasis-replica.opensciencegrid.org:8000/cvmfs/*;http://cvmfs.fnal.gov:8000/cvmfs/*;http://cvmfs.racf.bnl.gov:8000/cvmfs/*";
 
 static const char *cern_key_text = 
 "-----BEGIN PUBLIC KEY-----\n\
@@ -89,6 +89,9 @@ public:
 	std::list<int> wildcard_subst;
 	int subst_offset;
 	bool match_wildcard;
+	bool try_local_filesystem; // test for locally mounted cvmfs filesystem
+	bool use_local_filesystem; // always use locally mounted cvmfs filesystem
+	bool cvmfs_not_configured; // only local access is possible
 
 	cvmfs_filesystem *createMatch(char const *repo_name) const;
 };
@@ -371,6 +374,22 @@ static cvmfs_filesystem *cvmfs_filesystem_create(const char *repo_name, bool wil
 			proxy ? proxy : "",
 			&f->subst_offset,
 			user_options);
+
+	f->use_local_filesystem = false;
+	f->try_local_filesystem = false;
+	char *try_local_filesystem_pos = strstr(buf,"try_local_filesystem");
+	if( try_local_filesystem_pos ) {
+		f->try_local_filesystem = true;
+		char *rest = try_local_filesystem_pos+strlen("try_local_filesystem");
+		memmove(try_local_filesystem_pos,rest,strlen(rest)+1);
+	}
+
+	// see if this entry is just for local filesystem access, or if it supports parrot cvmfs access
+	f->cvmfs_not_configured = true;
+	if( strstr(buf,"url") ) {
+		f->cvmfs_not_configured = false;
+	}
+
 	f->cvmfs_options = buf;
 
 	f->match_wildcard = wildcard;
@@ -742,6 +761,39 @@ bool cvmfs_dirent::lookup(pfs_name * path, bool follow_leaf_symlinks, bool expan
 	if(!f) {
 		return false;
 	}
+	if( f->try_local_filesystem ) {
+		class pfs_service *local = pfs_service_lookup_default();
+		struct pfs_name local_fs;
+
+		snprintf(local_fs.rest,PFS_PATH_MAX,"/cvmfs/%s/%s",f->host.c_str(),f->path.c_str());
+		local_fs.rest[PFS_PATH_MAX-1] = '\0';
+		local_fs.is_local = 1;
+
+		struct pfs_stat st;
+		if( local->lstat(&local_fs,&st)==0 ) {
+			f->use_local_filesystem = true;
+			debug(D_CVMFS,"Found %s on local filesystem, so not using parrot cvmfs.",
+				  local_fs.rest);
+		}
+		else if( f->cvmfs_not_configured ) {
+			debug(D_CVMFS|D_NOTICE,"ERROR: Did not find %s on local filesystem (errno=%d %s), "
+				  "and parrot has not been configured to know how to access this CVMFS repository",
+				  local_fs.rest,errno,strerror(errno));
+			return false;
+		}
+		else {
+			debug(D_CVMFS,"Did not find %s on local filesystem (errno=%d %s), so using parrot cvmfs",
+				  local_fs.rest,errno,strerror(errno));
+		}
+		f->try_local_filesystem = false; // For efficiency, only test local access once.
+	}
+	if( f->use_local_filesystem ) {
+		// Tell caller to try again via the local filesystem.
+		strcpy(path->rest,path->logical_name);
+		path->is_local = 1;
+		errno = EAGAIN;
+		return false;
+	}
 
 	/*
 	If we attempt to lookup a directory name using a path
@@ -859,6 +911,10 @@ class pfs_service_cvmfs:public pfs_service {
 
 		if(!d.lookup(name, 1, 1)) {
 			// errno is set by lookup()
+			if( errno == EAGAIN ) {
+				class pfs_service *local = pfs_service_lookup_default();
+				return local->open(name,flags,mode);
+			}
 			return 0;
 		}
 
@@ -907,6 +963,10 @@ class pfs_service_cvmfs:public pfs_service {
 		*/
 
 		if(!d.lookup(name, 1, 1)) {
+			if( errno == EAGAIN ) {
+				class pfs_service *local = pfs_service_lookup_default();
+				return local->getdir(name);
+			}
 			return 0;
 		}
 
@@ -963,11 +1023,21 @@ class pfs_service_cvmfs:public pfs_service {
 	}
 
 	virtual int lstat(pfs_name * name, struct pfs_stat *info) {
-		return anystat(name,info,0,1);
+		int rc = anystat(name,info,0,1);
+		if( rc == -1 && errno == EAGAIN ) {
+			class pfs_service *local = pfs_service_lookup_default();
+			return local->lstat(name,info);
+		}
+		return rc;
 	}
 
 	virtual int stat(pfs_name * name, struct pfs_stat *info) {
-		return anystat(name,info,1,1);
+		int rc = anystat(name,info,1,1);
+		if( rc == -1 && errno == EAGAIN ) {
+			class pfs_service *local = pfs_service_lookup_default();
+			return local->stat(name,info);
+		}
+		return rc;
 	}
 
 	virtual int access(pfs_name * name, mode_t mode) {
@@ -1061,6 +1131,10 @@ class pfs_service_cvmfs:public pfs_service {
 		struct cvmfs_dirent d;
 
 		if(!d.lookup(name, 0, 0)) {
+			if( errno == EAGAIN ) {
+				class pfs_service *local = pfs_service_lookup_default();
+				return local->readlink(name,buf,bufsiz);
+			}
 			return -1;
 		}
 


### PR DESCRIPTION
Currently, we have problems on some OSG sites where we use Parrot to provide access to our CVMFS repositories.  The problem is that these sites have their own local CVMFS repository mounted to provide access to other software (e.g. the OSG client software).  When our jobs run under Parrot, they fail to to be able to access executables that happen to be on the locally mounted repository, because we didn't configure Parrot to know about this repository.  Rather than doing special configuration for each case such as this, we would prefer to have Parrot automatically fall back to local file access for CVMFS repositories that are locally mounted.  This patch makes that possible.

The new default behavior is to only fall back to locally mounted repositories if the repository is not configured for access via Parrot's cvmfs client.  If desired, the user can configure Parrot to instead use locally mounted repositories even if they are configured for access via Parrot.  In this case, Parrot's cvmfs client would only be used if the repository is not locally mounted.  The configuration is all managed by using the new try_local_filesytem option in the repository definitions listed in PARROT_CVMFS_REPO or in the --cvmfs-repos command-line option.

I would appreciate feedback on whether you think I am using the best method for falling back to local file access when that is desired.
