### PR TITLE
Police task usage

### DIFF
--- a/allpairs/src/allpairs_multicore.c
+++ b/allpairs/src/allpairs_multicore.c
@@ -23,7 +23,7 @@ See the file COPYING for details.
 #include "xxmalloc.h"
 #include "fast_popen.h"
 #include "text_list.h"
-#include "memory_info.h"
+#include "host_memory_info.h"
 #include "load_average.h"
 #include "macros.h"
 #include "full_io.h"
@@ -80,7 +80,7 @@ int block_size_estimate( struct text_list *seta )
 	UINT64_T total_data = 0,free_mem,total_mem;
 	int block_size;
 
-	memory_info_get(&free_mem, &total_mem);
+	host_memory_info_get(&free_mem, &total_mem);
 
 	for(i=0;i<count;i++) {
 		total_data += get_file_size(text_list_get(seta,i));

--- a/chirp/src/chirp_server.c
+++ b/chirp/src/chirp_server.c
@@ -25,16 +25,16 @@
 #include "daemon.h"
 #include "datagram.h"
 #include "debug.h"
-#include "disk_info.h"
 #include "domain_name_cache.h"
 #include "get_canonical_path.h"
 #include "getopt_aux.h"
+#include "host_disk_info.h"
+#include "host_memory_info.h"
 #include "json.h"
 #include "link.h"
 #include "list.h"
 #include "load_average.h"
 #include "macros.h"
-#include "memory_info.h"
 #include "path.h"
 #include "pattern.h"
 #include "random.h"
@@ -213,7 +213,7 @@ static int update_all_catalogs(const char *url)
 		memset(&info, 0, sizeof(info));
 	}
 
-	memory_info_get(&memory_avail, &memory_total);
+	host_memory_info_get(&memory_avail, &memory_total);
 
 	buffer_init(B);
 	buffer_max(B, DATAGRAM_PAYLOAD_MAX);

--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -21,7 +21,6 @@ SOURCES = \
 	console_login.c \
 	copy_stream.c \
 	create_dir.c \
-	cwd_disk_info.c \
 	daemon.c \
 	datagram.c \
 	debug.c \
@@ -31,7 +30,6 @@ SOURCES = \
 	debug_syslog.c \
 	disk_alloc.c \
 	disk_alloc_main.c \
-	disk_info.c \
 	domain_name.c \
 	domain_name_cache.c \
 	dpopen.c \
@@ -50,6 +48,8 @@ SOURCES = \
 	hash_table.c \
 	hdfs_library.c \
 	hmac.c \
+	host_disk_info.c \
+	host_memory_info.c \
 	http_query.c \
 	itable.c \
 	json.c \
@@ -61,13 +61,13 @@ SOURCES = \
 	load_average.c \
 	md5.c \
 	memfdexe.c \
-	memory_info.c \
 	mergesort.c \
 	mt19937-64.c \
 	nvpair.c \
 	nvpair_database.c \
 	password_cache.c \
 	path.c \
+	path_disk_size_info.c \
 	pattern.c \
 	preadwrite.c \
 	process.c \

--- a/dttools/src/catalog_update.c
+++ b/dttools/src/catalog_update.c
@@ -11,7 +11,7 @@ See the file COPYING for details.
 #include "domain_name_cache.h"
 #include "int_sizes.h"
 #include "load_average.h"
-#include "memory_info.h"
+#include "host_memory_info.h"
 #include "stringtools.h"
 #include "username.h"
 #include "uptime.h"
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
 	string_tolower(name.release);
 	load_average_get(load);
 	cpus = load_average_get_cpus();
-	memory_info_get(&memory_avail, &memory_total);
+	host_memory_info_get(&memory_avail, &memory_total);
 	uptime = uptime_get();
 	username_get(owner);
 

--- a/dttools/src/host_disk_info.c
+++ b/dttools/src/host_disk_info.c
@@ -5,8 +5,8 @@ This software is distributed under the GNU General Public License.
 See the file COPYING for details.
 */
 
-#include "disk_info.h"
-#include "cwd_disk_info.h"
+#include "host_disk_info.h"
+#include "path_disk_size_info.h"
 #include "debug.h"
 #include "macros.h"
 
@@ -28,7 +28,7 @@ See the file COPYING for details.
 #include <sys/vfs.h>
 #endif
 
