### PR TITLE
Disconnect if no waiting task at the worker can be executed

### DIFF
--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1816,10 +1816,13 @@ static void work_for_master(struct link *master) {
 			// If all resources are free, but we cannot execute any of the
 			// waiting tasks, then disconnect so that the master gets the tasks
 			// back. (Imagine for example that some other process in the host
-			// running the worker used so much memory or disk, that now no task cannot be
-			// scheduled.) Note we check against stored_tasks, and not
-			// active_tasks, so that we do not disconnect if there are results
-			// waiting to be sent back (which in turn may free some disk).
+			// running the worker used so much memory or disk, that now no task
+			// cannot be scheduled.) Note we check against stored_tasks, and
+			// not active_tasks, so that we do not disconnect if there are
+			// results waiting to be sent back (which in turn may free some
+			// disk).  Note also this is a short-term solution. In the long
+			// term we want the worker to report to the master something like
+			// 'task not done'.
 			if(list_size(waiting_tasks) > 0 && itable_size(stored_tasks) == 0)
 			{
 				debug(D_WQ, "No task can be executed with the available resources.\n");


### PR DESCRIPTION
@dthain, @dpandiar
