### PR TITLE
Edit the executable to change loader.

### DIFF
--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -57,6 +57,7 @@ SOURCES = \
 	list.c \
 	load_average.c \
 	md5.c \
+	memfdexe.c \
 	memory_info.c \
 	mergesort.c \
 	mt19937-64.c \

--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -33,6 +33,7 @@ SOURCES = \
 	domain_name.c \
 	domain_name_cache.c \
 	dpopen.c \
+	elfheader.c \
 	envtools.c \
 	fast_popen.c \
 	fd.c \
@@ -139,3 +140,5 @@ install: all
 test: all
 
 .PHONY: all clean install test
+
+# vim: set noexpandtab tabstop=4:

--- a/dttools/src/elfheader.c
+++ b/dttools/src/elfheader.c
@@ -1,0 +1,236 @@
+#include "catch.h"
+#include "debug.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef uint32_t Elf32_Addr;
+typedef uint16_t Elf32_Half;
+typedef uint32_t Elf32_Off;
+typedef int32_t  Elf32_Sword;
+typedef uint32_t Elf32_Word;
+
+typedef uint64_t Elf64_Addr;
+typedef uint16_t Elf64_Half;
+typedef uint64_t Elf64_Off;
+typedef uint32_t Elf64_Word;
+typedef int32_t  Elf64_Sword;
+
+typedef uint64_t Elf32_Xword;
+typedef int64_t  Elf32_Sxword;
+typedef uint64_t Elf64_Xword;
+typedef int64_t  Elf64_Sxword;
+
+#define EI_NIDENT 16
+#define ELFMAG "\x7f" "ELF"
+
+/* indexes */
+#define EI_MAG0 0
+#define EI_MAG1 1
+#define EI_MAG2 2
+#define EI_MAG3 3
+#define EI_CLASS 4
+#define EI_DATA 5
+#define EI_VERSION 6
+#define EI_PAD 7
+
+#define ELFCLASS32 1
+#define ELFCLASS64 2
+
+typedef struct {
+	unsigned char e_ident[EI_NIDENT];
+	Elf32_Half e_type;
+	Elf32_Half e_machine;
+	Elf32_Word e_version;
+	Elf32_Addr e_entry;
+	Elf32_Off e_phoff;
+	Elf32_Off e_shoff;
+	Elf32_Word e_flags;
+	Elf32_Half e_ehsize;
+	Elf32_Half e_phentsize;
+	Elf32_Half e_phnum;
+	Elf32_Half e_shentsize;
+	Elf32_Half e_shnum;
+	Elf32_Half e_shstrndx;
+} Elf32_Ehdr;
+
+typedef struct { 
+	unsigned char e_ident[EI_NIDENT];
+	Elf64_Half e_type;
+	Elf64_Half e_machine;
+	Elf64_Word e_version;
+	Elf64_Addr e_entry;
+	Elf64_Off e_phoff;
+	Elf64_Off e_shoff;
+	Elf64_Word e_flags;
+	Elf64_Half e_ehsize;
+	Elf64_Half e_phentsize;
+	Elf64_Half e_phnum;
+	Elf64_Half e_shentsize;
+	Elf64_Half e_shnum;
+	Elf64_Half e_shstrndx;
+} Elf64_Ehdr;
+
+typedef struct {
+	Elf32_Word p_type;
+	Elf32_Off p_offset;
+	Elf32_Addr p_vaddr;
+	Elf32_Addr p_paddr;
+	Elf32_Word p_filesz;
+	Elf32_Word p_memsz;
+	Elf32_Word p_flags;
+	Elf32_Word p_align;
+} Elf32_Phdr;
+
+typedef struct {
+	Elf64_Word p_type;
+	Elf64_Word p_flags;
+	Elf64_Off p_offset;
+	Elf64_Addr p_vaddr;
+	Elf64_Addr p_paddr;
+	Elf64_Xword p_filesz;
+	Elf64_Xword p_memsz;
+	Elf64_Xword p_align;
+} Elf64_Phdr;
+
+#define PT_INTERP 3
+
+#define p16(e) debug(D_DEBUG, "%s = %" PRIu16, #e, e)
+#define p32(e) debug(D_DEBUG, "%s = %" PRIu32, #e, e)
+#define p64(e) debug(D_DEBUG, "%s = %" PRIu64, #e, e)
+
+/* XXX We don't handle endianness of the object file */
+static int elf_interp(int fd, int set, char *interp)
+{
+	int rc;
+	void *addr = NULL;
+	size_t addr_len;
+	unsigned char *ident;
+	struct stat info;
+
+	CATCHUNIX(fstat(fd, &info));
+
+	if (info.st_size < (off_t)sizeof(Elf32_Ehdr))
+		CATCH(EINVAL);
+
+	addr_len = info.st_size;
+	addr = mmap(NULL, addr_len, PROT_READ|(set ? PROT_WRITE : 0), MAP_SHARED, fd, 0);
+	CATCHUNIX(addr == NULL ? -1 : 0);
+
+	if (strncmp((const char *)addr, ELFMAG, sizeof(ELFMAG)-1) != 0) {
+		debug(D_DEBUG, "not an ELF file");
+		CATCH(EINVAL);
+	}
+
+	ident = (unsigned char *)addr;
+	switch (ident[EI_CLASS]) {
+		case ELFCLASS32: {
+			int i;
+			Elf32_Phdr *phdr;
+			Elf32_Ehdr *hdr = addr;
+			p16(hdr->e_type);
+			p32(hdr->e_phoff);
+			p16(hdr->e_phentsize);
+			p16(hdr->e_phnum);
+
+			phdr = addr+sizeof(*hdr);
+			for (i = 0; i < hdr->e_phnum; i++) {
+				if ((uintptr_t)&phdr[i+1] >= ((uintptr_t)addr+addr_len))
+					CATCH(EINVAL);
+				p32(phdr[i].p_type);
+				p32(phdr[i].p_offset);
+				p32(phdr[i].p_filesz);
+				if (phdr[i].p_type == PT_INTERP) {
+					const char *old = (const char *)addr+phdr[i].p_offset;
+					if (set) {
+						debug(D_DEBUG, "old interp: '%s'", old);
+						phdr[i].p_offset = addr_len;
+						phdr[i].p_filesz = PATH_MAX;
+						CATCHUNIX(pwrite(fd, interp, PATH_MAX, phdr[i].p_offset));
+					} else {
+						strcpy(interp, old);
+						rc = 0;
+						goto out;
+					}
+				}
+			}
+			break;
+		}
+		case ELFCLASS64: {
+			int i;
+			Elf64_Phdr *phdr;
+			Elf64_Ehdr *hdr = addr;
+			p16(hdr->e_type);
+			p64(hdr->e_phoff);
+			p16(hdr->e_phentsize);
+			p16(hdr->e_phnum);
+
+			phdr = addr+sizeof(*hdr);
+			for (i = 0; i < hdr->e_phnum; i++) {
+				if ((uintptr_t)&phdr[i+1] >= ((uintptr_t)addr+addr_len))
+					CATCH(EINVAL);
+				p32(phdr[i].p_type);
+				p64(phdr[i].p_offset);
+				p64(phdr[i].p_filesz);
+				if (phdr[i].p_type == PT_INTERP) {
+					const char *old = (const char *)addr+phdr[i].p_offset;
+					if (set) {
+						/* So the basic idea here is that we just add 4096
+						 * bytes (PATH_MAX) to the end of the file and point to
+						 * that. It's not that inefficient and we can skip
+						 * fixing file offsets in all the ELF headers.
+						 */
+						debug(D_DEBUG, "old interp: '%s'", old);
+						phdr[i].p_offset = addr_len;
+						phdr[i].p_filesz = PATH_MAX;
+						CATCHUNIX(pwrite(fd, interp, PATH_MAX, phdr[i].p_offset));
+					} else {
+						strcpy(interp, old);
+						rc = 0;
+						goto out;
+					}
+				}
+			}
+			break;
+		}
+		default:
+			CATCH(EINVAL);
+	}
+
+	rc = 0;
+	goto out;
+out:
+	if (addr) {
+		munmap(addr, addr_len);
+	}
+	return RCUNIX(rc);
+}
+
+int elf_get_interp(int fd, char *interp)
+{
+	return elf_interp(fd, 0, interp);
+}
+
+
+int elf_set_interp(int fd, const char *interp)
+{
+	char path[PATH_MAX] = "";
+
+	if (strlen(interp) >= PATH_MAX)
+		return errno = ENAMETOOLONG, -1;
+	strcpy(path, interp);
+
+	return elf_interp(fd, 1, path);
+}
+
+/* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/elfheader.h
+++ b/dttools/src/elfheader.h
@@ -1,0 +1,28 @@
+/*
+Copyright (C) 2015- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#ifndef ELFHEADER_H
+#define ELFHEADER_H
+
+#include <limits.h>
+
+/** Get the interpreter (PT_INTERP) for the executable.
+ *
+ * @param fd The open file descriptor to the executable.
+ * @param interp The current interpreter.
+ * @return 0 on success; -1 + errno on failure.
+ */
+int elf_get_interp(int fd, char interp[PATH_MAX]);
+
+/** Set the interpreter (PT_INTERP) for the executable.
+ *
+ * @param fd The open O_RDWR file descriptor to the executable.
+ * @param interp The new interpreter.
+ * @return 0 on success; -1 + errno on failure.
+ */
+int elf_set_interp(int fd, const char *interp);
+
+#endif /* ELFHEADER_H */

