### PR TITLE
Before fullcopy of a file to new_path, remove new_path if it exists.

### DIFF
--- a/parrot/src/parrot_package_create.c
+++ b/parrot/src/parrot_package_create.c
@@ -365,9 +365,11 @@ int line_process(const char *path, char *caller, int ignore_direntry, int is_dir
 			if(target_stat.st_size) {
 				debug(D_DEBUG, "`%s`: fullcopy exist! pass!\n", path);
 			} else {
-				if(remove(new_path) == -1) {
-					debug(D_DEBUG, "remove(`%s`) fails: %s\n", new_path, strerror(errno));
-					return -1;
+				if(access(new_path, F_OK) == 0) {
+					if(remove(new_path) == -1) {
+						debug(D_DEBUG, "remove(`%s`) fails: %s\n", new_path, strerror(errno));
+						return -1;
+					}
 				}
 				if(copy_file_to_file(path, new_path) < 0) {
 					debug(D_DEBUG, "copy_file_to_file from %s to %s fails.\n", path, new_path);
@@ -384,6 +386,12 @@ int line_process(const char *path, char *caller, int ignore_direntry, int is_dir
 				line_process(dir_name, "metadatacopy", 1, 0, special_file);
 			}
 			if(fullcopy) {
+				if(access(new_path, F_OK) == 0) {
+					if(remove(new_path) == -1) {
+						debug(D_DEBUG, "remove(`%s`) fails: %s\n", new_path, strerror(errno));
+						return -1;
+					}
+				}
 				if(copy_file_to_file(path, new_path) < 0) {
 					debug(D_DEBUG, "copy_file_to_file from %s to %s fails.\n", path, new_path);
 					return -1;


### PR DESCRIPTION
Currently fullcopy of a file to new_path is implemented by `copy_file_to_file`. However,  if the new_path exists, `copy_file_to_file` will fail. 
Solution: Before each `copy_file_to_file`, remove new_path if if exists.