### PR TITLE
Use the default value of IFS inside configure

### DIFF
--- a/configure
+++ b/configure
@@ -219,9 +219,6 @@ then
 	globus_path=${GLOBUS_LOCATION}
 fi
 
-IFS=' ='
-set -- $*
-
 while [ $# -gt 0 ]
 do
 	case $1 in
@@ -412,9 +409,6 @@ done
 if [ "$optstrict" = 1 ]; then
 	ccflags="${ccflags} -Werror"
 fi
-
-IFS=" "
-export IFS
 
 potential_packages="dttools ${include_package_makeflow} work_queue ${include_package_apps} ${include_package_sand} ${include_package_allpairs} ${include_package_wavefront} ${include_package_ftplite} ${include_package_parrot} ${include_package_resource_monitor} ${include_package_chirp} ${include_package_weaver} ${include_package_doc}"
 


### PR DESCRIPTION
Adding `=` into IFS may cause the tilde expansion being ignored when configure is executed like this `./configure --prefix=~/cctools`.
To avoid the trouble caused by this, we should keep IFS as its default value, which includes `<space><tab><newline>`. 