--- a/dttools/src/memfdexe.c
+++ b/dttools/src/memfdexe.c
@@ -1,0 +1,78 @@
+#include "debug.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#if defined(__linux__)
+#	include <syscall.h>
+#endif
+#include <unistd.h>
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int memfdexe (const char *name, const char *extradir)
+{
+	int fd;
+
+#if defined(__linux__) && defined(SYS_memfd_create)
+	fd = syscall(SYS_memfd_create, name, 0);
+#else
+	errno = ENOSYS;
+	fd = -1;
+#endif /* defined(__linux__) && defined(SYS_memfd_create) */
+
+	if (fd == -1 && errno == ENOSYS) {
+		int i;
+		const char *dirs[] = {
+			"/dev/shm",
+			"/tmp",
+			"/var/tmp",
+			extradir,
+			NULL
+		};
+		size_t pagesize = getpagesize();
+		for (i = 0; dirs[i]; i++) {
+			char path[PATH_MAX];
+			snprintf(path, sizeof(path), "%s/%s.XXXXXX", dirs[i], name);
+
+			debug(D_DEBUG, "trying to create memfdexe '%s'", path);
+			fd = mkstemp(path);
+			if (fd >= 0) {
+				if (unlink(path) == -1) {
+					debug(D_DEBUG, "could not unlink memfdexe '%s': %s", path, strerror(errno));
+					/* no way to fix that, might as well continue... */
+				}
+				if (fchmod(fd, S_IRWXU) == -1) {
+					debug(D_DEBUG, "could not set permissions on memfdexe: %s", strerror(errno));
+					close(fd);
+					continue;
+				}
+
+				/* test if we can use it for executable data (i.e. is dir on a file system mounted with the 'noexec' option) */
+				if (ftruncate(fd, pagesize) == -1) {
+					debug(D_DEBUG, "could not grow memfdexe: %s", strerror(errno));
+					close(fd);
+					continue;
+				}
+				void *addr = mmap(NULL, pagesize, PROT_READ|PROT_EXEC, MAP_SHARED, fd, 0);
+				if (addr == MAP_FAILED) {
+					debug(D_DEBUG, "failed executable mapping: %s", strerror(errno));
+					close(fd);
+					continue;
+				}
+				munmap(addr, pagesize);
+				ftruncate(fd, 0);
+				break;
+			} else {
+				debug(D_DEBUG, "could not create memfdexe: %s", strerror(errno));
+			}
+		}
+	}
+	return fd;
+}
+
+/* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/memfdexe.h
+++ b/dttools/src/memfdexe.h
@@ -1,0 +1,12 @@
+/*
+Copyright (C) 2015- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#ifndef MEMFDEXE_H
+#define MEMFDEXE_H
+
+int memfdexe (const char *name, const char *extradir);
+
+#endif /* MEMFDEXE_H */

