### PR TITLE
Handle group-stop in Parrot.

### DIFF
--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -7,49 +7,56 @@ See the file COPYING for details.
 
 #include "linux-version.h"
 #include "pfs_channel.h"
-#include "pfs_process.h"
-#include "pfs_dispatch.h"
-#include "pfs_poll.h"
-#include "pfs_service.h"
 #include "pfs_critical.h"
+#include "pfs_dispatch.h"
 #include "pfs_paranoia.h"
+#include "pfs_poll.h"
+#include "pfs_process.h"
+#include "pfs_service.h"
 #include "ptrace.h"
 
+#ifndef PTRACE_EVENT_STOP
+#  define PTRACE_EVENT_STOP 128
+#endif
+
 extern "C" {
-#include "cctools.h"
-#include "tracer.h"
-#include "stringtools.h"
 #include "auth_all.h"
-#include "xxmalloc.h"
-#include "create_dir.h"
-#include "file_cache.h"
-#include "md5.h"
-#include "password_cache.h"
-#include "debug.h"
-#include "getopt.h"
-#include "pfs_resolve.h"
+#include "cctools.h"
 #include "chirp_client.h"
 #include "chirp_global.h"
 #include "chirp_ticket.h"
-#include "ftp_lite.h"
-#include "int_sizes.h"
+#include "create_dir.h"
+#include "debug.h"
 #include "delete_dir.h"
+#include "file_cache.h"
+#include "ftp_lite.h"
+#include "getopt.h"
+#include "int_sizes.h"
 #include "itable.h"
+#include "md5.h"
+#include "password_cache.h"
+#include "pfs_resolve.h"
+#include "stringtools.h"
+#include "tracer.h"
+#include "xxmalloc.h"
 }
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <errno.h>
-#include <string.h>
-#include <unistd.h>
-#include <signal.h>
-#include <time.h>
-#include <limits.h>
-#include <sys/wait.h>
 #include <fcntl.h>
-#include <sys/utsname.h>
 #include <termio.h>
 #include <termios.h>
+#include <unistd.h>
+
+#include <sys/utsname.h>
+#include <sys/wait.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 
 FILE *namelist_file;
 int linux_major;
