### PR TITLE
Rmonitor file list

### DIFF
--- a/doc/man/resource_monitor.m4
+++ b/doc/man/resource_monitor.m4
@@ -94,14 +94,11 @@ OPTION_TRIPLET(-l,limits-file,file)Use maxfile with list of var: value pairs for
 OPTION_TRIPLET(-L,limits,string)String of the form `"var: value, var: value\' to specify resource limits. (Could be specified multiple times.)
 OPTION_ITEM(`-f, --child-in-foreground')Keep the monitored process in foreground (for interactive use).
 OPTION_TRIPLET(-O,with-output-files,template)Specify template for log files (default=resource-pid-<pid>).
-OPTION_PAIR(--with-summary-file,file)Write resource summary to <file> (default=<template>.summary).
-OPTION_PAIR(--with-time-series,file)Write resource time series to <file> (default=<template>.series).
-OPTION_PAIR(`--with-opened-files',file)Write list of opened files to <file> (default=<template>.opened).
+OPTION_ITEM(--with-time-series)Write resource time series to <template>.series.
+OPTION_PAIR(--with-inotify)Write inotify statistics to <template>.files.
 OPTION_TRIPLET(-V,verbatim-to-summary,str)Include this string verbatim in a line in the summary. (Could be specified multiple times.)
-OPTION_ITEM(--without-summary-file)Do not write the summary log file.
 OPTION_ITEM(--without-time-series)Do not write the time-series log file.
 OPTION_ITEM(--without-opened-files)Do not write the list of opened files.
-OPTION_ITEM(--with-disk-footprint)Measure working directory footprint (potentially slow).
 OPTION_ITEM(--without-disk-footprint)Do not measure working directory footprint (default).
 OPTION_ITEM(`-v,--version')Show version string.
 OPTION_ITEM(`-h,--help')Show help text.
@@ -133,7 +130,7 @@ The exit status of the command line provided.
 
 SECTION(EXAMPLES)
 
-To monitor 'sleep 10', at 2 second intervals, with output to sleep-log.summary, sleep-log.series, and sleep-log.files, and with a monitor alarm at 5 seconds:
+To monitor 'sleep 10', at 2 second intervals, with output to sleep-log.summary, and with a monitor alarm at 5 seconds:
 
 LONGCODE_BEGIN
 % resource_monitor --interval=2 -L"wall_time: 5" -o sleep-log -- sleep 10

--- a/dttools/src/rmonitor.c
+++ b/dttools/src/rmonitor.c
@@ -115,7 +115,7 @@ char *resource_monitor_copy_to_wd(const char *path_from_cmdline)
 //to change it.
 char *resource_monitor_rewrite_command(const char *cmdline, const char *monitor_path, const char *template_filename, const char *limits_filename,
 					   const char *extra_monitor_options,
-					   int summary, int time_series, int opened_files)
+					   int time_series, int inotify_stats)
 {
 	char cmd_builder[PATH_MAX];
 	int  index;
@@ -127,18 +127,13 @@ char *resource_monitor_rewrite_command(const char *cmdline, const char *monitor_
 	if(!monitor_path)
 		monitor_path = monitor_exe;
 
-	index = sprintf(cmd_builder, "./%s --with-disk-footprint ", monitor_path);
+	index = sprintf(cmd_builder, "./%s --with-output-files=%s ", monitor_path, template_filename);
 
-	index += sprintf(cmd_builder + index, "--with-output-files=%s ", template_filename);
+	if(time_series)
+		index += sprintf(cmd_builder + index, "--with-time-series ");
 
-	if(!summary)
-		index += sprintf(cmd_builder + index, "--without-summary-file ");
-
-	if(!time_series)
-		index += sprintf(cmd_builder + index, "--without-time-series ");
-
-	if(!opened_files)
-		index += sprintf(cmd_builder + index, "--without-opened-files ");
+	if(inotify_stats)
+		index += sprintf(cmd_builder + index, "--with-inotify ");
 
 	if(limits_filename)
 		index += sprintf(cmd_builder + index, "--limits-file=%s ", limits_filename);

--- a/dttools/src/rmonitor.h
+++ b/dttools/src/rmonitor.h
@@ -27,7 +27,7 @@ the corresponding log file options.
 
 char *resource_monitor_rewrite_command(const char *cmdline, const char *monitor_path, const char *template_filename, const char *limits_filename,
 					   const char *extra_monitor_options,
-					   int summary, int time_series, int opened_files);
+					   int time_series, int opened_files);
 
 /** Looks for a resource monitor executable, and makes a copy in
 current working directory.

--- a/dttools/src/rmsummary.c
+++ b/dttools/src/rmsummary.c
@@ -187,8 +187,11 @@ struct rmsummary *rmsummary_parse_file_single(char *filename)
 	return s;
 }
 
-void rmsummary_print(FILE *stream, struct rmsummary *s, struct rmsummary *limits)
+void rmsummary_print(FILE *stream, struct rmsummary *s, struct rmsummary *limits, char *preamble, char *epilogue)
 {
+	if(preamble)
+		fprintf(stream, "%s", preamble);
+
 	if(s->command)
 		fprintf(stream, "%s %s\n",  "command:", s->command);
 
@@ -213,6 +216,9 @@ void rmsummary_print(FILE *stream, struct rmsummary *s, struct rmsummary *limits
 	if(limits) {
 		rmsummary_print_only_resources(stream, limits, "limits_");
 	}
+
+	if(epilogue)
+		fprintf(stream, "%s", epilogue);
 
 	fprintf(stream, "--\n\n");
 }

--- a/dttools/src/rmsummary.h
+++ b/dttools/src/rmsummary.h
@@ -66,7 +66,7 @@ struct rmsummary_field
 	}       value;
 };
 
-void rmsummary_print(FILE *stream, struct rmsummary *s, struct rmsummary *limits);
+void rmsummary_print(FILE *stream, struct rmsummary *s, struct rmsummary *limits, char *preamble, char *epilogue);
 void rmsummary_print_only_resources(FILE *stream, struct rmsummary *s, const char *prefix);
 
 

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -823,7 +823,7 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 
 			if(s)
 			{
-				rmsummary_print(stderr, s, NULL);
+				rmsummary_print(stderr, s, NULL, NULL, NULL);
 				free(s);
 				fprintf(stderr, "\n");
 			}

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -404,7 +404,6 @@ static char *makeflow_node_rmonitor_wrap_command( struct dag_node *n, const char
 			log_name_prefix,
 			monitor_limits_name,
 			extra_options,
-			1,						   /* summaries always enabled */
 			monitor_enable_time_series,
 			monitor_enable_list_files);
 

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -704,7 +704,7 @@ void rmonitor_add_files_to_summary(char *field, int outputs) {
 				continue;
 			}
 
-			buffer_putfstring(&b, "%s%20s%-50s, %20" PRId64 " ]", delimeter, "[ ", fname, (int64_t) ceil(1.0*file_size/ONE_MEGABYTE));
+			buffer_putfstring(&b, "%s%20s\"%s\", %" PRId64 " ]", delimeter, "[ ", fname, (int64_t) ceil(1.0*file_size/ONE_MEGABYTE));
 			delimeter = ",\n";
 		}
 

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -418,9 +418,7 @@ struct rmonitor_wdir_info *lookup_or_create_wd(struct rmonitor_wdir_info *previo
 void rmonitor_add_file_watch(char *filename, int is_output)
 {
 	struct rmonitor_file_info *finfo;
-	char **new_inotify_watches;
 	struct stat fst;
-	int iwd;
 
 	finfo = hash_table_lookup(files, filename);
 	if (finfo)
@@ -450,6 +448,9 @@ void rmonitor_add_file_watch(char *filename, int is_output)
 #if defined(CCTOOLS_OPSYS_LINUX) && defined(RESOURCE_MONITOR_USE_INOTIFY)
 	if (rmonitor_inotify_fd >= 0)
 	{
+		char **new_inotify_watches;
+		int iwd;
+
 		if ((iwd = inotify_add_watch(rmonitor_inotify_fd,
 					     filename,
 					     IN_CLOSE_WRITE|IN_CLOSE_NOWRITE|IN_ACCESS|IN_MODIFY)) < 0)

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -578,7 +578,7 @@ void rmonitor_collate_tree(struct rmsummary *tr, struct rmonitor_process_info *p
 	tr->cpu_time          = p->cpu.delta + tr->cpu_time;
 
 	if(tr->wall_time > 0)
-		tr->cores = (int64_t) ceil( ((double) tr->cpu_time)/tr->wall_time);
+		tr->cores = (int64_t) MAX(1, ceil( ((double) tr->cpu_time)/tr->wall_time));
 
 	tr->max_concurrent_processes     = (int64_t) itable_size(processes);
 	tr->total_processes     = summary->total_processes;

--- a/resource_monitor/src/rmonitor_helper.c
+++ b/resource_monitor/src/rmonitor_helper.c
@@ -134,6 +134,20 @@ int fchdir(int fd)
 	return status;
 }
 
+static int open_for_writing(int fd) {
+	int flags, access_mode;
+
+	flags       = fcntl(fd, F_GETFL);
+
+	if(flags == -1) {
+		/* if error, assume output. */
+		return 1;
+	}
+
+	access_mode = flags & O_ACCMODE;
+	return (access_mode != O_RDONLY);
+}
+
 FILE *fopen(const char *path, const char *mode)
 {
 	FILE *file;
@@ -146,7 +160,12 @@ FILE *fopen(const char *path, const char *mode)
 	{
 		struct rmonitor_msg msg;
 
-		msg.type   = OPEN;
+		if(open_for_writing(fileno(file))) {
+			msg.type   = OPEN_OUTPUT;
+		} else {
+			msg.type   = OPEN_INPUT;
+		}
+
 		msg.origin = getpid();
 		strcpy(msg.data.s, path);
 
@@ -175,7 +194,12 @@ int open(const char *path, int flags, ...)
 	{
 		struct rmonitor_msg msg;
 
-		msg.type   = OPEN;
+		if(open_for_writing(fd)) {
+			msg.type   = OPEN_OUTPUT;
+		} else {
+			msg.type   = OPEN_INPUT;
+		}
+
 		msg.origin = getpid();
 		strcpy(msg.data.s, path);
 
@@ -198,7 +222,12 @@ FILE *fopen64(const char *path, const char *mode)
 	{
 		struct rmonitor_msg msg;
 
-		msg.type   = OPEN;
+		if(open_for_writing(fileno(file))) {
+			msg.type   = OPEN_OUTPUT;
+		} else {
+			msg.type   = OPEN_INPUT;
+		}
+
 		msg.origin = getpid();
 		strcpy(msg.data.s, path);
 
@@ -227,7 +256,12 @@ int open64(const char *path, int flags, ...)
 	{
 		struct rmonitor_msg msg;
 
-		msg.type   = OPEN;
+		if(open_for_writing(fd)) {
+			msg.type   = OPEN_OUTPUT;
+		} else {
+			msg.type   = OPEN_INPUT;
+		}
+
 		msg.origin = getpid();
 		strcpy(msg.data.s, path);
 

--- a/resource_monitor/src/rmonitor_helper_comm.c
+++ b/resource_monitor/src/rmonitor_helper_comm.c
@@ -47,8 +47,11 @@ const char *str_msgtype(enum rmonitor_msg_type n)
 		case CHDIR:
 			return "chdir";
 			break;
-		case OPEN:
-			return "open-file";
+		case OPEN_INPUT:
+			return "open-input-file";
+			break;
+		case OPEN_OUTPUT:
+			return "open-output-file";
 			break;
 		case READ:
 			return "read";

--- a/resource_monitor/src/rmonitor_helper_comm.h
+++ b/resource_monitor/src/rmonitor_helper_comm.h
@@ -12,12 +12,13 @@ See the file COPYING for details.
 #define RESOURCE_MONITOR_HELPER_ENV_VAR "CCTOOLS_RESOURCE_MONITOR_HELPER"
 #define RESOURCE_MONITOR_INFO_ENV_VAR   "CCTOOLS_RESOURCE_MONITOR_INFO"
 
-enum rmonitor_msg_type { BRANCH, WAIT, END_WAIT, END, CHDIR, OPEN, READ, WRITE };
+enum rmonitor_msg_type { BRANCH, WAIT, END_WAIT, END, CHDIR, OPEN_INPUT, OPEN_OUTPUT, READ, WRITE };
 
 /* BRANCH: pid of parent
  * END:    pid of child that ended
  * CHDIR:  new working directory
- * OPEN:   path of the file opened, or "" if not a regular file.
+ * OPEN_INPUT:  path of the file opened, or "" if not a regular file.
+ * OPEN_OUTPUT: path of the file opened, or "" if not a regular file.
  * READ:   Number of bytes read.
  * WRITE:  Number of bytes written.
  */

--- a/resource_monitor/src/rmonitor_types.h
+++ b/resource_monitor/src/rmonitor_types.h
@@ -66,6 +66,7 @@ struct rmonitor_file_info
 	uint64_t n_closes;
 	uint64_t n_reads;
 	uint64_t n_writes;
+	int      is_output;
 	off_t size_on_open;            /* in bytes */
 	off_t size_on_close;           /* in bytes */
 	dev_t device;

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1142,7 +1142,7 @@ void resource_monitor_append_report(struct work_queue *q, struct work_queue_task
 
 	if(t->resources_measured)
 	{
-		rmsummary_print(q->monitor_file, t->resources_measured, NULL);
+		rmsummary_print(q->monitor_file, t->resources_measured, NULL, NULL, NULL);
 	}
 	else
 	{
@@ -4122,7 +4122,7 @@ void work_queue_disable_monitoring(struct work_queue *q) {
 		fprintf(final, "master_name: %s\n", q->name);
 
 	fprintf(final, "exit_type:   normal\n");
-	rmsummary_print(final, q->measured_local_resources, NULL);
+	rmsummary_print(final, q->measured_local_resources, NULL, NULL, NULL);
 
 	copy_fd_to_stream(summs_fd, final);
 
@@ -4139,7 +4139,7 @@ int work_queue_monitor_wrap(struct work_queue *q, struct work_queue_task *t)
 	char *template = string_format(RESOURCE_MONITOR_TASK_SUMMARY_NAME, getpid(), t->taskid);
 	char *summary  = string_format("%s.summary", template);
 
-	wrap_cmd = resource_monitor_rewrite_command(t->command_line, NULL, template, NULL, NULL, 1, 0, 0);
+	wrap_cmd = resource_monitor_rewrite_command(t->command_line, NULL, template, NULL, NULL, 0, 0);
 
 	//BUG: what if user changes current working directory?
 	work_queue_task_specify_file(t, q->monitor_exe, q->monitor_exe, WORK_QUEUE_INPUT, WORK_QUEUE_CACHE);


### PR DESCRIPTION
Include input and output files on task summary.

Classify inputs and outputs according to the mode used in open.

Simplify command line options.

Fix bug where a signal handler was executed twice.