### PR TITLE
Fix bug idle workers not timing out.

### DIFF
--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1775,7 +1775,7 @@ static void work_for_master(struct link *master) {
 		}
 
 		//Reset idle timeout if something interesting is happening at this worker.
-		if(itable_size(stored_tasks) > 0 || itable_size(results_to_be_sent) > 0) {
+		if(list_size(waiting_tasks) > 0 || itable_size(stored_tasks) > 0 || itable_size(results_to_be_sent) > 0) {
 			idle_stoptime = time(0) + idle_timeout;
 		}
 	}


### PR DESCRIPTION
The timeout stoptime was reset every time there was a message from the
master. This came because we were testing for the timeout in two
different places, and using both store and active tasks. This commit
consolidates reseting the timeout at the end of the function, and
making the comparison to the timeout stoptime the only condition to
abort on idle.