@@ -313,7 +320,6 @@ the event and take the appropriate action.
 static void handle_event( pid_t pid, int status, struct rusage *usage )
 {
 	struct pfs_process *p;
-	int signum;
 
 	p = pfs_process_lookup(pid);
 	if(!p) {
@@ -322,54 +328,89 @@ static void handle_event( pid_t pid, int status, struct rusage *usage )
 		return;
 	}
 
-	if(status>>8 == (SIGTRAP | (PTRACE_EVENT_CLONE<<8)) || status>>8 == (SIGTRAP | (PTRACE_EVENT_FORK<<8)) || status>>8 == (SIGTRAP | (PTRACE_EVENT_VFORK<<8))) {
-		pid_t child;
-
-		child = tracer_getevent(p->tracer);
-		debug(D_PROCESS, "pid %d cloned %d",pid,child);
+	if (WIFSTOPPED(status) && WSTOPSIG(status) == (SIGTRAP|0x80)) {
+		/* The common case, a syscall delivery stop. */
+		p->nsyscalls++;
+		pfs_dispatch(p, 0);
+	} else if (status>>8 == (SIGTRAP | (PTRACE_EVENT_CLONE<<8)) || status>>8 == (SIGTRAP | (PTRACE_EVENT_FORK<<8)) || status>>8 == (SIGTRAP | (PTRACE_EVENT_VFORK<<8))) {
+		pid_t child = tracer_getevent(p->tracer);
+		debug(D_PROCESS, "pid %d cloned %d", pid, child);
 
 		/* At this point the child is stopped, it will be resumed with
 		 * tracer_continue when clone finishes. We only do this because
 		 * CLONE_PTRACE is buggy with multithreaded code. */
-		tracer_continue(p->tracer,0);
-	} else if(WIFEXITED(status)) {
+		tracer_continue(p->tracer, 0);
+	} else if (status>>8 == (SIGTRAP | (PTRACE_EVENT_EXEC<<8))) {
+		debug(D_PROCESS, "pid %d is completing exec", (int)pid);
+		tracer_continue(p->tracer, 0);
+	} else if (WIFEXITED(status)) {
 		debug(D_PROCESS,"pid %d exited normally with code %d",pid,WEXITSTATUS(status));
 		pfs_process_stop(p,status,usage);
-		if(pid==root_pid) root_exitstatus = status;
-	} else if(WIFSIGNALED(status)) {
-		signum = WTERMSIG(status);
+		if (pid == root_pid)
+			root_exitstatus = status;
+	} else if (WIFSIGNALED(status)) {
+		int signum = WTERMSIG(status);
 		debug(D_PROCESS,"pid %d exited abnormally with signal %d (%s)",pid,signum,string_signal(signum));
 		pfs_process_stop(p,status,usage);
-		if(pid==root_pid) root_exitstatus = status;
-	} else if(WIFSTOPPED(status)) {
-		signum = WSTOPSIG(status);
-		if(signum==SIGTRAP) {
-			p->nsyscalls++;
-			pfs_dispatch(p,0);
+		if (pid == root_pid)
+			root_exitstatus = status;
+	} else if (WIFSTOPPED(status)) {
+		int signum = WSTOPSIG(status);
+		siginfo_t info;
+		if(signum == SIGTRAP && ((status>>16) == PTRACE_EVENT_STOP)) {
+			/* this is PTRACE_EVENT_STOP */
+			assert(linux_available(3,4,0));
+			tracer_continue(p->tracer, 0);
+		} else if((linux_available(3,4,0) && ((status>>16) == PTRACE_EVENT_STOP)) || (!linux_available(3,4,0) && ptrace(PTRACE_GETSIGINFO, pid, 0, &info) == -1 && errno == EINVAL)) {
+			/* group-stop, `man ptrace` for more information */
+			debug(D_PROCESS, "process %d has group-stopped due to signal %d (%s) (state %d)",pid,signum,string_signal(signum),p->state);
+			pfs_process_stop(p,status,usage);
+			tracer_listen(p->tracer);
 		} else {
+			/* signal-delivery-stop */
 			debug(D_PROCESS,"pid %d received signal %d (%s) (state %d)",pid,signum,string_signal(signum),p->state);
-			if(signum==SIGTTIN) {
-				tcsetpgrp(0,pid);
-				tracer_continue(p->tracer,SIGCONT);
-			} else if(signum==SIGTTOU) {
-				tcsetpgrp(1,pid);
-				tcsetpgrp(2,pid);
-				tracer_continue(p->tracer,SIGCONT);
-			} else {
-				debug(D_PROCESS,"pid %d stopped from signal %d (%s) (state %d) delivering with tracer_continue.",pid,signum,string_signal(signum),p->state);
-				tracer_continue(p->tracer,signum);
+			switch(signum) {
+				/* There are 4 process stop signals: SIGTTIN, SIGTTOU, SIGSTOP, and SIGTSTP.
+				 * The Open Group Base Specifications Issue 6
+				 * IEEE Std 1003.1, 2004 Edition
+				 * Also mentioned in `man ptrace`.
+				 */
+				case SIGTTIN:
+					tcsetpgrp(STDIN_FILENO,pid);
+					signum = 0; /* suppress delivery */
+					break;
+				case SIGTTOU:
+					tcsetpgrp(STDOUT_FILENO,pid);
+					tcsetpgrp(STDERR_FILENO,pid);
+					signum = 0; /* suppress delivery */
+					break;
+				case SIGSTOP:
+					/* Black magic to get threads working on old Linux kernels... */
 
-				if(signum==SIGSTOP && p->nsyscalls==0) {
-					if(p->thread)
-					{
-						static const int dummy = 0;
-						debug(D_PROCESS,"Adding thread %d to list of stopped threads\n", pid);
-						itable_insert(stopped_threads, p->pid, &dummy);
+					if(p->nsyscalls == 0) { /* stop before we begin running the process */
+						debug(D_DEBUG, "suppressing bootstrap SIGSTOP for %d",pid);
+						signum = 0; /* suppress delivery */
+
+						if(p->thread) {
+							static const int dummy = 0;
+							debug(D_PROCESS,"Adding thread %d to list of stopped threads\n", pid);
+							itable_insert(stopped_threads, p->pid, &dummy);
+						}
+						p->time_first_sigcont = time(NULL);
+						kill(p->pid,SIGCONT);
 					}
-					p->time_first_sigcont = time(NULL);
-					kill(p->pid,SIGCONT);
-				}
+					break;
+				case SIGTSTP:
+					break;
+				case SIGCONT:
+#ifdef __W_CONTINUED
+					pfs_process_continued(p, __W_CONTINUED, usage);
+#else
+					pfs_process_continued(p, 0xffff, usage);
+#endif
+					break;
 			}
+			tracer_continue(p->tracer,signum); /* deliver (or not) the signal */
 		}
 	} else {
 		fatal("pid %d stopped with strange status %d",pid,status);
@@ -766,13 +807,17 @@ int main( int argc, char *argv[] )
 		default:
 			show_help(argv[0]);
 			break;
-	}
+		}
 	}
 
 	if(optind>=argc) show_help(argv[0]);
 
 	cctools_version_debug(D_DEBUG, argv[0]);
 	get_linux_version(argv[0]);
+
+    if (!linux_available(3,4,0)) {
+        debug(D_NOTICE, "The ptrace interface cannot handle group-stop for this Linux version. This may not work...");
+    }
 
 	if(pfs_temp_dir[PFS_PATH_MAX - 1] != '\0')
 	{
@@ -899,6 +944,9 @@ int main( int argc, char *argv[] )
 
 			flags = WUNTRACED|__WALL|WNOHANG;
 			pid = wait4(trace_this_pid,&status,flags,&usage);
+#if 0 /* Enable this for extreme debugging... */
+			debug(D_DEBUG, "%d = wait4(%d, %p, %d, %p)", (int)pid, (int)trace_this_pid, &status, flags, &usage);
+#endif
 
 			if(pid == pfs_watchdog_pid) {
 				if (WIFEXITED(status) || WIFSIGNALED(status)) {

--- a/parrot/src/pfs_process.h
+++ b/parrot/src/pfs_process.h
@@ -29,6 +29,7 @@ extern "C" {
 #define PFS_PROCESS_STATE_WAITREAD 3
 #define PFS_PROCESS_STATE_WAITWRITE 4
 #define PFS_PROCESS_STATE_DONE 5
+#define PFS_PROCESS_STATE_STOPPED 6
 
 #define PFS_SCRATCH_SIZE 4096
 
@@ -41,7 +42,11 @@ struct pfs_process {
 
 	mode_t umask;
 	pid_t  pid, ppid, tgid;
-	int    flags, state;
+	int flags, state;
+	int parent_wcontinued;
+	int parent_wuntraced;
+	int interrupted;
+	int nsyscalls;
 	pfs_table *table;
 	struct tracer *tracer;
 	struct timeval seltime;
@@ -68,14 +73,13 @@ struct pfs_process {
 	struct rusage *wait_urusage;
 	int            wait_options;
 
-	struct rusage  exit_rusage;
-	int            exit_status;
-	int 	       exit_signal;
-	int            interrupted;
-	int            nsyscalls;
-
 	int            thread;                // True if thread, false if regular process.
 	time_t         time_first_sigcont;
+
+	/* status and rusage for parent call to wait*(...) */
+	struct rusage  wait_rusage;
+	int            wait_status;
+	int            exit_signal; /* signal sent to parent on process death */
 };
 
 struct pfs_process * pfs_process_create( pid_t pid, pid_t actual_ppid, pid_t notify_ppid, int share_table, int exit_signal );
@@ -83,6 +87,7 @@ struct pfs_process * pfs_process_lookup( pid_t pid );
 void pfs_process_delete( struct pfs_process *p );
 
 void pfs_process_stop( struct pfs_process *p, int status, struct rusage *usage );
+void pfs_process_continued( struct pfs_process *p, int status, struct rusage *usage );
 void pfs_process_exit_group( struct pfs_process *p );
 int pfs_process_waitpid( struct pfs_process *p, pid_t wait_pid, int *wait_ustatus, int wait_options, struct rusage *wait_urusage );
 

--- a/parrot/src/tracer.h
+++ b/parrot/src/tracer.h
@@ -16,9 +16,10 @@ See the file COPYING for details.
 struct tracer;
 
 int tracer_attach( pid_t pid );
-void tracer_detach( struct tracer *t );
+int tracer_detach( struct tracer *t );
 struct tracer *tracer_init( pid_t pid );
-void tracer_continue( struct tracer *t, int signum );
+int tracer_continue( struct tracer *t, int signum );
+int tracer_listen( struct tracer *t );
 unsigned long tracer_getevent( struct tracer *t );
 
 int             tracer_args_get( struct tracer *t, INT64_T *syscall, INT64_T args[TRACER_ARGS_MAX] );


### PR DESCRIPTION
This branch moves to using PTRACE_SEIZE (for Linux 3.4.0+) to enable handling group-stop.

Interesting tidbits:
- execve no longer has the extra SIGTRAP when using PTRACE_SEIZE. Right now ignoring it looks a little awkward code-wise. It could maybe be cleaned up.
- There is a new PFS_PROCESS_STOP_STATE.
- We now correctly wake parents waiting for continued children.

This may also fix the lost thread issue.

This branch needs some testing on older kernels before merging. A test case would be nice too.
