### PR TITLE
Change the structure of the cctools binary dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,10 @@ $(INSTALL_PACKAGES): $(CCTOOLS_PACKAGES)
 install: $(INSTALL_PACKAGES)
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/bin
 	for file in $(CYGWINLIB) ; do if [ -f /bin/$$file ] ; then cp /bin/$$file $(CCTOOLS_INSTALL_DIR)/bin/ ; fi ; done
-	mkdir -p ${CCTOOLS_INSTALL_DIR}/etc
-	cp config.mk ${CCTOOLS_INSTALL_DIR}/etc/
-	mkdir -p ${CCTOOLS_INSTALL_DIR}/doc
-	cp COPYING ${CCTOOLS_INSTALL_DIR}/doc/
-	cp README ${CCTOOLS_INSTALL_DIR}/doc/
+	mkdir -p ${CCTOOLS_INSTALL_DIR}/share/doc/cctools
+	cp config.mk ${CCTOOLS_INSTALL_DIR}/share/doc/cctools/
+	cp COPYING ${CCTOOLS_INSTALL_DIR}/share/doc/cctools/
+	cp README ${CCTOOLS_INSTALL_DIR}/share/doc/cctools/
 
 test: $(CCTOOLS_PACKAGES)
 	./run_all_tests.sh

--- a/apps/wq_sort/Makefile
+++ b/apps/wq_sort/Makefile
@@ -19,4 +19,4 @@ test: all
 
 install: all
 	mkdir -p ${CCTOOLS_INSTALL_DIR}/bin
-	cp ${PROGRAMS} ${CCTOOLS_INSTALL_DIR}/bin
+	cp ${PROGRAMS} ${CCTOOLS_INSTALL_DIR}/bin/

