### PR TITLE
Fix name of remotely cached files.

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1562,15 +1562,11 @@ static int send_file_or_directory( struct work_queue *q, struct work_queue_worke
 			free(remote_info);
 		}
 
-		char * cached_name = make_cached_name(t,tf);
-
 		if(S_ISDIR(local_info.st_mode)) {
 			result = send_directory(q, w, t, expanded_local_name, cached_name, total_bytes, tf->flags);
 		} else {
 			result = send_file(q, w, t, expanded_local_name, cached_name, tf->offset, tf->piece_length, total_bytes, tf->flags);
 		}
-
-		free(cached_name);
 
 		if(result && tf->flags & WORK_QUEUE_CACHE) {
 			remote_info = malloc(sizeof(*remote_info));


### PR DESCRIPTION
This is a small pull request but requires some discussion.  @btovar @dpandiar @malbrec2

First, I have factored the (repeated) generation of the remote cached name into make_cached_name() so it is defined in a single place.  Currently, a file is stored in the cache directory according to its remote name.

Second, there is a hash table that records what files are currently stored in the cache directory.  Currently, the hash table records each file under the hash key "remotename-localname".  I am fairly certain this is incorrect -- if the master wants to keep track of the contents of the directory, it should do that using exactly the names under which the file is stored.

So, this pull cleans up the handling of the hash table by using exactly the cached file name as the key for the worker->current files hash table.

The question as to _what_ name to use in the cache directory is a separate issue -- I am simply going for internal consistency at this point.

Does this look right?
