### PR TITLE
Removes scripts use of TARGET.Memory. 

### DIFF
--- a/work_queue/src/condor_submit_workers
+++ b/work_queue/src/condor_submit_workers
@@ -18,8 +18,7 @@ show_help()
 # which causes long-running workers to eventually sit idle in the queue.
 # The user can still add their own expression via the -r option.
 
-
-requirements="(Memory>0)"
+requirements=""
 transfer_input_files="work_queue_worker"
 
 parse_arguments()


### PR DESCRIPTION
User can still use TARGET.variable and it will override defaults. This does not prevent backwards compatibility, but users will receive warning of obsolete usage of TARGET.Variable, such as Memory or Disk. Please Review @btovar #197