--- a/parrot/src/pfs_process.cc
+++ b/parrot/src/pfs_process.cc
@@ -230,6 +230,7 @@ struct pfs_process * pfs_process_create( pid_t pid, pid_t ppid, int share_table 
 	child->did_stream_warning = 0;
 	child->nsyscalls = 0;
 	child->completing_execve = 0;
+	child->exefd = -1;
 
 	actual_parent = pfs_process_lookup(ppid);
 
@@ -279,6 +280,8 @@ static void pfs_process_delete( struct pfs_process *p )
 		if(!p->table->refs()) delete p->table;
 		p->table = 0;
 	}
+	if(p->exefd >= 0)
+		close(p->exefd);
 	pfs_paranoia_delete_pid(p->pid);
 	tracer_detach(p->tracer);
 	itable_remove(pfs_process_table,p->pid);

--- a/parrot/src/pfs_process.h
+++ b/parrot/src/pfs_process.h
@@ -50,6 +50,7 @@ struct pfs_process {
 	int completing_execve;
 	int did_stream_warning;
 	char new_logical_name[PFS_PATH_MAX]; /* saved during execve */
+	int exefd; /* during execve */
 
 	INT64_T syscall;
 	INT64_T syscall_original;

--- a/parrot/src/pfs_sys.cc
+++ b/parrot/src/pfs_sys.cc
@@ -501,7 +501,7 @@ int	pfs_mmap_delete( pfs_size_t logical_address, pfs_size_t length )
 	END
 }
 
