### PR TITLE
Use 0 based offsets.

### DIFF
--- a/dttools/src/pattern.c
+++ b/dttools/src/pattern.c
@@ -51,7 +51,7 @@ ptrdiff_t pattern_vmatch (const char *str, const char *patt, va_list va)
 					luaL_error(ms.L, "unfinished capture");
 				else if (l == CAP_POSITION) {
 					size_t *capture = va_arg(va, size_t *);
-					*capture = ms.capture[i].init - ms.src_init + 1;
+					*capture = ms.capture[i].init - ms.src_init;
 				} else {
 					char **capture = va_arg(va, char **);
 					*capture = malloc(l+1);

--- a/dttools/src/pattern.h
+++ b/dttools/src/pattern.h
@@ -16,6 +16,8 @@
  * Captures are passed through C varargs. String captures are heap
  * allocated and must be freed.
  *
+ * Note: position captures are C offsets in the string (based 0).
+ *
  * @return offset in str where match occurred or -1 if no match.
  * @see http://www.lua.org/manual/5.2/manual.html#6.4.1
  */

--- a/dttools/test/TR_pattern.sh
+++ b/dttools/test/TR_pattern.sh
@@ -43,11 +43,11 @@ int main (int argc, char *argv[])
 	check(pattern_match("foo", "bar"), -1);
 	check(pattern_match("foo", "(foo)()", &cap1, &ncap), 0);
 	check(strcmp(cap1, "foo"), 0);
-	check(ncap, 4);
+	check(ncap, 3);
 	free(cap1);
 	check(pattern_match("foobar", "(foo)()b(.*)", &cap1, &ncap, &cap2), 0);
 	check(strcmp(cap1, "foo"), 0);
-	check(ncap, 4);
+	check(ncap, 3);
 	check(strcmp(cap2, "ar"), 0);
 	free(cap1);
 	free(cap2);

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -443,7 +443,7 @@ int pfs_table::resolve_name(int is_special_syscall, const char *cname, struct pf
 	path_collapse(full_logical_name,pname->logical_name,1);
 
 	if(pattern_match(full_logical_name, "^/proc/self/()", &n) >= 0) {
-		snprintf(pname->logical_name, sizeof(pname->logical_name), "/proc/%d/%s", pfs_process_getpid(), &full_logical_name[n-1]);
+		snprintf(pname->logical_name, sizeof(pname->logical_name), "/proc/%d/%s", pfs_process_getpid(), &full_logical_name[n]);
 		strcpy(pname->path, pname->logical_name);
 		pname->service = pfs_service_lookup_default();
 		strcpy(pname->service_name,"local");
@@ -453,7 +453,7 @@ int pfs_table::resolve_name(int is_special_syscall, const char *cname, struct pf
 		pname->is_local = 1;
 		return 1;
 	} else if (pattern_match(full_logical_name, "^/dev/fd/()", &n) >= 0) {
-		snprintf(pname->logical_name, sizeof(pname->logical_name), "/proc/%d/fd/%s", pfs_process_getpid(), &full_logical_name[n-1]);
+		snprintf(pname->logical_name, sizeof(pname->logical_name), "/proc/%d/fd/%s", pfs_process_getpid(), &full_logical_name[n]);
 		strcpy(pname->path, pname->logical_name);
 		pname->service = pfs_service_lookup_default();
 		strcpy(pname->service_name,"local");


### PR DESCRIPTION
This allows for more natural string indexing. Using Lua's 1 based indexing was
a regular source of bugs.