### PR TITLE
Logs WQ status disconnects differently from normal

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1304,6 +1304,8 @@ static int process_queue_status( struct work_queue *q, struct work_queue_worker 
 	char request[WORK_QUEUE_LINE_MAX];
 	struct link *l = target->link;
 	
+    strcpy(target->hostname,"QUEUE_STATUS");
+
 	if(!sscanf(line, "%[^_]_status", request) == 1) {
 		return -1;
 	}
@@ -1424,7 +1426,10 @@ static void handle_worker(struct work_queue *q, struct link *l)
 		debug(D_WQ, "Invalid message from worker %s (%s): %s", w->hostname, w->addrport, line);
 		keep_worker = 0;
 	} else if(result < 0){
-		debug(D_WQ, "Failed to read from worker %s (%s)", w->hostname, w->addrport);
+		if(!strcmp(w->hostname, "QUEUE_STATUS"))
+			debug(D_WQ, "Work Queue Status worker disconnected (%s)", w->addrport);
+		else
+			debug(D_WQ, "Failed to read from worker %s (%s)", w->hostname, w->addrport);
 		keep_worker = 0;
 	} // otherwise do nothing..message was consumed and processed in recv_worker_msg()
 


### PR DESCRIPTION
Currently, a Work Queue status check behaves like a client. By this I mean that there is no ready message that sets the hostname. Also there is no instance, that I am aware of, of a worker requesting work queue status. Therefore, I am renaming the hostname from "unknown" to "QUEUE_STATUS". Handle_worker then checks if the host name is "QUEUE_STATUS", if it is the log records that the status worker disconnected. @btovar please review. #219
