### PR TITLE
Simplify killing processes.

### DIFF
--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -267,10 +267,6 @@ static void decode_write( struct pfs_process *p, int entering, int syscall, INT6
 		tracer_result_get(p->tracer,&actual);
 		debug(D_DEBUG, "channel wrote %" PRId64, actual);
 
-		if(actual!=args[2]) {
-			debug(D_NOTICE,"channel write returned %"PRId64" instead of %lld", actual, (long long int) args[2]);
-		}
-
 		if(actual>0) {
 			int fd = args[0];
 			pfs_off_t offset = args[3];
@@ -282,24 +278,15 @@ static void decode_write( struct pfs_process *p, int entering, int syscall, INT6
 				p->syscall_result = pfs_pwrite(fd,local_addr,actual,offset);
 			}
 
-			if(p->syscall_result>=0) {
-				if(p->syscall_result!=actual) {
-					debug(D_SYSCALL,"write returned %"PRId64" instead of %lld",p->syscall_result, (long long int) actual);
-				}
-				tracer_result_set(p->tracer,p->syscall_result);
-				p->state = PFS_PROCESS_STATE_KERNEL;
-				entering = 0;
-				pfs_write_count += p->syscall_result;
-			} else {
-				p->syscall_result = -errno;
-				tracer_result_set(p->tracer,p->syscall_result);
-				if(p->syscall_result==-EPIPE) {
-					// make sure that we are not in a wait state,
-					// otherwise pfs_process_raise will re-dispatch.
-					p->state = PFS_PROCESS_STATE_KERNEL;
-					pfs_process_raise(p->pid,SIGPIPE,1);
-				}
+			if(p->syscall_result!=actual) {
+				debug(D_SYSCALL,"write returned %"PRId64" instead of %"PRId64,p->syscall_result, actual);
 			}
+
+			if(p->syscall_result>=0)
+				pfs_write_count += p->syscall_result;
+			else
+				p->syscall_result = -errno;
+			tracer_result_set(p->tracer,p->syscall_result);
 		}
 		pfs_channel_free(p->io_channel_offset);
 	}
@@ -1320,6 +1307,7 @@ void decode_syscall( struct pfs_process *p, int entering )
 		case SYSCALL32_query_module:
 		case SYSCALL32_quotactl:
 		case SYSCALL32_reboot:
+		case SYSCALL32_rt_sigaction:
 		case SYSCALL32_rt_sigpending:
 		case SYSCALL32_rt_sigprocmask:
 		case SYSCALL32_rt_sigqueueinfo:
@@ -1350,7 +1338,9 @@ void decode_syscall( struct pfs_process *p, int entering )
 		case SYSCALL32_setsid:
 		case SYSCALL32_settimeofday:
 		case SYSCALL32_sgetmask:
+		case SYSCALL32_sigaction:
 		case SYSCALL32_sigaltstack:
+		case SYSCALL32_signal:
 		case SYSCALL32_sigpending:
 		case SYSCALL32_sigprocmask:
 		case SYSCALL32_sigreturn:
@@ -1409,33 +1399,20 @@ void decode_syscall( struct pfs_process *p, int entering )
 			}
 			break;
 
-		/* Note that we call pfs_process_raise here so that the process data
-		 * structures are made aware of the signal propagation, possibly
-		 * kicking someone out of sleep.  However, we do *not* convert this
-		 * call to a dummy, so that the sender can deliver itself, thus getting
-		 * the correct data into the sa_info structure.
-		 */
-
 		case SYSCALL32_kill:
 		case SYSCALL32_tkill:
 			if(entering) {
-				debug(D_PROCESS,"%s %d %d",tracer_syscall32_name(p->syscall),(int)args[0],(int)args[1]);
-				p->syscall_result = pfs_process_raise(args[0],args[1],0);
-				if (p->syscall_result == -1)
+				debug(D_PROCESS, "%s(%d, %d)", tracer_syscall_name(p->tracer, p->syscall), (int)args[0], (int)args[1]);
+				if (pfs_process_cankill(args[0]) == -1)
 					divert_to_dummy(p, -errno);
-				else
-					debug(D_PROCESS,"allowing process to send kill(%d, %d)",(int)args[0],(int)args[1]);
 			}
 			break;
 
 		case SYSCALL32_tgkill:
 			if(entering) {
-				debug(D_PROCESS,"tgkill %d %d %d",(int)args[0],(int)args[1],(int)args[2]);
-				p->syscall_result = pfs_process_raise(args[1],args[2],0);
-				if (p->syscall_result == -1)
+				debug(D_PROCESS, "tgkill(%d, %d, %d)", (int)args[0], (int)args[1], (int)args[2]);
+				if (pfs_process_cankill(args[1]) == -1)
 					divert_to_dummy(p, -errno);
-				else
-					debug(D_PROCESS,"allowing process to send tgkill(%d, %d)",(int)args[1],(int)args[2]);
 			}
 			break;
 
@@ -1502,38 +1479,6 @@ void decode_syscall( struct pfs_process *p, int entering )
 		case SYSCALL32_setfsgid32:
 			if (entering)
 				divert_to_dummy(p,0);
