### PR TITLE
Work Queue Cleanup Global Variables

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -5,14 +5,9 @@ See the file COPYING for details.
 */
 
 /*
-The following major problems must be fixed before this code
-can be released:
-
+The following major problems must be fixed:
 - The capacity code assumes one task per worker.
-
 - The log specification need to be updated.
-
-- The details reported to the catalog should be examined.
 */
 
 #include "work_queue.h"


### PR DESCRIPTION
Removed last two global variables in work_queue.c and converted into instance variables.
Moved computation of message timeout into send_worker_msg for consistency and clarity.
