### PR TITLE
Batch cache general enable/disable

### DIFF
--- a/doc/man/makeflow.m4
+++ b/doc/man/makeflow.m4
@@ -73,7 +73,7 @@ OPTION_TRIPLET(-Z, port-file, file)Select port at random and write it to this fi
 OPTION_TRIPLET(-P, priority, integer)Priority. Higher the value, higher the priority.
 OPTION_TRIPLET(-W, wq-schedule, mode)WorkQueue scheduling algorithm. (time|files|fcfs)
 OPTION_TRIPLET(-s, password, pwfile)Password file for authenticating workers.
-OPTION_ITEM(`--disable-wq-cache')Disable Work Queue caching. (default is false)
+OPTION_ITEM(`--disable-cache')Disable file caching (currently only Work Queue, default is false)
 OPTIONS_END
 
 SUBSECTION(Monitor Options)

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -74,7 +74,7 @@ enum { LONG_OPT_MONITOR_INTERVAL = 1,
        LONG_OPT_MONITOR_LIMITS,
        LONG_OPT_MONITOR_TIME_SERIES,
        LONG_OPT_MONITOR_OPENED_FILES,
-       LONG_OPT_DISABLE_WQ_CACHE,
+       LONG_OPT_DISABLE_BATCH_CACHE,
        LONG_OPT_PASSWORD,
        LONG_OPT_PPM_ROW,
        LONG_OPT_PPM_FILE,
@@ -110,7 +110,8 @@ static int priority = 0;
 static int port = 0;
 static const char *port_file = NULL;
 static int output_len_check = 0;
-static int work_queue_disable_cache = 0;
+
+static int cache_mode = 1;
 
 static char *makeflow_exe = NULL;
 static char *monitor_exe = NULL;
@@ -2377,7 +2378,7 @@ int main(int argc, char *argv[])
 		{"display-mode", required_argument, 0, 'D'},
 		{"dot-merge-similar", no_argument, 0,  LONG_OPT_DOT_CONDENSE},
 		{"dot-proportional",  no_argument, 0,  LONG_OPT_DOT_PROPORTIONAL},
-		{"disable-wq-cache", no_argument, 0, LONG_OPT_DISABLE_WQ_CACHE},
+		{"disable-cache", no_argument, 0, LONG_OPT_DISABLE_BATCH_CACHE},
 		{"ppm-highlight-row", required_argument, 0, LONG_OPT_PPM_ROW},
 		{"ppm-highlight-exe", required_argument, 0, LONG_OPT_PPM_EXE},
 		{"ppm-highlight-file", required_argument, 0, LONG_OPT_PPM_FILE},
@@ -2647,8 +2648,8 @@ int main(int argc, char *argv[])
 				return 1;
 			}
 			break;
-		case LONG_OPT_DISABLE_WQ_CACHE:
-			work_queue_disable_cache = 1;
+		case LONG_OPT_DISABLE_BATCH_CACHE:
+			cache_mode = 0;
 			break;
 		default:
 			show_help(argv[0]);
@@ -2931,12 +2932,12 @@ int main(int argc, char *argv[])
 		port = work_queue_port(q);
 		if(port_file)
 			opts_write_port_file(port_file, port);
-		if(work_queue_disable_cache){
-			batch_job_disable_caching_work_queue(remote_queue);
+		if(!cache_mode){
+			batch_job_disable_caching(remote_queue);
 			debug(D_DEBUG, "Work Queue caching is disabled.\n");
 		}
 		else {
-			batch_job_enable_caching_work_queue(remote_queue);
+			batch_job_enable_caching(remote_queue);
 		}
 	}
 

--- a/work_queue/src/batch_job.c
+++ b/work_queue/src/batch_job.c
@@ -374,16 +374,23 @@ int batch_queue_port(struct batch_queue *q)
 	}
 }
 
