### PR TITLE
remove restriction of maximum number of file descriptors for cvmfs

### DIFF
--- a/parrot/src/pfs_service_cvmfs.cc
+++ b/parrot/src/pfs_service_cvmfs.cc
@@ -60,7 +60,7 @@ static const char *default_cvmfs_repo =
  *.opensciencegrid.org:pubkey=" OASIS_KEY_PLACEHOLDER ",url=http://oasis-replica.opensciencegrid.org:8000/cvmfs/*;http://cvmfs.fnal.gov:8000/cvmfs/*;http://cvmfs.racf.bnl.gov:8000/cvmfs/*";
 
 #if LIBCVMFS_VERSION > 1
-static const char *default_cvmfs_global_config = "max_open_files=500,change_to_cache_directory,log_prefix=libcvmfs";
+static const char *default_cvmfs_global_config = "change_to_cache_directory,log_prefix=libcvmfs";
 #endif
 
 static bool wrote_cern_key;


### PR DESCRIPTION
The `max_open_files` option for cvmfs was originally meant to increase the maximum number of open files.  In the context of non-privileged users, that doesn't make much sense though because users are typically anyway at their limit. The current default has in many cases the opposite effect of restricting the user from the normal 1024 limit. The lhcb test case from the [LHC test applications](https://github.com/jblomer/parrot-test), for instance, does not work with a limit as small as 500. This patch removes the default limit.