### PR TITLE
Added --dot-details option to makeflow_viz

### DIFF
--- a/doc/man/makeflow_viz.m4
+++ b/doc/man/makeflow_viz.m4
@@ -21,6 +21,7 @@ OPTION_TRIPLET(-D, display, opt) Translate the makeflow to the desired visualiza
     dax      DAX format for use by the Pegasus workflow manager.
 OPTION_ITEM(`--dot-merge-similar')Condense similar boxes
 OPTION_ITEM(`--dot-proportional')Change the size of the boxes proportional to file size
+OPTION_ITEM(`--dot-details')Display a more detailed graph including an operating sandbox for each task
 OPTION_ITEM(` ')The following options for ppm generation are mutually exclusive:
 OPTION_PAIR(--ppm-highlight-row, row)Highlight row <row> in completion grap
 OPTION_PAIR(--ppm-highlight-file,file)Highlight node that creates file <file> in completion graph

--- a/dttools/src/itable.h
+++ b/dttools/src/itable.h
@@ -11,7 +11,7 @@ See the file COPYING for details.
 #include "int_sizes.h"
 
 /** @file itable.h An integer-indexed hash table.
-This hash table module map integers to arbitrary objects (void pointers).
+This hash table module maps integers to arbitrary objects (void pointers).
 For example, to store a filename using the file descriptor as a key:
 <pre>
 struct itable *t;
@@ -24,7 +24,7 @@ pathname = itable_remove(h,id);
 
 </pre>
 
-To list all of the items in a itable, use @ref itable_firstkey and @ref itable_nextkey like this:
+To list all of the items in an itable, use @ref itable_firstkey and @ref itable_nextkey like this:
 
 <pre>
 UINT64_T  key;

--- a/dttools/src/set.h
+++ b/dttools/src/set.h
@@ -93,7 +93,7 @@ int set_push(struct set *h, const void *element);
 
 int set_lookup(struct set *s, void *element);
 
-/** Remove a element.
+/** Remove an element.
 @param s A pointer to a set.
 @param element A pointer to remove.
 @return If found 1, otherwise 0.

--- a/makeflow/src/dag_node.h
+++ b/makeflow/src/dag_node.h
@@ -37,10 +37,10 @@ struct dag_node {
 
 	int nodeid;              /* The ordinal number as the rule appears in the makeflow file */
 	int linenum;             /* Line number of the node's rule definition */
-	int local_job;           /* Flag: does this node runs locally? */
+	int local_job;           /* Flag: does this node run locally? */
 
-	struct set *descendants; /* The nodes this node is an immediate ancestor */
-	struct set *ancestors;   /* The nodes this node is an immediate descendant */
+	struct set *descendants; /* The nodes of which this node is an immediate ancestor */
+	struct set *ancestors;   /* The nodes of which this node is an immediate descendant */
 	int ancestor_depth;      /* The depth of the ancestor tree for this node */
 
 	int nested_job;            /* Flag: Is this a recursive call to makeflow? */

--- a/makeflow/src/dag_visitors.h
+++ b/makeflow/src/dag_visitors.h
@@ -23,7 +23,7 @@ int dag_to_dax(const struct dag *d, const char *name );
 /* The dag_to_dot function writes a struct dag in memory to a dot
  * file (graphviz), giving the graphical presentation of the makeflow.
  */
-void dag_to_dot(struct dag *d, int condense_display, int change_size, int with_labels );
+void dag_to_dot(struct dag *d, int condense_display, int change_size, int with_labels, int with_detail );
 
 /* The dag_to_ppm function writes a struct dag in memory to a ppm
  * file, giving a graphical presentation of the makeflow

--- a/makeflow/src/makeflow_viz.c
+++ b/makeflow/src/makeflow_viz.c
@@ -64,7 +64,9 @@ enum { LONG_OPT_PPM_ROW,
        LONG_OPT_DOT_PROPORTIONAL,
        LONG_OPT_DOT_CONDENSE,
        LONG_OPT_DOT_LABELS,
-       LONG_OPT_DOT_NO_LABELS
+       LONG_OPT_DOT_NO_LABELS, 
+	   LONG_OPT_DOT_DETAILS, 
+	   LONG_OPT_DOT_NO_DETAILS
 };
 
 static void show_help_viz(const char *cmd)
@@ -102,6 +104,7 @@ int main(int argc, char *argv[])
 	int change_size = 0;
 	int ppm_mode = 0;
 	int dot_labels = 1;
+	int dot_details = 1;
 	char *ppm_option = NULL;
 
 	struct option long_options_viz[] = {
@@ -111,6 +114,8 @@ int main(int argc, char *argv[])
 		{"dot-proportional",  no_argument, 0,  LONG_OPT_DOT_PROPORTIONAL},
 		{"dot-no-labels", no_argument, 0, LONG_OPT_DOT_NO_LABELS},
 		{"dot-labels", no_argument, 0, LONG_OPT_DOT_LABELS},
+		{"dot-details", no_argument, 0, LONG_OPT_DOT_DETAILS}, 
+		{"dot-no-details", no_argument, 0, LONG_OPT_DOT_NO_DETAILS}, 
 		{"ppm-highlight-row", required_argument, 0, LONG_OPT_PPM_ROW},
 		{"ppm-highlight-exe", required_argument, 0, LONG_OPT_PPM_EXE},
 		{"ppm-highlight-file", required_argument, 0, LONG_OPT_PPM_FILE},
@@ -149,6 +154,12 @@ int main(int argc, char *argv[])
 				break;
 			case LONG_OPT_DOT_NO_LABELS:
 				dot_labels = 0;
+				break;
+			case LONG_OPT_DOT_DETAILS:
+				dot_details = 1;
+				break;
+			case LONG_OPT_DOT_NO_DETAILS:
+				dot_details = 0;
 				break;
 			case LONG_OPT_PPM_EXE:
 				display_mode = SHOW_DAG_PPM;
@@ -202,7 +213,7 @@ int main(int argc, char *argv[])
 		switch(display_mode)
 		{
 			case SHOW_DAG_DOT:
-				dag_to_dot(d, condense_display, change_size, dot_labels );
+				dag_to_dot(d, condense_display, change_size, dot_labels, dot_details );
 				break;
 			case SHOW_DAG_PPM:
 				dag_to_ppm(d, ppm_mode, ppm_option);


### PR DESCRIPTION
Added --dot-details option to makeflow_viz.
Modified dag_to_dot in dag_visitors.c: takes with_details parameter and inserts appropriate text in resulting .dot file to render more detailed version of the dag_to_dot conversion.
Fixed grammatical mistakes in itable.h,set.h,dag_node.h.
Docs reflect addition of --dot-details optionin makeflow_viz.