### PR TITLE
Chirp Inherit Default ACLs

### DIFF
--- a/chirp/src/chirp_acl.h
+++ b/chirp/src/chirp_acl.h
@@ -61,6 +61,7 @@ void chirp_acl_force_readonly();
 void chirp_acl_timeout_set(int t);
 int chirp_acl_timeout_get();
 void chirp_acl_default(const char *aclpath);
+void chirp_acl_inherit_default( int onoff );
 
 int chirp_acl_init_root(const char *path);
 int chirp_acl_init_copy(const char *path);

--- a/chirp/src/chirp_server.c
+++ b/chirp/src/chirp_server.c
@@ -1729,6 +1729,8 @@ static void install_handler(int sig, void (*handler) (int sig))
 	sigaction(sig, &s, 0);
 }
 
+#define LONG_OPT_INHERIT_DEFAULT_ACL 255
+
 static void show_help(const char *cmd)
 {
 	fprintf(stdout, "use: %s [options]\n", cmd);
@@ -1742,6 +1744,7 @@ static void show_help(const char *cmd)
 	fprintf(stdout, "\n");
 	fprintf(stdout, "Less common options are:\n");
 	fprintf(stdout, " %-30s Use this file as the default ACL.\n", "-A,--default-acl=<file>");
+	fprintf(stdout, " %-30s Directories without an ACL inherit from parent directories.\n","   --inherit-default-acl");
 	fprintf(stdout, " %-30s Enable this authentication method.\n", "-a,--auth=<method>");
 	fprintf(stdout, " %-30s Write process identifier (PID) to file.\n", "-B,--pid-file=<file>");
 	fprintf(stdout, " %-30s Run as a daemon.\n", "-b,--background");
@@ -1786,6 +1789,7 @@ int main(int argc, char *argv[])
 		{"debug", required_argument, 0, 'd'},
 		{"debug-file", required_argument, 0, 'o'},
 		{"default-acl", required_argument, 0, 'A'},
+		{"inherit-default-acl", no_argument, 0, LONG_OPT_INHERIT_DEFAULT_ACL},
 		{"free-space", required_argument, 0, 'F'},
 		{"group-cache-exp", required_argument, 0, 'T'},
 		{"group-url", required_argument, 0, 'G'},
@@ -1960,6 +1964,9 @@ int main(int argc, char *argv[])
 		case 'l':
 			/* not documented, internal testing */
 			sim_latency = atoi(optarg);
+			break;
+		case LONG_OPT_INHERIT_DEFAULT_ACL:
+			chirp_acl_inherit_default(1);
 			break;
 		case 'h':
 		default:

--- a/doc/chirp.html
+++ b/doc/chirp.html
@@ -5,7 +5,7 @@
 </head>
 
 <h1>Chirp User's Manual</h1>
-<b>July 2011</b>
+<b>December 2013</b>
 <p>
 Chirp is Copyright (C) 2003-2004 Douglas Thain and
 Copyright (C) 2005- The University of Notre Dame.

--- a/doc/man/chirp_server.m4
+++ b/doc/man/chirp_server.m4
@@ -23,11 +23,12 @@ SECTION(OPTIONS)
 
 OPTIONS_BEGIN
 OPTION_TRIPLET(-A, default-acl,file)Use this file as the default ACL.
+OPTION_ITEM(--inherit-default-acl) Directories without an ACL inherit from parent directories.
 OPTION_TRIPLET(-a, auth,method)Enable this authentication method.
 OPTION_ITEM(`-b, --background')Run as daemon.
 OPTION_TRIPLET(-B, pid-file,file)Write PID to file.
 OPTION_ITEM(`-C, --no-core-dump')Do not create a core dump, even due to a crash.
-OPTION_TRIPLET(-c, chalenge-dir,dir)Challenge directory for unix filesystem authentication.
+OPTION_TRIPLET(-c, challenge-dir,dir)Challenge directory for unix filesystem authentication.
 OPTION_TRIPLET(-d, debug, flag)Enable debugging for this sybsystem
 OPTION_ITEM(`-E, --parent-death')Exit if parent process dies.
 OPTION_TRIPLET(-e, parent-check,time)Check for presence of parent at this interval. (default is 300s)


### PR DESCRIPTION
Added --inherit-default-acl option which causes chirp to look in
parent directories when an ACL is not present.  Such ACLs are
copy-on-write when modified via setacl.

Addresses issue #239

@batrick please review.
