### PR TITLE
getdents64 places d_type before d_name.

### DIFF
--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -1659,10 +1659,13 @@ static void decode_syscall( struct pfs_process *p, int entering )
 						rc += buffer_putlstring(&B, (char *)&off64, sizeof(off64));
 					} else assert(0);
 					rc += buffer_putlstring(&B, (char *)&reclen, sizeof(reclen));
+					if (p->syscall == SYSCALL32_getdents64)
+						rc += buffer_putlstring(&B, (char *)&type, sizeof(type));
 					rc += buffer_putstring(&B, name);
 					rc += buffer_putliteral(&B, "\0"); /* NUL terminator for d_name */
 					rc += buffer_putlstring(&B, "\0\0\0\0\0\0\0\0", padding); /* uint64_t alignment padding */
-					rc += buffer_putlstring(&B, (char *)&type, sizeof(type));
+					if (p->syscall == SYSCALL32_getdents)
+						rc += buffer_putlstring(&B, (char *)&type, sizeof(type));
 					assert(rc == (int)reclen);
 					length -= rc;
 				}

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -1395,10 +1395,13 @@ static void decode_syscall( struct pfs_process *p, int entering )
 					rc += buffer_putlstring(&B, (char *)&ino, sizeof(ino));
 					rc += buffer_putlstring(&B, (char *)&off, sizeof(off));
 					rc += buffer_putlstring(&B, (char *)&reclen, sizeof(reclen));
+					if (p->syscall == SYSCALL64_getdents64)
+						rc += buffer_putlstring(&B, (char *)&type, sizeof(type));
 					rc += buffer_putstring(&B, name);
 					rc += buffer_putliteral(&B, "\0"); /* NUL terminator for d_name */
 					rc += buffer_putlstring(&B, "\0\0\0\0\0\0\0\0", padding); /* uint64_t alignment padding */
-					rc += buffer_putlstring(&B, (char *)&type, sizeof(type));
+					if (p->syscall == SYSCALL64_getdents)
+						rc += buffer_putlstring(&B, (char *)&type, sizeof(type));
 					assert(rc == (int)reclen);
 					length -= rc;
 				}


### PR DESCRIPTION
Addresses bug in lhcb test for #689. I believe the lhcb test is now working
properly.