### PR TITLE
Several Umbrella Features

### DIFF
--- a/doc/umbrella.html
+++ b/doc/umbrella.html
@@ -238,6 +238,7 @@ cmsDriver.py Hadronizer_MgmMatchTuneZ2star_8TeV_madgraph_cff.py -s GEN \
 	--inputs 'cms_complex.sh=cms_complex.sh' \
 	--localdir /tmp/umbrella_test/ \
 	--output /tmp/umbrella_test/parrot_cms_complex_output \
+	--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 	run '/bin/sh cms_complex.sh'</code>
 
 			<p>After umbrella finishes executing the CMS application, you can see the analysis result:
@@ -859,6 +860,7 @@ cmsDriver.py Hadronizer_MgmMatchTuneZ2star_8TeV_madgraph_cff.py -s GEN \
 	--inputs 'cms_complex.sh=cms_complex.sh' \
 	--localdir /tmp/umbrella_test/ \
 	--output /tmp/umbrella_test/parrot_cms_complex_output \
+	--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 	run '/bin/sh cms_complex.sh'</code>
 
 			<p>If you want to run this CMS application through Umbrella, please check the <a href="#try_cms">Try CMS Applications with Umbrella</a>.</p>

--- a/umbrella/example/cms_complex/README
+++ b/umbrella/example/cms_complex/README
@@ -9,6 +9,7 @@ umbrella \
 --inputs 'cms_complex.sh=cms_complex.sh' \
 --localdir /tmp/umbrella_test/ \
 --output /tmp/umbrella_test/parrot_cms_complex_output \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run '/bin/sh cms_complex.sh'
 
 #Docker execution engine test command. Don't do the docker test under your afs, it will fail due to the ACL of your afs.
@@ -19,6 +20,7 @@ umbrella \
 --inputs 'cms_complex.sh=cms_complex.sh' \
 --localdir /tmp/umbrella_test/ \
 --output /tmp/umbrella_test/docker_cms_complex_output \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run '/bin/sh cms_complex.sh'
 
 #Local execution engine test command. Don't test local execution engine under
@@ -31,6 +33,7 @@ umbrella \
 --inputs 'cms_complex.sh=cms_complex.sh' \
 --localdir /tmp/umbrella_test/ \
 --output /tmp/umbrella_test/local_cms_complex_output \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run '/bin/sh cms_complex.sh'
 
 #EC2 execution engine test command. To test this, you must set up the Amazon
@@ -51,6 +54,7 @@ umbrella \
 --inputs 'cms_complex.sh=cms_complex.sh' \
 --localdir /tmp/umbrella_test/ \
 --output /tmp/umbrella_test/ec2_cms_complex_output \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run '/bin/sh cms_complex.sh'
 
 #Condor execution engine test command. To test this, the machine you are using should have condor installed.
@@ -63,5 +67,6 @@ umbrella \
 --inputs 'cms_complex.sh=cms_complex.sh' \
 --localdir /tmp/umbrella_test/ \
 --output /tmp/umbrella_test/condor_cms_complex_output \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run '/bin/sh cms_complex.sh'
 

--- a/umbrella/example/cms_complex/cms_complex.sh
+++ b/umbrella/example/cms_complex/cms_complex.sh
@@ -4,14 +4,14 @@ rm -rf sim_job
 mkdir sim_job
 cd sim_job
 
-. /cvmfs/cms.cern.ch/cmsset_default.sh
+. ${CMS_DIR}/cmsset_default.sh
 scramv1 project -f CMSSW ${CMS_VERSION}
 cd ${CMS_VERSION}
 eval `scram runtime -sh`
 cd ..
 cmsDriver.py Hadronizer_MgmMatchTuneZ2star_8TeV_madgraph_cff.py -s GEN \
 --eventcontent=RAWSIM --datatier GEN -n 10 \
---filein=file:/tmp/final_events_2381.lhe \
+--filein=file:${INPUT_FILE} \
 --filetype=LHE --conditions=START52_V9::All
 
 # vim: set noexpandtab tabstop=4:

--- a/umbrella/example/cms_complex/cms_complex.umbrella
+++ b/umbrella/example/cms_complex/cms_complex.umbrella
@@ -16,11 +16,13 @@
 	},
 	"software": {
 		"cmssw-5.2.5-slc5-amd64": {
+			"mount_env": "CMS_DIR",
 			"mountpoint": "/cvmfs/cms.cern.ch"
 		}
 	},
 	"data": {
 		"final_events_2381.lhe": {
+			"mount_env": "INPUT_FILE",
 			"mountpoint": "/tmp/final_events_2381.lhe",
 			"action": "none"
 		}

--- a/umbrella/example/cms_opendata/README
+++ b/umbrella/example/cms_opendata/README
@@ -9,6 +9,7 @@ umbrella \
 --inputs 'cms_opendata.sh=cms_opendata.sh' \
 --localdir /tmp/umbrella_test/ \
 --output /tmp/umbrella_test/parrot_cms_opendata_output \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run '/bin/sh cms_opendata.sh'
 
 #Docker execution engine test command. Don't do the docker test under your afs, it will fail due to the ACL of your afs.
@@ -19,6 +20,7 @@ umbrella \
 --inputs 'cms_opendata.sh=cms_opendata.sh' \
 --localdir /tmp/umbrella_test/ \
 --output /tmp/umbrella_test/docker_cms_opendata_output \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run '/bin/sh cms_opendata.sh'
 
 #Local execution engine test command. Don't test local execution engine under
@@ -31,6 +33,7 @@ umbrella \
 --inputs 'cms_opendata.sh=cms_opendata.sh' \
 --localdir /tmp/umbrella_test/ \
 --output /tmp/umbrella_test/local_cms_opendata_output \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run '/bin/sh cms_opendata.sh'
 
 #EC2 execution engine test command. To test this, you must set up the Amazon
@@ -51,6 +54,7 @@ umbrella \
 --inputs 'cms_opendata.sh=cms_opendata.sh' \
 --localdir /tmp/umbrella_test/ \
 --output /tmp/umbrella_test/ec2_cms_opendata_output \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run '/bin/sh cms_opendata.sh'
 
 #Condor execution engine test command. To test this, the machine you are using should have condor installed.
@@ -63,5 +67,6 @@ umbrella \
 --inputs 'cms_opendata.sh=cms_opendata.sh' \
 --localdir /tmp/umbrella_test/ \
 --output /tmp/umbrella_test/condor_cms_opendata_output \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run '/bin/sh cms_opendata.sh'
 

--- a/umbrella/example/cms_opendata/README
+++ b/umbrella/example/cms_opendata/README
@@ -1,0 +1,67 @@
+The documentation illustrates how to use different execution engines of Umbrella to execute
+a complex CMS application.
+
+#parrot execution engine test command.
+umbrella \
+--sandbox_mode parrot \
+--log umbrella.log \
+--config cms_opendata.umbrella \
+--inputs 'cms_opendata.sh=cms_opendata.sh' \
+--localdir /tmp/umbrella_test/ \
+--output /tmp/umbrella_test/parrot_cms_opendata_output \
+run '/bin/sh cms_opendata.sh'
+
+#Docker execution engine test command. Don't do the docker test under your afs, it will fail due to the ACL of your afs.
+umbrella \
+--sandbox_mode docker \
+--log umbrella.log \
+--config cms_opendata.umbrella \
+--inputs 'cms_opendata.sh=cms_opendata.sh' \
+--localdir /tmp/umbrella_test/ \
+--output /tmp/umbrella_test/docker_cms_opendata_output \
+run '/bin/sh cms_opendata.sh'
+
+#Local execution engine test command. Don't test local execution engine under
+#your afs, because the ACL of your afs does not support importing an OS tarball
+#into a docker image.
+umbrella \
+--sandbox_mode local \
+--log umbrella.log \
+--config cms_opendata.umbrella \
+--inputs 'cms_opendata.sh=cms_opendata.sh' \
+--localdir /tmp/umbrella_test/ \
+--output /tmp/umbrella_test/local_cms_opendata_output \
+run '/bin/sh cms_opendata.sh'
+
+#EC2 execution engine test command. To test this, you must set up the Amazon
+#EC2 command line interface tools on Linux
+#(http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/set-up-ec2-cli-linux.html#setting_up_ec2_command_linux).
+#there is only one difference between the specification for ec2 execution engine
+#and the specification for the local execution engine (parrot/docker/chroot):
+#the `id` attribute of the os section is an AMI in the ec2 specification; the
+#`id` attribute of the os section is the checksum of the os image.
+umbrella \
+--sandbox_mode ec2 \
+--log umbrella.log \
+--ec2_log umbrella.log.ec2 \
+--ec2_sshkey ~/bin/feb272015.pem \
+--ec2_key feb272015 \
+--ec2_group 'sg-24f96141' \
+--config cms_opendata.umbrella \
+--inputs 'cms_opendata.sh=cms_opendata.sh' \
+--localdir /tmp/umbrella_test/ \
+--output /tmp/umbrella_test/ec2_cms_opendata_output \
+run '/bin/sh cms_opendata.sh'
+
+#Condor execution engine test command. To test this, the machine you are using should have condor installed.
+#Condor can not work together with afs. So don't do your test on your afs.
+umbrella \
+--sandbox_mode condor \
+--log umbrella.log \
+--condor_log umbrella.log.condor \
+--config cms_opendata.umbrella \
+--inputs 'cms_opendata.sh=cms_opendata.sh' \
+--localdir /tmp/umbrella_test/ \
+--output /tmp/umbrella_test/condor_cms_opendata_output \
+run '/bin/sh cms_opendata.sh'
+

--- a/umbrella/example/cms_opendata/cms_opendata.sh
+++ b/umbrella/example/cms_opendata/cms_opendata.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+#the setting of environment variables is moved into the umbrella specification.
+
+#setting environment variables is not necessary in the analysis code.
+
+rm -rf sim_job
+mkdir sim_job
+cd sim_job
+
+. ${CMS_DIR}/cmsset_default.sh
+#Execute the following command; this command builds the local release area (the directory structure) for CMSSW, and only needs to be run once:
+scramv1 project -f CMSSW ${CMS_VERSION}
+
+#Change to the CMSSW_4_2_8/src/ directory:
+cd ${CMS_VERSION}/src/
+
+#Then, run the following command to create the CMS runtime variables:
+#cmsenv
+eval `scram runtime -sh`
+
+#Create a working directory for the demo analyzer, change to that directory and create a "skeleton" for the analyzer:
+mkdir Demo
+cd Demo
+mkedanlzr DemoAnalyzer
+
+#Compile the code:
+cd DemoAnalyzer
+scram b
+
+#Change the file name in the configuration file demoanalyzer_cfg.py in the DemoAnalyzer directory: i.e. replace file:myfile.root with root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/AOD/Apr21ReReco-v1/0000/00459D48-EB70-E011-AF09-90E6BA19A252.root
+#Change the max number of events to 10 (i.e change -1 to 10 in process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1)).
+#the problem here is this is an interactive procedure, which by default is not supported by umbrella and parrot-packaging-tool.
+cp -f ${CONFIG_FILE} .
+
+#Move two directories back using:
+cd ../..
+
+#And then run:
+cmsRun Demo/DemoAnalyzer/demoanalyzer_cfg.py
+

--- a/umbrella/example/cms_opendata/cms_opendata.umbrella
+++ b/umbrella/example/cms_opendata/cms_opendata.umbrella
@@ -1,0 +1,36 @@
+{
+	"comment": "a CMS application whose software dependencies are all from CVMFS, and whose data dependencies are not from CVMFS.",
+	"hardware": {
+		"arch": "x86_64",
+		"cores": "1",
+		"memory": "2GB",
+		"disk": "3GB"
+	},
+	"kernel" : {
+		"name": "linux",
+		"version": ">=2.6.18"
+	},
+	"os": {
+		"name": "Redhat",
+		"version": "5.10"
+	},
+	"software": {
+		"cmssw-4.2.8-slc5-amd64": {
+			"mount_env": "CMS_DIR",
+			"mountpoint": "/cvmfs/cms.cern.ch"
+		}
+	},
+	"data": {
+		"cms_opendata_cfg": {
+			"mountpoint": "/tmp/demoanalyzer_cfg.py",
+			"mount_env": "CONFIG_FILE"
+		},
+		"cms_opendata_rootfile": {
+			"mount_env": "ROOT_FILE"
+		}
+	},
+	"environ": {
+		"CMS_VERSION": "CMSSW_4_2_8",
+		"SCRAM_ARCH": "slc5_amd64_gcc434"
+	}
+}

--- a/umbrella/example/cms_opendata/cms_opendata.umbrella
+++ b/umbrella/example/cms_opendata/cms_opendata.umbrella
@@ -21,11 +21,11 @@
 		}
 	},
 	"data": {
-		"cms_opendata_cfg": {
+		"demoanalyzer_cfg.py": {
 			"mountpoint": "/tmp/demoanalyzer_cfg.py",
 			"mount_env": "CONFIG_FILE"
 		},
-		"cms_opendata_rootfile": {
+		"00459D48-EB70-E011-AF09-90E6BA19A252.root": {
 			"mount_env": "ROOT_FILE"
 		}
 	},

--- a/umbrella/example/cms_simple/README
+++ b/umbrella/example/cms_simple/README
@@ -9,6 +9,7 @@ umbrella \
 --inputs 'cms_simple1.sh=cms_simple.sh' \
 --localdir /tmp/umbrella_test/ \
 --output /tmp/umbrella_test/parrot_cms_simple_output \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run '/bin/bash cms_simple1.sh'
 
 #Docker execution engine test command. Don't do the docker test under your afs,
@@ -20,6 +21,7 @@ umbrella \
 --inputs 'cms_simple1.sh=cms_simple.sh' \
 --localdir /tmp/umbrella_test/ \
 --output /tmp/umbrella_test/docker_cms_simple_output \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run '/bin/bash cms_simple1.sh'
 
 #Local execution engine test command. Don't test local execution engine under
@@ -32,6 +34,7 @@ umbrella \
 --inputs 'cms_simple1.sh=cms_simple.sh' \
 --localdir /tmp/umbrella_test/ \
 --output /tmp/umbrella_test/local_cms_simple_output \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run '/bin/bash cms_simple1.sh'
 
 #EC2 execution engine test command. To test this, you must set up the Amazon
@@ -52,6 +55,7 @@ umbrella \
 --inputs 'cms_simple1.sh=cms_simple.sh' \
 --localdir /tmp/umbrella_test/ \
 --output /tmp/umbrella_test/ec2_cms_simple_output \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run '/bin/bash cms_simple1.sh'
 
 #Condor execution engine test command. To test this, the machine you are using should have condor installed.
@@ -64,5 +68,6 @@ umbrella \
 --inputs 'cms_simple1.sh=cms_simple.sh' \
 --localdir /tmp/umbrella_test/ \
 --output /tmp/umbrella_test/condor_cms_simple_output \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run '/bin/bash cms_simple1.sh'
 

--- a/umbrella/example/cms_simple/cms_simple.sh
+++ b/umbrella/example/cms_simple/cms_simple.sh
@@ -4,7 +4,7 @@ rm -rf cmsjob
 mkdir cmsjob
 cd cmsjob
 
-. /cvmfs/cms.cern.ch/cmsset_default.sh
+. ${CMS_DIR}/cmsset_default.sh
 scramv1 project CMSSW ${CMS_VERSION}
 cd ${CMS_VERSION}
 eval `scram runtime -sh`

--- a/umbrella/example/cms_simple/cms_simple.umbrella
+++ b/umbrella/example/cms_simple/cms_simple.umbrella
@@ -16,6 +16,7 @@
 	},
 	"software": {
 		"cmssw-5.3.11-slc5-amd64": {
+			"mount_env": "CMS_DIR",
 			"mountpoint": "/cvmfs/cms.cern.ch"
 		}
 	},

--- a/umbrella/example/povray/README
+++ b/umbrella/example/povray/README
@@ -61,7 +61,7 @@ umbrella \
 --config povray.umbrella \
 --inputs '4_cubes.pov=4_cubes.pov,WRC_RubiksCube.inc=WRC_RubiksCube.inc' \
 --localdir /tmp/umbrella_test/ \
---output /tmp/umbrella_test/ec2_povray --remotelog umbrella.log.ec2 \
+--output /tmp/umbrella_test/ec2_povray \
 run "povray +I4_cubes.pov +Oframe000.png +K.0  -H50 -W50"
 
 #Condor execution engine test command. To test this, the machine you are using should have condor installed.

--- a/umbrella/src/README
+++ b/umbrella/src/README
@@ -40,7 +40,7 @@ Here is the specification JSON file for a Ray-Tracing application:
 Once the specification is ready, you can run the application through umbrella:
 
 umbrella \
-	--batch_type parrot \
+	--sandbox_mode parrot \
 	--log umbrella.log \
 	--config povray.umbrella \
 	--inputs '4_cubes.pov=4_cubes.pov,WRC_RubiksCube.inc=WRC_RubiksCube.inc' \

--- a/umbrella/src/umbrella.py
+++ b/umbrella/src/umbrella.py
@@ -1660,7 +1660,7 @@ def condor_process(spec_path, spec_json, spec_path_basename, packages_path, sand
 	condor_submit_file.write('universe = vanilla\n')
 	condor_submit_file.write('executable = %s\n' % cctools_python_path)
 	if cvmfs_http_proxy:
-		condor_submit_file.write('arguments = "./umbrella -s local -c %s --cvmfs_http_proxy %s --packages %s -l condor_umbrella -i \'%s\' -o %s --log condor_umbrella.log run \'%s\'"\n' % (spec_path_basename, os.path.basename(packages_path), cvmfs_http_proxy, new_input_options, os.path.basename(condor_output_dir), user_cmd[0]))
+		condor_submit_file.write('arguments = "./umbrella -s local -c %s --cvmfs_http_proxy %s --packages %s -l condor_umbrella -i \'%s\' -o %s --log condor_umbrella.log run \'%s\'"\n' % (spec_path_basename, cvmfs_http_proxy, os.path.basename(packages_path), new_input_options, os.path.basename(condor_output_dir), user_cmd[0]))
 	else:
 		condor_submit_file.write('arguments = "./umbrella -s local -c %s --packages %s -l condor_umbrella -i \'%s\' -o %s --log condor_umbrella.log run \'%s\'"\n' % (spec_path_basename, os.path.basename(packages_path), new_input_options, os.path.basename(condor_output_dir), user_cmd[0]))
 #	condor_submit_file.write('PostCmd = "echo"\n')

--- a/umbrella/src/umbrella.py
+++ b/umbrella/src/umbrella.py
@@ -72,14 +72,8 @@ To allow this, do remember to add the 5.0.1 cctools packages into the remote arc
 cctools-version: based on http://www3.nd.edu/~ccl/software/files/cctools-4.9.0-x86_64-redhat6.tar.gz
 Here, 4.9.0 is the version number I picked up to denote the latest master branch, the infomation of the HEAD is:
 	Author: Patrick Donnelly
-	Date:   2015-05-13 18:32:38 -0400
-	Commit: e25ce3debcbeae30dd0c2b82922aa441fa1f78db (master)
-	* Fix missing update to bytes written.
-
-	This caused an assertion failure when an *atomic* write completed
-	successfully but the return value did not indicate this.
-
-	Bug found by Haiyan, @hmeng-19.
+	Date:   2015-06-26 17:08:45 -0400
+	Commit: f2bb681fdf8403632aa3da767983bf566e40007d (master)
 """
 
 def subprocess_error(cmd, rc, stdout, stderr):

--- a/umbrella/src/umbrella.py
+++ b/umbrella/src/umbrella.py
@@ -720,6 +720,13 @@ def software_install(env_para_dict, os_id, software_spec, packages_json, sandbox
 			if mount_env and mountpoint:
 				env_para_dict[mount_env] = mountpoint
 
+			if not r4 and not env_para_dict.has_key('HTTP_PROXY'):
+				if os.environ.has_key('HTTP_PROXY'):
+					env_para_dict['HTTP_PROXY'] = os.environ['HTTP_PROXY']
+				else:
+					logging.debug("Access CVMFS through Parrot requires the HTTP_PROXY environment variable to be set first.")
+					sys.exit("Access CVMFS through Parrot requires the HTTP_PROXY environment variable to be set first.")
+
 	#if the OS distribution does not match, add the OS image into the dependency list of the application and download it into the local machine
 	if need_separate_rootfs == 1:
 		item = '%s-%s-%s' % (distro_name, distro_version, hardware_platform)

--- a/umbrella/src/working_principle
+++ b/umbrella/src/working_principle
@@ -137,10 +137,3 @@ umbrella: error: no such option: -r
 hmeng@ccl12 ~/git-development/cctools/umbrella/example/povray$ echo $?
 2
 
-func_notes.html: a html file including the help documents about all the modules and functions. The file is created by `pydoc` in the following way:
-1) copy umbrella into a new file whose name ends with .py. The reason why a file ending with .py is needed is pydoc only recognizes such files.
-$ cp umbrella umbrella.py
-2) create html document using pydoc, which will create a html file named umbrella.html including the help documents about all the modules and functions.
-$ pydoc -w umbrella
-3) rename umbrella.html to func_notes.html. This renaming is to avoid confusion between this html and the umbrella html document under cctools/doc.
-$ mv umbrella.html func_notes.html

--- a/umbrella/src/working_principle
+++ b/umbrella/src/working_principle
@@ -21,6 +21,8 @@ Options:
   -s SANDBOX_MODE, --sandbox_mode=SANDBOX_MODE
 						sandbox mode, which can be local, parrot, chroot,
 						docker, condor, ec2. (By default: local)
+  --cvmfs_http_proxy=CVMFS_HTTP_PROXY
+						HTTP_PROXY to access cvmfs (Used by Parrot)
   --packages=PACKAGES   The source of packages information. (By default:
 						./packages.json)
 						If the value of this option does not exist, one copy of packages.json will be downloaded into the sandbox from the ccl website.

--- a/umbrella/src/working_principle
+++ b/umbrella/src/working_principle
@@ -136,4 +136,3 @@ Usage: umbrella [options] run "command"
 umbrella: error: no such option: -r
 hmeng@ccl12 ~/git-development/cctools/umbrella/example/povray$ echo $?
 2
-


### PR DESCRIPTION
1) Add mount_env into the umbrella spec syntax
    
        mount_env allows the user's analysis code to ignore the data location, and
        also makes the relocation of the dependency easier without changing the
        analysis code and just change the spec file.

2) Add a new umbrella example for cern_opendata

        This example comes from the cern opendata website.

3) Check HTTP_PROXY for Umbrella+Docker+Parrot app

4) Use the right version of cctools
    
        If the sandbox mode is parrot, use the cctools version which matches
        the host machine.
        If the sandbox mode is docker or chroot, and parrot is needed inside
        the sandbox to deliver cvmfs, use the cctools version which matches
        the specification os requirement.
    
5)    Create mountpoint for each level of a path, Add fake mounts into parrot mount file
    
        If a mountitem '/a/b/c' is added into the parrot mountfile, and if '/a' does
        not exist or '/a/b' does not exist, `cd` fails because it needs to stat /a and
        stat /a/b.  Solution: create mountpoints for /a and /a/b when they do not
        exist.

6)    Replace the cctools binary in umbrella archive
    
        The new cctools binary is based on the commit:
                Date:   2015-06-26 17:08:45 -0400
                Commit: f2bb681fdf8403632aa3da767983bf566e40007d (master)

