### PR TITLE
Add advanced pattern matching facilities.

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -366,3 +366,26 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FILE dttools/src/luapatt.c:
+
+Copyright (C) 1994-2013 Lua.org, PUC-Rio.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -63,6 +63,7 @@ SOURCES = \
 	nvpair_database.c \
 	password_cache.c \
 	path.c \
+	pattern.c \
 	preadwrite.c \
 	process.c \
 	random_init.c \

--- a/dttools/src/luapatt.c
+++ b/dttools/src/luapatt.c
@@ -1,0 +1,329 @@
+/* Unmodified pattern matcher from Lua 5.2.3: lstrlib.c:187:510
+ *
+ * See top-level COPYING file for Lua's license.
+ */
+
+/*
+** {======================================================
+** PATTERN MATCHING
+** =======================================================
+*/
+
+
+#define CAP_UNFINISHED	(-1)
+#define CAP_POSITION	(-2)
+
+
+typedef struct MatchState {
+  int matchdepth;  /* control for recursive depth (to avoid C stack overflow) */
+  const char *src_init;  /* init of source string */
+  const char *src_end;  /* end ('\0') of source string */
+  const char *p_end;  /* end ('\0') of pattern */
+  lua_State *L;
+  int level;  /* total number of captures (finished or unfinished) */
+  struct {
+    const char *init;
+    ptrdiff_t len;
+  } capture[LUA_MAXCAPTURES];
+} MatchState;
+
+
+/* recursive function */
+static const char *match (MatchState *ms, const char *s, const char *p);
+
+
+/* maximum recursion depth for 'match' */
+#if !defined(MAXCCALLS)
+#define MAXCCALLS	200
+#endif
+
+
+#define L_ESC		'%'
+#define SPECIALS	"^$*+?.([%-"
+
+
+static int check_capture (MatchState *ms, int l) {
+  l -= '1';
+  if (l < 0 || l >= ms->level || ms->capture[l].len == CAP_UNFINISHED)
+    return luaL_error(ms->L, "invalid capture index %%%d", l + 1);
+  return l;
+}
+
+
+static int capture_to_close (MatchState *ms) {
+  int level = ms->level;
+  for (level--; level>=0; level--)
+    if (ms->capture[level].len == CAP_UNFINISHED) return level;
+  return luaL_error(ms->L, "invalid pattern capture");
+}
+
+
+static const char *classend (MatchState *ms, const char *p) {
+  switch (*p++) {
+    case L_ESC: {
+      if (p == ms->p_end)
+        luaL_error(ms->L, "malformed pattern (ends with " LUA_QL("%%") ")");
+      return p+1;
+    }
+    case '[': {
+      if (*p == '^') p++;
+      do {  /* look for a `]' */
+        if (p == ms->p_end)
+          luaL_error(ms->L, "malformed pattern (missing " LUA_QL("]") ")");
+        if (*(p++) == L_ESC && p < ms->p_end)
+          p++;  /* skip escapes (e.g. `%]') */
+      } while (*p != ']');
+      return p+1;
+    }
+    default: {
+      return p;
+    }
+  }
+}
+
+
+static int match_class (int c, int cl) {
+  int res;
+  switch (tolower(cl)) {
+    case 'a' : res = isalpha(c); break;
+    case 'c' : res = iscntrl(c); break;
+    case 'd' : res = isdigit(c); break;
+    case 'g' : res = isgraph(c); break;
+    case 'l' : res = islower(c); break;
+    case 'p' : res = ispunct(c); break;
+    case 's' : res = isspace(c); break;
+    case 'u' : res = isupper(c); break;
+    case 'w' : res = isalnum(c); break;
+    case 'x' : res = isxdigit(c); break;
+    case 'z' : res = (c == 0); break;  /* deprecated option */
+    default: return (cl == c);
+  }
+  return (islower(cl) ? res : !res);
+}
+
+
+static int matchbracketclass (int c, const char *p, const char *ec) {
+  int sig = 1;
+  if (*(p+1) == '^') {
+    sig = 0;
+    p++;  /* skip the `^' */
+  }
+  while (++p < ec) {
+    if (*p == L_ESC) {
+      p++;
+      if (match_class(c, uchar(*p)))
+        return sig;
+    }
+    else if ((*(p+1) == '-') && (p+2 < ec)) {
+      p+=2;
+      if (uchar(*(p-2)) <= c && c <= uchar(*p))
+        return sig;
+    }
+    else if (uchar(*p) == c) return sig;
+  }
+  return !sig;
+}
+
+
+static int singlematch (MatchState *ms, const char *s, const char *p,
+                        const char *ep) {
+  if (s >= ms->src_end)
+    return 0;
+  else {
+    int c = uchar(*s);
+    switch (*p) {
+      case '.': return 1;  /* matches any char */
+      case L_ESC: return match_class(c, uchar(*(p+1)));
+      case '[': return matchbracketclass(c, p, ep-1);
+      default:  return (uchar(*p) == c);
+    }
+  }
+}
+
+
+static const char *matchbalance (MatchState *ms, const char *s,
+                                   const char *p) {
+  if (p >= ms->p_end - 1)
+    luaL_error(ms->L, "malformed pattern "
+                      "(missing arguments to " LUA_QL("%%b") ")");
+  if (*s != *p) return NULL;
+  else {
+    int b = *p;
+    int e = *(p+1);
+    int cont = 1;
+    while (++s < ms->src_end) {
+      if (*s == e) {
+        if (--cont == 0) return s+1;
+      }
+      else if (*s == b) cont++;
+    }
+  }
+  return NULL;  /* string ends out of balance */
+}
+
+
+static const char *max_expand (MatchState *ms, const char *s,
+                                 const char *p, const char *ep) {
+  ptrdiff_t i = 0;  /* counts maximum expand for item */
+  while (singlematch(ms, s + i, p, ep))
+    i++;
+  /* keeps trying to match with the maximum repetitions */
+  while (i>=0) {
+    const char *res = match(ms, (s+i), ep+1);
+    if (res) return res;
+    i--;  /* else didn't match; reduce 1 repetition to try again */
+  }
+  return NULL;
+}
+
+
+static const char *min_expand (MatchState *ms, const char *s,
+                                 const char *p, const char *ep) {
+  for (;;) {
+    const char *res = match(ms, s, ep+1);
+    if (res != NULL)
+      return res;
+    else if (singlematch(ms, s, p, ep))
+      s++;  /* try with one more repetition */
+    else return NULL;
+  }
+}
+
+
+static const char *start_capture (MatchState *ms, const char *s,
+                                    const char *p, int what) {
+  const char *res;
+  int level = ms->level;
+  if (level >= LUA_MAXCAPTURES) luaL_error(ms->L, "too many captures");
+  ms->capture[level].init = s;
+  ms->capture[level].len = what;
+  ms->level = level+1;
+  if ((res=match(ms, s, p)) == NULL)  /* match failed? */
+    ms->level--;  /* undo capture */
+  return res;
+}
+
+
+static const char *end_capture (MatchState *ms, const char *s,
+                                  const char *p) {
+  int l = capture_to_close(ms);
+  const char *res;
+  ms->capture[l].len = s - ms->capture[l].init;  /* close capture */
+  if ((res = match(ms, s, p)) == NULL)  /* match failed? */
+    ms->capture[l].len = CAP_UNFINISHED;  /* undo capture */
+  return res;
+}
+
+
+static const char *match_capture (MatchState *ms, const char *s, int l) {
+  size_t len;
+  l = check_capture(ms, l);
+  len = ms->capture[l].len;
+  if ((size_t)(ms->src_end-s) >= len &&
+      memcmp(ms->capture[l].init, s, len) == 0)
+    return s+len;
+  else return NULL;
+}
+
+
+static const char *match (MatchState *ms, const char *s, const char *p) {
+  if (ms->matchdepth-- == 0)
+    luaL_error(ms->L, "pattern too complex");
+  init: /* using goto's to optimize tail recursion */
+  if (p != ms->p_end) {  /* end of pattern? */
+    switch (*p) {
+      case '(': {  /* start capture */
+        if (*(p + 1) == ')')  /* position capture? */
+          s = start_capture(ms, s, p + 2, CAP_POSITION);
+        else
+          s = start_capture(ms, s, p + 1, CAP_UNFINISHED);
+        break;
+      }
+      case ')': {  /* end capture */
+        s = end_capture(ms, s, p + 1);
+        break;
+      }
+      case '$': {
+        if ((p + 1) != ms->p_end)  /* is the `$' the last char in pattern? */
+          goto dflt;  /* no; go to default */
+        s = (s == ms->src_end) ? s : NULL;  /* check end of string */
+        break;
+      }
+      case L_ESC: {  /* escaped sequences not in the format class[*+?-]? */
+        switch (*(p + 1)) {
+          case 'b': {  /* balanced string? */
+            s = matchbalance(ms, s, p + 2);
+            if (s != NULL) {
+              p += 4; goto init;  /* return match(ms, s, p + 4); */
+            }  /* else fail (s == NULL) */
+            break;
+          }
+          case 'f': {  /* frontier? */
+            const char *ep; char previous;
+            p += 2;
+            if (*p != '[')
+              luaL_error(ms->L, "missing " LUA_QL("[") " after "
+                                 LUA_QL("%%f") " in pattern");
+            ep = classend(ms, p);  /* points to what is next */
+            previous = (s == ms->src_init) ? '\0' : *(s - 1);
+            if (!matchbracketclass(uchar(previous), p, ep - 1) &&
+               matchbracketclass(uchar(*s), p, ep - 1)) {
+              p = ep; goto init;  /* return match(ms, s, ep); */
+            }
+            s = NULL;  /* match failed */
+            break;
+          }
+          case '0': case '1': case '2': case '3':
+          case '4': case '5': case '6': case '7':
+          case '8': case '9': {  /* capture results (%0-%9)? */
+            s = match_capture(ms, s, uchar(*(p + 1)));
+            if (s != NULL) {
+              p += 2; goto init;  /* return match(ms, s, p + 2) */
+            }
+            break;
+          }
+          default: goto dflt;
+        }
+        break;
+      }
+      default: dflt: {  /* pattern class plus optional suffix */
+        const char *ep = classend(ms, p);  /* points to optional suffix */
+        /* does not match at least once? */
+        if (!singlematch(ms, s, p, ep)) {
+          if (*ep == '*' || *ep == '?' || *ep == '-') {  /* accept empty? */
+            p = ep + 1; goto init;  /* return match(ms, s, ep + 1); */
+          }
+          else  /* '+' or no suffix */
+            s = NULL;  /* fail */
+        }
+        else {  /* matched once */
+          switch (*ep) {  /* handle optional suffix */
+            case '?': {  /* optional */
+              const char *res;
+              if ((res = match(ms, s + 1, ep + 1)) != NULL)
+                s = res;
+              else {
+                p = ep + 1; goto init;  /* else return match(ms, s, ep + 1); */
+              }
+              break;
+            }
+            case '+':  /* 1 or more repetitions */
+              s++;  /* 1 match already done */
+              /* go through */
+            case '*':  /* 0 or more repetitions */
+              s = max_expand(ms, s, p, ep);
+              break;
+            case '-':  /* 0 or more repetitions (minimum) */
+              s = min_expand(ms, s, p, ep);
+              break;
+            default:  /* no suffix */
+              s++; p = ep; goto init;  /* return match(ms, s + 1, ep); */
+          }
+        }
+        break;
+      }
+    }
+  }
+  ms->matchdepth++;
+  return s;
+}

