### PR TITLE
Don't reset registers after execve.

### DIFF
--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -960,7 +960,6 @@ static int fix_execve ( struct pfs_process *p, uintptr_t old_user_argv, const ch
 	/* change the registers to reflect argv */
 	INT64_T nargs[] = {(INT64_T) (ldso[0] ? user_ldso : user_exe), (INT64_T)user_argv};
 	tracer_args_set(p->tracer,p->syscall,nargs,sizeof(nargs)/sizeof(nargs[0]));
-	p->syscall_args_changed = 1;
 	return 0;
 }
 

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -763,7 +763,6 @@ static int fix_execve ( struct pfs_process *p, uintptr_t old_user_argv, const ch
 	/* change the registers to reflect argv */
 	INT64_T nargs[] = {(INT64_T) (ldso[0] ? user_ldso : user_exe), (INT64_T)user_argv};
 	tracer_args_set(p->tracer,p->syscall,nargs,sizeof(nargs)/sizeof(nargs[0]));
-	p->syscall_args_changed = 1;
 	return 0;
 }
 


### PR DESCRIPTION
This was a fun one to debug, had to dig into glibc to figure out that rtld_fini
was being changed from NULL pointer to a garbage one.

Fixes #677.