### PR TITLE
Remove dependency on systemd.

### DIFF
--- a/configure
+++ b/configure
@@ -1065,9 +1065,10 @@ optional_include sys/statvfs.h HAS_SYS_STATVFS_H
 optional_include sys/xattr.h HAS_SYS_XATTR_H
 optional_include syslog.h HAS_SYSLOG_H
 
-if optional_library_function systemd/sd-journal.h sd_journal_print systemd HAS_SYSTEMD_JOURNAL_H; then
-	external_dynlibs="${external_dynlibs} -lsystemd"
-fi
+
+#if optional_library_function systemd/sd-journal.h sd_journal_print systemd HAS_SYSTEMD_JOURNAL_H; then
+#	external_dynlibs="${external_dynlibs} -lsystemd"
+#fi
 
 cctools_doctargets=
 


### PR DESCRIPTION
@btovar This is a quick hack to remove any introduction of a systemd dependency into our code, particularly in the link dependencies for work queue.  Let's get this quick change into 4.3.  @batrick Perhaps you can think of a way to make this an option or a soft dependency for later releases.
