### PR TITLE
Proposal for external downloads at a worker

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -971,8 +971,9 @@ char *make_cached_name( const struct work_queue_task *t, const struct work_queue
 		case WORK_QUEUE_REMOTECMD:
 			return string_format("cmd-%s",md5_string(digest));
 			break;
-		case WORK_QUEUE_URL:
-			return string_format("url-%s",md5_string(digest));
+		case WORK_QUEUE_EXTERNAL_URL:
+		/* case WORK_QUEUE_EXTERNAL_CHIRP: */
+			return string_format("external-%s",md5_string(digest));
 			break;
 		case WORK_QUEUE_BUFFER:
 		default:
@@ -2182,13 +2183,9 @@ static work_queue_result_code_t send_input_file(struct work_queue *q, struct wor
 		debug(D_WQ, "%s (%s) needs %s from remote filesystem using %s", w->hostname, w->addrport, f->remote_name, f->payload);
 		send_worker_msg(q,w, "thirdget %d %s %s\n",WORK_QUEUE_FS_CMD, f->cached_name, f->payload);
 		break;
-
-	case WORK_QUEUE_URL:
-		debug(D_WQ, "%s (%s) needs %s from the url, %s %d", w->hostname, w->addrport, f->cached_name, f->payload, f->length);
-		send_worker_msg(q,w, "url %s %d 0%o %d\n",f->cached_name, f->length, 0777, f->flags);
-		link_putlstring(w->link, f->payload, f->length, time(0) + q->short_timeout);
+	case WORK_QUEUE_EXTERNAL_URL:
+		// Do nothing. File is downloaded at the worker.
 		break;
-
 	case WORK_QUEUE_DIRECTORY:
 		// Do nothing.  Empty directories are handled by the task specification, while recursive directories are implemented as WORK_QUEUE_FILEs
 		break;
@@ -3316,7 +3313,7 @@ int work_queue_task_specify_url(struct work_queue_task *t, const char *file_url,
 		}
 	}
 
-	tf = work_queue_file_create(t, file_url, remote_name, WORK_QUEUE_URL, flags);
+	tf = work_queue_file_create(t, file_url, remote_name, WORK_QUEUE_EXTERNAL_URL, flags);
 	if(!tf) return 0;
 
 	list_push_tail(files, tf);

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -62,7 +62,15 @@ typedef enum {
 	WORK_QUEUE_RESULT_SIGNAL         = 8,       /**< The task was terminated with a signal **/
 	WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION = 16, /**< The task used more resources than requested **/
 	WORK_QUEUE_RESULT_TASK_TIMEOUT   = 32,      /**< The task ran after specified end time. **/
-	WORK_QUEUE_RESULT_UNKNOWN        = 64       /**< The task ran successfully **/
+	WORK_QUEUE_RESULT_UNKNOWN        = 64,      /**< The task encountered an unknown error. */
+
+	/* 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144 for future use */
+
+	WORK_QUEUE_RESULT_EXTERNAL_NO_RESOLVE    = 524288,    /**< External resource could not be resolved. */
+	WORK_QUEUE_RESULT_EXTERNAL_NO_CONNECT    = 1048576,   /**< Could not connect to external resource. */
+	WORK_QUEUE_RESULT_EXTERNAL_NO_AUTH       = 2097152,   /**< Could not authenticate to external resource. */
+	WORK_QUEUE_RESULT_EXTERNAL_WRITE_ERROR   = 4194304,   /**< Write error on external resource. */
+	WORK_QUEUE_RESULT_EXTERNAL_TIMEOUT       = 8388608    /**< Timeout when connecting to external resource. */
 } work_queue_result_t;
 
 typedef enum {

--- a/work_queue/src/work_queue_internal.h
+++ b/work_queue/src/work_queue_internal.h
@@ -15,7 +15,10 @@ typedef enum {
 	WORK_QUEUE_REMOTECMD,
 	WORK_QUEUE_FILE_PIECE,
 	WORK_QUEUE_DIRECTORY,
-	WORK_QUEUE_URL
+
+	/* externals */
+	/* e.g.: WORK_QUEUE_EXTERNAL_CHIRP */
+	WORK_QUEUE_EXTERNAL_URL
 } work_queue_file_t;
 
 struct work_queue_file {

--- a/work_queue/src/work_queue_process.h
+++ b/work_queue/src/work_queue_process.h
@@ -45,4 +45,6 @@ pid_t work_queue_process_execute( struct work_queue_process *p, int container_mo
 void  work_queue_process_kill( struct work_queue_process *p );
 void  work_queue_process_delete( struct work_queue_process *p);
 
+int work_queue_process_download_externals(struct work_queue_process *p);
+
 #endif


### PR DESCRIPTION
Download the files until the task is going to run. This makes it easier to associate errors with a task.
Uploads would be handled in the same way. 

Changed to externals_* to make it easier to add other resources, such as chirp.

If there is an error, the result of the task is an OR or INPUT_MISSING and an appropriate description.