### PR TITLE
Wq master monitor resources.

### DIFF
--- a/dttools/src/rmonitor_poll_internal.h
+++ b/dttools/src/rmonitor_poll_internal.h
@@ -39,6 +39,8 @@ See the file COPYING for details.
 #include "rmonitor_types.h"
 #include "rmsummary.h"
 
+#include "rmonitor_poll.h"
+
 void rmonitor_poll_all_processes_once(struct itable *processes, struct rmonitor_process_info *acc);
 void rmonitor_poll_all_wds_once(      struct hash_table *wdirs, struct rmonitor_wdir_info *acc);
 void rmonitor_poll_all_fss_once(      struct itable *filesysms, struct rmonitor_filesys_info *acc);


### PR DESCRIPTION
Based on #814 (only adds one more commit).

When using work_queue_enable_monitoring, the first summary of the resources report corresponds to the master. Resources are polled every 5 minutes. The summary also includes the master command line and the master project name (if given).

This follows the new convention on the resources archive, in which the first summary of a file is taken as the parent of all the summaries in that file.
