### PR TITLE
Update wq_submit_workers.common to correctly output help messages with h and help flags.

### DIFF
--- a/work_queue/src/wq_submit_workers.common
+++ b/work_queue/src/wq_submit_workers.common
@@ -137,7 +137,7 @@ parse_arguments_common()
 			requirements="$requirments $1"
 			;;
 			-h | --help)
-			show_help
+			show_help_common
 			;;
 			*)
 			break


### PR DESCRIPTION
This changes a function to correctly output help messages called from wq_submit_workers.common. @btovar
