### PR TITLE
Fixes in worker for handling relative paths for workspace and correctly symlinking files to and from cache.

### DIFF
--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -335,15 +335,18 @@ int link_file_in_workspace(char *localname, char *taskname, char *workspace, int
 			} 
 			
 			if((errno == EXDEV || errno == EPERM) && symlinks_enabled) {
-				char *cwd = path_getcwd();
-				char *absolute_sourcename = malloc((strlen(cwd) + strlen(sourcename) + 2) * sizeof(char));
-				sprintf(absolute_sourcename, "%s/%s", cwd, sourcename);
+				//use absolute path when symlinking. Else link will point to a 
+				//file relative to current directory.	
+				char *cwd = path_getcwd();	
+				char *absolute_sourcename = string_format("%s/%s", cwd, sourcename);	
 				free(cwd);	
 				debug(D_WQ, "symlinking file %s -> %s\n", absolute_sourcename, targetname);
 				if(symlink(absolute_sourcename, targetname)) {
 					debug(D_WQ, "Could not symlink file %s -> %s (%s)\n", absolute_sourcename, targetname, strerror(errno));
+					free(absolute_sourcename);	
 					return 0;
 				}
+				free(absolute_sourcename);	
 			} else {
 				return 0;
 			}


### PR DESCRIPTION
1. Fixes #345 by converting the specified relative path to absolute.
2. Uses absolute path for source when symlinking. Previously, the symlink was created relative to the current directory. Here is an example of the problem: consider a directory containing 2 subdirs - cache and t.1.

When we symlink a file `a.in` in `cache` into `t.1` as
`ln -s  cache/a.in  t.1/a.in` then `t.1/a.in` will simply point to a non-existent file as the link will be traversed relative to `t.1`.

@btovar
