### PR TITLE
Allow the "target" fd to be special for fcntl dup.

### DIFF
--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -1996,9 +1996,7 @@ static void decode_syscall( struct pfs_process *p, int entering )
 			/* special case for fcntl dup */
 			if (args[1] == F_DUPFD || args[1] == F_DUP2FD || args[1] == F_DUPFD_CLOEXEC) {
 				if (entering) {
-					if (p->table->isspecial(args[2])) {
-						divert_to_dummy(p, -EIO); /* best errno we can give */
-					} else if (!p->table->isvalid(args[2])) {
+					if (!p->table->isvalid(args[2])) {
 						divert_to_dummy(p, -EBADF);
 					}
 				} else if (!p->syscall_dummy) {

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -1844,9 +1844,7 @@ static void decode_syscall( struct pfs_process *p, int entering )
 			/* special case for fcntl dup */
 			if (args[1] == F_DUPFD || args[1] == F_DUP2FD || args[1] == F_DUPFD_CLOEXEC) {
 				if (entering) {
-					if (p->table->isspecial(args[2])) {
-						divert_to_dummy(p, -EIO); /* best errno we can give */
-					} else if (!p->table->isvalid(args[2])) {
+					if (!p->table->isvalid(args[2])) {
 						divert_to_dummy(p, -EBADF);
 					}
 				} else if (!p->syscall_dummy) {


### PR DESCRIPTION
Jakob Blomer reported a failure by /bin/rm to remove a directory containing a
file. The issue was caused by a failed F_DUPFD on the directory fd. Because of
this, /bin/rm does not iterate over the directory and instead tries to directly
execute rmdir.

The reason for the failed F_DUPFD was an unnecessary check to see if the target
fd was a "special file descriptor" (e.g. the Parrot channel). The target fd would
be the third argument of:

fcntl(fd, F_DUPFD, start);

The "start" fd can be any valid fd as the kernel does not close start fd, it
just uses it as a starting point in the table. [Contrast this with dup2, where
the target fd *is closed* and we *do* need the check.]

Fixes #688.