### PR TITLE
Improve Confuga internal API to use SQLite savepoints

### DIFF
--- a/chirp/src/chirp_sqlite.h
+++ b/chirp/src/chirp_sqlite.h
@@ -100,6 +100,22 @@ do {\
 	}\
 } while (0)
 
+#define sqlendsavepoint(savepoint) \
+do {\
+	if (rc) {\
+		char *errmsg;\
+		int erc = sqlite3_exec(db, "ROLLBACK TRANSACTION TO SAVEPOINT " #savepoint "; RELEASE SAVEPOINT " #savepoint ";", NULL, NULL, &errmsg);\
+		if (erc) {\
+			if (erc == SQLITE_ERROR /* cannot rollback because no transaction is active */) {\
+				; /* do nothing */\
+			} else {\
+				debug(D_DEBUG, "[%s:%d] sqlite3 error: %d `%s': %s", __FILE__, __LINE__, erc, sqlite3_errstr(erc), errmsg);\
+			}\
+			sqlite3_free(errmsg);\
+		}\
+	}\
+} while (0)
+
 #define IMMUTABLE(T) \
 		"CREATE TRIGGER " T "ImmutableI BEFORE INSERT ON " T " FOR EACH ROW" \
 		"    BEGIN" \

--- a/chirp/src/confuga_fs.h
+++ b/chirp/src/confuga_fs.h
@@ -46,7 +46,7 @@ CONFUGA_IAPI int confugaI_dbload (confuga *C, sqlite3 *attachdb);
 CONFUGA_IAPI int confugaI_dbclose (confuga *C);
 
 CONFUGA_IAPI int confugaR_replicate (confuga *C, confuga_fid_t fid, confuga_sid_t sid, const char *tag, time_t stoptime);
-CONFUGA_IAPI int confugaR_register (confuga *C, confuga_fid_t fid, confuga_off_t size, const struct confuga_host *host);
+CONFUGA_IAPI int confugaR_register (confuga *C, confuga_fid_t fid, confuga_off_t size, confuga_sid_t sid);
 CONFUGA_IAPI int confugaR_manager (confuga *C);
 
 CONFUGA_IAPI int confugaS_catalog (confuga *C, const char *catalog);

--- a/chirp/src/confuga_job.c
+++ b/chirp/src/confuga_job.c
@@ -1190,41 +1190,11 @@ out:
 	return rc;
 }
 