--- a/dttools/src/pattern.c
+++ b/dttools/src/pattern.c
@@ -1,0 +1,80 @@
+#include "debug.h"
+
+#include <ctype.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#undef lua_State
+#define lua_State void
+#undef LUA_MAXCAPTURES
+#define LUA_MAXCAPTURES 256
+#undef MAXCCALLS
+#define MAXCCALLS 200
+#undef LUA_QL
+#define LUA_QL(x) "'" x "'"
+#undef uchar
+#define uchar(c) ((unsigned char)(c))
+
+static int luaL_error (void *ms, const char *fmt, ...)
+{
+	va_list va;
+	va_start(va, fmt);
+	vdebug(D_FATAL|D_NOTICE|D_DEBUG, fmt, va);
+	va_end(va);
+	abort();
+	return 0;
+}
+
+#include "luapatt.c"
+
+ptrdiff_t pattern_vmatch (const char *str, const char *patt, va_list va)
+{
+	MatchState ms;
+	int anchor = (*patt == '^');
+	if (anchor) {
+		patt++; /* skip anchor character */
+	}
+	ms.matchdepth = MAXCCALLS;
+	ms.src_init = str;
+	ms.src_end = str + strlen(str);
+	ms.p_end = patt + strlen(patt);
+	do {
+		const char *rest;
+		ms.level = 0;
+		if ((rest = match(&ms, str, patt))) {
+			int i;
+			for (i = 0; i < ms.level; i++) {
+				ptrdiff_t l = ms.capture[i].len;
+				if (l == CAP_UNFINISHED)
+					luaL_error(ms.L, "unfinished capture");
+				else if (l == CAP_POSITION) {
+					size_t *capture = va_arg(va, size_t *);
+					*capture = ms.capture[i].init - ms.src_init + 1;
+				} else {
+					char **capture = va_arg(va, char **);
+					*capture = malloc(l+1);
+					if (*capture == NULL)
+						luaL_error(ms.L, "out of memory");
+					strncpy(*capture, ms.capture[i].init, l);
+					(*capture)[l] = '\0';
+				}
+			}
+			return str-ms.src_init;
+		}
+	} while (str++ < ms.src_end && !anchor);
+	return -1;
+}
+
+ptrdiff_t pattern_match (const char *str, const char *patt, ...)
+{
+	ptrdiff_t rc;
+	va_list va;
+	va_start(va, patt);
+	rc = pattern_vmatch(str, patt, va);
+	va_end(va);
+	return rc;
+}
+
+/* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/pattern.h
+++ b/dttools/src/pattern.h
@@ -1,0 +1,26 @@
+/* Copyright (C) 2014- The University of Notre Dame
+ * This software is distributed under the GNU General Public License.
+ * See the file COPYING for details.
+ */
+
+#ifndef PATTERN_H
+#define PATTERN_H
+
+#include <stdarg.h>
+#include <stddef.h>
+
+/** @file pattern.h Pattern Matching Facilities.
+ *
+ * Lua 5.2 pattern matching. See Lua manual for patterns supported.
+ *
+ * Captures are passed through C varargs. String captures are heap
+ * allocated and must be freed.
+ *
+ * @return offset in str where match occurred or -1 if no match.
+ * @see http://www.lua.org/manual/5.2/manual.html#6.4.1
+ */
+
+ptrdiff_t pattern_vmatch (const char *str, const char *patt, va_list va);
+ptrdiff_t pattern_match (const char *str, const char *patt, ...);
+
+#endif /* PATTERN_H */

