### PR TITLE
Add umbrella and prune into `potential_packages`

### DIFF
--- a/configure
+++ b/configure
@@ -425,7 +425,7 @@ if [ "$optstrict" = 1 ]; then
 	ccflags="${ccflags} -Werror"
 fi
 
-potential_packages="dttools ${include_package_makeflow} work_queue ${include_package_apps} ${include_package_sand} ${include_package_allpairs} ${include_package_wavefront} ${include_package_ftplite} ${include_package_parrot} ${include_package_resource_monitor} ${include_package_chirp} ${include_package_weaver} ${include_package_doc}"
+potential_packages="dttools ${include_package_makeflow} work_queue ${include_package_apps} ${include_package_sand} ${include_package_allpairs} ${include_package_wavefront} ${include_package_ftplite} ${include_package_parrot} ${include_package_resource_monitor} ${include_package_chirp} ${include_package_weaver} ${include_package_umbrella} ${include_package_prune} ${include_package_doc}"
 
 check_multiarch
 


### PR DESCRIPTION
The busy merging recently somehow changed the `potential_packages` string in the `configure`.
So currently compiling our master branch does not compile umbrella and prune.

This readds umbrella and prune into `potential_packages`.