-			break;
-
-		/* Generally speaking, the kernel implements signal handling, so we
-		 * just pass through operations such as sigaction and signal. However,
-		 * we must keep track of which signals are allowed to interrupt I/O
-		 * operations in progress.  Each process has an array,
-		 * signal_interruptible, that records this. The SA_RESTART flag to
-		 * sigaction can turn this on or off.  The traditional BSD signal()
-		 * always turns it on.
-		 */
-
-		case SYSCALL32_sigaction:
-		case SYSCALL32_rt_sigaction:
-			if(entering) {
-				if(args[1]) {
-					int sig = args[0];
-					struct pfs_kernel_sigaction act;
-					tracer_copy_in(p->tracer,&act,POINTER(args[1]),sizeof(act));
-					if(act.pfs_sa_flags&SA_RESTART) {
-						pfs_current->signal_interruptible[sig] = 0;
-					} else {
-						pfs_current->signal_interruptible[sig] = 1;
-					}
-				}
-			}
-			break;
-
-		case SYSCALL32_signal:
-			if(entering) {
-				int sig = args[0];
-				pfs_current->signal_interruptible[sig] = 0;
-			}
 			break;
 
 		/* Here begin all of the I/O operations, given in the same order as in
@@ -3090,13 +3035,6 @@ void decode_syscall( struct pfs_process *p, int entering )
 	}
 }
 
-/*
-Note that we clear the interrupted flag whenever
-we start a new system call or leave an old one.
-We don't want one system call to be interrupted
-by a signal from a previous system call.
-*/
-
 void pfs_dispatch32( struct pfs_process *p )
 {
 	struct pfs_process *oldcurrent = pfs_current;
@@ -3107,7 +3045,6 @@ void pfs_dispatch32( struct pfs_process *p )
 			decode_syscall(p,0);
 			break;
 		case PFS_PROCESS_STATE_USER:
-			p->interrupted = 0;
 			p->nsyscalls += 1;
 			decode_syscall(p,1);
 			break;

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -294,7 +294,7 @@ of our children for its consideration.
 
 static void pass_through( int sig )
 {
-	pfs_process_raise(root_pid, sig, 1 /* really send it */);
+	kill(root_pid, sig);
 }
 
 /*
@@ -476,11 +476,6 @@ struct timeval clock_to_timeval( clock_t c )
 	return result;
 }
 
-static void handle_sigio( int sig )
-{
-	pfs_process_sigio();
-}
-
 void write_rval(const char* message, int status) {
 	FILE *file = fopen(pfs_write_rval_file, "w+");
 	if(file) {
@@ -525,7 +520,7 @@ int main( int argc, char *argv[] )
 	install_handler(SIGINT,pass_through);
 	install_handler(SIGTTIN,control_terminal);
 	install_handler(SIGTTOU,control_terminal);
-	install_handler(SIGIO,handle_sigio);
+	install_handler(SIGIO,pfs_process_sigio);
 	install_handler(SIGXFSZ,ignore_signal);
 
 	if(isatty(0)) {

--- a/parrot/src/pfs_process.h
+++ b/parrot/src/pfs_process.h
@@ -45,7 +45,6 @@ struct pfs_process {
 	mode_t umask;
 	pid_t  pid, ppid, tgid;
 	int flags;
-	int interrupted;
 	uint64_t nsyscalls;
 	pfs_table *table;
 	struct tracer *tracer;
@@ -68,24 +67,21 @@ struct pfs_process {
 	int completing_execve;
 	int did_stream_warning;
 	int diverted_length;
-	int signal_interruptible[256];
 };
 
 struct pfs_process * pfs_process_create( pid_t pid, pid_t ppid, int share_table );
 void pfs_process_exec( struct pfs_process *p );
-struct pfs_process * pfs_process_lookup( pid_t pid );
-
 void pfs_process_stop( struct pfs_process *p, int status, struct rusage *usage );
 
-void pfs_process_sigio();
+extern "C" int pfs_process_getpid();
 int  pfs_process_count();
-int  pfs_process_raise( pid_t pid, int sig, int really_sendit );
+struct pfs_process * pfs_process_lookup( pid_t pid );
+int  pfs_process_cankill( pid_t pid );
+extern "C" char *pfs_process_name();
 
-extern "C" int  pfs_process_getpid();
-extern "C" char * pfs_process_name();
-extern "C" void pfs_process_kill();
 extern "C" void pfs_process_killall();
-extern "C" void pfs_process_kill_everyone(int);
+extern "C" void pfs_process_kill_everyone(int sig);
+extern "C" void pfs_process_sigio(int sig);
 
 uintptr_t pfs_process_scratch_address( struct pfs_process *p );
 void pfs_process_scratch_get( struct pfs_process *p, void *data, size_t len );


### PR DESCRIPTION
This is a branch I've been sitting on waiting for parrot-native-fd to be merged. This can now also be merged.
- Do not hook rt_sigaction or signal (32 bit).
- Old "interrupted" logic is unnecessary since parrot-native-fd branch.
- New pfs_process_cankill (formally pfs_process_raise) which encapsulates the
  logic pfs_dispatch*.cc needs for handling the kill system call.
- Remove obsolete logic in decode_write for handling SIGPIPE, which was necessary
  before parrot-native-fd when Parrot handled all tracee pipes.
