### PR TITLE
condor_submit_workers --autosize

### DIFF
--- a/work_queue/src/condor_submit_workers
+++ b/work_queue/src/condor_submit_workers
@@ -12,6 +12,7 @@ fi
 show_help() 
 {
 	echo "  -r <requirements>        Condor requirements ClassAd."
+	echo "  --autosize               Condor will automatically size the worker to the slot."
 }
 
 # This dummy requirement inhibits Condor from adding its own Memory expression,
@@ -30,9 +31,18 @@ parse_arguments()
 			shift
 			requirements="$requirements $1"
 			;;
+
+		        --autosize)
+			arguments="$arguments --cores \$\$(TotalSlotCpus) --memory \$\$(TotalSlotMemory) --disk \$\$(TotalSlotDisk)"
+			cores="TotalSlotCpus"
+			memory="TotalSlotMemory"
+			disk="TotalSlotDisk"
+			;;
+
 			*)
 			break
 			;;
+			
 		esac
 		shift
 	done


### PR DESCRIPTION
Added autosize option which enables workers to fill up whatever slots that they happen to match.
