### PR TITLE
Add --no-set-foreground option to parrot to execute the tracee in the background

### DIFF
--- a/doc/man/parrot_run.m4
+++ b/doc/man/parrot_run.m4
@@ -36,6 +36,7 @@ OPTION_TRIPLET(-m, ftab-file, file)Use this file as a mountlist.
 OPTION_TRIPLET(-M, mount, /foo=/bar)Mount (redirect) /foo to /bar.
 OPTION_TRIPLET(-e, env-list, path)Record the environment variables.
 OPTION_TRIPLET(-n, name-list, path)Record all the file names.
+OPTION_ITEM(`    --no-set-foreground')Disable changing the foreground process group of the session.
 OPTION_TRIPLET(-N, hostname, name)Pretend that this is my hostname.
 OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
 OPTION_TRIPLET(-O, debug-rotate-max, bytes)Rotate debug files of this size.

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -84,6 +84,7 @@ int pfs_write_rval = 0;
 int pfs_paranoid_mode = 0;
 const char *pfs_write_rval_file = "parrot.rval";
 int pfs_enable_small_file_optimizations = 1;
+int set_foreground = 1;
 
 char sys_temp_dir[PFS_PATH_MAX] = "/tmp";
 char pfs_temp_dir[PFS_PATH_MAX];
@@ -129,6 +130,7 @@ enum {
 	LONG_OPT_CVMFS_DISABLE_ALIEN_CACHE,
 	LONG_OPT_CVMFS_ALIEN_CACHE,
 	LONG_OPT_HELPER,
+	LONG_OPT_NO_SET_FOREGROUND,
 };
 
 static void get_linux_version(const char *cmd)
@@ -208,6 +210,7 @@ static void show_help( const char *cmd )
 	fprintf(stdout, " %-30s Do not checksum files.\n", "-k,--no-checksums");
 	fprintf(stdout, " %-30s Path to ld.so to use.                      (PARROT_LDSO_PATH)\n", "-l,--ld-path=<path>");
 	fprintf(stdout, " %-30s Record all the file names.\n", "-n,--name-list=<path>");
+	fprintf(stdout, " %-30s Disable changing the foreground process group of the session.\n","   --no-set-foreground");
 	fprintf(stdout, " %-30s Use this file as a mountlist.             (PARROT_MOUNT_FILE)\n", "-m,--ftab-file=<file>");
 	fprintf(stdout, " %-30s Mount (redirect) /foo to /bar.          (PARROT_MOUNT_STRING)\n", "-M,--mount=/foo=/bar");
 	fprintf(stdout, " %-30s Pretend that this is my hostname.          (PARROT_HOST_NAME)\n", "-N,--hostname=<name>");
@@ -550,6 +553,7 @@ int main( int argc, char *argv[] )
 		{"no-follow-symlinks", no_argument, 0, 'f'},
 		{"no-helper", no_argument, 0, 'H'},
 		{"no-optimize", no_argument, 0, 'D'},
+		{"no-set-foreground", no_argument, 0, LONG_OPT_NO_SET_FOREGROUND},
 		{"paranoid", no_argument, 0, 'P'},
 		{"proxy", required_argument, 0, 'p'},
 		{"root-checksum", required_argument, 0, 'R'},
@@ -728,6 +732,9 @@ int main( int argc, char *argv[] )
 		case 'W':
 			pfs_syscall_totals32 = (int*) calloc(SYSCALL32_MAX,sizeof(int));
 			pfs_syscall_totals64 = (int*) calloc(SYSCALL64_MAX,sizeof(int));
+			break;
+		case LONG_OPT_NO_SET_FOREGROUND:
+			set_foreground = 0;
 			break;
 		case LONG_OPT_HELPER:
 			pfs_use_helper = 1;
@@ -969,8 +976,8 @@ int main( int argc, char *argv[] )
 			pfs_helper_init();
 		pfs_paranoia_payload();
 		pfs_process_bootstrapfd();
-		setpgrp();
-		{
+		if(set_foreground) {
+			setpgrp();
 			int fd = open("/dev/tty", O_RDWR);
 			if (fd >= 0) {
 				tcsetpgrp(fd, getpgrp());


### PR DESCRIPTION
Currently, parrot allows the tracee to set its process group ID to its own PID and set its process group as the foreground process group of the session by default, which may break the program which first calls parrot and then needs to use terminal (to use terminal, the program must be in the foregroud process group).
