### PR TITLE
Remove wq_reset since there is no visible use-case.

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4091,26 +4091,6 @@ void release_all_workers(struct work_queue *q) {
 	}
 }
 
-void work_queue_reset(struct work_queue *q, int flags) {
-	struct work_queue_task *t;
-	
-	if(!q) return;
-
-	release_all_workers(q); 
-
-	if(flags == WORK_QUEUE_RESET_KEEP_TASKS) {
-		return;
-	}
-
-	//CLEANUP: Why would the user need to set KEEP_TASKS flag? 
-	
-	//WORK_QUEUE_RESET_ALL (or any other flag value) will clear out all tasks.
-	//tasks in running, finished, complete lists are deleted in release_worker().
-	while((t = list_pop_head(q->ready_list))) {
-		work_queue_task_delete(t);
-	}
-}
-
 int work_queue_empty(struct work_queue *q)
 {
 	return ((list_size(q->ready_list) + itable_size(q->running_tasks) + itable_size(q->finished_tasks) + list_size(q->complete_list)) == 0);

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -503,14 +503,6 @@ struct work_queue_task *work_queue_cancel_by_tasktag(struct work_queue *q, const
 */
 struct list * work_queue_cancel_all_tasks(struct work_queue *q);
 
-/** Reset a work queue and all attached workers.
-@param q A work queue object.
-@param flags Flags to indicate what to reset:
- - @ref WORK_QUEUE_RESET_ALL - deletes all submitted tasks and disconnects all workers.
- - @ref WORK_QUEUE_RESET_KEEP_TASKS - deletes all tasks except incomplete tasks and disconnects all workers.  Tasks will be resubmitted to workers at the next call to @ref work_queue_wait.
-*/
-void work_queue_reset(struct work_queue *q, int flags);
-
 /** Shut down workers connected to the work_queue system. Gives a best effort and then returns the number of workers given the shut down order.
 @param q A work queue object.
 @param n The number to shut down. All workers if given "0".

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1520,22 +1520,6 @@ static int do_release() {
 	return 0;
 }
 
-static int do_reset() {
-	
-	if(worker_mode == WORKER_MODE_FOREMAN) {
-		do_reset_results_to_be_sent();
-		work_queue_reset(foreman_q, WORK_QUEUE_RESET_ALL);
-	} else {
-		kill_all_tasks();
-	}
-	
-	if(delete_dir_contents(workspace) < 0) {
-		return 0;
-	}
-		
-	return 1;
-}
-
 static int send_keepalive(struct link *master){
 	send_master_message(master, "alive\n");
 	return 1;
@@ -1694,8 +1678,6 @@ static int handle_master(struct link *master) {
 			r = 0;
 		} else if(!strncmp(line, "check", 6)) {
 			r = send_keepalive(master);
-		} else if(!strncmp(line, "reset", 5)) {
-			r = do_reset();
 		} else if(!strncmp(line, "auth", 4)) {
 			fprintf(stderr,"work_queue_worker: this master requires a password. (use the -P option)\n");
 			r = 0;
@@ -1714,7 +1696,6 @@ static int handle_master(struct link *master) {
 
 	return r;
 }
-
 
 static int check_for_resources(struct work_queue_task *t) {
 	int64_t cores_used, disk_used, mem_used, gpus_used;


### PR DESCRIPTION
Internally, release_all_workers() can be used to achieve the same function. Intended for #282.
