### PR TITLE
OS X: remove hardocded link dependency on system Python Framework

### DIFF
--- a/configure
+++ b/configure
@@ -836,7 +836,6 @@ from distutils import sysconfig
 libs = sysconfig.get_config_var('LIBS').split() + sysconfig.get_config_var('SYSLIBS').split()
 if not sysconfig.get_config_var('Py_ENABLE_SHARED'):
     libs.insert(0, '-L' + sysconfig.get_config_var('LIBPL'))
-libs.extend(sysconfig.get_config_var('LINKFORSHARED').split())
 print ' '.join(libs)
 EOF
 				python_ccflags=`cat $python_ccflags_file`


### PR DESCRIPTION
This is from the release/4.1 branch (commit 78be08d):

I'm trying to get cctools (specifically the python WorkQueue bindings) to compile on my mac.
The current configure script results in the python_ldflags including a hardcoded value the Python Framework which ships with the OS that breaks the build.

```
$ ./configure --with-python-path /Applications/Canopy.app/appdata/canopy-1.1.0.1371.macosx-x86_64/Canopy.app/Contents/
…
LINK work_queue.dylib
SWIG work_queue.i (python)
COMPILE work_queue_wrap.o
LINK _work_queue.so
clang: error: no such file or directory: 'Python.framework/Versions/2.0.0.dev1-a8c3646/Python'
make[3]: *** [_work_queue.so] Error 1
```

**python_ldflags**
`-L/Applications/Canopy.app/appdata/canopy-1.1.0.1371.macosx-x86_64/Canopy.app/Contents/lib/python2.7/config -ldl -framework CoreFoundation -u _PyMac_Error Python.framework/Versions/2.0.0.dev1-a8c3646/Python`

The problem is the linking to the Python Framework which is hardcoded. This prevents usage of a different python other than that provided by the OS.
In particular, the problem is the `-u _PyMac_Error Python.framework/Versions/2.0.0.dev1-a8c3646/Python` parameters.

The fix is to remove getting the `LINKFORSHARED` confg variable from the detection of the python setup in configure.
This fix allows configure and make to run.
Testing to make sure that the `work_queue` module can be loaded into python:

```
$ cd work_queue/src/python
$ python -c 'import work_queue as m;print m'
<module 'work_queue' from 'work_queue.py'>
```
