### PR TITLE
Use 64 bit buffer lengths.

### DIFF
--- a/dttools/src/hmac.c
+++ b/dttools/src/hmac.c
@@ -14,11 +14,11 @@ See the file COPYING for details.
 #define MD5_BLOCK_SIZE 64
 #define SHA1_BLOCK_SIZE 64
 
-int hmac(const char *text, int text_len, const char *in_key, int in_key_len, unsigned char *digest, int digest_len, int block_size, void (*hash_func) (const char *, int, unsigned char *))
+int hmac(const void *text, size_t text_len, const void *in_key, size_t in_key_len, unsigned char *digest, size_t digest_len, size_t block_size, void (*hash_func) (const void *, size_t, unsigned char *))
 {
 	unsigned char *key;
 	char *inner, *outer;
-	int i;
+	size_t i;
 
 	key = malloc(block_size);
 	inner = malloc(block_size + text_len + 1);
@@ -63,12 +63,12 @@ int hmac(const char *text, int text_len, const char *in_key, int in_key_len, uns
 	return 0;
 }
 
-int hmac_md5(const char *text, int text_len, const char *in_key, int in_key_len, unsigned char digest[MD5_DIGEST_LENGTH])
+int hmac_md5(const void *text, size_t text_len, const void *in_key, size_t in_key_len, unsigned char digest[MD5_DIGEST_LENGTH])
 {
 	return hmac(text, text_len, in_key, in_key_len, digest, MD5_DIGEST_LENGTH, MD5_BLOCK_SIZE, &md5_buffer);
 }
 
-int hmac_sha1(const char *text, int text_len, const char *in_key, int in_key_len, unsigned char digest[SHA1_DIGEST_LENGTH])
+int hmac_sha1(const void *text, size_t text_len, const void *in_key, size_t in_key_len, unsigned char digest[SHA1_DIGEST_LENGTH])
 {
 	return hmac(text, text_len, in_key, in_key_len, digest, SHA1_DIGEST_LENGTH, SHA1_BLOCK_SIZE, &sha1_buffer);
 }

--- a/dttools/src/hmac.h
+++ b/dttools/src/hmac.h
@@ -7,6 +7,8 @@ See the file COPYING for details.
 #ifndef HMAC_H_
 #define HMAC_H_
 
+#include <stdlib.h>
+
 /** @file hmac.h
 Routines for computing Hash-based Message Authentication Codes.
 */
@@ -25,7 +27,7 @@ Routines for computing Hash-based Message Authentication Codes.
 @param block_size The size of the block used by the hash function in bytes.
 @param hash_func A function pointer to the hash function to be used.
 */
-int hmac(const char *buffer, int buffer_length, const char *key, int key_length, unsigned char *digest, int digest_len, int block_size, void (*hash_func) (const char *, int, unsigned char *));
+int hmac(const void *buffer, size_t buffer_length, const void *key, size_t key_length, unsigned char *digest, size_t digest_len, size_t block_size, void (*hash_func) (const void *, size_t, unsigned char *));
 
 /** Generate HMAC using md5 hash function
 Note that this function produces a digest in binary form which must be converted to a human readable form with md5_string.
@@ -35,7 +37,7 @@ Note that this function produces a digest in binary form which must be converted
 @param key_length The length of the key in bytes.
 @param digest Pointer to a buffer of size MD5_DIGEST_LENGTH to store the digest.
 */
-int hmac_md5(const char *buffer, int buffer_length, const char *key, int key_length, unsigned char digest[MD5_DIGEST_LENGTH]);
+int hmac_md5(const void *buffer, size_t buffer_length, const void *key, size_t key_length, unsigned char digest[MD5_DIGEST_LENGTH]);
 
 /** Generate HMAC using sha1 hash function
 Note that this function produces a digest in binary form which must be converted to a human readable form with sha1_string.
@@ -45,7 +47,7 @@ Note that this function produces a digest in binary form which must be converted
 @param key_length The length of the key in bytes.
 @param digest Pointer to a buffer of size SHA1_DIGEST_LENGTH to store the digest.
 */
-int hmac_sha1(const char *buffer, int buffer_length, const char *key, int key_length, unsigned char digest[SHA1_DIGEST_LENGTH]);
+int hmac_sha1(const void *buffer, size_t buffer_length, const void *key, size_t key_length, unsigned char digest[SHA1_DIGEST_LENGTH]);
 
 
 #endif

--- a/dttools/src/md5.h
+++ b/dttools/src/md5.h
@@ -7,23 +7,24 @@ See the file COPYING for details.
 #ifndef MD5_H
 #define MD5_H
 
+#include <stdint.h>
+#include <stdlib.h>
+
 /** @file md5.h
 Routines for computing MD5 checksums.
 */
-
-#include "int_sizes.h"
 
 #define MD5_DIGEST_LENGTH 16
 #define MD5_DIGEST_LENGTH_HEX (MD5_DIGEST_LENGTH<<1)
 
 typedef struct {
-	UINT32_T state[4];
-	UINT32_T count[2];
-	unsigned char buffer[64];
+	uint32_t state[4];
+	uint32_t count[2];
+	uint8_t buffer[64];
 } md5_context_t;
 
 void md5_init(md5_context_t * ctx);
-void md5_update(md5_context_t * ctx, const unsigned char *, unsigned int);
+void md5_update(md5_context_t * ctx, const void *, size_t);
 void md5_final(unsigned char digest[MD5_DIGEST_LENGTH], md5_context_t * ctx);
 
 /** Checksum a memory buffer.
@@ -34,7 +35,7 @@ which  must be converted to a human readable form with @ref md5_string.
 @param digest Pointer to a buffer to store the digest.
 */
 
-void md5_buffer(const char *buffer, int length, unsigned char digest[MD5_DIGEST_LENGTH]);
+void md5_buffer(const void *buffer, size_t length, unsigned char digest[MD5_DIGEST_LENGTH]);
 
 /** Checksum a local file.
 Note that this function produces a digest in binary form

--- a/dttools/src/sha1.h
+++ b/dttools/src/sha1.h
@@ -7,6 +7,9 @@ See the file COPYING for details.
 #ifndef SHA1_H
 #define SHA1_H
 
+#include <stdint.h>
+#include <stdlib.h>
+
 /** @file sha1.h
 Routines for computing SHA1 checksums.
 */
@@ -20,20 +23,18 @@ Routines for computing SHA1 checksums.
 #define sha1_file    dttools_sha1_file
 #define sha1_string  dttools_sha1_string
 
-#include "int_sizes.h"
-
 #define SHA1_DIGEST_LENGTH 20
 #define SHA1_DIGEST_ASCII_LENGTH 42
 
 typedef struct {
-	UINT32_T digest[5];
-	UINT32_T countLo, countHi;
-	UINT32_T data[16];
+	uint32_t digest[5];
+	size_t countLo, countHi;
+	uint32_t data[16];
 	int Endianness;
 } sha1_context_t;
 
 void sha1_init(sha1_context_t * ctx);
-void sha1_update(sha1_context_t * ctx, const unsigned char *, unsigned int);
+void sha1_update(sha1_context_t * ctx, const void *, size_t);
 void sha1_final(unsigned char digest[SHA1_DIGEST_LENGTH], sha1_context_t * ctx);
 
 /** Checksum a memory buffer.
@@ -44,7 +45,7 @@ which  must be converted to a human readable form with @ref sha1_string.
 @param digest Pointer to a buffer to store the digest.
 */
 
-void sha1_buffer(const char *buffer, int length, unsigned char digest[SHA1_DIGEST_LENGTH]);
+void sha1_buffer(const void *buffer, size_t length, unsigned char digest[SHA1_DIGEST_LENGTH]);
 
 /** Checksum a local file.
 Note that this function produces a digest in binary form


### PR DESCRIPTION
This is pulled out of the Confuga branch where we want to able to hash large
files. This commit also changes the <hash>_file routines to use mmap if
possible.
