### PR TITLE
replace whitespace in cached filename

### DIFF
--- a/dttools/src/stringtools.c
+++ b/dttools/src/stringtools.c
@@ -834,6 +834,20 @@ char *string_trim_quotes(char *s)
 	return front;
 }
 
+char *string_replace_spaces(char *s)
+{
+	char *cur = s;
+
+	while (*cur) {
+		if (isspace((int) *cur))
+			*cur = '_';
+
+		cur++;
+	}
+
+	return s;
+}
+
 int string_istrue(const char *str)
 {
 	if(str == NULL)

--- a/dttools/src/stringtools.h
+++ b/dttools/src/stringtools.h
@@ -76,6 +76,7 @@ int string_nformat(char *str, const size_t max, const char *fmt, ...);
 char *string_trim(char *s, int(func)(int));
 char *string_trim_spaces(char *s);
 char *string_trim_quotes(char *s);
+char *string_replace_spaces(char *str);
 
 /** Converts a string to a boolean value. "true", "yes", and "N">0 are,
  * case-insensitive, true. Everything else (including NULL) is false.

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -851,13 +851,18 @@ char * make_cached_name( struct work_queue_task *t, struct work_queue_file *f )
 	unsigned char digest[MD5_DIGEST_LENGTH];
 	md5_buffer(f->payload,strlen(f->payload),digest);
 
+	const char *tmp = path_basename(f->payload);
+	size_t len = strlen(tmp) + 1;
+	char basename[len];
+	strncpy(basename, tmp, len);
+
 	switch(f->type) {
 		case WORK_QUEUE_FILE:
 		case WORK_QUEUE_DIRECTORY:
-			return string_format("file-%s-%s",md5_string(digest),path_basename(f->payload));
+			return string_format("file-%s-%s",md5_string(digest), string_replace_spaces(basename));
 			break;
 		case WORK_QUEUE_FILE_PIECE:
-			return string_format("piece-%s-%s-%lld-%lld",md5_string(digest),path_basename(f->payload),(long long)f->offset,(long long)f->piece_length);
+			return string_format("piece-%s-%s-%lld-%lld",md5_string(digest), string_replace_spaces(basename),(long long)f->offset,(long long)f->piece_length);
 			break;
 		case WORK_QUEUE_REMOTECMD:
 			return string_format("cmd-%s",md5_string(digest));


### PR DESCRIPTION
Update `make_cached_name` to support filenames with spaces. Fixes part a of issue #514
