### PR TITLE
Foreman always wait

### DIFF
--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1736,6 +1736,16 @@ static void foreman_for_master(struct link *master) {
 				break;
 			}
 		}
+		else
+		{
+			if(!task && work_queue_empty(foreman_q))
+			{
+				//if no task returned, and the queue is empty, wait_internal
+				//did not wait at all. We wait here one second to avoid busy
+				//waiting.
+				link_sleep(master, 1 /* one second */, 1 /* read */, 0);
+			}
+		}
 		
 		idle_stoptime = time(0) + idle_timeout;
 	}


### PR DESCRIPTION
Under certain conditions, wq_wait returns immediately. This is useful for a master, but in the foreman wastes cpu cycles. This request makes the foreman wait at least one second if nothing interesting happens.

@dpandiar, @dthain
