### PR TITLE
Fixed caching of renamed files in makeflow -T wq

### DIFF
--- a/work_queue/src/batch_job_work_queue.c
+++ b/work_queue/src/batch_job_work_queue.c
@@ -126,10 +126,17 @@ static batch_job_id_t batch_job_wq_submit (struct batch_queue *q, const char *cm
 static batch_job_id_t batch_job_wq_submit_simple (struct batch_queue * q, const char *cmd, const char *extra_input_files, const char *extra_output_files)
 {
 	struct work_queue_task *t;
-	int caching = string_istrue(hash_table_lookup(q->options, "caching"));
+
+    int caching_flag = WORK_QUEUE_CACHE;
+
+    if(string_istrue(hash_table_lookup(q->options, "caching"))) {
+        caching_flag = WORK_QUEUE_CACHE;
+    } else {
+        caching_flag = WORK_QUEUE_NOCACHE;
+    }
 
 	t = work_queue_task_create(cmd);
-	specify_work_queue_task_files(t, extra_input_files, extra_output_files, caching);
+	specify_work_queue_task_files(t, extra_input_files, extra_output_files, caching_flag);
 
 	struct rmsummary *resources = parse_batch_options_resources(hash_table_lookup(q->options, "batch-options"));
 	if(resources)


### PR DESCRIPTION
This commit enables caching for all files in batch_job_work_queue, even those that are renamed.
Earlier versions of WQ would handle this caching incorrectly, but it works fine in the current version.
