### PR TITLE
Wq race condition removed.

### DIFF
--- a/work_queue/src/work_queue_resources.c
+++ b/work_queue/src/work_queue_resources.c
@@ -66,7 +66,6 @@ void work_queue_resources_send( struct link *master, struct work_queue_resources
 	work_queue_resource_send(master, &r->disk,    "disk",   stoptime);
 	work_queue_resource_send(master, &r->memory,  "memory", stoptime);
 	work_queue_resource_send(master, &r->gpus,    "gpus",   stoptime);
-    sleep(20);
 	work_queue_resource_send(master, &r->cores,   "cores",  stoptime);
 }
 


### PR DESCRIPTION
Cores are now reported last. As long as cores remains 0, the master will not give a task to it. This allows for the rest of the resources to report successfully. @btovar please review this code. #178
