### PR TITLE
Job chirp bindings

### DIFF
--- a/chirp/src/chirp.i
+++ b/chirp/src/chirp.i
@@ -33,7 +33,6 @@
 #ifdef SWIGPERL
 	$1 = (uint64_t) SvIV($input);
 #endif
-
 }
 
 /* vdebug() takes va_list as arg but SWIG can't wrap such functions. */

--- a/chirp/src/chirp_swig_wrap.c
+++ b/chirp/src/chirp_swig_wrap.c
@@ -54,4 +54,73 @@ char *chirp_wrap_whoami(const char *hostname, time_t stoptime)
 	return xxstrdup(id);
 }
 
+int64_t chirp_wrap_job_create (const char *host, const char *json, time_t stoptime)
+{
+	chirp_jobid_t id;
+
+	int64_t result;
+	result = chirp_reli_job_create(host, json, &id, stoptime);
+
+	if(result < 0)
+		return result;
+
+	return id;
+}
+
+
+int64_t chirp_wrap_job_commit (const char *host, const char *json, time_t stoptime)
+{
+	int64_t result;
+	result = chirp_reli_job_commit(host, json, stoptime);
+
+	return result;
+}
+
+
+int64_t chirp_wrap_job_kill (const char *host, const char *json, time_t stoptime)
+{
+	int64_t result;
+	result = chirp_reli_job_kill(host, json, stoptime);
+
+	return result;
+}
+
+
+int64_t chirp_wrap_job_reap (const char *host, const char *json, time_t stoptime)
+{
+	int64_t result;
+	result = chirp_reli_job_reap(host, json, stoptime);
+
+	return result;
+}
+
+
+char *chirp_wrap_job_status (const char *host, const char *json, time_t stoptime)
+{
+	char *status;
+
+	int64_t result;
+	result = chirp_reli_job_status(host, json, &status, stoptime);
+
+	if(result < 0)
+		return NULL;
+
+	return status;
+}
+
+
+char *chirp_wrap_job_wait  (const char *host, chirp_jobid_t id, int64_t timeout, time_t stoptime)
+{
+	char *status;
+
+	int64_t result;
+	result = chirp_reli_job_wait(host, id, timeout, &status, stoptime);
+
+	if(result < 0)
+		return NULL;
+
+	return status;
+}
+
+
 /* vim: set noexpandtab tabstop=4: */

