### PR TITLE
Do not resolve link target for ACL check.

### DIFF
--- a/chirp/src/chirp_server.c
+++ b/chirp/src/chirp_server.c
@@ -1232,7 +1232,7 @@ static void chirp_handler(struct link *l, const char *addr, const char *subject)
 		} else if(sscanf(line, "link %s %s", path, newpath) == 2) {
 			/* Can only hard link to files on which you already have r/w perms */
 			path_fix(path);
-			if(!chirp_acl_check(path, subject, CHIRP_ACL_READ | CHIRP_ACL_WRITE))
+			if(!chirp_acl_check_link(path, subject, CHIRP_ACL_READ | CHIRP_ACL_WRITE))
 				goto failure;
 			path_fix(newpath);
 			if(!chirp_acl_check(newpath, subject, CHIRP_ACL_WRITE))


### PR DESCRIPTION
The link RPC, as with the normal UNIX link syscall, allows for symbolic links
to be hard linked. For example:

    $ ln -s foo bar
    $ ln bar baz
    $ ls -la bar baz
    lrwxrwxrwx 2 batrick users 3 Aug 11 10:45 bar -> foo
    lrwxrwxrwx 2 batrick users 3 Aug 11 10:45 baz -> foo

Currently the Chirp server would perform ACL checks on the resolved target, in
this case foo instead of bar. If this symbolic link points somewhere the
current subject lacks rights, then the RPC will fail with permission denied.

The fix is to use chirp_acl_check_link instead of chirp_acl_check on the
target.

Fixes #887.