### PR TITLE
Change the method of spliting `chirp` cmd into args

### DIFF
--- a/chirp/src/chirp_tool.c
+++ b/chirp/src/chirp_tool.c
@@ -1302,7 +1302,7 @@ int main(int argc, char *argv[])
 
 				if(user_argv)
 					free(user_argv);
-				string_split(start, &user_argc, &user_argv);
+				string_split_quotes(start, &user_argc, &user_argv);
 				if(user_argc == 0) {
 					start++;
 					continue;


### PR DESCRIPTION
  Change the method of spliting `chirp` cmd into args from `string_split` to `string_split_quotes`. `string_split` only considers spaces to split a string; `string_split_quotes` considers spaces, backslashes, quotes to split a string.