--- a/chirp/src/chirp_swig_wrap.h
+++ b/chirp/src/chirp_swig_wrap.h
@@ -5,3 +5,10 @@ struct chirp_stat *chirp_wrap_stat(const char *hostname, const char *path, time_
 char *chirp_wrap_listacl(const char *hostname, const char *path, time_t stoptime);
 
 char *chirp_wrap_whoami(const char *hostname, time_t stoptime);
+
+int64_t chirp_wrap_job_create(const char *host, const char *json, time_t stoptime);
+int64_t chirp_wrap_job_commit(const char *host, const char *json, time_t stoptime);
+int64_t chirp_wrap_job_kill  (const char *host, const char *json, time_t stoptime);
+int64_t chirp_wrap_job_reap  (const char *host, const char *json, time_t stoptime);
+char   *chirp_wrap_job_status(const char *host, const char *json, time_t stoptime);
+char   *chirp_wrap_job_wait  (const char *host, chirp_jobid_t id, int64_t timeout, time_t stoptime);

--- a/chirp/src/perl/Chirp/Client.pm
+++ b/chirp/src/perl/Chirp/Client.pm
@@ -173,8 +173,86 @@ sub rm {
 
 	my $result = chirp_reli_rmall($self->hostport, $path, $self->__stoptime(%args));
 
-	croak("Could not recursevely remove path '$path' (status $result).\n") if $result < 0;
+	croak("Could not recursively remove path '$path' (status $result).\n") if $result < 0;
 	return $result;
+}
+
+eval "use JSON qw(to_json from_json);";
+if ($@) {
+	# JSON module is not installed.
+	sub to_json {
+		croak("The chirp job interface needs the JSON module from CPAN.\n");
+	}
+
+	sub from_json {
+		croak("The chirp job interface needs the JSON module from CPAN.\n");
+	}
+}
+
+sub __json_of_ids {
+	my ($self, @numbers) = @_;
+	return to_json([ map { $_ + 0 } @numbers ]);
+}
+
+sub job_create {
+	my ($self, $job_description) = @_;
+
+	my $job_json = to_json($job_description);
+
+	my $job_id   = chirp_wrap_job_create($self->hostport, $job_json, $self->__stoptime);
+	croak("Could not create job.\n") if $job_id < 0;
+
+	return $job_id;
+}
+
+sub job_commit {
+	my ($self, @job_ids) = @_;
+
+	my $job_ids_str = $self->__json_of_ids(@job_ids);
+	my $result      = chirp_wrap_job_commit($self->hostport, $job_ids_str, $self->__stoptime);
+
+	croak("Could not commit jobs: $job_ids_str") if $result < 0;
+	return $result;
+}
+
+sub job_kill {
+	my ($self, @job_ids) = @_;
+
+	my $job_ids_str = $self->__json_of_ids(@job_ids);
+	my $result      = chirp_wrap_job_kill($self->hostport, $job_ids_str, $self->__stoptime);
+
+	croak("Could not kill jobs: $job_ids_str\n") if $result < 0;
+	return $result;
+}
+
+sub job_reap {
+	my ($self, @job_ids) = @_;
+
+	my $job_ids_str = $self->__json_of_ids(@job_ids);
+	my $result      = chirp_wrap_job_reap($self->hostport, $job_ids_str, $self->__stoptime);
+
+	croak("Could not reap jobs: $job_ids_str\n") if $result < 0;
+	return $result;
+}
+
+sub job_status {
+	my ($self, @job_ids) = @_;
+
+	my $job_ids_str = $self->__json_of_ids(@job_ids);
+	my $status      = chirp_wrap_job_status($self->hostport, $job_ids_str, $self->__stoptime);
+
+	croak("Could not get status of jobs: $job_ids_str\n") unless $status;
+	return from_json($status);
+}
+
+sub job_wait {
+	my ($self, $waiting_time, %args) = @_;
+	$args{job_id} ||= 0;
+
+	my $state = chirp_wrap_job_wait($self->hostport, $args{job_id}, $waiting_time, $self->__stoptime);
+
+	croak("Error when waiting for job: $args{job_id}.\n") unless $state;
+	return from_json($state);
 }
 
 1;
@@ -318,5 +396,97 @@ Removes the given file or directory from the server. Dies on error.
 =item path                Target file/directory.
 
 =back
+
+=head2 C<< rm(path) >>
+
+Chirp job interface. (Needs the JSON module from CPAN).
+
+=head3 C<< job_create(job_description) >>
+
+Creates a chirp job. See http://ccl.cse.nd.edu/software/manuals/chirp.html for details.
+
+		my $job_description = {
+			executable => "/bin/tar",
+			arguments  =>  qw(tar -cf archive.tar a b),
+			files      => { task_path => 'a',
+							serv_path => '/users/magrat/a.txt'
+							type      => 'INPUT' },
+						  { task_path => 'b',
+							serv_path => '/users/magrat/b.txt'
+							type      => 'INPUT' },
+						  { task_path => 'archive.tar',
+							serv_path => '/users/magrat/archive.tar'
+							type      => 'OUTPUT' }
+		};
+
+		my $job_id = $client->job_create($job_description);
+
+=over 12
+
+=item job_description A hash reference with a job chirp description.
+
+=back
+
+
+=head3 C<< job_commit(job_id, job_id, ...) >>
+
+Commits (starts running) the jobs identified with the different job ids.
+
+		$client->commit($job_id);
+
+=item job_id,... Job ids of the chirp jobs to be committed.
+
+=back
+
+
+=head3 C<< job_kill(job_id, job_id, ...) >>
+
+		$client->commit($job_id);
+
+Kills the jobs identified with the different job ids.
+
+=item job_id,... Job ids of the chirp jobs to be killed.
+
+=back
+
+
+=head3 C<< job_reap(job_id, job_id, ...) >>
+
+Reaps the jobs identified with the different job ids.
+
+=item job_id,... Job ids of the chirp jobs to be reaped.
+
+=back
+
+
+=head3 C<< job_status(job_id, job_id, ...) >>
+
+Obtains the current status for each job id. The value returned is an array
+reference, which contains a hash reference per job_id.
+
+		my $jobs_states = $client->job_status($job_a, $job_b);
+
+		for my $state ($jobs_states) {
+			print 'Job ' . $state->{id} . ' is ' . $state->{status} . "\n";
+		}
+
+=item job_id,... Job ids of the chirp jobs to request an status update.
+
+=back
+
+
+=head3 C<< job_wait(waiting_time, job_id=>id) >>
+
+Waits waiting_time seconds for the job_id to terminate. Return value is the
+same as job_status. If the call timesout, an empty string is returned. If
+job_id is missing, C<<job_wait>> waits for any of the user's job.
+
+=item waiting_time maximum number of seconds to wait for a job to finish.
+=item job_id id of the job to wait.
+
+=back
+
+1;
+
 
 =cut

--- a/chirp/src/perl/chirp_jobs_perl_example.pl
+++ b/chirp/src/perl/chirp_jobs_perl_example.pl
@@ -1,0 +1,75 @@
+#!/usr/bin/env perl
+
+use v5.8.8;
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+
+use Chirp::Client;
+
+sub make_job {
+	my ($job_number) = @_;
+
+	return {
+		executable => './my_script',
+		arguments  => ['my_script', "$job_number"],
+		files      => [
+		{
+			task_path => 'my_script',
+			serv_path => '/my_script.sh',
+			type    => 'INPUT',
+			binding => 'LINK'
+		},
+
+		{ task_path => 'my.output',
+			serv_path => "/my.$job_number.output",
+			type      => 'OUTPUT' }
+		] };
+}
+
+die "Usage: $0 HOST:PORT" if @ARGV < 1;
+
+my ($hostport) = @ARGV;
+
+my $client;
+eval { $client = Chirp::Client->new(hostport       => $hostport,
+									authentication => ['unix'],
+									timeout        => 15,
+									debug          => 1) };
+die "Could not connect to server: $@" if $@;
+
+print 'Chirp server sees me as ' . $client->identity . "\n";
+
+my @jobs = map { make_job $_ } (1..10);
+
+$client->put('my_script.sh', destination => '/my_script.sh');
+
+my $jobs_running = 0;
+for my $job (@jobs) {
+	my $job_id = $client->job_create($job);
+	$client->job_commit($job_id);
+	$jobs_running++;
+}
+
+while($jobs_running) {
+	my $job_states;
+	$job_states = $client->job_wait(2);
+
+	for my $job_state (@{$job_states}) {
+		print 'job ' . $job_state->{id} . ' is ' . lc($job_state->{status}) . "\n";
+
+		my $status = $job_state->{status};
+
+		$client->job_reap( $job_state->{id} ) if $status eq 'FINISHED';
+		$client->job_kill( $job_state->{id} ) if $status eq 'ERRORED';
+
+		$jobs_running--;
+	}
+}
+
+
+exit 0;
+
+__END__

--- a/chirp/src/perl/chirp_perl_example.pl
+++ b/chirp/src/perl/chirp_perl_example.pl
@@ -67,4 +67,3 @@ unlink 'bar.txt', 'foo.txt';
 exit 0;
 
 __END__
-

--- a/chirp/src/perl/chirp_perl_example.pl
+++ b/chirp/src/perl/chirp_perl_example.pl
@@ -36,7 +36,7 @@ eval { $client = Chirp::Client->new(hostport       => $hostport,
 									debug          => 1) };
 die "Could not connect to server: $@" if $@;
 
-print 'Chirp server sees me as ' . $client->{identity} . "\n";
+print 'Chirp server sees me as ' . $client->identity . "\n";
 
 eval {
 		print "ACL on / is @{[$client->listacl('/')]}" . "\n";

--- a/chirp/src/perl/my_script.sh
+++ b/chirp/src/perl/my_script.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+sleep 1
+echo Hello $1 > my.output

--- a/chirp/src/python/chirp_jobs_python_example.py
+++ b/chirp/src/python/chirp_jobs_python_example.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env cctools_python
+# CCTOOLS_PYTHON_VERSION 2.7 2.6 2.5 2.4 3
+
+import sys
+
+try:
+    import Chirp
+except ImportError:
+    print 'Could not find Chirp module. Please set PYTHONPATH accordingly.'
+    sys.exit(1)
+
+def make_job(job_number):
+    job = { 'executable' : './my_script',
+            'arguments'  : ['my_script', str(job_number)],
+            'files'      : [ { 'task_path':  'my_script',
+                               'serv_path':  '/my_script.sh',
+                               'type':  'INPUT',
+                             },
+                             { 'task_path':  'my.output',
+                               'serv_path':  "/my." + str(job_number) + ".output",
+                               'type':  'OUTPUT' } ] }
+    return job
+
+
+if __name__ == '__main__':
+
+    if(len(sys.argv) != 2):
+        print "Usage: %s HOST:PORT" % sys.argv[0]
+        sys.exit(1)
+
+    hostport = sys.argv[1]
+
+    try:
+        client = Chirp.Client(hostport,
+                              authentication = ['unix'],
+                              timeout = 15,
+                              debug   = True)
+    except Chirp.AuthenticationFailure, e:
+         print "Could not authenticate using: %s" % ', '.join(e.value)
+         sys.exit(1)
+
+    print 'Chirp server sees me, ' + client.identity
+
+    jobs = [ make_job(x) for x in range(1,10) ]
+
+    client.put('my_script.sh', '/my_script.sh')
+
+    jobs_running = 0
+    for job in jobs:
+        job_id = client.job_create(job)
+        client.job_commit(job_id)
+        jobs_running += 1
+
+    while(jobs_running > 0):
+        job_states = client.job_wait(5)
+
+        for state in job_states:
+            print 'job ' + str(state['id']) + ' is ' + state['status'] + "\n"
+
+            if   state['status'] == 'FINISHED':
+                client.job_reap( state['id'] )
+            elif state['status'] == 'ERRORED':
+                client.job_kill( state['id'] )
+
+            jobs_running -= 1
+
+    sys.exit(0)

--- a/chirp/src/python/my_script.sh
+++ b/chirp/src/python/my_script.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+sleep 1
+echo Hello $1 > my.output


### PR DESCRIPTION
Python and Perl bindings for the chirp job interface.

Examples:
chirp/src/python/chirp_jobs_python_example.py
and
chirp/src/perl/chirp_jobs_perl_example.pl

Bindings are written so that a user should not need to write json directly, but instead use hashes.
