### PR TITLE
Disable NSCD when using parrot_identity_box

### DIFF
--- a/parrot/src/parrot_identity_box
+++ b/parrot/src/parrot_identity_box
@@ -46,4 +46,4 @@ then
 fi
 
 # Finally, fork off parrot with a private environment and password file.
-exec /usr/bin/env -i HOME=${HOME} SHELL=${SHELL} LANG=${LANG} TERM=${TERM} ${parrot} -H -M/etc/passwd=${HOME}/.passwd -M/etc/group=${HOME}/.group -u $vid -- $command
+exec /usr/bin/env -i HOME=${HOME} SHELL=${SHELL} LANG=${LANG} TERM=${TERM} ${parrot} -H -M/etc/passwd=${HOME}/.passwd -M/etc/group=${HOME}/.group  -M/var/run/nscd/socket=ENOENT -u $vid -- $command


### PR DESCRIPTION
Name Service Cache Daemon (NSCD) is installed in CSE workstations for
passwd, group services, which does not check /etc/passwd and /etc/group.
parrot_identity_box is based on adding items into /etc/passwd and /etc/group.
