### PR TITLE
Removed TARGET.Memory from Requirements as the command is obsolete. Adde...

### DIFF
--- a/work_queue/src/condor_submit_workers
+++ b/work_queue/src/condor_submit_workers
@@ -32,7 +32,8 @@ show_help()
 # which causes long-running workers to eventually sit idle in the queue.
 # The user can still add their own expression via the -r option.
 
-requirements="(Memory>0)"
+requirements=""
+memory=0
 
 submit_dir=/tmp/${USER}-workers
 arguments=""
@@ -200,6 +201,7 @@ output = worker.\$(PROCESS).output
 error = worker.\$(PROCESS).error
 log = workers.log
 getenv = true
+request_memory = $memory
 requirements = $requirements
 queue $count
 EOF


### PR DESCRIPTION
Removed TARGET.Memory. Changed to request_memory. Please review @btover. #197
