### PR TITLE
Add `/tmp /tmp` into common-mountlist

### DIFF
--- a/parrot/src/parrot_package_create.c
+++ b/parrot/src/parrot_package_create.c
@@ -534,6 +534,7 @@ int post_process( ) {
 		(fputs("/proc /proc\n", file) == EOF) ||
 		(fputs("/sys /sys\n", file) == EOF) ||
 		(fputs("/var /var\n", file) == EOF) ||
+		(fputs("/tmp /tmp\n", file) == EOF) ||
 		(fputs("/selinux /selinux\n", file) == EOF)) {
 			debug(D_DEBUG, "fputs fails: %s\n", strerror(errno));
 			exit(EXIT_FAILURE);


### PR DESCRIPTION
	Allow the filesystem created by `parrot_package_run` to use /tmp from the host machine.