### PR TITLE
Add `make rpm` into Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ include rules.mk
 
 CYGWINLIB = cygwin1.dll cyggcc_s-1.dll cygintl-8.dll cygreadline7.dll cygncursesw-10.dll cygiconv-2.dll cygattr-1.dll sh.exe
 
+#set the default values for RPM_VERSION and RPM_RELEASE
+RPM_VERSION=4.4.1
+RPM_RELEASE=1
+
 all: $(CCTOOLS_PACKAGES)
 
 config.mk:
@@ -41,4 +45,8 @@ install: $(INSTALL_PACKAGES)
 test: $(CCTOOLS_PACKAGES)
 	./run_all_tests.sh
 
-.PHONY: $(CCTOOLS_PACKAGES) $(INSTALL_PACKAGES) $(CLEAN_PACKAGES) all clean install test
+rpm:
+	./packaging/rpm/rpm_creator.sh $(RPM_VERSION) $(RPM_RELEASE)
+
+.PHONY: $(CCTOOLS_PACKAGES) $(INSTALL_PACKAGES) $(CLEAN_PACKAGES) all clean install test rpm
+	

--- a/packaging/rpm/README
+++ b/packaging/rpm/README
@@ -1,0 +1,66 @@
+To create RPMs for cctools, go to the source code directory of cctools, and run:
+make rpm RPM_VERSION=<rpm_version> RPM_RELEASE=<rpm_release>
+
+The full feature of ndcctools depends on 9 packages: fuse, python, globus, swig, libuuid, readline, zlib, perl, and cvmfs.
+To create RPMs for ndcctools with all package support mentioned above, there are two options.
+Option 1: Use `./configure.afs` inside the `%build` section and create RPMs on a machine which supports the access of /afs/crc.nd.edu/group/ccl/software/cctools-dependencies.
+This option is currently supported by the `make rpm` rule of cctools.
+
+Option 2: Specify each package dependency as a `BuildRequires` attribute, and create RPMs on a machine with all these dependencies installed or you have root access to install these dependencies.
+This option is currently not supported by the `make rpm` rule of cctools.
+`BuildRequires` attributes are needed to specify the relative package dependencies, and more options (like --with-python-path, --with-cvmfs-path) should be added into the `./configure` command inside the `%build` section. (Note: here we use `./configure` instead of `./configure.afs`)
+#BuildRequires:  fuse-devel
+#BuildRequires:  python-devel
+#BuildRequires:  globus-connect-server
+#BuildRequires:  swig
+#BuildRequires:  libuuid-devel
+#BuildRequires:  readline-devel
+#BuildRequires:  zlib-devel
+#BuildRequires:  perl
+#BuildRequires:  cvmfs-devel
+
+#BuildRequires:  openssl-devel
+
+#%build
+#./configure --prefix /usr \
+#    --with-python-path /usr \
+#    --with-swig-path /usr \
+#    --with-readline-path /usr \
+#    --with-zlib-path /usr \
+#    --with-perl-path /usr \
+#    --with-cvmfs-path /usr \
+#    --with-fuse-path / \
+#    --with-uuid-path / 
+#make %{?_smp_mflags}
+
+#the globus dependency is too complex and ignored for now. When the globus dependency is ready, just add `--with-globus-path / \` into the `./configure` command.
+
+Here is the instructions how to create ndcctools RPMs separately from the `make rpm` rule of cctools:
+#install RPM development tools. This is the only operation which needs the root access.
+yum install rpmdevtools
+
+#set up an RPM build directory in your ~/rpmbuild directory. This command can be executed multiple times without scratching your current ~/rpmbuild directory.
+rpmdev-setuptree
+
+#put the source code compressed tarball of cctools into the ~/rpmbuild/SOURCES dirctory:
+
+#create a template .spec file for ndcctools under ~/rpmbuild/SPECS:
+cd ~/rpmbuild/SPECS
+rpmdev-newspec ndcctools #alternatively, you can also directly create and edit the .spec file.
+
+#edit ~/rpmbuild/SPECS/ndcctools.spec
+
+#build source and binary RPMs from ndcctools.spec:
+rpmbuild -ba ndcctools.spec
+
+#You can also just build source RPMs from ndcctools.spec:
+rpmbuild -bs ndcctools.spec
+
+#You can also just build binary RPMs from ndcctools.spec:
+rpmbuild -bb ndcctools.spec
+
+#check for errors of the SPEC files, RPMs and SRPMs using rpmlint:
+rpmlint -i ndcctools.spec ../SRPMS/ndcctools* ../RPMS/*/ndcctools*
+
+To change the name of RPMs for cctools, rename ndcctools.spec to <new_name>.spec, and change the `Name` attribute in the .spec file into <new_name>. In fact, you can just change the `Name` attribute in the .spec file into <new_name>, and leave the name of .spec file unchanged. However, it would look inconsistent.
+

--- a/packaging/rpm/README
+++ b/packaging/rpm/README
@@ -1,39 +1,21 @@
 To create RPMs for cctools, go to the source code directory of cctools, and run:
 make rpm RPM_VERSION=<rpm_version> RPM_RELEASE=<rpm_release>
 
-The full feature of ndcctools depends on 9 packages: fuse, python, globus, swig, libuuid, readline, zlib, perl, and cvmfs.
-To create RPMs for ndcctools with all package support mentioned above, there are two options.
-Option 1: Use `./configure.afs` inside the `%build` section and create RPMs on a machine which supports the access of /afs/crc.nd.edu/group/ccl/software/cctools-dependencies.
-This option is currently supported by the `make rpm` rule of cctools.
+`rpmbuild` requires the following package: rpmdevtools.
 
-Option 2: Specify each package dependency as a `BuildRequires` attribute, and create RPMs on a machine with all these dependencies installed or you have root access to install these dependencies.
-This option is currently not supported by the `make rpm` rule of cctools.
-`BuildRequires` attributes are needed to specify the relative package dependencies, and more options (like --with-python-path, --with-cvmfs-path) should be added into the `./configure` command inside the `%build` section. (Note: here we use `./configure` instead of `./configure.afs`)
-#BuildRequires:  fuse-devel
-#BuildRequires:  python-devel
-#BuildRequires:  globus-connect-server
-#BuildRequires:  swig
-#BuildRequires:  libuuid-devel
-#BuildRequires:  readline-devel
-#BuildRequires:  zlib-devel
-#BuildRequires:  perl
-#BuildRequires:  cvmfs-devel
+The full feature of ndcctools depends on the following packages: fuse-devel, python-devel, swig, libuuid-devel, readline-devel, zlib-devel, perl, perl-ExtUtils-Embed, cvmfs-devel, openssl-devel, gcc, gcc-c++, make, m4, tar, wget, which, grep, freetype.
 
-#BuildRequires:  openssl-devel
+To install cvmfs-devel, first add cernvm.repo into /etc/yum.repo.d by running the following command:
+	rpm -Uvh http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/6/`uname -i`/cvmfs-release-2-4.el6.noarch.rpm
 
-#%build
-#./configure --prefix /usr \
-#    --with-python-path /usr \
-#    --with-swig-path /usr \
-#    --with-readline-path /usr \
-#    --with-zlib-path /usr \
-#    --with-perl-path /usr \
-#    --with-cvmfs-path /usr \
-#    --with-fuse-path / \
-#    --with-uuid-path / 
-#make %{?_smp_mflags}
+`make rpm RPM_VERSION=<rpm_version> RPM_RELEASE=<rpm_release>` tries to check every dependency and warn you if any of them is missing. 
 
-#the globus dependency is too complex and ignored for now. When the globus dependency is ready, just add `--with-globus-path / \` into the `./configure` command.
+To make a rpm for ndccools, the machine you are working should satisfy one of the following requirements:
+1) With all the dependencies mentioned above installed.
+2) You have root access, which can be a virtual machine or a Docker image.
+The virtual machine used for our test is from the Amazon EC2: AMI ID: RHEL-6.6_HVM_GA-20150128-x86_64-1-Hourly2-GP2 (ami-0b5f073b)
+The Docker image used for our test can be obtained by the following command: docker pull centos:6
+
 
 Here is the instructions how to create ndcctools RPMs separately from the `make rpm` rule of cctools:
 #install RPM development tools. This is the only operation which needs the root access.

--- a/packaging/rpm/ndcctools_template.spec
+++ b/packaging/rpm/ndcctools_template.spec
@@ -1,0 +1,94 @@
+Summary:        Cooperative Computing Tools
+Group:          Applications/System
+License:        GPLv2
+URL:            http://ccl.cse.nd.edu/software/
+Source0:        http://ccl.cse.nd.edu/software/files/cctools-%{version}-source.tar.gz
+BuildRoot:       %{_topdir}/BUILDROOT/
+
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  make
+BuildRequires:  m4
+
+#cctools package dependencies
+#BuildRequires:  fuse-devel
+#BuildRequires:  python-devel
+#BuildRequires:  globus-connect-server
+#BuildRequires:  swig
+#BuildRequires:  libuuid-devel
+#BuildRequires:  readline-devel
+#BuildRequires:  zlib-devel
+#BuildRequires:  perl
+#BuildRequires:  cvmfs-devel
+
+#required by cvmfs-devel
+#BuildRequires:  openssl-devel
+
+Requires(post): info
+Requires(preun): info
+
+%description
+The Cooperative Computing Tools (%{name}) contains Parrot, 
+Chirp, Makeflow, Work Queue, SAND, and other software.
+
+%package devel
+Summary: CCTools package development libraries
+Group: Applications/System
+
+%description devel
+The CCTools package static libraries and header files
+
+%prep
+%setup -n cctools-%{version}-source -q
+
+%build
+./configure.afs --prefix /usr 
+make %{?_smp_mflags}
+
+#%build
+#./configure --prefix /usr \
+#    --with-python-path /usr \
+#    --with-swig-path /usr \
+#    --with-readline-path /usr \
+#    --with-zlib-path /usr \
+#    --with-perl-path /usr \
+#    --with-cvmfs-path /usr \
+#    --with-fuse-path / \
+#    --with-uuid-path / 
+#make %{?_smp_mflags}
+
+#the globus dependency is too complex and ignored for now. When the globus dependency is ready, just add `--with-globus-path / \` into the `./configure` command.
+
+%install
+rm -rf $RPM_BUILD_ROOT
+make CCTOOLS_INSTALL_DIR=%{buildroot}/usr install
+rm -rf %{buildroot}/usr/etc
+mkdir -p %{buildroot}%{_defaultdocdir}/cctools
+mv %{buildroot}/usr/doc/* %{buildroot}%{_defaultdocdir}/cctools
+rm -rf %{buildroot}/usr/doc
+%ifarch x86_64
+mv %{buildroot}/usr/lib %{buildroot}%{_libdir}
+%endif
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files 
+%defattr(-,root,root,-)
+%doc %{_defaultdocdir}/cctools/*
+#%{_bindir}/*
+%{_mandir}/man1/*
+%attr(0755,root,root) %{_bindir}/*
+
+%files devel
+%defattr(-,root,root,-)
+%doc %{_defaultdocdir}/cctools/COPYING
+%{_includedir}/cctools/*
+%{_libdir}/*.a
+%{_libdir}/*.so
+%{_libdir}/lib64/*.so
+%{_libdir}/python*
+%{_libdir}/perl*
+%{_libdir}/resource_monitor_visualizer_static*
+%attr(0755,root,root) %{_libdir}/*.so
+%attr(0755,root,root) %{_libdir}/lib64/*.so

--- a/packaging/rpm/ndcctools_template.spec
+++ b/packaging/rpm/ndcctools_template.spec
@@ -11,18 +11,24 @@ BuildRequires:  make
 BuildRequires:  m4
 
 #cctools package dependencies
-#BuildRequires:  fuse-devel
-#BuildRequires:  python-devel
+BuildRequires:  fuse-devel
+BuildRequires:  python-devel
+BuildRequires:  swig
+BuildRequires:  libuuid-devel
+BuildRequires:  readline-devel
+BuildRequires:  zlib-devel
+BuildRequires:  perl
+BuildRequires:  perl-ExtUtils-Embed
+BuildRequires:  cvmfs-devel
+
+#the dependencies of globus-connect-server are complex, and ignored for now.
 #BuildRequires:  globus-connect-server
-#BuildRequires:  swig
-#BuildRequires:  libuuid-devel
-#BuildRequires:  readline-devel
-#BuildRequires:  zlib-devel
-#BuildRequires:  perl
-#BuildRequires:  cvmfs-devel
 
 #required by cvmfs-devel
-#BuildRequires:  openssl-devel
+BuildRequires:  openssl-devel
+
+#required by cvmfs applications
+BuildRequires:  freetype
 
 Requires(post): info
 Requires(preun): info
@@ -42,20 +48,16 @@ The CCTools package static libraries and header files
 %setup -n cctools-%{version}-source -q
 
 %build
-./configure.afs --prefix /usr 
+./configure --prefix /usr \
+    --with-python-path /usr \
+    --with-swig-path /usr \
+    --with-readline-path /usr \
+    --with-zlib-path /usr \
+    --with-perl-path /usr \
+    --with-cvmfs-path /usr \
+    --with-fuse-path /usr \
+    --with-uuid-path /usr
 make %{?_smp_mflags}
-
-#%build
-#./configure --prefix /usr \
-#    --with-python-path /usr \
-#    --with-swig-path /usr \
-#    --with-readline-path /usr \
-#    --with-zlib-path /usr \
-#    --with-perl-path /usr \
-#    --with-cvmfs-path /usr \
-#    --with-fuse-path / \
-#    --with-uuid-path / 
-#make %{?_smp_mflags}
 
 #the globus dependency is too complex and ignored for now. When the globus dependency is ready, just add `--with-globus-path / \` into the `./configure` command.
 
@@ -77,7 +79,7 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root,-)
 %doc %{_defaultdocdir}/cctools/*
 #%{_bindir}/*
-%{_mandir}/man1/*
+%{_datadir}/*
 %attr(0755,root,root) %{_bindir}/*
 
 %files devel

--- a/packaging/rpm/rpm_creator.sh
+++ b/packaging/rpm/rpm_creator.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+#Parrot inside the old cctools versions like 4.4.1 and 4.4.2 are buggy.
 rpm_version="${1}"
 rpm_release="${2}"
 
@@ -9,18 +10,22 @@ if [ -z "${rpm_version}" -o -z "${rpm_release}" ]; then
 	exit 1
 fi
 
-echo "${rpm_version}"
-echo "${rpm_release}"
+type which>/dev/null 2>&1
+if [ "$?" -ne 0 ]; then
+	echo "Please guarantee which is installed on your system!"
+	echo "To install which, please run: yum install which"
+	exit 1
+fi
 
 #check whether rpmdev-setuptree and rpmbuild are available
-if [ -z $(which rpmbuild) -o -z $(which rpmdev-setuptree) ]; then
+if [ -z "$(which rpmbuild)" -o -z "$(which rpmdev-setuptree)" ]; then
 	echo "Please guarantee rpmdevtools is installed on your system, rpmbuild and rpmdev-setuptree are needed to create RPMs!"
 	echo "To install rpmdevtools, please run: yum install rpmdevtools"
 	exit 1	
 fi
 
 #preserve the path of the current working directory
-make_dir=$(pwd)
+make_dir="$(pwd)"
 
 #set up an RPM build directory in your ~/rpmbuild directory. This command can be executed multiple times without scratching your current ~/rpmbuild directory.
 cd ~
@@ -34,6 +39,12 @@ fi
 cd ~/rpmbuild/SOURCES
 if [ ! -e cctools-"${rpm_version}"-source.tar.gz ]; then
 	source=http://ccl.cse.nd.edu/software/files/cctools-"${rpm_version}"-source.tar.gz
+	#first check whether wget is available.
+	if [ -z "$(which wget)" ]; then
+		echo "Please guarantee wget is installed on your system!"
+		echo "To install wget, please run: yum install wget"
+		exit 1
+	fi
 	wget "${source}"
 	if [ "$?" -ne 0 ]; then
 		echo "Failed to download cctools source code tarball from ${source}"
@@ -45,14 +56,13 @@ cd -
 
 #create a template .spec file for ndcctools. 
 #Even if the .spec files are recommended to be put under ~/rpmbuild/SPECS, in fact you can put it in other places, just be consistent the location of the .spec file with the rpmbuild command.
-echo "${make_dir}"
 cd "${make_dir}"/packaging/rpm
-temp_file=$(mktemp -p .)
+temp_file="$(mktemp -p .)"
 if [ "$?" -ne 0 ]; then
 	echo "Fails to create a tmp spec file under ${make_dir}/packaging/rpm directory!"
 	exit 1
 else
-	echo "Create a tmp spec file:  $(pwd)/${temp_file}"
+	echo "Create a tmp spec file:  "$(pwd)"/${temp_file}"
 fi
 
 #set the attributes at the beginning of the spec file
@@ -66,9 +76,138 @@ cat ndcctools_template.spec>>"${temp_file}"
 #set the attributes at the end of the spec file
 echo "%changelog">>"${temp_file}"
 #the name and email addr here should be modified to be more ccl-style.
-date_str=$(date +"%a %b %d %Y")
+date_str="$(date +"%a %b %d %Y")"
 echo "* ${date_str} Haiyan Meng <hmeng@nd.edu> - ${rpm_version}-${rpm_release}">>"${temp_file}"
 echo "- Initial version of the package">>"${temp_file}"
+
+#check whether tar is available
+if [ -z "$(which tar)" ]; then
+	echo "Please guarantee tar is installed on your system!"
+	echo "To install tar, please run: yum install tar"
+	exit 1
+fi
+
+#check whether gcc is available
+if [ -z "$(which gcc)" ]; then
+	echo "Please guarantee gcc is installed on your system!"
+	echo "To install gcc, please run: yum install gcc"
+	exit 1
+fi
+
+#check whether gcc-c++ is available
+if [ -z "$(rpm -qa gcc-c++)" ]; then
+	echo "Please guarantee gcc-c++ is installed on your system!"
+	echo "To install gcc-c++, please run: yum install gcc-c++"
+	exit 1
+fi
+
+#check whether make is available
+if [ -z "$(which make)" ]; then
+	echo "Please guarantee make is installed on your system!"
+	echo "To install make, please run: yum install make"
+	exit 1
+fi
+
+#check whether m4 is available
+if [ -z "$(which m4)" ]; then
+	echo "Please guarantee m4 is installed on your system!"
+	echo "To install m4, please run: yum install m4"
+	exit 1
+fi
+
+#check whether fuse-devel is available
+if [ -z "$(rpm -qa fuse-devel)" ]; then
+	echo "Please guarantee fuse-devel is installed on your system!"
+	echo "To install fuse-devel, please run: yum install fuse-devel"
+	exit 1
+fi
+
+#check whether grep is available
+if [ -z "$(which grep)" ]; then
+	echo "Please guarantee grep is installed on your system!"
+	echo "To install grep, please run: yum install grep"
+	exit 1
+fi
+
+libfuse_path="$(rpm -ql fuse-devel | grep libfuse.so)" 
+libfuse_dir="$(printf "%s" "$libfuse_path" | tail -c +0 | head -c 4)"
+echo ${libfuse_dir}
+if [ "${libfuse_dir}" != "/usr" -a ! -e "/usr${libfuse_path}" ]; then
+	echo "Please put a copy of ${libfuse_path} into /usr${libfuse_path}"
+	exit 1
+fi
+
+#check whether python-devel is available
+if [ -z "$(rpm -qa python-devel)" ]; then
+	echo "Please guarantee python-devel is installed on your system!"
+	echo "To install python-devel, please run: yum install python-devel"
+	exit 1
+fi
+
+#check whether swig is available
+if [ -z "$(rpm -qa swig)" ]; then
+	echo "Please guarantee swig is installed on your system!"
+	echo "To install swig, please run: yum install swig"
+	exit 1
+fi
+
+#check whether libuuid-devel is available
+if [ -z "$(rpm -qa libuuid-devel)" ]; then
+	echo "Please guarantee libuuid-devel is installed on your system!"
+	echo "To install libuuid-devel, please run: yum install libuuid-devel"
+	exit 1
+fi
+
+#check whether readline-devel is available
+if [ -z "$(rpm -qa readline-devel)" ]; then
+	echo "Please guarantee readline-devel is installed on your system!"
+	echo "To install readline-devel, please run: yum install readline-devel"
+	exit 1
+fi
+
+#check whether zlib-devel is available
+if [ -z "$(rpm -qa zlib-devel)" ]; then
+	echo "Please guarantee zlib-devel is installed on your system!"
+	echo "To install zlib-devel, please run: yum install zlib-devel"
+	exit 1
+fi
+
+#check whether perl is available
+if [ -z "$(rpm -qa perl)" ]; then
+	echo "Please guarantee perl is installed on your system!"
+	echo "To install perl, please run: yum install perl"
+	exit 1
+fi
+
+#check whether perl-ExtUtils-Embed is available
+if [ -z "$(rpm -qa perl-ExtUtils-Embed)" ]; then
+	echo "Please guarantee perl-ExtUtils-Embed is installed on your system!"
+	echo "To install perl-ExtUtils-Embed, please run: yum install perl-ExtUtils-Embed"
+	exit 1
+fi
+
+#check whether openssl-devel is available
+if [ -z "$(rpm -qa openssl-devel)" ]; then
+	echo "Please guarantee openssl-devel is installed on your system!"
+	echo "To install openssl-devel, please run: yum install openssl-devel"
+	exit 1
+fi
+
+#check whether cvmfs-devel is available
+if [ -z "$(rpm -qa cvmfs-devel)" ]; then
+	echo "Please guarantee cvmfs-devel is installed on your system!"
+	echo "To install cvmfs-devel, first add cernvm.repo into /etc/yum.repo.d by running the following command:"
+	echo "	rpm -Uvh http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/6/`uname -i`/cvmfs-release-2-4.el6.noarch.rpm"
+	echo "Then you can install cvmfs-devel by running: yum install cvmfs-devel"
+	exit 1
+fi
+	
+#check whether freetype is available
+if [ -z "$(rpm -qa freetype)" ]; then
+	echo "Please guarantee freetype is installed on your system!"
+	echo "To install freetype, please run: yum install freetype"
+	exit 1
+fi
 
 #build source and binary RPMs from ndcctools.spec:
 rpmbuild -ba "${temp_file}"
@@ -83,10 +222,10 @@ fi
 #remove temp_file
 rm -f "${temp_file}"
 if [ "$?" -ne 0 ]; then
-	echo "Fails to delete the tmp spec file: $(pwd)/${temp_file}"
+	echo "Fails to delete the tmp spec file: "$(pwd)"/${temp_file}"
 	exit 1
 else
-	echo "Delete the tmp spec file: $(pwd)/${temp_file}"
+	echo "Delete the tmp spec file: "$(pwd)"/${temp_file}"
 fi
 
 cd -

--- a/packaging/rpm/rpm_creator.sh
+++ b/packaging/rpm/rpm_creator.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+rpm_version="${1}"
+rpm_release="${2}"
+
+#check whether both rpm_version and rpm_release are set
+if [ -z "${rpm_version}" -o -z "${rpm_release}" ]; then
+	echo "Please specify both rpm_version and rpm_release: ${0} <rpm_version> <rpm_release>"
+	exit 1
+fi
+
+echo "${rpm_version}"
+echo "${rpm_release}"
+
+#check whether rpmdev-setuptree and rpmbuild are available
+if [ -z $(which rpmbuild) -o -z $(which rpmdev-setuptree) ]; then
+	echo "Please guarantee rpmdevtools is installed on your system, rpmbuild and rpmdev-setuptree are needed to create RPMs!"
+	echo "To install rpmdevtools, please run: yum install rpmdevtools"
+	exit 1	
+fi
+
+#preserve the path of the current working directory
+make_dir=$(pwd)
+
+#set up an RPM build directory in your ~/rpmbuild directory. This command can be executed multiple times without scratching your current ~/rpmbuild directory.
+cd ~
+rpmdev-setuptree
+if [ "$?" -ne 0 ]; then
+	echo "rpmdev-setuptree fails to create RPM build directory in your ~/rpmbuild directory!"
+	exit 1
+fi
+
+#put the source code compressed tarball of cctools into the ~/rpmbuild/SOURCES dirctory:
+cd ~/rpmbuild/SOURCES
+if [ ! -e cctools-"${rpm_version}"-source.tar.gz ]; then
+	source=http://ccl.cse.nd.edu/software/files/cctools-"${rpm_version}"-source.tar.gz
+	wget "${source}"
+	if [ "$?" -ne 0 ]; then
+		echo "Failed to download cctools source code tarball from ${source}"
+		exit 1
+	fi
+fi
+
+cd -
+
+#create a template .spec file for ndcctools. 
+#Even if the .spec files are recommended to be put under ~/rpmbuild/SPECS, in fact you can put it in other places, just be consistent the location of the .spec file with the rpmbuild command.
+echo "${make_dir}"
+cd "${make_dir}"/packaging/rpm
+temp_file=$(mktemp -p .)
+if [ "$?" -ne 0 ]; then
+	echo "Fails to create a tmp spec file under ${make_dir}/packaging/rpm directory!"
+	exit 1
+else
+	echo "Create a tmp spec file:  $(pwd)/${temp_file}"
+fi
+
+#set the attributes at the beginning of the spec file
+echo "Name: ndcctools">>"${temp_file}"
+echo "Version: ${rpm_version}">>"${temp_file}"
+echo "Release: ${rpm_release}%{?dist}">>"${temp_file}"
+
+#ndcctools_template.spec contains all the neutral information which should be applied to any rpm version and release.
+cat ndcctools_template.spec>>"${temp_file}"
+
+#set the attributes at the end of the spec file
+echo "%changelog">>"${temp_file}"
+#the name and email addr here should be modified to be more ccl-style.
+date_str=$(date +"%a %b %d %Y")
+echo "* ${date_str} Haiyan Meng <hmeng@nd.edu> - ${rpm_version}-${rpm_release}">>"${temp_file}"
+echo "- Initial version of the package">>"${temp_file}"
+
+#build source and binary RPMs from ndcctools.spec:
+rpmbuild -ba "${temp_file}"
+if [ "$?" -ne 0 ]; then
+	echo "Fails to create RPMs and SRPMs for cctools!"
+	exit 1
+else
+	echo "The created RPMs are under ~/rpmbuild/RPMs"
+	echo "The created SRPMs are under ~/rpmbuild/SRPMs"
+fi
+
+#remove temp_file
+rm -f "${temp_file}"
+if [ "$?" -ne 0 ]; then
+	echo "Fails to delete the tmp spec file: $(pwd)/${temp_file}"
+	exit 1
+else
+	echo "Delete the tmp spec file: $(pwd)/${temp_file}"
+fi
+
+cd -


### PR DESCRIPTION
Add `make rpm` into Makefile
Put RPM stuff into cctools/packaging/rpm

The full feature of ndcctools depends on 9 packages: fuse, python, globus, swig, libuuid, readline, zlib, perl, and cvmfs.
To create RPMs for ndcctools with all package support mentioned above, there are two options.
Option 1: Use `./configure.afs` inside the `%build` section and create RPMs on a machine which supports the access of /afs/crc.nd.edu/group/ccl/software/cctools-dependencies.
This option is currently supported by the `make rpm` rule of cctools.

Option 2: Specify each package dependency as a `BuildRequires` attribute, and create RPMs on a machine with all these dependencies installed or you have root access to install these dependencies.
This option is currently not supported by the `make rpm` rule of cctools.
