### PR TITLE
Partially revert fc07b6e1b93086ca2a1600b8891069b28db1b534.

### DIFF
--- a/parrot/src/pfs_process.cc
+++ b/parrot/src/pfs_process.cc
@@ -367,7 +367,7 @@ int pfs_process_waitpid( struct pfs_process *p, pid_t wait_pid, int *wait_ustatu
 
 	itable_firstkey(pfs_process_table);
 	while(itable_nextkey(pfs_process_table,&childpid,(void**)&child)) {
-		if(child && child->ppid == p->pid) {
+		if(child && child->ppid == p->pid && child->tgid == child->pid) {
 			nchildren++;
 			if(pfs_process_may_wake(p,child)) return 1;
 		}


### PR DESCRIPTION
It seems this commit was added to ensure the actual parent (i.e. the process
that called clone) is notified on process death. Apparently this isn't correct
behavior as the man page for clone(2) states:

```
A new thread created with CLONE_THREAD has the same parent process as the
caller of clone() (i.e., like CLONE_PARENT), so that calls to getppid(2)
return the same  value  for all of the threads in a thread group.  When a
CLONE_THREAD thread terminates, the thread that created it using clone() is
not sent a SIGCHLD (or other termination) signal; nor can the status of
such a thread be obtained using wait(2).  (The thread is said to be
detached.)
```

Since notify_parent is only set when flags&(CLONE_PARENT|CLONE_THREAD), we
do not need to send SIGCHLD to the actual_parent in any event.

This problem caused the issue #419 reported by Michi. waitpid(2) returned a
thread id when it should report an error ECHILD.

Fixes #419.
