### PR TITLE
catalog queries should use domain_name_cache_lookup

### DIFF
--- a/dttools/src/http_query.c
+++ b/dttools/src/http_query.c
@@ -10,7 +10,7 @@ See the file COPYING for details.
 #include "buffer.h"
 #include "stringtools.h"
 #include "debug.h"
-#include "domain_name.h"
+#include "domain_name_cache.h"
 #include "url_encode.h"
 
 #include <errno.h>
@@ -126,7 +126,7 @@ struct link *http_query_size_via_proxy(const char *proxy, const char *urlin, con
 	}
 
 	debug(D_HTTP, "connect %s port %d", actual_host, actual_port);
-	if(!domain_name_lookup(actual_host, addr))
+	if(!domain_name_cache_lookup(actual_host, addr))
 		return 0;
 
 	link = link_connect(addr, actual_port, stoptime);


### PR DESCRIPTION
HEP is reporting excessive DNS load when running with 7000 workers.
We observe that the work_queue_worker is not caching lookups to the catalog server.
The http query used by the catalog is (incorrectly) not using our internal dns cache.
This patch may help with that issue.