--- a/dttools/test/TR_pattern.sh
+++ b/dttools/test/TR_pattern.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+. ../../dttools/src/test_runner.common.sh
+
+exe="pattern.test"
+
+prepare()
+{
+	gcc -I../src/ -g -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
+#include "pattern.h"
+#include "debug.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define check(expected,rc) \\
+	do {\\
+		ptrdiff_t e = (expected);\\
+		if (e != rc)\\
+			fatal("[%s:%d]: unexpected failure: %d (got) -> %d (expected)\n\t%s", __FILE__, __LINE__, (int)e, rc, #expected);\\
+	} while (0)
+
+int main (int argc, char *argv[])
+{
+	char *cap1;
+	char *cap2;
+	size_t ncap;
+	check(pattern_match("foo", "foo"), 0);
+	check(pattern_match("foo", "o"), 1);
+	check(pattern_match("foo", "oo"), 1);
+	check(pattern_match("foo", "o$"), 2);
+	check(pattern_match("foo", "^foo"), 0);
+	check(pattern_match("foo", "^f"), 0);
+	check(pattern_match("foo", "^"), 0);
+	check(pattern_match("foo", "^o"), -1);
+	check(pattern_match("foo", "(foo)", &cap1), 0);
+	check(strcmp(cap1, "foo"), 0);
+	free(cap1);
+	check(pattern_match("foo", "bar"), -1);
+	check(pattern_match("foo", "(foo)()", &cap1, &ncap), 0);
+	check(strcmp(cap1, "foo"), 0);
+	check(ncap, 4);
+	free(cap1);
+	check(pattern_match("foobar", "(foo)()b(.*)", &cap1, &ncap, &cap2), 0);
+	check(strcmp(cap1, "foo"), 0);
+	check(ncap, 4);
+	check(strcmp(cap2, "ar"), 0);
+	free(cap1);
+	free(cap2);
+	return 0;
+}
+EOF
+	return $?
+}
+
+run()
+{
+	./"$exe"
+	return $?
+}
+
+clean()
+{
+	rm -f "$exe"
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:


### PR DESCRIPTION
This commit some much more advanced pattern matching facilities to CCTools. The
pattern matcher is pulled from Lua 5.2 source code. Lua's pattern matching is
documented in [1]. Lua is distributed under the MIT license which is GPLv2
compatible.

The total lines of code are:

$ wc -l dttools/src/pattern.c dttools/src/luapatt.c dttools/src/pattern.h
78 dttools/src/pattern.c
329 dttools/src/luapatt.c
25 dttools/src/pattern.h
432 total

Which is a pretty small price for what it gives us. For example, we can now do:

char _number;
ptrdiff_t where = string_match(subject, "^option%s_=%s*(%d+)$", &number);
int i = atoi(number);
free(number);

[1] http://www.lua.org/manual/5.2/manual.html#6.4.1
