### PR TITLE
Turn some errors into resource exhaustion signals

### DIFF
--- a/dttools/src/rmsummary.c
+++ b/dttools/src/rmsummary.c
@@ -56,9 +56,11 @@ int rmsummary_assign_field(struct rmsummary *s, char *key, char *value)
 	rmsummary_assign_as_time_field  (s, key, value, start);
 	rmsummary_assign_as_time_field  (s, key, value, end);
 	rmsummary_assign_as_string_field(s, key, value, exit_type);
+	rmsummary_assign_as_int_field   (s, key, value, last_error);
 	rmsummary_assign_as_int_field   (s, key, value, signal);
 	rmsummary_assign_as_string_field(s, key, value, limits_exceeded);
 	rmsummary_assign_as_int_field   (s, key, value, exit_status);
+	rmsummary_assign_as_int_field   (s, key, value, last_error);
 	rmsummary_assign_as_time_field  (s, key, value, wall_time);
 	rmsummary_assign_as_int_field   (s, key, value, max_concurrent_processes);
 	rmsummary_assign_as_int_field   (s, key, value, total_processes);
@@ -202,6 +204,9 @@ void rmsummary_print(FILE *stream, struct rmsummary *s, struct rmsummary *limits
 		fprintf(stream, "%-20s%20s\n",  "exit_type:", s->exit_type);
 
 	fprintf(stream, "%-20s%20" PRId64 "\n",  "exit_status:", s->exit_status);
+
+	if(s->last_error)
+		fprintf(stream, "%-20s%20" PRId64 " %s\n",  "last_error:", s->last_error, strerror(s->last_error));
 
 	if(s->exit_type)
 	{
@@ -360,6 +365,7 @@ void rmsummary_bin_op(struct rmsummary *dest, struct rmsummary *src, rm_bin_op f
 	rmsummary_apply_op(dest, src, fn, start);
 	rmsummary_apply_op(dest, src, fn, end);
 	rmsummary_apply_op(dest, src, fn, exit_status);
+	rmsummary_apply_op(dest, src, fn, last_error);
 	rmsummary_apply_op(dest, src, fn, wall_time);
 	rmsummary_apply_op(dest, src, fn, max_concurrent_processes);
 	rmsummary_apply_op(dest, src, fn, total_processes);

--- a/dttools/src/rmsummary.c
+++ b/dttools/src/rmsummary.c
@@ -56,7 +56,6 @@ int rmsummary_assign_field(struct rmsummary *s, char *key, char *value)
 	rmsummary_assign_as_time_field  (s, key, value, start);
 	rmsummary_assign_as_time_field  (s, key, value, end);
 	rmsummary_assign_as_string_field(s, key, value, exit_type);
-	rmsummary_assign_as_int_field   (s, key, value, last_error);
 	rmsummary_assign_as_int_field   (s, key, value, signal);
 	rmsummary_assign_as_string_field(s, key, value, limits_exceeded);
 	rmsummary_assign_as_int_field   (s, key, value, exit_status);

--- a/dttools/src/rmsummary.h
+++ b/dttools/src/rmsummary.h
@@ -33,6 +33,7 @@ struct rmsummary
 	int64_t  signal;
 	char    *limits_exceeded;
 	int64_t  exit_status;
+	int64_t  last_error;
 
 	int64_t  wall_time;
 	int64_t  total_processes;

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -1181,14 +1181,27 @@ void rmonitor_dispatch_msg(void)
 					break;
 				case EMFILE:
 					/* Eventually report that we ran out of file descriptors. */
+					debug(D_DEBUG, "Process %d ran out of file descriptors.\n", msg.origin);
 					break;
 				default:
+					/* Clear the error, as it is not related to resources. */
+					msg.error = 0;
 					break;
 			}
 			break;
         case READ:
             break;
         case WRITE:
+			switch(msg.error) {
+				case ENOSPC:
+					/* Eventually report that we ran out of space. */
+					debug(D_DEBUG, "Process %d ran out of disk space.\n", msg.origin);
+					break;
+				default:
+					/* Clear the error, as it is not related to resources. */
+					msg.error = 0;
+					break;
+			}
             break;
         default:
             break;

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -451,9 +451,7 @@ void rmonitor_add_file_watch(char *filename, int is_output)
 		char **new_inotify_watches;
 		int iwd;
 
-		if ((iwd = inotify_add_watch(rmonitor_inotify_fd,
-					     filename,
-					     IN_CLOSE_WRITE|IN_CLOSE_NOWRITE|IN_ACCESS|IN_MODIFY)) < 0)
+		if ((iwd = inotify_add_watch(rmonitor_inotify_fd, filename, IN_CLOSE_WRITE|IN_CLOSE_NOWRITE|IN_ACCESS|IN_MODIFY)) < 0)
 		{
 			debug(D_DEBUG, "inotify_add_watch for file %s fails: %s", filename, strerror(errno));
 		} else {
@@ -1177,7 +1175,7 @@ void rmonitor_dispatch_msg(void)
 			switch(msg.error) {
 				case 0:
 					debug(D_DEBUG, "File %s has been opened.\n", msg.data.s);
-					rmonitor_inotify_add_watch(msg.data.s, msg.type == OPEN_OUTPUT);
+					rmonitor_add_file_watch(msg.data.s, msg.type == OPEN_OUTPUT);
 					break;
 				case EMFILE:
 					/* Eventually report that we ran out of file descriptors. */

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -1209,7 +1209,7 @@ void rmonitor_dispatch_msg(void)
 
 	summary->last_error = msg.error;
 
-	if(rmonitor_check_limits(summary))
+	if(!rmonitor_check_limits(summary))
 		rmonitor_final_cleanup(SIGTERM);
 
 }

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -1168,14 +1168,20 @@ void rmonitor_dispatch_msg(void)
         case CHDIR:
             p->wd = lookup_or_create_wd(p->wd, msg.data.s);
             break;
-        case OPEN_INPUT:
-            debug(D_DEBUG, "File %s has been opened as input.\n", msg.data.s);
-            rmonitor_add_file_watch(msg.data.s, 0);
-            break;
-        case OPEN_OUTPUT:
-            debug(D_DEBUG, "File %s has been opened as output.\n", msg.data.s);
-            rmonitor_add_file_watch(msg.data.s, 1);
-            break;
+		case OPEN_INPUT:
+		case OPEN_OUTPUT:
+			switch(msg.error) {
+				case 0:
+					debug(D_DEBUG, "File %s has been opened.\n", msg.data.s);
+					rmonitor_inotify_add_watch(msg.data.s, msg.type == OPEN_OUTPUT);
+					break;
+				case EMFILE:
+					/* Eventually report that we ran out of file descriptors. */
+					break;
+				default:
+					break;
+			}
+			break;
         case READ:
             break;
         case WRITE:

--- a/resource_monitor/src/rmonitor_helper.c
+++ b/resource_monitor/src/rmonitor_helper.c
@@ -212,7 +212,6 @@ int open(const char *path, int flags, ...)
 		fd = original_open(path, flags, mode);
 	POP_ERRNO(msg)
 
-	struct rmonitor_msg msg;
 	if(fd > -1)
 	{
 
@@ -247,8 +246,6 @@ FILE *fopen64(const char *path, const char *mode)
 
 	if(file)
 	{
-		struct rmonitor_msg msg;
-
 		if(open_for_writing(fileno(file))) {
 			msg.type   = OPEN_OUTPUT;
 		} else {
@@ -286,8 +283,6 @@ int open64(const char *path, int flags, ...)
 
 	if(fd > -1)
 	{
-		struct rmonitor_msg msg;
-
 		if(open_for_writing(fd)) {
 			msg.type   = OPEN_OUTPUT;
 		} else {

--- a/resource_monitor/src/rmonitor_helper_comm.h
+++ b/resource_monitor/src/rmonitor_helper_comm.h
@@ -27,6 +27,7 @@ struct rmonitor_msg
 {
 	enum rmonitor_msg_type type;
 	pid_t                 origin;
+	int                   error;
 	union {
 		pid_t    p;
 		uint64_t n;


### PR DESCRIPTION
1) Keep last related error.
2) Capture write with ld preload.
3) Quit on no space and no file descriptors.