### PR TITLE
report running and waiting from hierarchy

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -420,6 +420,10 @@ int process_info(struct work_queue *q, struct work_queue_worker *w, char *line)
 		w->stats->total_bytes_sent = atoll(value);
 	} else if(string_prefix_is(field, "total_bytes_received")) {
 		w->stats->total_bytes_received = atoll(value);
+	} else if(string_prefix_is(field, "tasks_waiting")) {
+		w->stats->tasks_waiting = atoll(value);
+	} else if(string_prefix_is(field, "tasks_running")) {
+		w->stats->tasks_running = atoll(value);
 	}
 
 	//Note we always mark info messages as processed, as they are optional.
@@ -4749,6 +4753,10 @@ void work_queue_get_stats_hierarchy(struct work_queue *q, struct work_queue_stat
 	char *key;
 	struct work_queue_worker *w;
 
+	s->tasks_waiting = 0;
+	s->tasks_running = 0;
+	s->total_workers_connected = 0;
+
 	hash_table_firstkey(q->worker_table);
 	while(hash_table_nextkey(q->worker_table, &key, (void **) &w)) {
 		if(w->foreman)
@@ -4761,7 +4769,15 @@ void work_queue_get_stats_hierarchy(struct work_queue *q, struct work_queue_stat
 			accumulate_stat(s, w->stats, total_bytes_sent);
 			accumulate_stat(s, w->stats, total_bytes_received);
 		}
+		else {
+			s->total_workers_connected++;
+		}
+
+		accumulate_stat(s, w->stats, tasks_waiting);
+		accumulate_stat(s, w->stats, tasks_running);
 	}
+
+	s->total_workers_connected += s->total_workers_joined - s->total_workers_removed;
 
 	s->total_workers_joined  += q->stats_disconnected_workers->total_workers_joined;
 	s->total_workers_removed += q->stats_disconnected_workers->total_workers_removed;

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -332,6 +332,13 @@ static void send_stats_update( struct link *master, int force_update)
 		send_master_message(master, "info total_execute_time %lld\n", (long long) s.total_execute_time);
 		send_master_message(master, "info total_bytes_sent %lld\n", (long long) s.total_bytes_sent);
 		send_master_message(master, "info total_bytes_received %lld\n", (long long) s.total_bytes_received);
+
+		send_master_message(master, "info tasks_waiting %lld\n", (long long) s.tasks_waiting);
+		send_master_message(master, "info tasks_running %lld\n", (long long) s.tasks_running);
+	}
+	else {
+		send_master_message(master, "info tasks_waiting %lld\n", (long long) list_size(procs_waiting));
+		send_master_message(master, "info tasks_running %lld\n", (long long) itable_size(procs_running));
 	}
 
 	last_send_time = time(0);
@@ -1403,6 +1410,7 @@ static void work_for_master(struct link *master) {
 
 		if(!ok) break;
 
+		send_stats_update(master,0);
 		send_resource_update(master,0);
 
 		//Reset idle_stoptime if something interesting is happening at this worker.


### PR DESCRIPTION
As requested by @annawoodard, stats_hierarchy now does not report tasks waiting at a foreman as running.

The regular stats (without hierarchy) follows the previous behavior (anything dispatched from the master is considered as running).