-static int addoutput (confuga *C, chirp_jobid_t id, const char *tag, confuga_sid_t sid, const char *task_path, confuga_fid_t fid, confuga_off_t size)
-{
-	static const char SQL[] =
-		"INSERT INTO ConfugaOutputFile (jid, task_path, fid, size) VALUES (?, ?, ?, ?);"
-		;
-
-	int rc;
-	sqlite3 *db = C->db;
-	sqlite3_stmt *stmt = NULL;
-	const char *current = SQL;
-
-	debug(D_DEBUG, "creating replica fid = " CONFUGA_FID_PRIFMT " size = %" PRICONFUGA_OFF_T " sid = " CONFUGA_SID_PRIFMT, CONFUGA_FID_PRIARGS(fid), size, sid);
-
-	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
-	if (task_path) {
-		jdebug(D_DEBUG, id, tag, "setting output fid = " CONFUGA_FID_PRIFMT " size = %" PRICONFUGA_OFF_T " task_path = `%s'", CONFUGA_FID_PRIARGS(fid), size, task_path);
-		sqlcatch(sqlite3_bind_int64(stmt, 1, id));
-		sqlcatch(sqlite3_bind_text(stmt, 2, task_path, -1, SQLITE_STATIC));
-		sqlcatch(sqlite3_bind_blob(stmt, 3, fid.id, sizeof(fid.id), SQLITE_STATIC));
-		sqlcatch(sqlite3_bind_int64(stmt, 4, size));
-		sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
-	}
-	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
-
-	rc = 0;
-	goto out;
-out:
-	sqlite3_finalize(stmt);
-	return rc;
-}
-
 static int jwait (confuga *C, chirp_jobid_t id, const char *tag, confuga_sid_t sid, const char *hostport, chirp_jobid_t cid)
 {
 	static const char SQL[] =
 		"BEGIN TRANSACTION;"
+		"INSERT INTO ConfugaOutputFile (jid, task_path, fid, size) VALUES (?, ?, ?, ?);"
 		"INSERT OR REPLACE INTO ConfugaJobWaitResult (id, error, exit_code, exit_signal, exit_status, status)"
 		"	VALUES (?, ?, ?, ?, ?, ?);"
 		"UPDATE ConfugaJob"
@@ -1271,6 +1241,7 @@ static int jwait (confuga *C, chirp_jobid_t id, const char *tag, confuga_sid_t s
 			json_value *exit_status = jsonA_getname(job, "exit_status", json_string);
 			json_value *status = jsonA_getname(job, "status", json_string);
 
+			sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
 			if (status && strcmp(status->u.string.ptr, "FINISHED") == 0 && exit_status && strcmp(exit_status->u.string.ptr, "EXITED") == 0) {
 				json_value *files = jsonA_getname(job, "files", json_array);
 				if (files) {
@@ -1307,10 +1278,14 @@ static int jwait (confuga *C, chirp_jobid_t id, const char *tag, confuga_sid_t s
 
 									CATCH(confugaR_register(C, fid, size->u.integer, sid));
 									if (streql(file_tag->u.string.ptr, CONFUGA_OUTPUT_TAG)) {
-										addoutput(C, id, tag, sid, task_path->u.string.ptr, fid, size->u.integer);
-									} else if (streql(file_tag->u.string.ptr, CONFUGA_PULL_TAG)) {
-										addoutput(C, id, tag, sid, NULL, fid, size->u.integer);
-									} else assert(0);
+										jdebug(D_DEBUG, id, tag, "setting output fid = " CONFUGA_FID_PRIFMT " size = %" PRICONFUGA_OFF_T " task_path = `%s'", CONFUGA_FID_PRIARGS(fid), size, task_path);
+										sqlcatch(sqlite3_reset(stmt));
+										sqlcatch(sqlite3_bind_int64(stmt, 1, id));
+										sqlcatch(sqlite3_bind_text(stmt, 2, task_path->u.string.ptr, -1, SQLITE_STATIC));
+										sqlcatch(sqlite3_bind_blob(stmt, 3, fid.id, sizeof(fid.id), SQLITE_STATIC));
+										sqlcatch(sqlite3_bind_int64(stmt, 4, size->u.integer));
+										sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
+									}
 								}
 							} else {
 								CATCH(EINVAL);
@@ -1324,6 +1299,7 @@ static int jwait (confuga *C, chirp_jobid_t id, const char *tag, confuga_sid_t s
 				/* This indicates the job failed startup, probably could not source a URL. We should retry the job! */
 				CATCH(EIO);
 			}
+			sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
 
 			sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
 			sqlcatch(sqlite3_bind_int64(stmt, 1, id));

--- a/chirp/src/confuga_replica.c
+++ b/chirp/src/confuga_replica.c
@@ -72,12 +72,16 @@ CONFUGA_IAPI int confugaR_register (confuga *C, confuga_fid_t fid, confuga_off_t
 	sqlcatch(sqlite3_bind_blob(stmt, 1, fid.id, sizeof(fid.id), SQLITE_STATIC));
 	sqlcatch(sqlite3_bind_int64(stmt, 2, size));
 	sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
+	if (sqlite3_changes(db))
+		debug(D_DEBUG, "created new file fid = " CONFUGA_FID_PRIFMT " size = %" PRICONFUGA_OFF_T, CONFUGA_FID_PRIARGS(fid), size);
 	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
 
 	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
 	sqlcatch(sqlite3_bind_blob(stmt, 1, fid.id, sizeof(fid.id), SQLITE_STATIC));
 	sqlcatch(sqlite3_bind_int64(stmt, 2, sid));
 	sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
+	if (sqlite3_changes(db))
+		debug(D_DEBUG, "created new replica fid = " CONFUGA_FID_PRIFMT " sid = " CONFUGA_SID_PRIFMT, CONFUGA_FID_PRIARGS(fid), sid);
 	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
 
 	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));


### PR DESCRIPTION
This simplifies the code by utilizing nested transactions. This allows internal functions to be used normally as they can now be called from within a transaction.