-int batch_job_enable_caching_work_queue(struct batch_queue * q)
+int batch_job_enable_caching(struct batch_queue * q)
 {
-	if(!q) return 0;
-	q->caching = WORK_QUEUE_CACHE;
+	if(!q) 
+		return 0;
+
+	q->caching = 1;
+
 	return 1;
 }
 
-int batch_job_disable_caching_work_queue(struct batch_queue * q)
+int batch_job_disable_caching(struct batch_queue * q)
 {
-	if(!q) return 0;
-	q->caching = WORK_QUEUE_NOCACHE;
+	if(!q) 
+		return 0;
+
+	q->caching = 0;
+
 	return 1;
 }
+

--- a/work_queue/src/batch_job.h
+++ b/work_queue/src/batch_job.h
@@ -189,6 +189,7 @@ Currently only relevant for the work queue implementation.
 */
 int batch_queue_port(struct batch_queue *q);
 
-int batch_job_enable_caching_work_queue(struct batch_queue * q);
-int batch_job_disable_caching_work_queue(struct batch_queue * q);
+int batch_job_enable_caching(struct batch_queue * q);
+int batch_job_disable_caching(struct batch_queue * q);
+
 #endif

--- a/work_queue/src/batch_job_work_queue.c
+++ b/work_queue/src/batch_job_work_queue.c
@@ -25,17 +25,22 @@ void specify_work_queue_task_files(struct work_queue_task *t, const char *input_
 			p = strchr(f, '=');
 			if(p) {
 				*p = 0;
-				if(strcmp(f, p+1) || caching_directive == WORK_QUEUE_NOCACHE) {
+
+				if(strcmp(f, p+1) || !caching_directive)
 					caching = WORK_QUEUE_NOCACHE;
-				} else {
+				else
 					caching = WORK_QUEUE_CACHE;
-				}
+			
 				work_queue_task_specify_file(t, f, p + 1, WORK_QUEUE_INPUT, caching);
 				debug(D_BATCH, "local file %s is %s on remote system:", f, p + 1);
 				*p = '=';
 			} else {
-				if(caching_directive == WORK_QUEUE_NOCACHE) caching = WORK_QUEUE_NOCACHE;
-				else caching = WORK_QUEUE_CACHE;
+
+				if(caching_directive == WORK_QUEUE_NOCACHE) 
+					caching = WORK_QUEUE_NOCACHE;
+				else 
+					caching = WORK_QUEUE_CACHE;
+
 				work_queue_task_specify_file(t, f, f, WORK_QUEUE_INPUT, caching);
 			}
 			f = strtok(0, " \t,");
@@ -50,17 +55,22 @@ void specify_work_queue_task_files(struct work_queue_task *t, const char *input_
 			p = strchr(f, '=');
 			if(p) {
 				*p = 0;
-				if(strcmp(f, p+1) || caching_directive == WORK_QUEUE_NOCACHE) {
+
+				if(strcmp(f, p+1) || !caching_directive)
 					caching = WORK_QUEUE_NOCACHE;
-				} else {
+				else
 					caching = WORK_QUEUE_CACHE;
-				}
+
 				work_queue_task_specify_file(t, f, p + 1, WORK_QUEUE_OUTPUT, caching);
 				debug(D_BATCH, "remote file %s is %s on local system:", p + 1, f);
 				*p = '=';
 			} else {
-				if(caching_directive == WORK_QUEUE_NOCACHE) caching = WORK_QUEUE_NOCACHE;
-				else caching = WORK_QUEUE_CACHE;
+
+				if(caching_directive == WORK_QUEUE_NOCACHE) 
+					caching = WORK_QUEUE_NOCACHE;
+				else 
+					caching = WORK_QUEUE_CACHE;
+
 				work_queue_task_specify_file(t, f, f, WORK_QUEUE_OUTPUT, caching);
 			}
 			f = strtok(0, " \t,");


### PR DESCRIPTION
Given that we are keeping the cache flag inside the batch structure, I renamed the functions to make them less wq specific.
