### PR TITLE
output files can also be excluded from the cache

### DIFF
--- a/work_queue/src/batch_job_work_queue.c
+++ b/work_queue/src/batch_job_work_queue.c
@@ -50,7 +50,7 @@ void specify_work_queue_task_files(struct work_queue_task *t, const char *input_
 			p = strchr(f, '=');
 			if(p) {
 				*p = 0;
-				if(strcmp(f, p+1)) {
+				if(strcmp(f, p+1) || caching_directive == WORK_QUEUE_NOCACHE) {
 					caching = WORK_QUEUE_NOCACHE;
 				} else {
 					caching = WORK_QUEUE_CACHE;
@@ -59,7 +59,9 @@ void specify_work_queue_task_files(struct work_queue_task *t, const char *input_
 				debug(D_BATCH, "remote file %s is %s on local system:", p + 1, f);
 				*p = '=';
 			} else {
-				work_queue_task_specify_file(t, f, f, WORK_QUEUE_OUTPUT, WORK_QUEUE_CACHE);
+				if(caching_directive == WORK_QUEUE_NOCACHE) caching = WORK_QUEUE_NOCACHE;
+				else caching = WORK_QUEUE_CACHE;
+				work_queue_task_specify_file(t, f, f, WORK_QUEUE_OUTPUT, caching);
 			}
 			f = strtok(0, " \t,");
 		}


### PR DESCRIPTION
Apparently this was missed in the previous pull request (#206). Caching should be disabled for output files as well as input files.