-int pfs_get_local_name( const char *rpath, char *lpath, char *firstline, int length )
+int pfs_get_local_name( const char *rpath, char *lpath, char *firstline, size_t length )
 {
 	int fd;
 	int result;

--- a/parrot/src/pfs_sys.h
+++ b/parrot/src/pfs_sys.h
@@ -108,7 +108,7 @@ int		pfs_timeout( const char *str );
 
 int		pfs_get_real_fd( int fd );
 int		pfs_get_full_name( int fd, char *name );
-int		pfs_get_local_name( const char *rpath, char *lpath, char *firstline, int length );
+int		pfs_get_local_name( const char *rpath, char *lpath, char *firstline, size_t length );
 int		pfs_resolve_name( int is_special_syscall, const char *path, struct pfs_name *pname );
 
 int		pfs_search( const char *path, const char *pattern, int flags, char *buffer, size_t buffer_length, size_t *i);


### PR DESCRIPTION
This commit addreses two different bugs:
    
o Executing the loader as a wrapper unconditionally changes argv[0]. So prior
  to this commit, Parrot would change the runtime loader by executing:
    
    execve("/path/to/loader.so", [argv[0], "/path/to/exe", argv[1], argv[2], ...], [...]);
    
  Unfortunately, the loader will replace argv[0] with "/path/to/exe".
  Applications sensitive to that change will fail. This is issue #678.
    
o If the loader referred to by the executable (PT_INTERP) is in a non-local
  file system, like cvmfs, then the kernel will not be able execute the program.
  execve will fail with ENOENT. This is issue #781.
    
This commit solves these problems by editing the PT_INTERP program header of
executable to refer to a local copy of the loader.