### PR TITLE
Fix the calculation of the total time on worker.

### DIFF
--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -72,6 +72,8 @@ struct work_queue_task {
 	char *host;			/**< The address and port of the host on which it ran. */
 	char *hostname;			/**< The name of the host on which it ran. */		
 
+	timestamp_t time_committed;	/**< The time at which a task was committed to a worker. */
+
 	timestamp_t time_task_submit;	/**< The time at which this task was submitted. */
 	timestamp_t time_task_finish;	/**< The time at which this task was finished. */
 	timestamp_t time_send_input_start;	/**< The time at which it started to transfer input files. */


### PR DESCRIPTION
A task's time_execute_cmd_start is not guaranteed to be set to a correct value when a worker is cleaned up.

This introduces another task variable to keep track of when a task has been committed to a worker.  This time is checked when a worker is removed to avoid adding too much time to the total time on worker.
