### PR TITLE
Python exec

### DIFF
--- a/apps/makeflow_blasr/makeflow_blasr
+++ b/apps/makeflow_blasr/makeflow_blasr
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (C) 2014- The University of Notre Dame
 # This software is distributed under the GNU General Public License.

--- a/apps/makeflow_blast/makeflow_blast
+++ b/apps/makeflow_blast/makeflow_blast
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (C) 2011- The University of Notre Dame
 # This software is distributed under the GNU General Public License.

--- a/apps/makeflow_bwa/makeflow_bwa
+++ b/apps/makeflow_bwa/makeflow_bwa
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 #
 #Copyright (C) 2013- The University of Notre Dame
 #This software is distributed under the GNU General Public License.

--- a/apps/makeflow_gatk/makeflow_gatk
+++ b/apps/makeflow_gatk/makeflow_gatk
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 #
 #Copyright (C) 2013- The University of Notre Dame
 #This software is distributed under the GNU General Public License.

--- a/apps/wq_replica_exchange/protomol_functions.py
+++ b/apps/wq_replica_exchange/protomol_functions.py
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 import random
 import math
 

--- a/apps/wq_replica_exchange/wq_replica_exchange
+++ b/apps/wq_replica_exchange/wq_replica_exchange
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # replica_exchange.py
 #

--- a/deltadb/src/python-old/catalog_history_count
+++ b/deltadb/src/python-old/catalog_history_count
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (c) 2010- The University of Notre Dame.
 # This software is distributed under the GNU General Public License.

--- a/deltadb/src/python-old/catalog_history_filter
+++ b/deltadb/src/python-old/catalog_history_filter
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (c) 2010- The University of Notre Dame.
 # This software is distributed under the GNU General Public License.

--- a/deltadb/src/python-old/catalog_history_plot
+++ b/deltadb/src/python-old/catalog_history_plot
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (c) 2010- The University of Notre Dame.
 # This software is distributed under the GNU General Public License.

--- a/deltadb/src/python-old/catalog_history_read_and_print
+++ b/deltadb/src/python-old/catalog_history_read_and_print
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (c) 2010- The University of Notre Dame.
 # This software is distributed under the GNU General Public License.

--- a/deltadb/src/python-old/catalog_history_select
+++ b/deltadb/src/python-old/catalog_history_select
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (c) 2010- The University of Notre Dame.
 # This software is distributed under the GNU General Public License.

--- a/deltadb/src/python-old/catalog_history_stream
+++ b/deltadb/src/python-old/catalog_history_stream
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (c) 2010- The University of Notre Dame.
 # This software is distributed under the GNU General Public License.

--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -110,7 +110,7 @@ HEADERS_PUBLIC = \
 LIBRARIES = libdttools.a
 OBJECTS = $(SOURCES:%.c=%.o)
 PROGRAMS = catalog_update catalog_server watchdog
-SCRIPTS = cctools_gpu_autodetect
+SCRIPTS = cctools_gpu_autodetect cctools_python
 TARGETS = $(LIBRARIES) $(PROGRAMS) $(TEST_PROGRAMS)
 TEST_PROGRAMS = auth_test microbench multirun
 

--- a/dttools/src/cctools_python
+++ b/dttools/src/cctools_python
@@ -46,7 +46,7 @@ then
   exit 1
 fi
 
-required_alternatives=$(sed -n '2{s/^#[\t ]*CCTOOLS_PYTHON_VERSION//p;q}' < $script)
+required_alternatives=$(sed -n '2{s/^#[\t ]*CCTOOLS_PYTHON_VERSION//p;q;}' < $script)
 
 if [ -z "$required_alternatives" ]
 then

