### PR TITLE
Fix parrot-chirp tests.

### DIFF
--- a/chirp/test/chirp-common.sh
+++ b/chirp/test/chirp-common.sh
@@ -1,16 +1,16 @@
 chirp() {
-	echo ../src/chirp -d chirp "$@" >&2
-	../src/chirp -d chirp "$@"
+	echo ../../chirp/src/chirp -d chirp "$@" >&2
+	../../chirp/src/chirp -d chirp "$@"
 }
 
 chirp_benchmark() {
-	echo ../src/chirp_benchmark "$@" >&2
-	../src/chirp_benchmark "$@"
+	echo ../../chirp/src/chirp_benchmark "$@" >&2
+	../../chirp/src/chirp_benchmark "$@"
 }
 
 chirp_server() {
-	echo ../src/chirp "$@" >&2
-	../src/chirp_server "$@"
+	echo ../../chirp/src/chirp "$@" >&2
+	../../chirp/src/chirp_server "$@"
 }
 
 chirp_start() {


### PR DESCRIPTION
 Paths in chirp-common.sh must reach back to the common root, since chirp-common.sh is also used by the parrot tests.  @pdonnel please check
