### PR TITLE
Safe file send and cache

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -963,7 +963,10 @@ char *make_cached_name( const struct work_queue_task *t, const struct work_queue
 	/* 0 for cache files, taskid for non-cache files. With this, non-cache
 	 * files cannot be shared among tasks, and can be safely deleted once a
 	 * task finishes. */
-	int cache_task_id = f->flags | WORK_QUEUE_CACHE ? 0 : t->taskid;;
+	int cache_task_id = 0;
+	if(t && !(f->flags | WORK_QUEUE_CACHE)) {
+		cache_task_id = t->taskid;
+	}
 
 	switch(f->type) {
 		case WORK_QUEUE_FILE:
@@ -1090,30 +1093,34 @@ static work_queue_result_code_t get_output_files( struct work_queue *q, struct w
 	return result;
 }
 
+static void delete_worker_file( struct work_queue *q, struct work_queue_worker *w, struct work_queue_file *tf, int except_flags ) {
+	if(!(tf->flags & except_flags)) {
+		send_worker_msg(q,w, "unlink %s\n", tf->cached_name);
+		hash_table_remove(w->current_files, tf->cached_name);
+	}
+}
+
 // Sends "unlink file" for every file in the list except those that match one or more of the "except_flags"
-static void delete_worker_files( struct work_queue *q, struct work_queue_worker *w, struct work_queue_task *t, struct list *files, int except_flags ) {
+static void delete_worker_files( struct work_queue *q, struct work_queue_worker *w, struct list *files, int except_flags ) {
 	struct work_queue_file *tf;
 
 	if(!files) return;
 
 	list_first_item(files);
 	while((tf = list_next_item(files))) {
-		if(!(tf->flags & except_flags)) {
-			send_worker_msg(q,w, "unlink %s\n", tf->cached_name);
-			hash_table_remove(w->current_files, tf->cached_name);
-		}
+		delete_worker_file(q, w, tf, except_flags);
 	}
 }
 
 static void delete_task_output_files(struct work_queue *q, struct work_queue_worker *w, struct work_queue_task *t)
 {
-	delete_worker_files(q, w, t, t->output_files, 0);
+	delete_worker_files(q, w, t->output_files, 0);
 }
 
 static void delete_uncacheable_files( struct work_queue *q, struct work_queue_worker *w, struct work_queue_task *t )
 {
-	delete_worker_files(q, w, t, t->input_files, WORK_QUEUE_CACHE | WORK_QUEUE_PREEXIST);
-	delete_worker_files(q, w, t, t->output_files, WORK_QUEUE_CACHE | WORK_QUEUE_PREEXIST);
+	delete_worker_files(q, w, t->input_files, WORK_QUEUE_CACHE | WORK_QUEUE_PREEXIST);
+	delete_worker_files(q, w, t->output_files, WORK_QUEUE_CACHE | WORK_QUEUE_PREEXIST);
 }
 
 void resource_monitor_append_report(struct work_queue *q, struct work_queue_task *t)
@@ -2993,10 +3000,10 @@ static int cancel_task_on_worker(struct work_queue *q, struct work_queue_task *t
 		debug(D_WQ, "Task with id %d is aborted at worker %s (%s) and removed.", t->taskid, w->hostname, w->addrport);
 
 		//Delete any input files that are not to be cached.
-		delete_worker_files(q, w, t, t->input_files, WORK_QUEUE_CACHE | WORK_QUEUE_PREEXIST);
+		delete_worker_files(q, w, t->input_files, WORK_QUEUE_CACHE | WORK_QUEUE_PREEXIST);
 
 		//Delete all output files since they are not needed as the task was aborted.
-		delete_worker_files(q, w, t, t->output_files, 0);
+		delete_worker_files(q, w, t->output_files, 0);
 
 		//update tables.
 		reap_task_from_worker(q, w, t, new_state);
@@ -3658,6 +3665,46 @@ void work_queue_file_delete(struct work_queue_file *tf) {
 		free(tf->cached_name);
 	free(tf);
 }
+
+void work_queue_invalidate_cached_file(struct work_queue *q, const char *local_name, work_queue_file_flags_t type) {
+	struct work_queue_file *f = work_queue_file_create(NULL, local_name, local_name, type, WORK_QUEUE_CACHE);
+
+	char *key;
+	struct work_queue_worker *w;
+	hash_table_firstkey(q->worker_table);
+	while(hash_table_nextkey(q->worker_table, &key, (void**)&w)) {
+		if(!hash_table_lookup(w->current_files, f->cached_name))
+			continue;
+
+		struct work_queue_task *t;
+		uint64_t taskid;
+
+		itable_firstkey(w->current_tasks);
+		while(itable_nextkey(w->current_tasks, &taskid, (void**)&t)) {
+			struct work_queue_file *tf;
+			list_first_item(t->input_files);
+
+			while((tf = list_next_item(t->input_files))) {
+				if(strcmp(f->cached_name, tf->cached_name) == 0) {
+					cancel_task_on_worker(q, t, WORK_QUEUE_TASK_READY);
+					continue;
+				}
+			}
+
+			while((tf = list_next_item(t->output_files))) {
+				if(strcmp(f->cached_name, tf->cached_name) == 0) {
+					cancel_task_on_worker(q, t, WORK_QUEUE_TASK_READY);
+					continue;
+				}
+			}
+		}
+
+		delete_worker_file(q, w, f, WORK_QUEUE_PREEXIST);
+	}
+
+	work_queue_file_delete(f);
+}
+
 
 void work_queue_task_delete(struct work_queue_task *t)
 {
@@ -4599,10 +4646,10 @@ struct list * work_queue_cancel_all_tasks(struct work_queue *q) {
 		itable_firstkey(w->current_tasks);
 		while(itable_nextkey(w->current_tasks, &taskid, (void**)&t)) {
 			//Delete any input files that are not to be cached.
-			delete_worker_files(q, w, t, t->input_files, WORK_QUEUE_CACHE | WORK_QUEUE_PREEXIST);
+			delete_worker_files(q, w, t->input_files, WORK_QUEUE_CACHE | WORK_QUEUE_PREEXIST);
 
 			//Delete all output files since they are not needed as the task was aborted.
-			delete_worker_files(q, w, t, t->output_files, 0);
+			delete_worker_files(q, w, t->output_files, 0);
 			reap_task_from_worker(q, w, t, WORK_QUEUE_TASK_CANCELED);
 
 			list_push_tail(l, t);

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -62,7 +62,8 @@ typedef enum {
 	WORK_QUEUE_RESULT_SIGNAL         = 8,       /**< The task was terminated with a signal **/
 	WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION = 16, /**< The task used more resources than requested **/
 	WORK_QUEUE_RESULT_TASK_TIMEOUT   = 32,      /**< The task ran after specified end time. **/
-	WORK_QUEUE_RESULT_UNKNOWN        = 64       /**< The task ran successfully **/
+	WORK_QUEUE_RESULT_UNKNOWN        = 64,      /**< The result could not be classified. **/
+	WORK_QUEUE_RESULT_FORSAKEN       = 128      /**< The task failed, but it was neither a task or worker error **/
 } work_queue_result_t;
 
 typedef enum {
@@ -72,8 +73,10 @@ typedef enum {
 	WORK_QUEUE_TASK_WAITING_RETRIEVAL, /**< Task results are available at the worker **/
 	WORK_QUEUE_TASK_RETRIEVED,         /**< Task results are available at the master **/
 	WORK_QUEUE_TASK_DONE,              /**< Task is done, and returned through work_queue_wait >**/
-	WORK_QUEUE_TASK_CANCELED           /**< Task was canceled before completion **/
+	WORK_QUEUE_TASK_CANCELED,           /**< Task was canceled before completion **/
+	WORK_QUEUE_TASK_WAITING_RESUBMISSION /**< Worker gave up on the task, and task should be resubmitted >**/
 } work_queue_task_state_t;
+
 
 extern double wq_option_fast_abort_multiplier; /**< Initial setting for fast abort multiplier upon
 												 creating queue. Turned off if less than 0. Change

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -74,8 +74,17 @@ typedef enum {
 	WORK_QUEUE_TASK_RETRIEVED,         /**< Task results are available at the master **/
 	WORK_QUEUE_TASK_DONE,              /**< Task is done, and returned through work_queue_wait >**/
 	WORK_QUEUE_TASK_CANCELED,           /**< Task was canceled before completion **/
-	WORK_QUEUE_TASK_WAITING_RESUBMISSION /**< Worker gave up on the task, and task should be resubmitted >**/
+	WORK_QUEUE_TASK_WAITING_RESUBMISSION /**< Worker gave up on the task, and task will be resubmitted >**/
 } work_queue_task_state_t;
+
+typedef enum {
+	WORK_QUEUE_FILE = 1,              /**< File-spec is a regular file **/
+	WORK_QUEUE_BUFFER,                /**< Data comes from buffer memory **/
+	WORK_QUEUE_REMOTECMD,             /**< File-spec is a regular file **/
+	WORK_QUEUE_FILE_PIECE,            /**< File-spec refers to only a part of a file **/
+	WORK_QUEUE_DIRECTORY,             /**< File-spec is a directory **/
+	WORK_QUEUE_URL                    /**< File-spec refers to an URL **/
+} work_queue_file_t;
 
 
 extern double wq_option_fast_abort_multiplier; /**< Initial setting for fast abort multiplier upon
@@ -423,6 +432,22 @@ void work_queue_blacklist_remove(struct work_queue *q, const char *hostname);
 @param q A work queue object.
 */
 void work_queue_blacklist_clear(struct work_queue *q);
+
+/** Invalidate cached file.
+The file or directory with the given local name specification is deleted from
+the workers' cache, so that a newer version may be used. Any running task using
+the file is canceled and resubmitted. Completed tasks waiting for retrieval are
+not affected.
+(Currently anonymous buffers and file pieces cannot be deleted once cached in a worker.)
+@param q A work queue object.
+@param local_name The name of the file on local disk or shared filesystem, or uri.
+@param type One of:
+- @ref WORK_QUEUE_FILE
+- @ref WORK_QUEUE_DIRECTORY
+- @ref WORK_QUEUE_URL
+*/
+void work_queue_invalidate_cached_file(struct work_queue *q, const char *local_name, work_queue_file_flags_t type);
+
 
 /** Wait for a task to complete.
 This call will block until either a task has completed, the timeout has expired, or the queue is empty.

--- a/work_queue/src/work_queue_internal.h
+++ b/work_queue/src/work_queue_internal.h
@@ -9,15 +9,6 @@ See the file COPYING for details.
 
 #include "list.h"
 
-typedef enum {
-	WORK_QUEUE_FILE = 1,
-	WORK_QUEUE_BUFFER,
-	WORK_QUEUE_REMOTECMD,
-	WORK_QUEUE_FILE_PIECE,
-	WORK_QUEUE_DIRECTORY,
-	WORK_QUEUE_URL
-} work_queue_file_t;
-
 struct work_queue_file {
 	work_queue_file_t type;
 	int flags;		// WORK_QUEUE_CACHE or others in the future.

--- a/work_queue/src/work_queue_internal.h
+++ b/work_queue/src/work_queue_internal.h
@@ -38,6 +38,9 @@ work_queue_submit_internal is the submit function used in foreman, where the
 taskid should not be modified.*/
 int work_queue_submit_internal(struct work_queue *q, struct work_queue_task *t);
 
+/** Same as @ref work_queue_invalidate_cached_file, but takes filename as face value, rather than computing cached_name. */
+void work_queue_invalidate_cached_file_internal(struct work_queue *q, const char *filename);
+
 void release_all_workers(struct work_queue *q);
 
 void update_catalog(struct work_queue *q, struct link *foreman_uplink, int force_update );

--- a/work_queue/src/work_queue_protocol.h
+++ b/work_queue/src/work_queue_protocol.h
@@ -14,7 +14,7 @@ This file should not be installed and should only be included by .c files.
 #ifndef WORK_QUEUE_PROTOCOL_H
 #define WORK_QUEUE_PROTOCOL_H
 
-#define WORK_QUEUE_PROTOCOL_VERSION 3
+#define WORK_QUEUE_PROTOCOL_VERSION 4
 
 #define WORK_QUEUE_LINE_MAX 4096       /**< Maximum length of a work queue message line. */
 #define WORK_QUEUE_POOL_NAME_MAX 128   /**< Maximum length of a work queue pool name. */

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1157,6 +1157,18 @@ static void kill_all_tasks() {
 	debug(D_WQ,"all data structures are clean");
 }
 
+/* Remove a file, even when mark as cached. Foreman broadcast this message to
+ * foremen down its hierarchy. It is invalid for a worker to receice this message. */
+static int do_invalidate_file(const char *filename) {
+
+	if(worker_mode == WORKER_MODE_FOREMAN) {
+		work_queue_invalidate_cached_file_internal(foreman_q, filename);
+		return 1;
+	}
+
+	return -1;
+}
+
 static int do_release() {
 	debug(D_WQ, "released by master %s:%d.\n", master_addr, master_port);
 	released_by_master = 1;
@@ -1239,6 +1251,8 @@ static int handle_master(struct link *master) {
 				kill_all_tasks();
 				r = 1;
 			}
+		} else if(sscanf(line, "invalidate-file %s", filename) == 1) {
+			r = do_invalidate_file(filename);
 		} else if(!strncmp(line, "release", 8)) {
 			r = do_release();
 		} else if(!strncmp(line, "exit", 5)) {


### PR DESCRIPTION
1) Cache files are never updated automatically, even when changed locally.
2) Non-cache files receive names per task, even when locally they are the same file.
3) Added wq_invalidate_file to manually remove cached files. It also cancels any running task using the file.

invalidate_file does not work for buffers or commands. I am not sure how to that yet.