### PR TITLE
Make it easier to print tracee mappings.

### DIFF
--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -2235,14 +2235,14 @@ void pfs_table::mmap_proc (pid_t pid, buffer_t *B)
 	struct pfs_process *p = pfs_process_lookup(pid);
 	if (p) {
 		for(struct pfs_mmap *m = p->table->mmap_list; m; m = m->next) {
-			buffer_putfstring(B, "%08" PRIx64 "-%08" PRIx64, (uint64_t)(uintptr_t)m->logical_addr, (uint64_t)(uintptr_t)m->logical_addr+(uint64_t)m->map_length);
+			buffer_putfstring(B, "%016" PRIx64 "-%016" PRIx64, (uint64_t)(uintptr_t)m->logical_addr, (uint64_t)(uintptr_t)m->logical_addr+(uint64_t)m->map_length);
 			buffer_putfstring(B, " ");
 			buffer_putfstring(B, "%c", m->prot & PROT_READ ? 'r' : '-');
 			buffer_putfstring(B, "%c", m->prot & PROT_WRITE ? 'w' : '-');
 			buffer_putfstring(B, "%c", m->prot & PROT_EXEC ? 'w' : '-');
 			buffer_putfstring(B, "%c", m->flags & MAP_PRIVATE ? 'p' : '-');
 			buffer_putfstring(B, " ");
-			buffer_putfstring(B, "%08" PRIx64, m->file_offset);
+			buffer_putfstring(B, "%016" PRIx64, m->file_offset);
 			buffer_putfstring(B, " ");
 			buffer_putfstring(B, "%02" PRIx32 ":%02" PRIx32, major(m->finfo.st_dev), minor(m->finfo.st_dev));
 			buffer_putfstring(B, " ");
@@ -2260,9 +2260,9 @@ void pfs_table::mmap_proc (pid_t pid, buffer_t *B)
 			char *start = NULL, *end = NULL, *perm = NULL, *off = NULL, *dev = NULL, *ino = NULL, *path = NULL;
 			if (pattern_match(line, "^(%x+)%-(%x+)%s+(%S+)%s+(%x+)%s+([%d:]+)%s+(%d+)%s+(.-)%s*$", &start, &end, &perm, &off, &dev, &ino, &path) >= 0) {
 				size_t current = buffer_pos(B);
-				buffer_putfstring(B, "%08" PRIx64 "-%08" PRIx64, (uint64_t)strtoul(start, NULL, 16), (uint64_t)strtoul(end, NULL, 16));
+				buffer_putfstring(B, "%016" PRIx64 "-%016" PRIx64, (uint64_t)strtoul(start, NULL, 16), (uint64_t)strtoul(end, NULL, 16));
 				buffer_putfstring(B, " %s", perm);
-				buffer_putfstring(B, " %08" PRIx64, (uint64_t)strtoul(off, NULL, 16));
+				buffer_putfstring(B, " %016" PRIx64, (uint64_t)strtoul(off, NULL, 16));
 				buffer_putfstring(B, " %s", dev);
 				buffer_putfstring(B, " %08" PRIu64, (uint64_t)strtoul(ino, NULL, 16));
 				buffer_putfstring(B, " %s", path);

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -2271,6 +2271,8 @@ void pfs_table::mmap_proc (pid_t pid, buffer_t *B)
 					/* OKAY: heap/stack/etc. */
 				} else if (pattern_match(dev, "0+:0+") >= 0) {
 					/* OKAY: anonymous mapping */
+				} else if (pattern_match(path, ".-parrot%-channel") < 0) {
+					/* OKAY: ! parrot mapping */
 				} else {
 					/* not printed */
 					buffer_rewind(B, current);

--- a/parrot/src/pfs_table.h
+++ b/parrot/src/pfs_table.h
@@ -8,6 +8,10 @@ See the file COPYING for details.
 #ifndef PFS_TABLE_H
 #define PFS_TABLE_H
 
+extern "C" {
+#include "buffer.h"
+}
+
 #include "pfs_mmap.h"
 #include "pfs_name.h"
 #include "pfs_refcount.h"
@@ -123,10 +127,11 @@ public:
 	int	resolve_name( int is_special_syscall, const char *cname, pfs_name *pname, bool do_follow_symlink = true, int depth = 0 );
 
 	/* mmap operations */
-	pfs_size_t mmap_create( int fd, pfs_size_t file_offset, pfs_size_t length, int prot, int flags );
-	int	       mmap_update( pfs_size_t logical_address, pfs_size_t channel_address );
-	int	       mmap_delete( pfs_size_t logical_address, pfs_size_t length );
-	void       mmap_print();
+	pfs_size_t  mmap_create( int fd, pfs_size_t file_offset, pfs_size_t length, int prot, int flags );
+	int         mmap_update( pfs_size_t logical_address, pfs_size_t channel_address );
+	int         mmap_delete( pfs_size_t logical_address, pfs_size_t length );
+	void        mmap_print();
+	static void mmap_proc(pid_t pid, buffer_t *B);
 
 	pfs_file * open_object( const char *path, int flags, mode_t mode, int force_cache );
 
@@ -138,7 +143,6 @@ private:
 
 	void complete_path( const char *short_path, char *long_path );
 
-	static void mmap_proc(pid_t pid, char *path);
 	pfs_size_t mmap_create_object( pfs_file *file, pfs_size_t channel_offset, pfs_size_t map_length, pfs_size_t file_offset, int prot, int flags );
 
 	int         pointer_count;


### PR DESCRIPTION
mmap_proc now takes a buffer to put output in, instead of a filename.  We can
now use mmap_proc to print mappings for a tracee that segfaults.

Additionally, I've improved the output of mmap_proc to be easier to read and
included some missing mappings (the executable file).