### PR TITLE
delete the `L` parameter and enable `l` parameter

### DIFF
--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -584,7 +584,7 @@ int main( int argc, char *argv[] )
         {0,0,0,0}
 	};
 
-	while((c=getopt_long(argc,argv,"+ha:b:B:c:Cd:DFfG:Hi:I:kKlL:m:M:N:o:O:p:PQr:R:sSt:T:U:u:vw:WY", long_options, NULL)) > -1) {
+	while((c=getopt_long(argc,argv,"+ha:b:B:c:Cd:DFfG:Hi:I:kKl:m:M:N:o:O:p:PQr:R:sSt:T:U:u:vw:WY", long_options, NULL)) > -1) {
 		switch(c) {
 		case 'a':
 			if(!auth_register_byname(optarg)) {


### PR DESCRIPTION
`-L` parameter was used for namelist, and not is replaced by long-option `--name-list`.
Change "lL:" to "l:" so that `-l` parameter can function normally.
