### PR TITLE
wq tasks left

### DIFF
--- a/work_queue/src/perl/Work_Queue.pm
+++ b/work_queue/src/perl/Work_Queue.pm
@@ -136,6 +136,11 @@ sub specify_priority {
 	return work_queue_specify_priority($self->{_work_queue}, $priority);
 }
 
+sub specify_num_tasks_left {
+	my ($self, $ntasks) = @_;
+	return work_queue_specify_num_tasks_left($self->{_work_queue}, $ntasks);
+}
+
 sub specify_master_mode {
 	my ($self, $mode) = @_;
 	return work_queue_specify_master_mode($self->{_work_queue}, $mode);
@@ -439,6 +444,23 @@ Change the project priority for the given queue.
 An integer that presents the priorty of this work queue master. The higher the value, the higher the priority.
 
 =back
+
+=head3 C<specify_num_tasks_left>
+
+Specify the number of tasks not yet submitted to the queue.
+It is used by work_queue_pool to determine the number of workers to launch.
+If not specified, it defaults to 0.
+work_queue_pool considers the number of tasks as:
+num tasks left + num tasks running + num tasks read.
+
+=over 12
+
+=item ntasks
+
+ntasks Number of tasks yet to be submitted.
+
+=back
+
 
 =head3 C<specify_master_mode>
 

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -739,6 +739,16 @@ class WorkQueue(_object):
     def specify_priority(self, priority):
         return work_queue_specify_priority(self._work_queue, priority)
 
+    ## Specify the number of tasks not yet submitted to the queue.
+    # It is used by work_queue_pool to determine the number of workers to launch.
+    # If not specified, it defaults to 0.
+    # work_queue_pool considers the number of tasks as:
+    # num tasks left + num tasks running + num tasks read.
+    # @param q A work queue object.
+    # @param ntasks Number of tasks yet to be submitted.
+    def specify_num_tasks_left(self, ntasks):
+        return work_queue_specify_num_tasks_left(self._work_queue, ntasks)
+
     ##
     # Specify the master mode for the given queue.
     #

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -115,6 +115,7 @@ struct work_queue {
 	char *name;
 	int port;
 	int priority;
+	int num_tasks_left;
 
 	char workingdir[PATH_MAX];
 
@@ -1596,6 +1597,7 @@ static struct nvpair * queue_to_nvpair( struct work_queue *q, struct link *forem
 
 	nvpair_insert_integer(nv,"port",info.port);
 	nvpair_insert_integer(nv,"priority",info.priority);
+	nvpair_insert_integer(nv,"tasks_left",q->num_tasks_left);
 
 	//send info on workers
 	nvpair_insert_integer(nv,"workers",info.total_workers_connected);
@@ -4013,6 +4015,16 @@ const char *work_queue_name(struct work_queue *q)
 void work_queue_specify_priority(struct work_queue *q, int priority)
 {
 	q->priority = priority;
+}
+
+void work_queue_specify_num_tasks_left(struct work_queue *q, int ntasks)
+{
+	if(ntasks < 1) {
+		q->num_tasks_left = 0;
+	}
+	else {
+		q->num_tasks_left = ntasks;
+	}
 }
 
 void work_queue_specify_master_mode(struct work_queue *q, int mode)

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -574,6 +574,16 @@ void work_queue_specify_name(struct work_queue *q, const char *name);
 */
 void work_queue_specify_priority(struct work_queue *q, int priority);
 
+/** Specify the number of tasks not yet submitted to the queue.
+	It is used by work_queue_pool to determine the number of workers to launch.
+	If not specified, it defaults to 0.
+	work_queue_pool considers the number of tasks as:
+	num tasks left + num tasks running + num tasks read.
+  @param q A work queue object.
+  @param ntasks Number of tasks yet to be submitted.
+  */
+void work_queue_specify_num_tasks_left(struct work_queue *q, int ntasks);
+
 /** Specify the catalog server the master should report to.
 @param q A work queue object.
 @param hostname The catalog server's hostname.
@@ -700,6 +710,7 @@ void work_queue_specify_task_order(struct work_queue *q, int order);
 @deprecated Enabled automatically when @ref work_queue_specify_name is used.
 */
 void work_queue_specify_master_mode(struct work_queue *q, int mode);
+
 
 /** Change whether to estimate master capacity for a given queue.
 @param q A work queue object.

--- a/work_queue/src/work_queue_pool.c
+++ b/work_queue/src/work_queue_pool.c
@@ -89,9 +89,10 @@ static int count_workers_needed( struct list *masters_list, int only_waiting )
 		const char *owner =  nvpair_lookup_string(nv,"owner");
 		const int tr =       nvpair_lookup_integer(nv,"tasks_running");
 		const int tw =       nvpair_lookup_integer(nv,"tasks_waiting");
+		const int tl =       nvpair_lookup_integer(nv,"tasks_left");
 		const int capacity = nvpair_lookup_integer(nv,"capacity");
 
-		int tasks = tr+tw;
+		int tasks = tr+tw+tl;
 
 		int need;
 


### PR DESCRIPTION
As requested by @klannon, @awoodward, and @matz-e.

Applications such as Lobster submit tasks according to the number of workers available. This creates a chicken-and-egg problem when using work_queue_pool, as the pool does not grow if there are no tasks available. Setting a minimum number of workers in the pool is not a good solution, as many workers may go underutilized with long tails.

This request gives the master the API work_queue_specify_num_tasks_left. work_queue_pool can then compute the number of tasks as: left + running + waiting. Lobster can then inform the catalog how many tasks are left to be created, and the pool can create the workers accordingly.