--- a/dttools/src/cctools_python
+++ b/dttools/src/cctools_python
@@ -1,25 +1,25 @@
-#! /bin/sh
+#!/bin/sh
 
 pythons="$PYTHON2 $PYTHON python2.7 python2.6 python2.4 python2 python3 python"
 
 major_version () {
-	local version=$1
+	version=$1
 	echo ${version%%.*}
 }
 
 minor_version () {
-	local version=$1
-	local major=$(major_version $version)
+	version=$1
+	major=$(major_version $version)
 	echo ${version#${major}} | cut -d . -f 2
 }
 
 match_versions () {
-	local required=$1
-	local available=$2
-	local major_r=$(major_version $required)
-	local minor_r=$(minor_version $required)
-	local major_a=$(major_version $available)
-	local minor_a=$(minor_version $available)
+	required=$1
+	available=$2
+	major_r=$(major_version $required)
+	minor_r=$(minor_version $required)
+	major_a=$(major_version $available)
+	minor_a=$(minor_version $available)
 
 	# majors do not match
 	if [ "$major_r" != "$major_a" ]
@@ -76,6 +76,7 @@ if [ $python = 0 ]
 then
 	echo "Could not find a valid python version ($required_alternatives )." 1>&2
 	echo 'Please set the environment variables PYTHON or PYTHON2 appropriately.' 1>&2
+	exit 1
 else
-	exec $python "$@"
+	exec "$python" "$@"
 fi

--- a/dttools/src/cctools_python
+++ b/dttools/src/cctools_python
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-pythons="$PYTHON2 $PYTHON python2.7 python2.6 python2 python3 python"
+pythons="$PYTHON2 $PYTHON python2.7 python2.6 python2.4 python2 python3 python"
 
 major_version () {
 	local version=$1

--- a/dttools/src/cctools_python
+++ b/dttools/src/cctools_python
@@ -1,0 +1,81 @@
+#! /bin/sh
+
+pythons="$PYTHON2 $PYTHON python2.7 python2.6 python2 python3 python"
+
+major_version () {
+	local version=$1
+	echo ${version%%.*}
+}
+
+minor_version () {
+	local version=$1
+	local major=$(major_version $version)
+	echo ${version#${major}} | cut -d . -f 2
+}
+
+match_versions () {
+	local required=$1
+	local available=$2
+	local major_r=$(major_version $required)
+	local minor_r=$(minor_version $required)
+	local major_a=$(major_version $available)
+	local minor_a=$(minor_version $available)
+
+	# majors do not match
+	if [ "$major_r" != "$major_a" ]
+	then
+	  echo 0
+	  return
+	fi
+
+	# minors do not match
+	if [ -n "$minor_r" -a "$minor_r" != "$minor_a" ]
+	then
+	  echo 0
+	  return
+	fi
+
+	# versions did match
+	echo 1
+}
+
+script=$1
+if [ -z "$script" ]
+then
+  echo 'Missing script name.' 1>&2
+  exit 1
+fi
+
+required_alternatives=$(sed -n '2{s/^#[\t ]*CCTOOLS_PYTHON_VERSION//p;q}' < $script)
+
+if [ -z "$required_alternatives" ]
+then
+	echo "No version of python was specified for $script." 1>&2
+	exit 1
+fi
+
+python=0
+for alt in $required_alternatives
+do
+	for candidate in $pythons
+	do
+		candidate_full=$(which $candidate 2> /dev/null)
+		[ -x $candidate_full ] || continue
+		candidate_version=$(${candidate_full} -V 2>&1 | cut -d " " -f 2)
+
+		match=$(match_versions $alt $candidate_version)
+		if [ "$match" = 1 ]
+		then
+			python=$candidate_full
+			break 2
+		fi
+	done
+done
+
+if [ $python = 0 ]
+then
+	echo "Could not find a valid python version ($required_alternatives )." 1>&2
+	echo 'Please set the environment variables PYTHON or PYTHON2 appropriately.' 1>&2
+else
+	exec $python "$@"
+fi

--- a/galaxy/cctools.py
+++ b/galaxy/cctools.py
@@ -1,4 +1,5 @@
-"""
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 CCTools datatypes
 
 """

--- a/galaxy/makeflow_gatk_wrapper.py
+++ b/galaxy/makeflow_gatk_wrapper.py
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 #
 #Copyright (C) 2013- The University of Notre Dame
 #This software is distributed under the GNU General Public License.

--- a/makeflow/src/makeflow_linker_python_driver
+++ b/makeflow/src/makeflow_linker_python_driver
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (C) 2013- The University of Notre Dame
 # This software is distributed under the GNU General Public License.

--- a/makeflow/src/makeflow_monitor
+++ b/makeflow/src/makeflow_monitor
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (c) 2010- The University of Notre Dame.
 # This software is distributed under the GNU General Public License.

--- a/makeflow/src/starch
+++ b/makeflow/src/starch
@@ -1,5 +1,5 @@
 #! /usr/bin/env cctools_python
-# CCTOOLS_PYTHON_VERSION 2.7 2.6 3
+# CCTOOLS_PYTHON_VERSION 2.7 2.6 2.5 2.4 3
 
 # Copyright (c) 2010- The University of Notre Dame.
 # This software is distributed under the GNU General Public License.

--- a/makeflow/src/starch
+++ b/makeflow/src/starch
@@ -1,4 +1,4 @@
-#! /usr/bin/env cctools_python
+#!/usr/bin/env cctools_python
 # CCTOOLS_PYTHON_VERSION 2.7 2.6 2.5 2.4 3
 
 # Copyright (c) 2010- The University of Notre Dame.

--- a/makeflow/src/starch
+++ b/makeflow/src/starch
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#! /usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6 3
 
 # Copyright (c) 2010- The University of Notre Dame.
 # This software is distributed under the GNU General Public License.

--- a/prune/src/prune.in
+++ b/prune/src/prune.in
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 #
 
 # Copyright (c) 2010- The University of Notre Dame.

--- a/resource_monitor/src/resource_monitor_visualizer.py
+++ b/resource_monitor/src/resource_monitor_visualizer.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 import os
 import sys

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -22,6 +22,9 @@ export CCTOOLS_TEST_LOG
 
 echo "[$(date)] Testing on $(uname -a)." > "$CCTOOLS_TEST_LOG"
 
+# we need cctools_python in the path.
+export PATH="$(pwd)/dttools/src:$PATH"
+
 SUCCESS=0
 FAILURE=0
 START_TIME=$(date +%s)

--- a/umbrella/src/umbrella.py
+++ b/umbrella/src/umbrella.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 """
 Umbrella is a tool for specifying and materializing comprehensive execution environments, from the hardware all the way up to software and data.  A user simply invokes Umbrella with the desired task, and Umbrella determines the minimum mechanism necessary to run the task, whether it be direct execution, a system container, a local virtual machine, or submission to a cloud or grid environment.  We present the overall design of Umbrella and demonstrate its use to precisely execute a high energy physics application and a ray-tracing application across many platforms using a combination of Parrot, Chroot, Docker, VMware, Condor, and Amazon EC2.
 

--- a/weaver/src/examples/arguments.py
+++ b/weaver/src/examples/arguments.py
@@ -1,3 +1,4 @@
-""" Print out arguments given to Weaver. """
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 print(CurrentScript().arguments)

--- a/weaver/src/tests.py
+++ b/weaver/src/tests.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (c) 2012- The University of Notre Dame.
 # This software is distributed under the GNU General Public License.

--- a/weaver/src/weaver.in
+++ b/weaver/src/weaver.in
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (c) 2010- The University of Notre Dame.
 # This software is distributed under the GNU General Public License.

--- a/work_queue/src/python/work_queue_detailed_example_1.py
+++ b/work_queue/src/python/work_queue_detailed_example_1.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (c) 2010- The University of Notre Dame.
 # This software is distributed under the GNU General Public License.

--- a/work_queue/src/python/work_queue_detailed_example_2.py
+++ b/work_queue/src/python/work_queue_detailed_example_2.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 import work_queue
 import os

--- a/work_queue/src/python/work_queue_example.py
+++ b/work_queue/src/python/work_queue_example.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (c) 2010- The University of Notre Dame.
 # This software is distributed under the GNU General Public License.

--- a/work_queue/src/work_queue_graph_log
+++ b/work_queue/src/work_queue_graph_log
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (C) 2014- The University of Notre Dame
 # This software is distributed under the GNU General Public License.


### PR DESCRIPTION
Proposal to resolve #801.
You can check its use with starch.

Note that I did not want to use hard coded values from configure, as that may break for the binary releases.

cctool_python reads the second line of a python script, which
should be of the form:

  # CCTOOLS_PYTHON_VERSION 2.7 3 2.6 42

which lists, in order of preference, the acceptable versions to run the
script. For example:

  # CCTOOLS_PYTHON_VERSION 2.4

means: only run on python 2.4.

  # CCTOOLS_PYTHON_VERSION 2.7 2.6

means: 2.7 and 2.6 are both ok, but prefer 2.7.

  # CCTOOLS_PYTHON_VERSION 3

means: any version 3 is ok.
