### PR TITLE
Additional WQ statistics

### DIFF
--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -432,6 +432,30 @@ class Task(_object):
         return self._task.time_receive_output_finish
 
     ## 
+    # Get the number of bytes received since task started receiving input data.
+    # Must be called only after the task completes execution.
+    # @a Note: This is defined using property decorator. So it must be called without parentheses
+    # (). For example:
+    # @code
+    # >>> print t.total_bytes_received
+    # @endcode
+    @property
+    def total_bytes_received(self):
+        return self._task.total_bytes_received
+
+    ## 
+    # Get the number of bytes sent since task started sending input data.
+    # Must be called only after the task completes execution.
+    # @a Note: This is defined using property decorator. So it must be called without parentheses
+    # (). For example:
+    # @code
+    # >>> print t.total_bytes_sent
+    # @endcode
+    @property
+    def total_bytes_sent(self):
+        return self._task.total_bytes_sent
+
+    ## 
     # Get the number of bytes transferred since task started transferring input data.
     # Must be called only after the task completes execution.
     # @a Note: This is defined using property decorator. So it must be called without parentheses

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -896,6 +896,7 @@ static int get_output_file( struct work_queue *q, struct work_queue_worker *w, s
 	if(total_bytes>0) {
 		q->total_bytes_received += total_bytes;
 		q->total_receive_time += sum_time;
+		t->total_bytes_received += total_bytes;
 		t->total_bytes_transferred += total_bytes;
 		t->total_transfer_time += sum_time;
 		w->total_bytes_transferred += total_bytes;
@@ -1971,6 +1972,7 @@ static int send_input_file(struct work_queue *q, struct work_queue_worker *w, st
 		timestamp_t close_time = timestamp_get();
 		timestamp_t elapsed_time = close_time-open_time;
 
+		t->total_bytes_sent += total_bytes;
 		t->total_bytes_transferred += total_bytes;
 		t->total_transfer_time += elapsed_time;
 
@@ -3526,6 +3528,8 @@ int work_queue_submit_internal(struct work_queue *q, struct work_queue_task *t)
 		free(t->host);
 		t->host = 0;
 	}
+	t->total_bytes_received = 0;
+	t->total_bytes_sent = 0;
 	t->total_transfer_time = 0;
 	t->cmd_execution_time = 0;
 	t->result = 0;

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -84,6 +84,8 @@ struct work_queue_task {
 	timestamp_t time_receive_output_start;	/**< The time at which it started to transfer output files. */
 	timestamp_t time_receive_output_finish;	/**< The time at which it finished transferring output files. */
 
+	int64_t total_bytes_received;/**< Number of bytes received since task has last started receiving input data. */
+	int64_t total_bytes_sent;/**< Number of bytes sent since task has last started sending input data. */
 	int64_t total_bytes_transferred;/**< Number of bytes transferred since task has last started transferring input data. */
 	timestamp_t total_transfer_time;    /**< Time comsumed in microseconds for transferring total_bytes_transferred. */
 	timestamp_t cmd_execution_time;	   /**< Time spent in microseconds for executing the command on the worker. */


### PR DESCRIPTION
I've found it interesting to keep track of some quantities that are not provided out of the box:
- the number of times a task has been internally resubmitted (i.e. due to a worker being removed)
- keeping track of the total computing time on any worker, not just the last time a job has been run
- splitting the amount of data transferred into sent + received

Any interest in this?
