### PR TITLE
Print makeflow parse progress with rule number.

### DIFF
--- a/makeflow/src/dag.c
+++ b/makeflow/src/dag.c
@@ -22,6 +22,8 @@ See the file COPYING for details.
 
 #include "dag.h"
 
+#define PARSING_RULE_MOD_COUNTER 250
+
 struct dag *dag_create()
 {
 	struct dag *d = malloc(sizeof(*d));
@@ -140,6 +142,12 @@ struct dag_node *dag_node_create(struct dag *d, int linenum)
 	n->ancestors = set_create(0);
 
 	n->ancestor_depth = -1;
+
+	if(d->nodeid_counter % PARSING_RULE_MOD_COUNTER == 0)
+	{
+		fprintf(stdout, "\rRules parsed: %d", d->nodeid_counter + 1);
+		fflush(stdout);
+	}
 
 	return n;
 }

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -2917,6 +2917,9 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+	fprintf(stdout, "\r     Total rules: %d", d->nodeid_counter);
+	fprintf(stdout, "\nStarting execution of workflow: %s.\n", dagfile); 
+
 	if(batch_queue_type == BATCH_QUEUE_TYPE_CONDOR && !skip_afs_check) {
 		char *cwd = path_getcwd();
 		if(!strncmp(cwd, "/afs", 4)) {


### PR DESCRIPTION
Per Neil Best request, Makeflow prints the node id of the rule it is
parsing (It prints the number every 250 rules, on the same line as the
previous number).
