### PR TITLE
Change cvmfs symlink error to ENOENT.

### DIFF
--- a/parrot/src/pfs_service_cvmfs.cc
+++ b/parrot/src/pfs_service_cvmfs.cc
@@ -942,7 +942,7 @@ static bool path_expand_symlink(struct pfs_name *path, struct pfs_name *xpath)
 
 			if(sscanf(link_target, "/cvmfs/%[^/]%[^\n]", xpath->host, path_head) < 1)
 			{
-				errno = EXDEV;
+				errno = ENOENT;
 				return false;
 			}
 


### PR DESCRIPTION
As reported by Brian Bockelman. EXDEV is only valid for errors regarding
hard links.

