### PR TITLE
Fix Bug in Makeflow Wrapper

### DIFF
--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -147,13 +147,13 @@ static void makeflow_wrapper_add_command( const char *cmd )
 static void makeflow_wrapper_add_input_file( const char *file )
 {
  	if(!wrapper_input_files) wrapper_input_files = list_create();
-	list_push_tail(wrapper_input_files,dag_file_create(optarg));
+	list_push_tail(wrapper_input_files,dag_file_create(file));
 }
 
 static void makeflow_wrapper_add_output_file( const char *file )
 {
-	if(!wrapper_input_files) wrapper_input_files = list_create();
-	list_push_tail(wrapper_input_files,dag_file_create(optarg));
+	if(!wrapper_output_files) wrapper_output_files = list_create();
+	list_push_tail(wrapper_output_files,dag_file_create(file));
 }
 
 /*


### PR DESCRIPTION
Fixed my dumb copy-paste mistake:
- Use file argument instead of optarg.
- Replace input w/output as needed.