### PR TITLE
Use the interpreter as the logical_exe.

### DIFF
--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -1023,10 +1023,10 @@ static void decode_execve( struct pfs_process *p, int entering, INT64_T syscall,
 				goto failure;
 
 			if (strlen(interp_arg)) {
-				if (fix_execve(p, old_user_argv, physical_name, logical_name, interp_exe, interp_arg, logical_name) == -1)
+				if (fix_execve(p, old_user_argv, physical_name, interp_exe, interp_exe, interp_arg, logical_name) == -1)
 					goto failure;
 			} else {
-				if (fix_execve(p, old_user_argv, physical_name, logical_name, interp_exe, logical_name, NULL) == -1)
+				if (fix_execve(p, old_user_argv, physical_name, interp_exe, interp_exe, logical_name, NULL) == -1)
 					goto failure;
 			}
 		} else {

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -826,10 +826,10 @@ static void decode_execve( struct pfs_process *p, int entering, INT64_T syscall,
 				goto failure;
 
 			if (strlen(interp_arg)) {
-				if (fix_execve(p, old_user_argv, physical_name, logical_name, interp_exe, interp_arg, logical_name) == -1)
+				if (fix_execve(p, old_user_argv, physical_name, interp_exe, interp_exe, interp_arg, logical_name) == -1)
 					goto failure;
 			} else {
-				if (fix_execve(p, old_user_argv, physical_name, logical_name, interp_exe, logical_name, NULL) == -1)
+				if (fix_execve(p, old_user_argv, physical_name, interp_exe, interp_exe, logical_name, NULL) == -1)
 					goto failure;
 			}
 		} else {

--- a/parrot/test/TR_parrot_execve.sh
+++ b/parrot/test/TR_parrot_execve.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+set -e
+
+. ../../dttools/test/test_runner_common.sh
+. ../../chirp/test/chirp-common.sh
+
+c="./hostport.$PPID"
+parrot_debug=parrot.debug
+
+parrot() {
+	../src/parrot_run --no-chirp-catalog --debug=all --debug-file="$parrot_debug" --work-dir="/chirp/$hostport/" "$@"
+}
+
+prepare()
+{
+	chirp_start local
+	echo "$hostport" > "$c"
+
+	return 0
+}
+
+run()
+{
+	hostport=$(cat "$c")
+
+	parrot /bin/sh <<EOF1
+cat > a.py <<EOF2
+#!/chirp/$hostport/python
+
+import sys
+
+print(' '.join(sys.argv))
+EOF2
+cp "$(which python)" "$(which sh)" .
+chmod 700 a.py python sh
+EOF1
+	for loader in /lib64/ld-linux*.so* /lib/ld-linux*.so*; do
+		[ "$(parrot --ld-path="$loader" -- ./a.py 1 2 | tee /dev/tty)" = './a.py 1 2' ]
+		[ "$(parrot --ld-path="$loader" -- ./sh -c 'echo "$0"' | tee /dev/tty)" = './sh' ]
+		return 0
+	done
+	return 1
+}
+
+clean()
+{
+	chirp_clean
+	rm -f "$c" "$parrot_debug"
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:


### PR DESCRIPTION
The loader must be given a real executable to load, not an interpreted one.

Fixes #660.