### PR TITLE
Remove Chirp job file SYMLINK binding.

### DIFF
--- a/chirp/src/chirp_fs_local_scheduler.c
+++ b/chirp/src/chirp_fs_local_scheduler.c
@@ -302,19 +302,13 @@ static int bindfile (sqlite3 *db, chirp_jobid_t id, const char *subject, const c
 		CATCHUNIX(create_dir(task_path_dir, S_IRWXU) ? 0 : -1);
 
 		if (strcmp(type, "INPUT") == 0) {
-			if (strcmp(binding, "SYMLINK") == 0) {
-				CATCHUNIX(symlink(serv_path_resolved, task_path_resolved));
-			} else if (strcmp(binding, "LINK") == 0) {
+			if (strcmp(binding, "LINK") == 0) {
 				CATCHUNIX(link(serv_path_resolved, task_path_resolved));
 			} else if (strcmp(binding, "COPY") == 0) {
 				CATCHUNIX(copy_file_to_file(serv_path_resolved, task_path_resolved));
 			} else assert(0);
 			CATCHUNIX(chmod(serv_path_resolved, S_IRWXU));
-		} else if (strcmp(type, "OUTPUT") == 0) {
-			if (strcmp(binding, "SYMLINK") == 0) {
-				CATCHUNIX(symlink(serv_path_resolved, task_path_resolved));
-			}
-		} else assert(0);
+		}
 	} else if (mode == STRAPBOOT) {
 		if (strcmp(type, "OUTPUT") == 0) {
 			struct stat info;

--- a/chirp/src/chirp_job.c
+++ b/chirp/src/chirp_job.c
@@ -151,7 +151,7 @@ static int db_init (sqlite3 *db)
 		IMMUTABLE_JOB_INSUPD("JobEnvironment")
 		"CREATE TABLE JobFile("
 		"	id INTEGER REFERENCES Job (id),"
-		"	binding TEXT NOT NULL DEFAULT 'SYMLINK' REFERENCES FileBinding (binding),"
+		"	binding TEXT NOT NULL DEFAULT 'LINK' REFERENCES FileBinding (binding),"
 		"	serv_path TEXT NOT NULL," /* no UTF encoding? */
 		"	task_path TEXT NOT NULL," /* no UTF encoding? */
 		"	tag TEXT," /* user value */
@@ -161,7 +161,7 @@ static int db_init (sqlite3 *db)
 		IMMUTABLE_JOB_INSUPD("JobFile")
 		/* We use FileType as an SQLite enum */
 		"CREATE TABLE FileBinding (binding TEXT PRIMARY KEY);"
-		"INSERT INTO FileBinding VALUES ('LINK'), ('SYMLINK'), ('COPY'), ('URL');"
+		"INSERT INTO FileBinding VALUES ('LINK'), ('COPY'), ('URL');"
 		IMMUTABLE("FileBinding")
 		"CREATE TABLE FileType (type TEXT PRIMARY KEY);"
 		"INSERT INTO FileType VALUES ('INPUT'), ('OUTPUT');"
@@ -427,7 +427,7 @@ restart:
 				CATCH(ENAMETOOLONG);
 			sqlcatch(sqlite3_bind_text(stmt, 5, task_path->u.string.ptr, -1, SQLITE_STATIC));
 
-			sqlcatch(sqlite3_bind_text(stmt, 6, binding ? binding->u.string.ptr : "SYMLINK", -1, SQLITE_STATIC));
+			sqlcatch(sqlite3_bind_text(stmt, 6, binding ? binding->u.string.ptr : NULL, -1, SQLITE_STATIC));
 
 			sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
 			debug(D_DEBUG, "job %" PRICHIRP_JOBID_T " new file `%s' bound as `%s' type `%s'", *id, serv_path->u.string.ptr, task_path->u.string.ptr, type->u.string.ptr);

--- a/chirp/test/TR_chirp_job.sh
+++ b/chirp/test/TR_chirp_job.sh
@@ -82,7 +82,7 @@ EOF
 			"serv_path": "/users/$(whoami)/data/db.txt",
 			"task_path": "foo_sym",
 			"type": "INPUT",
-			"binding": "SYMLINK"
+			"binding": "LINK"
 		},
 		{
 			"serv_path": "/users/$(whoami)/data/output.txt",
@@ -155,7 +155,7 @@ EOF
 			"serv_path": "/users/$(whoami)/data/db.txt",
 			"task_path": "foo_sym",
 			"type": "INPUT",
-			"binding": "SYMLINK"
+			"binding": "LINK"
 		},
 		{
 			"serv_path": "/users/$(whoami)/data/output.txt",
@@ -226,7 +226,7 @@ EOF
 			"serv_path": "/users/$(whoami)/data/db.txt",
 			"task_path": "foo_sym",
 			"type": "INPUT",
-			"binding": "SYMLINK"
+			"binding": "LINK"
 		},
 		{
 			"serv_path": "/users/$(whoami)/data/output.txt",

--- a/doc/chirp.html
+++ b/doc/chirp.html
@@ -983,19 +983,19 @@ This file is bound into the server namespace at task completion.</p>
             "task_path": "a",
             "serv_path": "/users/pdonnel3/a.txt",
             "type": "INPUT",
-            "binding": "SYMLINK"
+            "binding": "LINK"
         },
         {
             "task_path": "b",
             "serv_path": "/users/pdonnel3/b.txt",
             "type": "INPUT",
-            "binding": "SYMLINK"
+            "binding": "LINK"
         },
         {
             "task_path": "archive.tar",
             "serv_path": "/users/pdonnel3/archive.tar",
             "type": "OUTPUT",
-            "binding": "SYMLINK"
+            "binding": "LINK"
         }
     ]
 }
