### PR TITLE
invalidate file path in the channel cache if a file is unlinked/renamed

### DIFF
--- a/parrot/src/pfs_channel.c
+++ b/parrot/src/pfs_channel.c
@@ -194,6 +194,26 @@ int pfs_channel_lookup( const char *name, pfs_size_t *start )
 	return 0;
 }
 
+int pfs_channel_update_name( const char *oldname, const char *newname )
+{
+	struct entry *e = head;
+    debug(D_CHANNEL,"updating channel for file '%s'",oldname);
+	do {
+		if(e->name && !strcmp(e->name,oldname)) {
+			if(e->name)
+				free(e->name);
+			if(newname)
+				e->name = xxstrdup(newname);
+			else
+				e->name = 0;
+			return 1;
+		}
+		e = e->next;
+	} while(e!=head);
+
+	return 0;
+}
+
 void pfs_channel_free( pfs_size_t start )
 {
 	struct entry *e = head;

--- a/parrot/src/pfs_channel.h
+++ b/parrot/src/pfs_channel.h
@@ -23,6 +23,8 @@ int    pfs_channel_lookup( const char *name, pfs_size_t *start );
 int    pfs_channel_alloc( const char *name, pfs_size_t length, pfs_size_t *start );
 void   pfs_channel_free( pfs_size_t start );
 
+int    pfs_channel_update_name( const char* oldname, const char* newname );
+
 #ifdef __cplusplus
 }
 #endif

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -842,7 +842,7 @@ pfs_ssize_t pfs_table::writev( int fd, const struct iovec *vector, int count )
 	int i;
 	pfs_ssize_t result = 0;
 	pfs_ssize_t chunk;
-
+	
 	for( i = 0; i < count; i++ ) {
 		chunk = this->write( fd, vector->iov_base, vector->iov_len );
 		if( chunk < 0 ) return chunk;
@@ -1473,7 +1473,7 @@ int pfs_table::lutimens( const char *n, const struct timespec times[2] )
 {
 	pfs_name pname;
 	int result=-1;
-
+	
 	if(resolve_name("lutimens",n,&pname,false)) {
 		result = pname.service->lutimens(&pname,times);
 	}
@@ -1489,7 +1489,10 @@ int pfs_table::unlink( const char *n )
 
 	if(resolve_name("unlink",n,&pname,false)) {
 		result = pname.service->unlink(&pname);
-		if(result==0) pfs_cache_invalidate(&pname);
+		if(result==0) {
+			pfs_cache_invalidate(&pname);
+			pfs_channel_update_name(pname.path,0);
+		}
 	}
 
 	return result;
@@ -1556,6 +1559,7 @@ int pfs_table::rename( const char *n1, const char *n2 )
 			if(result==0) {
 				pfs_cache_invalidate(&p1);
 				pfs_cache_invalidate(&p2);
+				pfs_channel_update_name(p1.path, p2.path);
 			}
 		} else {
 			errno = EXDEV;


### PR DESCRIPTION
Partial fix for https://github.com/cooperative-computing-lab/cctools/issues/360. There seem to be other issues with AthenaMP, but this fixes the wrong channel re-using behavior if a file is mmap()ed, unlinked, re-created and mmap()ed again.
