### PR TITLE
Move the CMS env variables into cmsjob.sh

### DIFF
--- a/apps/parrot_cms/cmsjob.sh
+++ b/apps/parrot_cms/cmsjob.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+export CMS_VERSION=CMSSW_5_3_11
+export SCRAM_ARCH=slc5_amd64_gcc462
+
 rm -rf cmsjob
 mkdir cmsjob
 cd cmsjob

--- a/apps/parrot_cms/parrot.cmsjob.sh
+++ b/apps/parrot_cms/parrot.cmsjob.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 
 export HTTP_PROXY=http://cache01.hep.wisc.edu:3128
-export CMS_VERSION=CMSSW_5_3_11
-export SCRAM_ARCH=slc5_amd64_gcc462
 
 parrot_run -M /cvmfs/cms.cern.ch/SITECONF/local=`pwd`/SITECONF/local ./cmsjob.sh
 


### PR DESCRIPTION
	If parrot is not needed, the user can run ./cmsjob.sh directly.