### PR TITLE
Worker fixes

### DIFF
--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1605,7 +1605,7 @@ static int serve_master_by_hostport( const char *host, int port, const char *ver
 		work_for_master(master);
 	}
 
-	last_task_received  = -1;
+	last_task_received     = 0;
 	results_to_be_sent_msg = 0;
 
 	workspace_cleanup();

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -163,8 +163,8 @@ static int64_t gpus_allocated = 0;
 
 static int64_t disk_measured = 0;
 
-static int send_resources_interval = 30;
-static int send_stats_interval     = 60;
+static int send_resources_interval = 180;
+static int send_stats_interval     = 180;
 
 static struct work_queue *foreman_q = NULL;
 


### PR DESCRIPTION
Without this fix, if the worker connects to a second master it never gets tasks.
(Will merge as soon as autobuild completes.)