### PR TITLE
printf CCTOOLS_VERSION_MICRO in '%s', not in '%d'

### DIFF
--- a/ftsh/src/ftsh.c
+++ b/ftsh/src/ftsh.c
@@ -176,7 +176,7 @@ static int ftsh_main( int argc, char *argv[] )
 
 	/* Reset the environment for my children */
 
-	sprintf(env,"FTSH_VERSION=%d.%d.%d",CCTOOLS_VERSION_MAJOR,CCTOOLS_VERSION_MINOR,CCTOOLS_VERSION_MICRO);
+	sprintf(env,"FTSH_VERSION=%d.%d.%s",CCTOOLS_VERSION_MAJOR,CCTOOLS_VERSION_MINOR,CCTOOLS_VERSION_MICRO);
 	putenv(xxstrdup(env));
 
 	if(log_file) {
@@ -204,7 +204,7 @@ static int ftsh_main( int argc, char *argv[] )
 	sprintf(env,"FTSH_VERSION_MINOR=%d",CCTOOLS_VERSION_MINOR);
 	putenv(xxstrdup(env));
 
-	sprintf(env,"FTSH_VERSION_MICRO=%d",CCTOOLS_VERSION_MICRO);
+	sprintf(env,"FTSH_VERSION_MICRO=%s",CCTOOLS_VERSION_MICRO);
 	putenv(xxstrdup(env));
 
 	/* Now, initialize my systems */


### PR DESCRIPTION
The printf type of CCTOOLS_VERSION_MICRO should be string type('%s').
However, ftsh.c treated it as an int variable('%d').