-int disk_info_get(const char *path, UINT64_T * avail, UINT64_T * total)
+int host_disk_info_get(const char *path, UINT64_T * avail, UINT64_T * total)
 {
 #ifdef CCTOOLS_OPSYS_SUNOS
 	int result;
@@ -61,7 +61,7 @@ int check_disk_space_for_filesize(char *path, int64_t file_size, uint64_t disk_a
 	uint64_t disk_avail, disk_total;
 
 	if(disk_avail_threshold > 0) {
-		disk_info_get(path, &disk_avail, &disk_total);
+		host_disk_info_get(path, &disk_avail, &disk_total);
 		if(file_size > 0) {
 			if((uint64_t)file_size > disk_avail || (disk_avail - file_size) < disk_avail_threshold) {
 				debug(D_DEBUG, "File of size %"PRId64" MB will lower available disk space (%"PRIu64" MB) below threshold (%"PRIu64" MB).\n", file_size/MEGA, disk_avail/MEGA, disk_avail_threshold/MEGA);

--- a/dttools/src/host_disk_info.h
+++ b/dttools/src/host_disk_info.h
@@ -11,7 +11,7 @@ See the file COPYING for details.
 #include "int_sizes.h"
 #include <time.h>
 
-/** @file disk_info.h
+/** @file host_disk_info.h
 Query disk space properties.
 */
 
@@ -21,7 +21,7 @@ Query disk space properties.
 @param total A pointer to an integer that will be filled with the total space in bytes.
 @return Greater than or equal to zero on success, less than zero otherwise.
 */
-int disk_info_get(const char *path, UINT64_T * avail, UINT64_T * total);
+int host_disk_info_get(const char *path, UINT64_T * avail, UINT64_T * total);
 
 /** Return whether a file will fit in the given directory.
 @param path A filename of the disk to be measured.

--- a/dttools/src/host_memory_info.c
+++ b/dttools/src/host_memory_info.c
@@ -4,13 +4,13 @@ This software is distributed under the GNU General Public License.
 See the file COPYING for details.
 */
 
-#include "memory_info.h"
+#include "host_memory_info.h"
 
 #if defined(CCTOOLS_OPSYS_LINUX) || defined(CCTOOLS_OPSYS_SUNOS)
 
 #include <unistd.h>
 
-int memory_info_get(UINT64_T * avail, UINT64_T * total)
+int host_memory_info_get(UINT64_T * avail, UINT64_T * total)
 {
 	*total = getpagesize() * (UINT64_T) sysconf(_SC_PHYS_PAGES);
 	*avail = getpagesize() * (UINT64_T) sysconf(_SC_AVPHYS_PAGES);
@@ -22,7 +22,7 @@ int memory_info_get(UINT64_T * avail, UINT64_T * total)
 #include <sys/types.h>
 #include <sys/sysctl.h>
 
-int memory_info_get(UINT64_T * avail, UINT64_T * total)
+int host_memory_info_get(UINT64_T * avail, UINT64_T * total)
 {
 	unsigned x = 0;
 	size_t s = sizeof(x);
@@ -33,7 +33,7 @@ int memory_info_get(UINT64_T * avail, UINT64_T * total)
 
 #else
 
-int memory_info_get(UINT64_T * avail, UINT64_T * total)
+int host_memory_info_get(UINT64_T * avail, UINT64_T * total)
 {
 	*total = 0;
 	*avail = 0;
@@ -46,7 +46,7 @@ int memory_info_get(UINT64_T * avail, UINT64_T * total)
 #include <stdio.h>
 #include <unistd.h>
 
-int memory_usage_get(UINT64_T * rssp, UINT64_T * totalp)
+int host_memory_usage_get(UINT64_T * rssp, UINT64_T * totalp)
 {
 #ifdef CCTOOLS_OPSYS_LINUX
 	/*

--- a/dttools/src/host_memory_info.h
+++ b/dttools/src/host_memory_info.h
@@ -10,7 +10,7 @@ See the file COPYING for details.
 
 #include "int_sizes.h"
 
-/** @file memory_info.h Get current memory status. */
+/** @file host_memory_info.h Get current memory status. */
 
 /** Get current memory status.
 Uses various techniques on different processors to get
@@ -19,13 +19,13 @@ the physical amount of memory installed, and the amount currently available.
 @param total Will be filled in with the memory physically installed, measured in bytes.
 @return One on success, zero on failure.
 */
-int memory_info_get(UINT64_T * avail, UINT64_T * total);
+int host_memory_info_get(UINT64_T * avail, UINT64_T * total);
 
 /** Get current memory usage by this process.
 @param rss Will be filled in with the current resident memory usage of this process, in bytes.
 @param total Will be filled in with the total virtual memory size of this process, in bytes.
 */
 
-int memory_usage_get(UINT64_T * rss, UINT64_T * total);
+int host_memory_usage_get(UINT64_T * rss, UINT64_T * total);
 
 #endif

--- a/dttools/src/path_disk_size_info.c
+++ b/dttools/src/path_disk_size_info.c
@@ -6,46 +6,155 @@ See the file COPYING for details.
 
 #include "path_disk_size_info.h"
 
+#include <dirent.h>
+#include <errno.h>
 #include <limits.h>
-#include <ftw.h>
+#include <string.h>
+#include <sys/stat.h>
 
 #include "debug.h"
+#include "list.h"
+#include "macros.h"
+#include "stringtools.h"
+#include "xxmalloc.h"
 
-/* Use at most 128 file descriptors before reusing them. */
-/* Hierarchies deeper than that will produce a hit in performance. */
-#define MAX_FILE_DESCRIPTORS 128
+int path_disk_size_info_get(const char *path, int64_t *measured_size, int64_t *number_of_files) {
+	struct path_disk_size_info *state = NULL;
+	int result = path_disk_size_info_get_r(path, -1, &state);
 
-static int64_t total_usage = 0;
+	*measured_size   = state->last_byte_size_complete;
+	*number_of_files = state->last_file_count_complete;
 
-static int update_cwd_usage(const char *path, const struct stat *s, int typeflag, struct FTW *f)
-{
-	switch(typeflag)
-	{
-		case FTW_F:
-			total_usage += s->st_size;
-			break;
-		default:
-			break;
-	}
-
-	return 0;
-}
-
-int path_disk_size_info_get(const char *path, int64_t *total)
-{
-	total_usage = 0;
-
-	int result = nftw(path, update_cwd_usage, MAX_FILE_DESCRIPTORS, FTW_PHYS);
-
-	if(result != 0) {
-		debug(D_DEBUG, "error reading %s disk usage.\n", path);
-		result = 0;
-	}
-
-	/* B to MB */
-	*total = total_usage/(1024 * 1024);
+	path_disk_size_info_delete_state(state);
 
 	return result;
+}
+
+int path_disk_size_info_get_r(const char *path, int64_t max_secs, struct path_disk_size_info **state) {
+	int64_t start_time = time(0);
+	int result = 0;
+
+	if(!*state) {
+		/* if state is null, there is no state, and path is the root of the measurement. */
+		*state = calloc(1, sizeof(struct path_disk_size_info));
+	}
+
+	struct path_disk_size_info *s = *state;     /* shortcut for *state, so we do not need to type (*state)->... */
+
+	/* if no current_dirs, we begin a new measurement. */
+	if(!s->current_dirs) {
+		s->complete_measurement = 0;
+
+		DIR *here;
+		if((here = opendir(path))) {
+			s->current_dirs = list_create(0);
+			s->size_so_far  = 0;
+			s->count_so_far = 1;                     /* count the root directory */
+			list_push_tail(s->current_dirs, here);
+		} else {
+			debug(D_DEBUG, "error reading disk usage on directory: %s.\n", path);
+			s->size_so_far  = -1;
+			s->count_so_far = -1;
+			s->complete_measurement = 1;
+			result       = -1;
+			goto timeout;
+		}
+	}
+
+	DIR *tail;
+	while((tail = list_peek_tail(s->current_dirs))) {
+		struct dirent *entry;
+		struct stat   file_info;
+		while((entry = readdir(tail))) {
+			if( strcmp(".", entry->d_name) == 0 || strcmp("..", entry->d_name) == 0)
+				continue;
+
+			char *composed_path;
+			if(entry->d_name[0] == '/') {
+				composed_path = xxstrdup(entry->d_name);
+			} else {
+				composed_path = string_format("%s/%s", path, entry->d_name);
+			}
+
+			if(lstat(composed_path, &file_info) < 0) {
+				if(errno == ENOENT) {
+					/* our DIR structure is stale, and a file went away. We simply do nothing. */
+				} else {
+					debug(D_DEBUG, "error reading disk usage on '%s'.\n", path);
+					result = -1;
+				}
+				continue;
+			}
+
+			s->count_so_far++;
+			if(S_ISREG(file_info.st_mode)) {
+				s->size_so_far += file_info.st_size;
+			} else if(S_ISDIR(file_info.st_mode)) {
+				DIR *branch;
+				if((branch = opendir(composed_path))) {
+					/* next while we read from the branch */
+					list_push_tail(s->current_dirs, branch);
+				} else {
+					result = -1;
+					continue;
+				}
+			} else if(S_ISLNK(file_info.st_mode)) {
+				/* do nothing, avoiding infinite loops. */
+			}
+
+			if(max_secs > -1) {
+				if( time(0) - start_time >= max_secs ) {
+					goto timeout;
+				}
+			}
+		}
+
+		/* we are done reading a complete directory, and we go to the next in the queue */
+		tail = list_pop_tail(s->current_dirs);
+		closedir(tail);
+	}
+
+	list_delete(s->current_dirs);
+	s->current_dirs = NULL;       /* signal that a new measurement is needed, if state structure is reused. */
+	s->complete_measurement = 1;
+
+timeout:
+	if(s->complete_measurement) {
+		/* if a complete measurement has been done, then update
+		 * for the found value */
+		s->last_byte_size_complete  = s->size_so_far;
+		s->last_file_count_complete = s->count_so_far;
+
+		debug(D_DEBUG, "completed measurement on '%s', %" PRId64 " files using %3.2lf MB\n",
+				path, s->count_so_far, (double) s->size_so_far/(1024.0*1024));
+	}
+	else {
+		/* else, we hit a timeout. measurement reported is conservative, from
+		 * what we knew, and know so far. */
+
+		s->last_byte_size_complete  = MAX(s->last_byte_size_complete, s->size_so_far);
+		s->last_file_count_complete = MAX(s->last_file_count_complete, s->count_so_far);
+
+		debug(D_DEBUG, "partial measurement on '%s', %" PRId64 " files using %3.3lf MB\n",
+				path, s->count_so_far, (double) s->size_so_far/(1024.0*1024));
+	}
+
+	return result;
+}
+
+void path_disk_size_info_delete_state(struct path_disk_size_info *state) {
+	if(!state)
+		return;
+
+	if(state->current_dirs) {
+		DIR *dir;
+		while((dir = list_pop_head(state->current_dirs))) {
+			closedir(dir);
+		}
+		list_delete(state->current_dirs);
+	}
+
+	free(state);
 }
 
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/path_disk_size_info.c
+++ b/dttools/src/path_disk_size_info.c
@@ -4,7 +4,7 @@ This software is distributed under the GNU General Public License.
 See the file COPYING for details.
 */
 
-#include "cwd_disk_info.h"
+#include "path_disk_size_info.h"
 
 #include <limits.h>
 #include <ftw.h>
@@ -31,7 +31,7 @@ static int update_cwd_usage(const char *path, const struct stat *s, int typeflag
 	return 0;
 }
 
-int cwd_disk_info_get(const char *path, int64_t *total)
+int path_disk_size_info_get(const char *path, int64_t *total)
 {
 	total_usage = 0;
 

--- a/dttools/src/path_disk_size_info.h
+++ b/dttools/src/path_disk_size_info.h
@@ -9,7 +9,7 @@ See the file COPYING for details.
 
 #include "int_sizes.h"
 
-/** @file cwd_info.h
+/** @file path_disk_size_info.h
 Query disk space on the given directory.
 */
 
@@ -18,6 +18,6 @@ Query disk space on the given directory.
 @param total A pointer to an integer that will be filled with the total space in bytes.
 @return Greater than or equal to zero on success, less than zero otherwise.
 */
-int cwd_disk_info_get(const char *path, int64_t * total);
+int path_disk_size_info_get(const char *path, int64_t * total);
 
 #endif

--- a/dttools/src/path_disk_size_info.h
+++ b/dttools/src/path_disk_size_info.h
@@ -8,6 +8,18 @@ See the file COPYING for details.
 #define CWD_INFO_H
 
 #include "int_sizes.h"
+#include "list.h"
+
+struct path_disk_size_info {
+	int     complete_measurement;
+	int64_t last_byte_size_complete;
+	int64_t last_file_count_complete;
+
+	int64_t size_so_far;
+	int64_t count_so_far;
+
+	struct list *current_dirs;
+};
 
 /** @file path_disk_size_info.h
 Query disk space on the given directory.
@@ -15,9 +27,23 @@ Query disk space on the given directory.
 
 /** Get the total disk usage on path.
 @param path Directory to be measured.
-@param total A pointer to an integer that will be filled with the total space in bytes.
-@return Greater than or equal to zero on success, less than zero otherwise.
+@param *measured_size A pointer to an integer that will be filled with the total space in bytes.
+@param *number_of_files A pointer to an integer that will be filled with the total number of files, directories, and symbolic links.
+@return zero on success, -1 if an error is encounterd (see errno).
 */
-int path_disk_size_info_get(const char *path, int64_t * total);
+int path_disk_size_info_get(const char *path, int64_t *measured_size, int64_t *number_of_files);
+
+/** Get a (perhaps partial) disk usage on path, but measure by max_secs at a time.
+If *state is NULL, start a new measurement, otherwise continue from
+the state recorded in state (see @ref path_disk_size_info).
+When the function returns, if *state->complete_measurement is 1, then the measurement was completed before a timeout.
+@param path Directory to be measured.
+@param max_secs Maximum number of seconds to spend in the measurement.
+@param *state State of the measurement.
+@return zero on success, -1 if an error is encounterd (see errno).
+*/
+int path_disk_size_info_get_r(const char *path, int64_t max_secs, struct path_disk_size_info **state);
+
+void path_disk_size_info_delete_state(struct path_disk_size_info *state);
 
 #endif

--- a/makeflow/src/makeflow_analyze.c
+++ b/makeflow/src/makeflow_analyze.c
@@ -23,7 +23,7 @@ See the file COPYING for details.
 #include "copy_stream.h"
 #include "work_queue_catalog.h"
 #include "datagram.h"
-#include "disk_info.h"
+#include "host_disk_info.h"
 #include "domain_name_cache.h"
 #include "link.h"
 #include "macros.h"

--- a/makeflow/src/makeflow_gc.c
+++ b/makeflow/src/makeflow_gc.c
@@ -12,7 +12,7 @@ See the file COPYING for details.
 #include "xxmalloc.h"
 #include "set.h"
 #include "timestamp.h"
-#include "disk_info.h"
+#include "host_disk_info.h"
 #include "stringtools.h"
 
 #include <dirent.h>
@@ -63,7 +63,7 @@ static int directory_low_disk( const char *path )
 {
 	UINT64_T avail, total;
 
-	if(disk_info_get(path, &avail, &total) >= 0)
+	if(host_disk_info_get(path, &avail, &total) >= 0)
 		return avail <= MAKEFLOW_MIN_SPACE;
 
 	return 0;

--- a/makeflow/src/makeflow_viz.c
+++ b/makeflow/src/makeflow_viz.c
@@ -23,7 +23,7 @@ See the file COPYING for details.
 #include "copy_stream.h"
 #include "work_queue_catalog.h"
 #include "datagram.h"
-#include "disk_info.h"
+#include "host_disk_info.h"
 #include "domain_name_cache.h"
 #include "link.h"
 #include "macros.h"

--- a/makeflow/src/parser.c
+++ b/makeflow/src/parser.c
@@ -23,7 +23,7 @@ See the file COPYING for details.
 #include "copy_stream.h"
 #include "work_queue_catalog.h"
 #include "datagram.h"
-#include "disk_info.h"
+#include "host_disk_info.h"
 #include "domain_name_cache.h"
 #include "link.h"
 #include "macros.h"

--- a/sand/src/sand_filter_kernel.c
+++ b/sand/src/sand_filter_kernel.c
@@ -14,7 +14,7 @@ See the file COPYING for details.
 #include <limits.h>
 
 #include "cctools.h"
-#include "memory_info.h"
+#include "host_memory_info.h"
 #include "debug.h"
 #include "macros.h"
 
@@ -37,14 +37,14 @@ static char *output_filename = 0;
 static unsigned long get_mem_avail()
 {
 	UINT64_T total, avail;
-	memory_info_get(&total, &avail);
+	host_memory_info_get(&total, &avail);
 	return (unsigned long) avail / 1024;
 }
 
 static unsigned long get_mem_usage()
 {
 	UINT64_T rss, total;
-	memory_usage_get(&rss, &total);
+	host_memory_usage_get(&rss, &total);
 	return rss / 1024;
 }
 

--- a/sand/src/sand_filter_master.c
+++ b/sand/src/sand_filter_master.c
@@ -19,7 +19,7 @@ See the file COPYING for details.
 #include "debug.h"
 #include "work_queue.h"
 #include "work_queue_catalog.h"
-#include "memory_info.h"
+#include "host_memory_info.h"
 #include "macros.h"
 #include "delete_dir.h"
 #include "envtools.h"

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -43,7 +43,7 @@ The following major problems must be fixed:
 #include "md5.h"
 #include "url_encode.h"
 
-#include "disk_info.h"
+#include "host_disk_info.h"
 
 #include <unistd.h>
 #include <dirent.h>

--- a/work_queue/src/work_queue_process.c
+++ b/work_queue/src/work_queue_process.c
@@ -5,11 +5,13 @@
 
 #include "debug.h"
 #include "errno.h"
+#include "macros.h"
 #include "stringtools.h"
 #include "create_dir.h"
 #include "delete_dir.h"
 #include "list.h"
 
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -17,6 +19,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <signal.h>
+#include <dirent.h>
 
 #include <sys/resource.h>
 #include <sys/wait.h>
@@ -64,6 +67,10 @@ void work_queue_process_delete(struct work_queue_process *p)
 	if(p->sandbox) {
 		delete_dir(p->sandbox);
 		free(p->sandbox);
+	}
+
+	if(p->disk_measurement_state) {
+		path_disk_size_info_delete_state(p->disk_measurement_state);
 	}
 
 	free(p);
@@ -296,7 +303,7 @@ void  work_queue_process_compute_disk_needed( struct work_queue_process *p ) {
 				continue;
 
 			/* p->disk is in MD, st_size in bytes. */
-			p->disk -= s.st_size/(1024*1024);
+			p->disk -= s.st_size/MEGA;
 		}
 	}
 
@@ -304,6 +311,28 @@ void  work_queue_process_compute_disk_needed( struct work_queue_process *p ) {
 		p->disk = -1;
 	}
 
+}
+
+int work_queue_process_measure_disk(struct work_queue_process *p, int max_time_on_measurement) {
+	/* we can't have pointers to struct members, thus we create temp variables here */
+
+	struct path_disk_size_info *state = p->disk_measurement_state;
+
+	int result = path_disk_size_info_get_r(p->sandbox, max_time_on_measurement, &state);
+
+	/* not a memory leak... Either disk_measurement_state was NULL or the same as state. */
+	p->disk_measurement_state = state;
+
+	if(state->last_byte_size_complete >= 0) {
+		p->sandbox_size = (int64_t) ceil(state->last_byte_size_complete/(1.0*MEGA));
+	}
+	else {
+		p->sandbox_size = -1;
+	}
+
+	p->sandbox_file_count = state->last_file_count_complete;
+
+	return result;
 }
 
 /* vim: set noexpandtab tabstop=4: */

--- a/work_queue/src/work_queue_process.h
+++ b/work_queue/src/work_queue_process.h
@@ -36,13 +36,17 @@ struct work_queue_process {
 
 	struct work_queue_task *task;
 
-		char container_id[MAX_BUFFER_SIZE];
+	/* expected disk usage by the process. If no cache is used, it is the same as in task. */
+	int64_t disk;
+
+	char container_id[MAX_BUFFER_SIZE];
 };
 
 struct work_queue_process * work_queue_process_create( int taskid );
 pid_t work_queue_process_execute( struct work_queue_process *p, int container_mode, ... );
 // lunching process with container, arg_3 can be either img_name or container_name, depending on container_mode
 void  work_queue_process_kill( struct work_queue_process *p );
-void  work_queue_process_delete( struct work_queue_process *p);
+void  work_queue_process_delete( struct work_queue_process *p );
+void  work_queue_process_compute_disk_needed( struct work_queue_process *p );
 
 #endif

--- a/work_queue/src/work_queue_process.h
+++ b/work_queue/src/work_queue_process.h
@@ -3,6 +3,7 @@
 
 #include "work_queue.h"
 #include "timestamp.h"
+#include "path_disk_size_info.h"
 
 #include <unistd.h>
 #include <sys/types.h>
@@ -39,6 +40,13 @@ struct work_queue_process {
 	/* expected disk usage by the process. If no cache is used, it is the same as in task. */
 	int64_t disk;
 
+	/* disk size and number of files found in the process sandbox. */
+	int64_t sandbox_size;
+	int64_t sandbox_file_count;
+
+	/* state between complete disk measurements. */
+	struct path_disk_size_info *disk_measurement_state;
+
 	char container_id[MAX_BUFFER_SIZE];
 };
 
@@ -48,5 +56,7 @@ pid_t work_queue_process_execute( struct work_queue_process *p, int container_mo
 void  work_queue_process_kill( struct work_queue_process *p );
 void  work_queue_process_delete( struct work_queue_process *p );
 void  work_queue_process_compute_disk_needed( struct work_queue_process *p );
+
+int work_queue_process_measure_disk(struct work_queue_process *p, int max_time_on_measurement);
 
 #endif

--- a/work_queue/src/work_queue_resources.c
+++ b/work_queue/src/work_queue_resources.c
@@ -8,8 +8,8 @@ See the file COPYING for details.
 
 #include "link.h"
 #include "load_average.h"
-#include "memory_info.h"
-#include "disk_info.h"
+#include "host_disk_info.h"
+#include "host_memory_info.h"
 #include "gpu_info.h"
 #include "macros.h"
 #include "debug.h"
@@ -44,11 +44,11 @@ void work_queue_resources_measure_locally( struct work_queue_resources *r, const
 	 * not executing by itself, but that it has to share its resources with
 	 * other processes/workers. */
 
-	disk_info_get(disk_path,&avail,&total);
+	host_disk_info_get(disk_path,&avail,&total);
 	r->disk.total = (avail / (UINT64_T) MEGA) + r->disk.inuse; // Free + whatever we are using.
 	r->disk.largest = r->disk.smallest = r->disk.total;
 
-	memory_info_get(&avail,&total);
+	host_memory_info_get(&avail,&total);
 	r->memory.total = (avail / (UINT64_T) MEGA) + r->memory.inuse; // Free + whatever we are using.
 	r->memory.largest = r->memory.smallest = r->memory.total;
 

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -18,9 +18,9 @@ See the file COPYING for details.
 #include "domain_name_cache.h"
 #include "nvpair.h"
 #include "copy_stream.h"
-#include "memory_info.h"
-#include "disk_info.h"
-#include "cwd_disk_info.h"
+#include "host_memory_info.h"
+#include "host_disk_info.h"
+#include "path_disk_size_info.h"
 #include "hash_cache.h"
 #include "link.h"
 #include "link_auth.h"
@@ -240,7 +240,7 @@ and apply any operations that override.
 void resources_measure_locally(struct work_queue_resources *r)
 {
 	work_queue_resources_measure_locally(r,workspace);
-	cwd_disk_info_get(".", &disk_measured);
+	path_disk_size_info_get(".", &disk_measured);
 
 	if(worker_mode == WORKER_MODE_FOREMAN) {
 		r->cores.total = 0;

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -832,7 +832,8 @@ static int do_task( struct link *master, int taskid, time_t stoptime )
 			}
 			free(env);
 		} else if(!strcmp(line,"end")) {
-				break;
+			work_queue_process_compute_disk_needed(p);
+			break;
 		} else {
 			debug(D_WQ|D_NOTICE,"invalid command from master: %s",line);
 			work_queue_process_delete(p);
@@ -1182,7 +1183,7 @@ static void finish_running_tasks(work_queue_result_t result) {
 
 static int enforce_process_limits(struct work_queue_process *p) {
 	/* If the task did not specify disk usage, return right away. */
-	if(p->task->disk < 1)
+	if(p->disk < 1)
 		return 1;
 
 	int64_t sandbox_size = 0;


### PR DESCRIPTION
Rename functions related to worker resource measuring, to make clear they are about the host.

On the worker side:
- Size of files in the cache is subtracted from the size of the box needed by a wq process.
- If a task exhaust it limits, that task result is RESOURCE_EXHAUSTION. Other running tasks are stopped, with result FORSAKEN.

