### PR TITLE
Work Queue Tuning for NDCMS

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4026,6 +4026,8 @@ int work_queue_task_state( struct work_queue *q, int taskid) {
 static uintptr_t change_task_state( struct work_queue *q, struct work_queue_task *t, uintptr_t new_state ) {
 	uintptr_t old_state = (uintptr_t) itable_lookup(q->task_state_map, t->taskid);
 
+	debug(D_WQ, "Task %d state change: %d to %d\n", t->taskid, (int) old_state, (int) new_state);
+
 	switch(new_state) {
 		case WORK_QUEUE_TASK_READY:
 			break;

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -77,6 +77,9 @@ static int idle_timeout = 900;
 // Current time at which we will give up if no work is received.
 static time_t idle_stoptime = 0;
 
+// Current time at which we will give up if no master is found.
+static time_t connect_stoptime = 0;
+
 // Maximum time to attempt connecting to all available masters before giving up.
 static int connect_timeout = 900;
 
@@ -1564,6 +1567,9 @@ static int serve_master_by_hostport( const char *host, int port, const char *ver
 
 static int serve_master_by_name( const char *catalog_host, int catalog_port, const char *project_regex )
 {
+	static char *last_addr = NULL; 
+	static int   last_port = -1; 
+
 	struct list *masters_list = work_queue_catalog_query_cached(catalog_host,catalog_port,project_regex);
 
 	debug(D_WQ,"project name %s matches %d masters",project_regex,list_size(masters_list));
@@ -1577,15 +1583,38 @@ static int serve_master_by_name( const char *catalog_host, int catalog_port, con
 		list_push_tail(masters_list,list_pop_head(masters_list));
 	}
 
-	struct nvpair *nv = list_peek_head(masters_list);
-	const char *project = nvpair_lookup_string(nv,"project");
-	const char *name = nvpair_lookup_string(nv,"name");
-	const char *addr = nvpair_lookup_string(nv,"address");
-	int port = nvpair_lookup_integer(nv,"port");
+	while(1) {
+		struct nvpair *nv = list_peek_head(masters_list);
+		const char *project = nvpair_lookup_string(nv,"project");
+		const char *name = nvpair_lookup_string(nv,"name");
+		const char *addr = nvpair_lookup_string(nv,"address");
+		int port = nvpair_lookup_integer(nv,"port");
 
-	debug(D_WQ,"selected master with project=%s name=%s addr=%s port=%d",project,name,addr,port);
+		/* Do not connect to the same master after idle disconnection. */
+		if(last_addr) {
+			if( time(0) > idle_stoptime && strcmp(addr, last_addr) == 0 && port == last_port) {
+				if(list_size(masters_list) < 2) {
+					free(last_addr);
+					/* convert idle_stoptime into connect_stoptime (e.g., time already served). */
+					connect_stoptime = idle_stoptime;
+					debug(D_WQ,"Previous idle disconnection from only master available project=%s name=%s addr=%s port=%d",project,name,addr,port);
+					return 0;
+				} else {
+					list_push_tail(masters_list,list_pop_head(masters_list));
+					continue;
+				}
+			}
 
-	return serve_master_by_hostport(addr,port,project);
+			free(last_addr);
+		}
+
+		last_addr = xxstrdup(addr);
+		last_port = port;
+
+		debug(D_WQ,"selected master with project=%s name=%s addr=%s port=%d",project,name,addr,port);
+
+		return serve_master_by_hostport(addr,port,project);
+	}
 }
 
 void set_worker_id() {
@@ -2012,7 +2041,7 @@ int main(int argc, char *argv[])
 	resources_measure_locally(local_resources);
 
 	int backoff_interval = init_backoff_interval;
-	time_t connect_stoptime = time(0) + connect_timeout;
+	connect_stoptime = time(0) + connect_timeout;
 
 	while(1) {
 		int result;
@@ -2051,7 +2080,7 @@ int main(int argc, char *argv[])
 		}
 
 		if(time(0)>connect_stoptime) {
-			debug(D_NOTICE,"stopping: could not connect after %d seconds (--connect-timeout)",connect_timeout);
+			debug(D_NOTICE,"stopping: could not connect after %d seconds.",connect_timeout);
 			break;
 		}
 

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -36,6 +36,7 @@ See the file COPYING for details.
 #include "itable.h"
 #include "random.h"
 #include "url_encode.h"
+#include "md5.h"
 
 #include <unistd.h>
 #include <dirent.h>
@@ -112,6 +113,9 @@ char *password = 0;
 
 // Allow worker to use symlinks when link() fails.  Enabled by default.
 static int symlinks_enabled = 1;
+
+// Worker id. A unique id for this worker instance.
+static char *worker_id;
 
 static int worker_mode = WORKER_MODE_WORKER;
 static const char *master_host = 0;
@@ -1539,6 +1543,8 @@ static int serve_master_by_hostport( const char *host, int port, const char *ver
 	workspace_prepare();
 	report_worker_ready(master);
 
+	send_master_message(master, "info worker-id %s\n", worker_id);
+
 	if(worker_mode == WORKER_MODE_FOREMAN) {
 		foreman_for_master(master);
 	} else {
@@ -1579,6 +1585,16 @@ static int serve_master_by_name( const char *catalog_host, int catalog_port, con
 	debug(D_WQ,"selected master with project=%s name=%s addr=%s port=%d",project,name,addr,port);
 
 	return serve_master_by_hostport(addr,port,project);
+}
+
+void set_worker_id() {
+	srand(time(NULL));
+
+	char *salt_and_pepper = string_format("%d%d%d", getpid(), getppid(), rand());
+	unsigned char digest[MD5_DIGEST_LENGTH];
+
+	md5_buffer(salt_and_pepper, strlen(salt_and_pepper), digest);
+	worker_id = string_format("worker-%s", md5_string(digest));
 }
 
 static void handle_abort(int sig)
@@ -1697,6 +1713,8 @@ int main(int argc, char *argv[])
         int catalog_port = CATALOG_PORT;
 
 	worker_start_time = time(0);
+
+	set_worker_id();
 
 	//obtain the architecture and os on which worker is running.
 	uname(&uname_data);

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1267,6 +1267,7 @@ static void work_for_master(struct link *master) {
 
 		if(time(0) > idle_stoptime) {
 			debug(D_NOTICE, "disconnecting from %s:%d because I did not receive any task in %d seconds (--idle-timeout).\n", master_addr,master_port,idle_timeout);
+			send_master_message(master, "info idle-disconnecting %lld\n", (long long) idle_timeout);
 			break;
 		}
 


### PR DESCRIPTION
Adds a unique worker id to easy work queue debugging on workers' reconnection.

Workers send an info message when disconnecting on idle.

Workers do not reconnect to a master that made them idle.