### PR TITLE
Fixes to WQ workers started as SGE jobs on a big cluster with a shared file system

### DIFF
--- a/dttools/src/disk_info.c
+++ b/dttools/src/disk_info.c
@@ -58,19 +58,19 @@ int disk_info_get(const char *path, UINT64_T * avail, UINT64_T * total)
 }
 
 /* Slower disk check, poor man's du on workspace */
-int check_disk_workspace(char *workspace, int64_t *workspace_usage, int force, int64_t manual_disk_option, int measure_wd_interval, time_t last_cwd_measure_time, int64_t last_workspace_usage, UINT64_T disk_avail_threshold) {
+int check_disk_workspace(char *workspace, int64_t *workspace_usage, int force, int64_t manual_disk_option, int measure_wd_interval, time_t *last_cwd_measure_time, int64_t *last_workspace_usage, UINT64_T disk_avail_threshold) {
 
 	if(manual_disk_option < 1)
 		return 1;
 
-	if( force || (time(0) - last_cwd_measure_time) >= measure_wd_interval ) {
-		cwd_disk_info_get(workspace, &last_workspace_usage);
-		debug(D_DEBUG, "worker disk usage: %" PRId64 "\n", last_workspace_usage);
-		last_cwd_measure_time = time(0);
+	if( force || (time(0) - *last_cwd_measure_time) >= measure_wd_interval ) {
+		cwd_disk_info_get(workspace, last_workspace_usage);
+		debug(D_DEBUG, "worker disk usage: %" PRId64 "\n", *last_workspace_usage);
+		*last_cwd_measure_time = time(0);
 	}
 
 	if(workspace_usage) {
-		*workspace_usage = last_workspace_usage;
+		*workspace_usage = *last_workspace_usage;
 	}
 
 	// Use threshold only if smaller than specified disk size.
@@ -78,8 +78,8 @@ int check_disk_workspace(char *workspace, int64_t *workspace_usage, int force, i
 	if(disk_limit < 0)
 		disk_limit = manual_disk_option;
 
-	if(last_workspace_usage > disk_limit) {
-		debug(D_DEBUG, "worker disk usage %"PRId64 " larger than: %" PRId64 "!\n", last_workspace_usage + disk_avail_threshold, manual_disk_option);
+	if(*last_workspace_usage > disk_limit) {
+		debug(D_DEBUG, "worker disk usage %"PRId64 " larger than: %" PRId64 "!\n", *last_workspace_usage + disk_avail_threshold, manual_disk_option);
 		return 0;
 	} else {
 		return 1;

--- a/dttools/src/disk_info.h
+++ b/dttools/src/disk_info.h
@@ -33,7 +33,7 @@ int disk_info_get(const char *path, UINT64_T * avail, UINT64_T * total);
 @param disk_avail_threshold An unsigned integer that describes the lowest amount of free space to be left.
 @return Zero if the file will not fit, one if the file fits.
 */
-int check_disk_workspace(char *workspace, int64_t *workspace_usage, int force, int64_t manual_disk_option, int measure_wd_interval, time_t last_cwd_measure_time, int64_t last_workspace_usage, UINT64_T disk_avail_threshold);
+int check_disk_workspace(char *workspace, int64_t *workspace_usage, int force, int64_t manual_disk_option, int measure_wd_interval, time_t *last_cwd_measure_time, int64_t *last_workspace_usage, UINT64_T disk_avail_threshold);
 
 
 /** Return whether a file will fit in the given directory.

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -2006,6 +2006,11 @@ int main(int argc, char *argv[])
 	signal(SIGTERM, handle_abort);
 	signal(SIGQUIT, handle_abort);
 	signal(SIGINT, handle_abort);
+	//Also do cleanup on SIGUSR1 & SIGUSR2 to allow using -notify and -l s_rt= options if submitting 
+	//this worker process with SGE qsub. Otherwise task processes are left running when SGE
+	//terminates this process with SIGKILL.
+	signal(SIGUSR1, handle_abort);
+	signal(SIGUSR2, handle_abort);
 	signal(SIGCHLD, handle_sigchld);
 
 	random_init();

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1273,6 +1273,11 @@ static void work_for_master(struct link *master) {
 
 	sigemptyset(&mask);
 	sigaddset(&mask, SIGCHLD);
+	sigaddset(&mask, SIGTERM);
+	sigaddset(&mask, SIGQUIT);
+	sigaddset(&mask, SIGINT);
+	sigaddset(&mask, SIGUSR1);
+	sigaddset(&mask, SIGUSR2);
 
 	reset_idle_timer();
 


### PR DESCRIPTION
This branch addresses two critical problems that manifested themselves under the use case identified in the title of this pull request

Scenario: I use sge_submit_workers to submit a 1000 workers on a big cluster where all file systems are shared, so the worker sandbox space has to be on a shared FS. `CentOS 6; OGS/Grid Engine 2011.11.`

Problems and fixes:

1. When SGE has to kill the worker (e.g. hard wallclock limit in a queue is reached or I do qdel), SGE  sends SIGKILL to the process group that it has created for the worker. Worker, however, runs its task subprocesses under a new process group. Worker cannot trap SIGKILL, so it gets killed, and tasks keep running (they are under different process group) and wreck havoc.

  Fixes: 
 - added wallclock run-time option to worker so that it will exit before its job wallclock runs out
 - worker traps now SIGUSR1 and SIGUSR2 and exits killing tasks, so that it can be submitted with SGE qsub options `-notify` and `-l s_rt XXX` which result in these signals being send to the job before the SIGKILL or SIGSTOP
 - killing tasks as soon as possible after detecting the exit request

 The fixes above are partial solutions. Nothing 100% proof can be done without using cgroups.

2. In the main worker loop, check_disk_space_for_filesize has been called once per 10 ms (before any changes introduced in p.1 above), bringing down the shared file system with statvfs calls when a 1000 workers were running at the same time.

 Fixes:
 - results of that call are now cached and calls only made every 20s

Tests

No unit tests added, but these changes were tested in an actual large scale runs, as well as with temporarily added diagnostic printouts.