### PR TITLE
change name of executable invoked in test

### DIFF
--- a/makeflow/test/TR_makeflow_020_syntax_variable_issues.sh
+++ b/makeflow/test/TR_makeflow_020_syntax_variable_issues.sh
@@ -11,7 +11,7 @@ run()
 {
     cd syntax
 
-    if ../../src/makeflow -k variable_issues.makeflow
+    if ../../src/makeflow_analyze -k variable_issues.makeflow
     then
       exit 1
     else


### PR DESCRIPTION
Fix 'invalid option -k' message
