### PR TITLE
Parse shell-like line continuation in makeflow files

### DIFF
--- a/makeflow/test/TR_makeflow_020_line_continuation.sh
+++ b/makeflow/test/TR_makeflow_020_line_continuation.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+. ../../dttools/src/test_runner.common.sh
+
+prepare()
+{
+    clean $@
+}
+
+run()
+{
+    cd syntax && ../../src/makeflow line_continuation.makeflow && exit 0
+    exit 1
+}
+
+clean()
+{
+    cd syntax; ../../src/makeflow -c line_continuation.makeflow && exit 0
+    exit 1
+}
+
+dispatch $@
+
+# vim: set noexpandtab tabstop=4:

--- a/makeflow/test/syntax/line_continuation.makeflow
+++ b/makeflow/test/syntax/line_continuation.makeflow
@@ -1,0 +1,6 @@
+out1:
+    echo "One" "Two" \
+    "Three" > out1
+out2: out1
+    grep "One Two Three" out1 > out2 \
+


### PR DESCRIPTION
Sometimes I write makeflows by hand instead of generating them,
and prefer the makeflows to be readable.
In those cases, it is convenient to split long commands across
multiple lines using backslash at the end of the line.
This branch implements parsing and provides the test case.
