### PR TITLE
Master now checks if there is space to receive file.

### DIFF
--- a/dttools/src/disk_info.c
+++ b/dttools/src/disk_info.c
@@ -6,6 +6,8 @@ See the file COPYING for details.
 */
 
 #include "disk_info.h"
+#include "debug.h"
+#include "macros.h"
 
 #include <sys/types.h>
 #include <sys/param.h>
@@ -51,5 +53,28 @@ int disk_info_get(const char *path, UINT64_T * avail, UINT64_T * total)
 	return 0;
 #endif
 }
+
+int check_disk_space_for_filesize(char *path, INT64_T file_size, UINT64_T disk_avail_threshold) {
+    uint64_t disk_avail, disk_total;
+
+    if(disk_avail_threshold > 0) {
+        disk_info_get(path, &disk_avail, &disk_total);
+        if(file_size > 0) {
+            if((uint64_t)file_size > disk_avail || (disk_avail - file_size) < disk_avail_threshold) {
+                debug(D_WQ, "File of size %"PRId64" MB will lower available disk space (%"PRIu64" MB) below threshold (%"PRIu64" MB).\n", file_size/MEGA, disk_avail/MEGA, disk_avail_threshold/MEGA);
+                return 0;
+            }
+        } else {
+            if(disk_avail < disk_avail_threshold) {
+                debug(D_WQ, "Available disk space (%"PRIu64" MB) lower than threshold (%"PRIu64" MB).\n", disk_avail/MEGA, disk_avail_threshold/MEGA);
+                return 0;
+            }
+        }
+    }
+
+    return 1;
+}
+
+
 
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/disk_info.c
+++ b/dttools/src/disk_info.c
@@ -6,8 +6,11 @@ See the file COPYING for details.
 */
 
 #include "disk_info.h"
+#include "cwd_disk_info.h"
 #include "debug.h"
 #include "macros.h"
+
+#include <time.h>
 
 #include <sys/types.h>
 #include <sys/param.h>
@@ -54,6 +57,35 @@ int disk_info_get(const char *path, UINT64_T * avail, UINT64_T * total)
 #endif
 }
 
