### PR TITLE
no static linking on DARWIN

### DIFF
--- a/configure
+++ b/configure
@@ -423,6 +423,9 @@ fi
 if [ $build_sys = LINUX ]
 then
         ldflags="-Xlinker -Bstatic -static-libgcc -Xlinker -Bdynamic ${link_as_needed}"
+elif [ $build_sys = DARWIN ]
+then
+        ldflags=""
 else
         ldflags="-static-libgcc"
 fi


### PR DESCRIPTION
clang: error: unsupported option '-static-libgcc'

see: https://developer.apple.com/library/mac/qa/qa1118/_index.html
