### PR TITLE
Compute total disk and memory according to available and inuse.

### DIFF
--- a/work_queue/src/work_queue_resources.c
+++ b/work_queue/src/work_queue_resources.c
@@ -37,13 +37,16 @@ void work_queue_resources_measure_locally( struct work_queue_resources *r, const
 	r->cores.total = load_average_get_cpus();
 	r->cores.largest = r->cores.smallest = r->cores.total;
 
+	/* For disk and memory, we compute the total thinking that the worker is
+	 * not executing by itself, but that it has to share its resources with
+	 * other processes/workers. */
+
 	disk_info_get(disk_path,&avail,&total);
-	r->disk.total = total / (UINT64_T) MEGA;
-	r->disk.inuse = avail / (UINT64_T) MEGA;
+	r->disk.total = (avail / (UINT64_T) MEGA) + r->disk.inuse; // Free + whatever we are using.
 	r->disk.largest = r->disk.smallest = r->disk.total;
 
 	memory_info_get(&avail,&total);
-	r->memory.total = avail / (UINT64_T) MEGA;
+	r->memory.total = (avail / (UINT64_T) MEGA) + r->memory.inuse; // Free + whatever we are using.
 	r->memory.largest = r->memory.smallest = r->memory.total;
 
 	r->gpus.total = gpu_info_get();


### PR DESCRIPTION
There is not a perfect way to measure what is available to the worker, since it might be sharing the node with some other processes. This commit proposes to measure the total disk and total memory as the free available + whatever the worker has "inuse". 
