### PR TITLE
Parrot alien cache

### DIFF
--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -32,6 +32,7 @@ extern "C" {
 #include "chirp_ticket.h"
 #include "ftp_lite.h"
 #include "int_sizes.h"
+#include "delete_dir.h"
 }
 
 #include <stdlib.h>
@@ -88,6 +89,7 @@ INT64_T pfs_write_count = 0;
 const char * pfs_cvmfs_repo_arg = 0;
 bool pfs_cvmfs_repo_switching = false;
 char pfs_cvmfs_alien_cache_dir[PFS_PATH_MAX];
+char pfs_cvmfs_locks_dir[PFS_PATH_MAX];
 
 int pfs_irods_debug_level = 0;
 
@@ -722,6 +724,7 @@ int main( int argc, char *argv[] )
 		sprintf(pfs_cvmfs_alien_cache_dir,"%s/cvmfs", pfs_temp_dir);
 	}
 
+	sprintf(pfs_cvmfs_locks_dir, "%s/cvmfs_locks_%d", pfs_temp_dir, getpid());
 
 	pfs_file_cache = file_cache_init(pfs_temp_dir);
 	if(!pfs_file_cache) fatal("couldn't setup cache in %s: %s\n",pfs_temp_dir,strerror(errno));
@@ -868,6 +871,8 @@ int main( int argc, char *argv[] )
 	}
 
 	if(pfs_paranoid_mode) pfs_paranoia_cleanup();
+
+	delete_dir(pfs_cvmfs_locks_dir);
 
 	if(WIFEXITED(root_exitstatus)) {
 		status = WEXITSTATUS(root_exitstatus);

--- a/parrot/src/pfs_service_cvmfs.cc
+++ b/parrot/src/pfs_service_cvmfs.cc
@@ -34,6 +34,7 @@ extern char pfs_temp_dir[];
 extern const char * pfs_cvmfs_repo_arg;
 extern bool pfs_cvmfs_repo_switching;
 extern char pfs_cvmfs_alien_cache_dir[];
+extern char pfs_cvmfs_locks_dir[];
 
 static bool cvmfs_configured = false;
 static struct cvmfs_filesystem *cvmfs_filesystem_list = 0;
@@ -362,13 +363,12 @@ static cvmfs_filesystem *cvmfs_filesystem_create(const char *repo_name, bool wil
 
 	int repo_name_offset = 0;
 	int repo_name_in_cachedir_offset = 0;
-	char *buf = string_format("repo_name=%n%s,cachedir=%s/cvmfs_locks_%d/%n%s,alien_cachedir=%s/%n%s,timeout=%d,timeout_direct=%d%s%s,%n%s",
+	char *buf = string_format("repo_name=%n%s,cachedir=%s/%n%s,alien_cachedir=%s/%n%s,timeout=%d,timeout_direct=%d%s%s,%n%s",
 			&repo_name_offset,
 			repo_name,
 
 			//cachedir
-			pfs_temp_dir,
-			getpid(),                       // add pid to name, since cachedir needs to be exclusive
+			pfs_cvmfs_locks_dir,
 			&repo_name_in_cachedir_offset,
 			repo_name,
 


### PR DESCRIPTION
Fixes #298. Adds alien_cache option to cvmfs so that multiple instances of parrot can access a cvmfs repository simultaneously, from the same machine.