@@ -1003,7 +1003,7 @@ This file is bound into the server namespace at task completion.</p>
 
 <p>Here, each file is bound as a symbolic link the location on the server. This
 type of access is usually fast as the server does not need make a copy. You may
-also bind files as <tt>COPY</tt> if necessary. <tt>SYMLINK</tt> is the
+also bind files as <tt>COPY</tt> if necessary. <tt>LINK</tt> is the
 default.</p>
 
 <h4 id="jobs.create.e3">Example 3 -- Using custom executable.<a class="sectionlink" href="#jobs.create.e3" title="Link to this section.">&#x21d7;</a></h4>
@@ -1024,13 +1024,13 @@ you would any other file and give a relative (task) path for the
             "task_path": "myscript.sh",
             "serv_path": "/users/pdonnel3/myscript.sh",
             "type": "INPUT",
-            "binding": "SYMLINK"
+            "binding": "LINK"
         },
         {
             "task_path": "output.txt",
             "serv_path": "/users/pdonnel3/output.txt",
             "type": "OUTPUT",
-            "binding": "SYMLINK"
+            "binding": "LINK"
         }
     ]
 }
@@ -1098,7 +1098,7 @@ information is JSON-encoded and holds all job metadata.</p>
         "serv_path":"\/users\/pdonnel3\/my.0.output",
         "task_path":"my.output",
         "type":"OUTPUT",
-        "binding":"SYMLINK"
+        "binding":"LINK"
       }
     ]
   }
@@ -1140,7 +1140,7 @@ information is JSON-encoded and holds all job metadata.</p>
         "serv_path":"\/users\/pdonnel3\/my.0.output",
         "task_path":"my.output",
         "type":"OUTPUT",
-        "binding":"SYMLINK"
+        "binding":"LINK"
       }
     ]
   }
@@ -1181,7 +1181,7 @@ information is JSON-encoded and holds all job metadata.</p>
         "serv_path":"\/users\/pdonnel3\/my.0.output",
         "task_path":"my.output",
         "type":"OUTPUT",
-        "binding":"SYMLINK"
+        "binding":"LINK"
       }
     ]
   }
@@ -1246,7 +1246,7 @@ information is JSON-encoded and holds all job metadata.</p>
           "serv_path":"\/users\/pdonnel3\/my.0.output",
           "task_path":"my.output",
           "type":"OUTPUT",
-          "binding":"SYMLINK"
+          "binding":"LINK"
         }
       ]
     }


### PR DESCRIPTION
This binding was added to allow for job sandboxes to be on another file system
while maintaining cheap startup/cleanup (as COPY is naturally expensive). With
commit 8c6065e moving job sandboxes to the Chirp root, this is unnecessary to
support.

It's also worth adding that SYMLINK violated the conceptual design of jobs by
allowing output files to be written to during job execution, rather than at job
completion. It's also possible for applications to readlink the symlink to
obtain the real path of the file under the Chirp root. In principle, we don't
want to allow this.