### PR TITLE
Make Tests More Portable

### DIFF
--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -210,8 +210,10 @@ and would be better handled by invoking batch_job_local.
 static void makeflow_node_export_variables( struct dag *d, struct dag_node *n )
 {
 	struct nvpair *nv = dag_node_env_create(d,n);
-	nvpair_export(nv);
-	nvpair_delete(nv);
+	if(nv) {
+		nvpair_export(nv);
+		nvpair_delete(nv);
+	}
 }
 
 /*

--- a/makeflow/test/TR_makeflow_src_example.sh
+++ b/makeflow/test/TR_makeflow_src_example.sh
@@ -11,6 +11,9 @@ if [ -z "$CONVERT" ]; then
 		CONVERT=/usr/local/bin/convert
 	elif [ -f /opt/local/bin/convert ]; then
 		CONVERT=/opt/local/bin/convert
+	else 
+		echo "Could not find convert!"
+		exit 1
 	fi
 fi
 


### PR DESCRIPTION
Make tests more portable (and more likely to succeed) by removing dependencies on curl/convert and other external programs.

(Still adding tests, don't merge yet.)