--- a/chirp/src/Makefile
+++ b/chirp/src/Makefile
@@ -59,8 +59,8 @@ install: all install-bindings
 	if [ -f $(CCTOOLS_INSTALL_DIR)/bin/chirp_server ]; then mv $(CCTOOLS_INSTALL_DIR)/bin/chirp_server $(CCTOOLS_INSTALL_DIR)/bin/chirp_server.old; fi
 	chmod 755 $(SCRIPTS)
 	cp $(PROGRAMS) $(SCRIPTS) $(CCTOOLS_INSTALL_DIR)/bin/
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib
-	cp $(LIBRARIES) $(CCTOOLS_INSTALL_DIR)/lib/
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib/cctools
+	cp $(LIBRARIES) $(CCTOOLS_INSTALL_DIR)/lib/cctools/
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/include/cctools
 	cp $(PUBLIC_HEADERS) $(CCTOOLS_INSTALL_DIR)/include/cctools/
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -43,15 +43,15 @@ api/html/work_queue_task_perl.html:
 	gzip < $< > $@
 
 install: all
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc/man
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc/images
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/share/doc/cctools
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/share/doc/cctools/man
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/share/doc/cctools/images
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/share/man/man1
-	cp *.html manual.css $(CCTOOLS_INSTALL_DIR)/doc
-	if [ -f man/chirp.html ]; then cp man/*.html $(CCTOOLS_INSTALL_DIR)/doc/man; fi
-	if [ -f man/chirp.1.gz ]; then cp man/*.1.gz $(CCTOOLS_INSTALL_DIR)/share/man/man1; fi
-	if [ -d api ]; then cp -rp api $(CCTOOLS_INSTALL_DIR)/doc; fi
-	if [ -d images ]; then cp images/*.gif $(CCTOOLS_INSTALL_DIR)/doc/images; fi
+	cp *.html manual.css $(CCTOOLS_INSTALL_DIR)/share/doc/cctools/
+	if [ -f man/chirp.html ]; then cp man/*.html $(CCTOOLS_INSTALL_DIR)/share/doc/cctools/man/; fi
+	if [ -f man/chirp.1.gz ]; then cp man/*.1.gz $(CCTOOLS_INSTALL_DIR)/share/man/man1/; fi
+	if [ -d api ]; then cp -rp api $(CCTOOLS_INSTALL_DIR)/share/doc/cctools/; fi
+	if [ -d images ]; then cp images/*.gif $(CCTOOLS_INSTALL_DIR)/share/doc/cctools/images/; fi
 
 test:
 

--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -128,8 +128,8 @@ clean:
 install: all
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/bin
 	cp $(SCRIPTS) $(PROGRAMS) $(CCTOOLS_INSTALL_DIR)/bin/
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib
-	cp $(LIBRARIES) $(CCTOOLS_INSTALL_DIR)/lib/
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib/cctools
+	cp $(LIBRARIES) $(CCTOOLS_INSTALL_DIR)/lib/cctools/
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/include/cctools
 	cp $(HEADERS_PUBLIC) $(CCTOOLS_INSTALL_DIR)/include/cctools/
 

--- a/ftp_lite/src/Makefile
+++ b/ftp_lite/src/Makefile
@@ -20,8 +20,8 @@ clean:
 	rm -f $(OBJECTS) $(TARGETS)
 
 install: all
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib
-	cp $(LIBRARIES) $(CCTOOLS_INSTALL_DIR)/lib/
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib/cctools
+	cp $(LIBRARIES) $(CCTOOLS_INSTALL_DIR)/lib/cctools/
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/include/cctools
 	cp $(HEADERS_PUBLIC) $(CCTOOLS_INSTALL_DIR)/include/cctools/
 

--- a/parrot/src/Makefile
+++ b/parrot/src/Makefile
@@ -80,14 +80,14 @@ install: all
 	cp $(PROGRAMS) $(SCRIPTS) $(CCTOOLS_INSTALL_DIR)/bin/
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/include/cctools
 	cp $(HEADERS_PUBLIC) $(CCTOOLS_INSTALL_DIR)/include/cctools/
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib/cctools
 ifeq ($(CCTOOLS_BUILD_LIB64PARROT_HELPER),yes)
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib/lib64
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib/cctools/lib64
 endif
 ifeq ($(CCTOOLS_BUILD_LIB32PARROT_HELPER),yes)
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib/lib
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib/cctools/lib
 endif
-	for lib in $(LIBRARIES); do cp $$lib $(CCTOOLS_INSTALL_DIR)/lib/$$lib; done
+	for lib in $(LIBRARIES); do cp $$lib $(CCTOOLS_INSTALL_DIR)/lib/cctools/$$lib; done
 
 test: all
 

--- a/resource_monitor/src/Makefile
+++ b/resource_monitor/src/Makefile
@@ -58,9 +58,9 @@ install: all
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/bin
 	cp $(PROGRAMS) $(CCTOOLS_INSTALL_DIR)/bin/
 	cp $(SCRIPTS) $(CCTOOLS_INSTALL_DIR)/bin/
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib
-	cp $(LIBRARIES) $(CCTOOLS_INSTALL_DIR)/lib/
-	cp -r resource_monitor_visualizer_static $(CCTOOLS_INSTALL_DIR)/lib
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib/cctools
+	cp $(LIBRARIES) $(CCTOOLS_INSTALL_DIR)/lib/cctools/
+	cp -r resource_monitor_visualizer_static $(CCTOOLS_INSTALL_DIR)/lib/cctools/
 
 test: all
 

--- a/weaver/Makefile
+++ b/weaver/Makefile
@@ -25,8 +25,8 @@ $(INSTALL_TARGETS):
 	$(CCTOOLS_PYTHON) setup.py install_lib     -d $(PYTHON_INSTALL_DIR)
 
 install-examples: examples
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc/weaver_examples
-	cp examples/* $(CCTOOLS_INSTALL_DIR)/doc/weaver_examples
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/share/doc/cctools/weaver_examples
+	cp examples/* $(CCTOOLS_INSTALL_DIR)/share/doc/cctools/weaver_examples/
 
 install: $(INSTALL_TARGETS) install-examples
 

--- a/work_queue/src/Makefile
+++ b/work_queue/src/Makefile
@@ -62,10 +62,10 @@ install: all install-bindings
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/bin
 	chmod 755 $(SCRIPTS)
 	cp $(PROGRAMS) $(SCRIPTS) $(CCTOOLS_INSTALL_DIR)/bin/
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib
-	cp $(LIBRARIES) $(CCTOOLS_INSTALL_DIR)/lib/
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc
-	cp work_queue_example.c $(CCTOOLS_INSTALL_DIR)/doc/
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib/cctools
+	cp $(LIBRARIES) $(CCTOOLS_INSTALL_DIR)/lib/cctools/
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/share/doc/cctools
+	cp work_queue_example.c $(CCTOOLS_INSTALL_DIR)/share/doc/cctools/
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/include/cctools
 	cp $(PUBLIC_HEADERS) $(CCTOOLS_INSTALL_DIR)/include/cctools/
 

--- a/work_queue/src/perl/Makefile
+++ b/work_queue/src/perl/Makefile
@@ -33,6 +33,6 @@ install: all
 	mkdir -p              $(PERL_INSTALL_DIR)/Work_Queue
 	cp Work_Queue.pm      $(PERL_INSTALL_DIR)
 	cp Work_Queue/Task.pm $(PERL_INSTALL_DIR)/Work_Queue
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/share/doc/cctools
 	chmod 755 work_queue_example.pl
-	cp work_queue_example.pl $(CCTOOLS_INSTALL_DIR)/doc/
+	cp work_queue_example.pl $(CCTOOLS_INSTALL_DIR)/share/doc/cctools/

--- a/work_queue/src/python/Makefile
+++ b/work_queue/src/python/Makefile
@@ -36,5 +36,5 @@ install: all
 	mkdir -p $(PYTHON_INSTALL_DIR)
 	chmod 755 work_queue_example.py
 	cp work_queue.py $(WQPYTHONSO) $(PYTHON_INSTALL_DIR)/
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc
-	cp work_queue_example.py $(CCTOOLS_INSTALL_DIR)/doc/
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/share/doc/cctools
+	cp work_queue_example.py $(CCTOOLS_INSTALL_DIR)/share/doc/cctools/

--- a/work_queue/src/python3/Makefile
+++ b/work_queue/src/python3/Makefile
@@ -43,5 +43,5 @@ clean:
 install: all
 	mkdir -p $(PYTHON_INSTALL_DIR)
 	cp work_queue.py _work_queue.$(CCTOOLS_DYNAMIC_SUFFIX) $(PYTHON_INSTALL_DIR)/
-	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc
-	cp work_queue_example.py3 $(CCTOOLS_INSTALL_DIR)/doc/
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/share/doc/cctools
+	cp work_queue_example.py3 $(CCTOOLS_INSTALL_DIR)/share/doc/cctools/


### PR DESCRIPTION
The changes are:
mv cctools/doc to cctools/share/doc/cctools
mv config.mk to cctools/share/doc/cctools/config.mk
remove cctools/etc
mv cctools/lib/* to cctools/lib/cctools/* (except for cctools/lib/perl5 and cctools/lib/python*)