### PR TITLE
bugfix: incorrect string len causing memory corruption.

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -2320,14 +2320,13 @@ static work_queue_result_code_t start_one_task(struct work_queue *q, struct work
 	send_worker_msg(q,w, "disk %"PRId64"\n",    t->disk );
 	send_worker_msg(q,w, "gpus %d\n",    t->gpus );
 
-	/* Note we send environment variables after resources. If the user, for
-	 * example, specifies manually CORES as a variable, the task will be
-	 * scheduled with the value of specify_cores, but the environment variable
-	 * will have the value given by the user. */
+	/* Note that even when environment variables after resources, values for
+	 * CORES, MEMORY, etc. will be set at the worker to the values of
+	 * specify_*, if used. */
 	char *var;
 	list_first_item(t->env_list);
 	while((var=list_next_item(t->env_list))) {
-		send_worker_msg(q,w,"env %d\n%s\n",(int)strlen(var),var);
+		send_worker_msg(q, w,"env %d\n%s\n", (int) strlen(var), var);
 	}
 
 	char remote_name_encoded[PATH_MAX];

--- a/work_queue/src/work_queue_process.c
+++ b/work_queue/src/work_queue_process.c
@@ -168,8 +168,10 @@ pid_t work_queue_process_execute(struct work_queue_process *p, int container_mod
 
 		close(p->output_fd);
 
-		specify_resources_vars(p);
 		export_environment(p->task->env_list);
+
+		/* overwrite CORES, MEMORY, or DISK variables, if the task used specify_* */
+		specify_resources_vars(p);
 
 		va_list arg_lst;
 		if(container_mode == NONE) {

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -821,9 +821,9 @@ static int do_task( struct link *master, int taskid, time_t stoptime )
 		} else if(sscanf(line,"gpus %d",&n)) {
 			work_queue_task_specify_gpus(task, n);
 		} else if(sscanf(line,"env %d",&length)==1) {
-			char *env = malloc(length+1);
-			link_read(master,env,length,stoptime);
-			env[length] = 0;
+			char *env = malloc(length+2); /* +2 for \n and \0 */
+			link_read(master, env, length+1, stoptime);
+			env[length] = 0;              /* replace \n with \0 */
 			char *value = strchr(env,'=');
 			if(value) {
 				*value = 0;


### PR DESCRIPTION
We used link_read to read an env var=value pair. The master send
strlen(var=value) "var=value\n". On the worker side, the \0 would appear
after the '\n', outside the computed length.

Also in this commit, overwrite custom value of CORES, MEMORY and DISK
with the value from specify_*.

Fix for #891 