+/* Slower disk check, poor man's du on workspace */
+int check_disk_workspace(char *workspace, int64_t *workspace_usage, int force, int64_t manual_disk_option, int measure_wd_interval, time_t last_cwd_measure_time, int64_t last_workspace_usage, UINT64_T disk_avail_threshold) {
+
+    if(manual_disk_option < 1)
+        return 1;
+
+    if( force || (time(0) - last_cwd_measure_time) >= measure_wd_interval ) {
+        cwd_disk_info_get(workspace, &last_workspace_usage);
+        debug(D_DEBUG, "worker disk usage: %" PRId64 "\n", last_workspace_usage);
+        last_cwd_measure_time = time(0);
+    }
+
+    if(workspace_usage) {
+        *workspace_usage = last_workspace_usage;
+    }
+
+	// Use threshold only if smaller than specified disk size.
+    int64_t disk_limit = manual_disk_option - disk_avail_threshold;
+    if(disk_limit < 0)
+        disk_limit = manual_disk_option;
+
+    if(last_workspace_usage > disk_limit) {
+        debug(D_DEBUG, "worker disk usage %"PRId64 " larger than: %" PRId64 "!\n", last_workspace_usage + disk_avail_threshold, manual_disk_option);
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
 int check_disk_space_for_filesize(char *path, INT64_T file_size, UINT64_T disk_avail_threshold) {
     uint64_t disk_avail, disk_total;
 
@@ -61,12 +93,12 @@ int check_disk_space_for_filesize(char *path, INT64_T file_size, UINT64_T disk_a
         disk_info_get(path, &disk_avail, &disk_total);
         if(file_size > 0) {
             if((uint64_t)file_size > disk_avail || (disk_avail - file_size) < disk_avail_threshold) {
-                debug(D_WQ, "File of size %"PRId64" MB will lower available disk space (%"PRIu64" MB) below threshold (%"PRIu64" MB).\n", file_size/MEGA, disk_avail/MEGA, disk_avail_threshold/MEGA);
+                debug(D_DEBUG, "File of size %"PRId64" MB will lower available disk space (%"PRIu64" MB) below threshold (%"PRIu64" MB).\n", file_size/MEGA, disk_avail/MEGA, disk_avail_threshold/MEGA);
                 return 0;
             }
         } else {
             if(disk_avail < disk_avail_threshold) {
-                debug(D_WQ, "Available disk space (%"PRIu64" MB) lower than threshold (%"PRIu64" MB).\n", disk_avail/MEGA, disk_avail_threshold/MEGA);
+                debug(D_DEBUG, "Available disk space (%"PRIu64" MB) lower than threshold (%"PRIu64" MB).\n", disk_avail/MEGA, disk_avail_threshold/MEGA);
                 return 0;
             }
         }

--- a/dttools/src/disk_info.h
+++ b/dttools/src/disk_info.h
@@ -9,6 +9,7 @@ See the file COPYING for details.
 #define DISK_INFO_H
 
 #include "int_sizes.h"
+#include <time.h>
 
 /** @file disk_info.h
 Query disk space properties.
@@ -21,6 +22,19 @@ Query disk space properties.
 @return Greater than or equal to zero on success, less than zero otherwise.
 */
 int disk_info_get(const char *path, UINT64_T * avail, UINT64_T * total);
+
+/** Return whether a file will fit in the given directory.
+@param workspace_usage A pointer to an integer that will be filled with the workspace usage.
+@param force An integer that describes if the action is to be forced.
+@param manual_disk_option An integer that describes static manual_disk_option in worker.
+@param measure_wq_interval An integer that describes how often the cwd should be rechecked.
+@param last_cwd_measure_time An time value that describes how recently cwd was checked.
+@param last_workspace_usage An integer that describes previous reading from check_disk_workspace.
+@param disk_avail_threshold An unsigned integer that describes the lowest amount of free space to be left.
+@return Zero if the file will not fit, one if the file fits.
+*/
+int check_disk_workspace(char *workspace, int64_t *workspace_usage, int force, int64_t manual_disk_option, int measure_wd_interval, time_t last_cwd_measure_time, int64_t last_workspace_usage, UINT64_T disk_avail_threshold);
+
 
 /** Return whether a file will fit in the given directory.
 @param path A filename of the disk to be measured.

--- a/dttools/src/disk_info.h
+++ b/dttools/src/disk_info.h
@@ -22,4 +22,12 @@ Query disk space properties.
 */
 int disk_info_get(const char *path, UINT64_T * avail, UINT64_T * total);
 
+/** Return whether a file will fit in the given directory.
+@param path A filename of the disk to be measured.
+@param file_size An integer that describes how large the incoming file is.
+@param disk_avail_threshold An unsigned integer that describes the minimum available space to leave.
+@return Zero if the file will not fit, one if the file fits.
+*/
+int check_disk_space_for_filesize(char *path, INT64_T file_size, UINT64_T disk_avail_threshold);
+
 #endif

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -811,7 +811,7 @@ static int get_file( struct work_queue *q, struct work_queue_worker *w, struct w
 	// Check if there is space for incoming file at master
 	if(!check_disk_space_for_filesize(length)) {
         debug(D_WQ, "Could not recieve file %s, not enough disk space (%"PRId64" bytes needed)\n", local_name, length);
-        return WORKER_FAILURE;
+        return APP_FAILURE;
     }
 
 	int fd = open(local_name, O_WRONLY | O_TRUNC | O_CREAT, 0700);

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -41,6 +41,8 @@ The following major problems must be fixed:
 #include "md5.h"
 #include "url_encode.h"
 
+#include "disk_info.h"
+
 #include <unistd.h>
 #include <dirent.h>
 #include <fcntl.h>
@@ -81,6 +83,11 @@ extern int setenv(const char *name, const char *value, int overwrite);
 #define RESOURCE_MONITOR_TASK_SUMMARY_NAME "cctools-work-queue-%d-resource-monitor-task-%d"
 
 #define MAX_TASK_STDOUT_STORAGE (1*GIGABYTE)
+
+
+// Threshold for available disk space (MB) beyond which files are not received from worker.
+static uint64_t disk_avail_threshold = 100;
+ 
 
 /* Default: When there is a choice, send a task rather than receive 1 out of 2 times.
  * Classical WQ:   1.0 (always prefer to send)
@@ -751,6 +758,28 @@ static void add_worker(struct work_queue *q)
 	return;
 }
 
+/* faster disk check, overall with statfs */
+static int check_disk_space_for_filesize(int64_t file_size) {
+    uint64_t disk_avail, disk_total;
+
+    if(disk_avail_threshold > 0) {
+        disk_info_get(".", &disk_avail, &disk_total);
+        if(file_size > 0) {
+            if((uint64_t)file_size > disk_avail || (disk_avail - file_size) < disk_avail_threshold) {
+                debug(D_WQ, "Incoming file of size %"PRId64" MB will lower available disk space (%"PRIu64" MB) below threshold (%"PRIu64" MB).\n", file_size/MEGA, disk_avail/MEGA, disk_avail_threshold/MEGA);
+                return 0;
+            }
+        } else {
+            if(disk_avail < disk_avail_threshold) {
+                debug(D_WQ, "Available disk space (%"PRIu64" MB) lower than threshold (%"PRIu64" MB).\n", disk_avail/MEGA, disk_avail_threshold/MEGA);
+                return 0;
+            }
+        }
+    }
+
+    return 1;
+}
+
 /*
 Get a single file from a remote worker.
 Returns 1 on success, 0 on failure to receive, -1 on failure to access.
@@ -779,6 +808,12 @@ static int get_file( struct work_queue *q, struct work_queue_worker *w, struct w
 
 	// Create the local file.
 	debug(D_WQ, "Receiving file %s (size: %"PRId64" bytes) from %s (%s) ...", local_name, length, w->addrport, w->hostname);
+	// Check if there is space for incoming file at master
+	if(!check_disk_space_for_filesize(length)) {
+        debug(D_WQ, "Could not recieve file %s, not enough disk space (%"PRId64" bytes needed)\n", local_name, length);
+        return WORKER_FAILURE;
+    }
+
 	int fd = open(local_name, O_WRONLY | O_TRUNC | O_CREAT, 0700);
 	if(fd < 0) {
 		debug(D_NOTICE, "Cannot open file %s for writing: %s", local_name, strerror(errno));

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -634,29 +634,6 @@ static int check_disk_workspace(int64_t *workspace_usage, int force) {
 	}
 }
 
-
-/* faster disk check, overall with statfs */
-static int check_disk_space_for_filesize(int64_t file_size) {
-	uint64_t disk_avail, disk_total;
-
-	if(disk_avail_threshold > 0) {
-		disk_info_get(".", &disk_avail, &disk_total);
-		if(file_size > 0) {
-			if((uint64_t)file_size > disk_avail || (disk_avail - file_size) < disk_avail_threshold) {
-				debug(D_WQ, "Incoming file of size %"PRId64" MB will lower available disk space (%"PRIu64" MB) below threshold (%"PRIu64" MB).\n", file_size/MEGA, disk_avail/MEGA, disk_avail_threshold/MEGA);
-				return 0;
-			}
-		} else {
-			if(disk_avail < disk_avail_threshold) {
-				debug(D_WQ, "Available disk space (%"PRIu64" MB) lower than threshold (%"PRIu64" MB).\n", disk_avail/MEGA, disk_avail_threshold/MEGA);
-				return 0;
-			}
-		}
-    }
-
-	return 1;
-}
-
 /**
  * Stream file/directory contents for the rget protocol.
  * Format:
@@ -914,7 +891,7 @@ static int do_put( struct link *master, char *filename, int64_t length, int mode
 	char *cur_pos;
 
 	debug(D_WQ, "Putting file %s into workspace\n", filename);
-	if(!check_disk_space_for_filesize(length)) {
+	if(!check_disk_space_for_filesize(".", length, disk_avail_threshold)) {
 		debug(D_WQ, "Could not put file %s, not enough disk space (%"PRId64" bytes needed)\n", filename, length);
 		return 0;
 	}
@@ -1384,7 +1361,7 @@ static void work_for_master(struct link *master) {
 			}
 		}
 
-		ok &= check_disk_space_for_filesize(0);
+		ok &= check_disk_space_for_filesize(".", 0, disk_avail_threshold);
 
 		int64_t disk_usage;
 		if(!check_disk_workspace(&disk_usage, 0)) {
@@ -2150,7 +2127,7 @@ int main(int argc, char *argv[])
 
 	watcher = work_queue_watcher_create();
 
-	if(!check_disk_space_for_filesize(0)) {
+	if(!check_disk_space_for_filesize(".", 0, disk_avail_threshold)) {
 		fprintf(stderr,"work_queue_worker: %s has less than minimum disk space %"PRIu64" MB\n",workspace,disk_avail_threshold);
 		return 1;
 	}

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -154,6 +154,9 @@ static int64_t manual_disk_option = 0;
 static int64_t manual_memory_option = 0;
 static int64_t manual_gpus_option = 0;
 
+static time_t  last_cwd_measure_time = 0;
+static int64_t last_workspace_usage  = 0;
+
 static int64_t cores_allocated = 0;
 static int64_t memory_allocated = 0;
 static int64_t disk_allocated = 0;
@@ -601,37 +604,6 @@ static int handle_tasks(struct link *master)
 
 	}
 	return 1;
-}
-
-/* slower disk check, poor man's du on workspace */
-static int check_disk_workspace(int64_t *workspace_usage, int force) {
-	static time_t  last_cwd_measure_time = 0;
-	static int64_t last_workspace_usage  = 0;
-
-	if(manual_disk_option < 1)
-		return 1;
-
-	if( force || (time(0) - last_cwd_measure_time) >= measure_wd_interval ) {
-		cwd_disk_info_get(workspace, &last_workspace_usage);
-		debug(D_WQ, "worker disk usage: %" PRId64 "\n", last_workspace_usage);
-		last_cwd_measure_time = time(0);
-	}
-
-	if(workspace_usage) {
-		*workspace_usage = last_workspace_usage;
-	}
-
-	// Use thershold only if smaller than specified disk size.
-	int64_t disk_limit = manual_disk_option - disk_avail_threshold; 
-	if(disk_limit < 0)
-		disk_limit = manual_disk_option;
-
-	if(last_workspace_usage > disk_limit) {
-		debug(D_WQ, "worker disk usage %"PRId64 " larger than: %" PRId64 "!\n", last_workspace_usage + disk_avail_threshold, manual_disk_option);
-		return 0;
-	} else {
-		return 1;
-	}
 }
 
 /**
@@ -1364,7 +1336,7 @@ static void work_for_master(struct link *master) {
 		ok &= check_disk_space_for_filesize(".", 0, disk_avail_threshold);
 
 		int64_t disk_usage;
-		if(!check_disk_workspace(&disk_usage, 0)) {
+		if(!check_disk_workspace(workspace, &disk_usage, 0, manual_disk_option, measure_wd_interval, last_cwd_measure_time, last_workspace_usage, disk_avail_threshold)) {
 			fprintf(stderr,"work_queue_worker: %s has less than the promised disk space %"PRIu64" < %"PRIu64" MB\n",workspace, manual_cores_option, disk_usage);
 			send_master_message(master, "info disk_space_exhausted %lld\n", (long long) disk_usage);
 			ok = 0;
@@ -1601,7 +1573,7 @@ static int serve_master_by_hostport( const char *host, int port, const char *ver
 
 	workspace_prepare();
 
-	check_disk_workspace(NULL, 1);
+	check_disk_workspace(workspace, NULL, 1, manual_disk_option, measure_wd_interval, last_cwd_measure_time, last_workspace_usage, disk_avail_threshold);
 	report_worker_ready(master);
 
 	send_master_message(master, "info worker-id %s\n", worker_id);


### PR DESCRIPTION
This functionality existed in the fact that if a file was to big it would transfer until it failed and then realize that the lengths were not the same. It would report that the files were different length and not the cause of the issue. This preemptively checks and fails if won't fit.