### PR TITLE
Improved Environment for Parrot Packaging

### DIFF
--- a/parrot/src/parrot_package_run
+++ b/parrot/src/parrot_package_run
@@ -86,16 +86,9 @@ fi
 
 #import environment varibales
 export_env() {
-	while read line
+	while read -r -d '' line
 	do
-		IFS="="     # Set the field separator
-		set $line      # Breaks the string into $1, $2, ...
-		variable_name="$1"
-		name_len="${#variable_name}"
-		name_len=$(expr "${name_len}" + 1)
-		variable_value="${line:name_len}"
-		export "${variable_name}"="${variable_value}"
-		IFS=" "
+		export "${line}"
 	done < "${env_path}"
 }
 export_env

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -796,7 +796,7 @@ int main( int argc, char *argv[] )
 		if(!fp)
 			fatal("Can not open envlist file: %s", envlist);
 		for (int i = 0; environ[i]; i++)
-			fprintf(fp, "%s\n", environ[i]);
+			fprintf(fp, "%s%c", environ[i], '\0');
 		char working_dir[PATH_MAX];
 		::getcwd(working_dir,sizeof(working_dir));
 		if(working_dir == NULL)


### PR DESCRIPTION
Background:
When `parrot_package_run` is used to repeat one command within a package, the env variables from <package>/env_list need to be imported.

Problem:
Some environment variables use backslash + newline to construct a long command, and some environment variables include escape sequences (e.g., PS1="\u@\h \w\$ "). the `read` command, without the `-r` option, uses backslash as an escape character, causing the line `PS1="\u@\h \w\$ "` to be `PS1="u@h w$ "`. The `-r` option of `read` disables this behavior, but introduces a new problem - the long commands constructed through backslash + newline will be split into multiple lines.

Solution:
First merge the long commands constructed through backslash + newline in the env_list into one single line, then use `read -r` to read the file.