### PR TITLE
Hardcode Linux 2.5.46 base version requirement.

### DIFF
--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -77,8 +77,6 @@ extern INT64_T pfs_syscall_count;
 extern INT64_T pfs_read_count;
 extern INT64_T pfs_write_count;
 
-extern int pfs_trap_after_fork;
-
 extern char *pfs_ldso_path;
 extern int *pfs_syscall_totals64;
 
@@ -995,78 +993,15 @@ static void decode_syscall( struct pfs_process *p, INT64_T entering )
 			break;
 
 		case SYSCALL64_vfork:
-			if (entering && !linux_available(2,5,46)) {
-				static int notified = 0;
-				if (!notified) {
-					debug(D_NOTICE, "sorry, I cannot run this program (%s) without parrot_helper.so.",p->name);
-					notified = 0;
-				}
-				divert_to_dummy(p,-ENOSYS);
-				break;
-			}
-			/* no break */
 		case SYSCALL64_fork:
 		case SYSCALL64_clone:
 			if(entering) {
-				if (!linux_available(2,5,46)) {
-					/* Some variants of fork do not propagate ptrace, so we
-					 * must convert them into clone with appropriate flags.
-					 * Once a fork is started, we must trace only that pid so
-					 * that we can determine the child pid before seeing any
-					 * events from the child. On return, we must fill in the
-					 * child process with its parent's ppid.
-					 */
-					if(p->syscall==SYSCALL64_fork || p->syscall==SYSCALL64_vfork) {
-						args[0] = CLONE_PTRACE|CLONE_PARENT|SIGCHLD;
-						args[1] = 0;
-						p->syscall_args_changed = 2;
-						tracer_args_set(p->tracer,SYSCALL64_clone,args,2);
-						debug(D_SYSCALL,"converting fork into clone(%"PRIx64")",args[0]);
-					} else {
-						INT64_T newarg = (args[0]&~0xff)|CLONE_PTRACE|CLONE_PARENT|SIGCHLD;
-						debug(D_SYSCALL,"adjusting clone(%"PRIx64",%"PRIx64",%"PRIx64",%"PRIx64") -> clone(%"PRIx64")",args[0],args[1],args[2],args[3],newarg);
-						args[0] = newarg;
-						p->syscall_args_changed = 1;
-						tracer_args_set(p->tracer,SYSCALL64_clone,args,1);
-					}
-				}
-				/* else tracing children handled by PTRACE_SETOPTIONS in tracer.c */
+				/* Once a fork is started, we must trace only that pid so that
+				 * we can determine the child pid before seeing any events from
+				 * the child. On return, we must fill in the child process with
+				 * its parent's ppid.
+				 */
 				trace_this_pid = p->pid;
-			} else if (!linux_available(2,5,46)) {
-				INT64_T childpid;
-				struct pfs_process *child;
-				tracer_result_get(p->tracer,&childpid);
-				if(childpid>0) {
-					INT64_T child_signal,clone_files;
-					if(p->syscall_original==SYSCALL64_fork) {
-						child_signal = SIGCHLD;
-						clone_files = 0;
-					} else {
-						child_signal = args[0]&0xff;
-						clone_files = args[0]&CLONE_FILES;
-					}
-					pid_t notify_parent;
-					if(args[0]&(CLONE_PARENT|CLONE_THREAD)) {
-						notify_parent = p->ppid;
-					} else {
-						notify_parent = p->pid;
-					}
-					child = pfs_process_create(childpid,p->pid,notify_parent,clone_files,child_signal);
-					child->syscall_result = 0;
-					if(args[0]&CLONE_THREAD) child->tgid = p->tgid;
-					if(p->syscall_original==SYSCALL64_fork) {
-						memcpy(child->syscall_args,p->syscall_args,sizeof(p->syscall_args));
-						child->syscall_args_changed = 1;
-					}
-					if(pfs_trap_after_fork) {
-						child->state = PFS_PROCESS_STATE_KERNEL;
-					} else {
-						child->state = PFS_PROCESS_STATE_USER;
-					}
-					debug(D_PROCESS,"%d created pid %"PRId64,p->pid,childpid);
-					/* now trace any process at all */
-					trace_this_pid = -1;
-				}
 			}
 			break;
 

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -69,7 +69,6 @@ pid_t trace_this_pid = -1;
 int pfs_master_timeout = 300;
 struct file_cache *pfs_file_cache = 0;
 struct password_cache *pfs_password_cache = 0;
-int pfs_trap_after_fork = 0;
 int pfs_force_stream = 0;
 int pfs_force_cache = 0;
 int pfs_force_sync = 0;
@@ -148,13 +147,11 @@ static void get_linux_version(const char *cmd)
 
 	debug(D_DEBUG,"kernel is %s %s",name.sysname,name.release);
 
-	/* compatibility checking */
-	if(!linux_available(2,4,0))
-		pfs_trap_after_fork = 1;
-
 	/* warning for latest untested version of Linux */
-	if(linux_available(3,3,0))
+	if(linux_available(3,15,3))
 		debug(D_NOTICE,"parrot_run %d.%d.%s has not been tested on %s %s yet, this may not work",CCTOOLS_VERSION_MAJOR,CCTOOLS_VERSION_MINOR,CCTOOLS_VERSION_MICRO,name.sysname,name.release);
+	else if (!linux_available(2,5,46))
+		fatal("this version of Parrot requires at least kernel version 2.5.46");
 }
 
 static void pfs_helper_init( const char *argv0 ) 

--- a/parrot/src/tracer.c
+++ b/parrot/src/tracer.c
@@ -13,17 +13,19 @@ See the file COPYING for details.
 #include "linux-version.h"
 #include "ptrace.h"
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <errno.h>
-#include <string.h>
-#include <unistd.h>
-#include <signal.h>
-#include <time.h>
 #include <fcntl.h>
-#include <limits.h>
+#include <unistd.h>
 
 #include <sys/wait.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 
 #define FATAL fatal("tracer: %d %s",t->pid,strerror(errno));
 
@@ -76,8 +78,7 @@ int tracer_attach (pid_t pid)
 
 	if (linux_available(3,8,0))
 		options |= PTRACE_O_EXITKILL;
-	else if (!linux_available(2,5,46))
-		fatal("linux is too old");
+	assert(linux_available(2,5,46));
 
 	if (linux_available(3,4,0)) {
 		/* So this is a really annoying situation, in order to correctly deal


### PR DESCRIPTION
Linux 2.5.46 was circa 2003.

The requirement was already enforced in tracer.c:80 via commit
5ef1eca8d78eea302c2fb82a9d755973cd6bd8ce. This commit just enforces that
consistently and removes unnecessary checks.
