### PR TITLE
fix arg cores comparison

### DIFF
--- a/work_queue/src/pbs_submit_workers
+++ b/work_queue/src/pbs_submit_workers
@@ -21,7 +21,7 @@ pbs_parameters=""
 
 parse_arguments()
 {
-	if [ -z "$cores" -o $cores=0 ]
+	if [ -z "$cores" -o $cores = 0 ]
 	then
 		cores=1
 	fi

--- a/work_queue/src/pbs_submit_workers
+++ b/work_queue/src/pbs_submit_workers
@@ -21,7 +21,7 @@ pbs_parameters=""
 
 parse_arguments()
 {
-	if [ -z "$cores" -o $cores = 0 ]
+	if [ -z "$cores" -o "$cores" = 0 ]
 	then
 		cores=1
 	fi

--- a/work_queue/src/sge_submit_workers
+++ b/work_queue/src/sge_submit_workers
@@ -23,7 +23,7 @@ sge_parameters=""
 # Used options (as in the getopts format):  aM:N:C:t:d:w:i:b:z:A:O:s:P:jp:h
 parse_arguments()
 {
-	if [ -z "$cores" -o $cores = 0 ]
+	if [ -z "$cores" -o "$cores" = 0 ]
 	then
 		cores=1
 	fi

--- a/work_queue/src/sge_submit_workers
+++ b/work_queue/src/sge_submit_workers
@@ -23,10 +23,13 @@ sge_parameters=""
 # Used options (as in the getopts format):  aM:N:C:t:d:w:i:b:z:A:O:s:P:jp:h
 parse_arguments()
 {
-	if [ -z "$cores" -o $cores=0 ]
+	if [ -z "$cores" -o $cores = 0 ]
 	then
 		cores=1
 	fi
+
+	echo $cores
+	exit
 
 	while [ $# -gt 0 ]
 	do

--- a/work_queue/src/slurm_submit_workers
+++ b/work_queue/src/slurm_submit_workers
@@ -21,7 +21,7 @@ slurm_parameters=""
 
 parse_arguments()
 {
-	if [ -z "$cores" -o $cores=0 ]
+	if [ -z "$cores" -o $cores = 0 ]
 	then
 		slurm_parameters="$slurm_parameters --exclusive"
 	else

--- a/work_queue/src/slurm_submit_workers
+++ b/work_queue/src/slurm_submit_workers
@@ -21,7 +21,7 @@ slurm_parameters=""
 
 parse_arguments()
 {
-	if [ -z "$cores" -o $cores = 0 ]
+	if [ -z "$cores" -o "$cores" = 0 ]
 	then
 		slurm_parameters="$slurm_parameters --exclusive"
 	else

--- a/work_queue/src/torque_submit_workers
+++ b/work_queue/src/torque_submit_workers
@@ -20,7 +20,7 @@ torque_parameters=""
 
 parse_arguments()
 {
-	if [ -z "$cores" -o $cores = 0 ]
+	if [ -z "$cores" -o "$cores" = 0 ]
 	then
 		cores=1
 	fi

--- a/work_queue/src/torque_submit_workers
+++ b/work_queue/src/torque_submit_workers
@@ -20,8 +20,7 @@ torque_parameters=""
 
 parse_arguments()
 {
-
-	if [ -z "$cores" -o $cores=0 ]
+	if [ -z "$cores" -o $cores = 0 ]
 	then
 		cores=1
 	fi


### PR DESCRIPTION
While preparing for XSEDE tutorial @nhazekam found a problem with the submission workers. @nhazekam found that in  if [ $cores=0 ], the variable is assigned, rather than compared. @nhazekam also found the solution:  if [ $cores=0 ].

This pr implements the solution that @nhazekam found.

Credit to @nhazekam.