### PR TITLE
Set glibc variables tracking the program name.

### DIFF
--- a/dttools/src/change_process_title.c
+++ b/dttools/src/change_process_title.c
@@ -34,6 +34,14 @@ void change_process_title_init(char **argv)
 
 	/* save the space where we were operating */
 	process_title = argv[0];
+#ifdef _GNU_SOURCE
+	{
+		extern char *program_invocation_name;
+		extern char *program_invocation_short_name;
+		program_invocation_name = argv[0];
+		program_invocation_short_name = argv[0];
+	}
+#endif
 	process_title_end = argv[argc - 1] + strlen(argv[argc - 1]);
 	process_title_length = process_title_end - process_title;
 


### PR DESCRIPTION
This also affects /proc/pid/cmdline.

I think another way to do this is Linux prctl and POSIX pthread_setname_np
(which on Linux wraps prctl). However, there are two problems: (1) prctl limits
the length to 16 characters including the NUL terminator and (2) not all
utilities read /proc/pid/comm (which prctl changes). It seems most utilities
prefer /proc/pid/cmdline which is based off of argv[0]. How it is actually
changed is not very clear. These glibc variables appear to affect it.

setproctitle (BSD, but also on Linux) is another way to change the title.
