### PR TITLE
Add option --recheck-file-creation.

### DIFF
--- a/doc/man/makeflow.m4
+++ b/doc/man/makeflow.m4
@@ -51,6 +51,8 @@ OPTION_TRIPLET(-L, batch-log, logfile)Use this file for the batch system log. (d
 OPTION_ITEM(`-R, --retry')Automatically retry failed batch jobs up to 100 times.
 OPTION_TRIPLET(-r, retry-count, n)Automatically retry failed batch jobs up to n times.
 OPTION_ITEM(`--recheck-file-creation')Do not fail if an output file is not immediately created.
+OPTION_PAIR(--recheck-file-tries, #)When rechecking file creation, try this many times. (default is 5)
+OPTION_PAIR(--recheck-file-wait-time, #)When rechecking file creation, wait this many seconds between tries (default is 1s).
 OPTION_TRIPLET(-S, submission-timeout, timeout)Time to retry failed batch job submission. (default is 3600s)
 OPTION_TRIPLET(-T, batch-type, type)Batch system type: local, condor, sge, moab, cluster, wq, hadoop, mpi-queue. (default is local)
 OPTIONS_END


### PR DESCRIPTION
To handle NFS semantics, this option tells makeflow not to fail
if a file from a succesful job is not immeditely available. Makeflow
retries for the file before failing.
