### PR TITLE
readlink `/proc/self/exe` returns absolute path

### DIFF
--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -1628,6 +1628,9 @@ int pfs_table::readlink( const char *n, char *buf, pfs_size_t size )
 		} else if(sscanf(pname.path,"/proc/%d/exe",&pid)==1) {
 			struct pfs_process *target = pfs_process_lookup(pid);
 			if(target) {
+				char complete_target_name[PFS_PATH_MAX];
+				complete_path(target->name,complete_target_name);
+				collapse_path(complete_target_name, target->name, 1);
 				strncpy(buf,target->name,size);
 				result = MIN(size,(pfs_size_t)strlen(target->name));
 			} else {


### PR DESCRIPTION
Problem: `readlink /proc/self/exe` returns relative path if the executable begins with `./` under Parrot

Solution: Under Parrot, when the access path of readlink system call is `/proc/self/exe`, Parrot will call `pfs_process_lookup(pid)` to obtain the `pfs_process` struct and store the file name referred by `/proc/self/exe` into `target->name`. 
What we need to do is ensure the `target->name` to be absolute path.

fixes #348.
