### PR TITLE
Remove trailing slashes from paths ret. by getcwd.

### DIFF
--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -1121,7 +1121,14 @@ int pfs_table::chdir( const char *path )
 
 char *pfs_table::getcwd( char *path, pfs_size_t size )
 {
-	strncpy(path,working_dir,size);
+	char cwd[PFS_PATH_MAX];
+	strcpy(cwd, working_dir);
+	path_remove_trailing_slashes(cwd);
+	if (strlen(cwd)+1 > (size_t)size) {
+		errno = ERANGE;
+		return NULL;
+	}
+	strcpy(path, cwd);
 	return path;
 }
 


### PR DESCRIPTION
Fixes #823.

    UNIX makes no guarantees [1] about the form of paths returned by getcwd,
    only that it is an absolute path. However some applications [2] assume that
    the path returned by getcwd has no redundant trailing slashes.

    Haiyan found this problem in a CMS application (made of Perl scripts) which
    would fail when a getcwd path had redundant terminating slashes. The Perl
    code is here [2]. The failing function is verifypath.

    The fix for this problem is to simply strip trailing slashes in
    pfs_table::getcwd. PR incoming.

    [1] http://pubs.opengroup.org/onlinepubs/009695399/functions/getcwd.html
    [2] /cvmfs/cms.cern.ch/slc5_amd64_gcc434/cms/cmssw/CMSSW_4_2_8/bin/slc5_amd64_gcc434/SkelParser.pm