### PR TITLE
initialize J

### DIFF
--- a/chirp/src/chirp_job.c
+++ b/chirp/src/chirp_job.c
@@ -826,7 +826,7 @@ int chirp_job_wait (chirp_jobid_t id, const char *subject, INT64_T timeout, buff
 	int rc;
 	int i, n;
 	chirp_jobid_t jobs[1024];
-	json_value *J;
+	json_value *J=NULL;
 
 	if (!chirp_job_enabled) return ENOSYS;
 	CATCH(db_get(&db));


### PR DESCRIPTION
Removes error:

```
chirp_job.c:832:2: warning: variable 'J' is used uninitialized whenever
'if' condition is true [-Wsometimes-uninitialized]
```
