### PR TITLE
WQ pool config file

### DIFF
--- a/doc/man/work_queue_pool.m4
+++ b/doc/man/work_queue_pool.m4
@@ -53,6 +53,7 @@ OPTION_TRIPLET(-W,max-workers,workers) Maximum workers running.  (default=100)
 OPTION_ITEM(-c --capacity) Use worker capacity reported by masters.
 OPTION_TRIPLET(-P,password,file) Password file for workers to authenticate to master.
 OPTION_TRIPLET(-t,timeout,time)Abort after this amount of idle time.
+OPTION_TRIPLET(-C,config-file,file)Use the configuration file <file>.
 OPTION_TRIPLET(-E,extra-options,options)Extra options that should be added to the worker.
 OPTION_TRIPLET(-S,scratch,file)Scratch directory. (default is /tmp/${USER}-workers)
 OPTION_TRIPLET(-d,debug,flag)Enable debugging for this subsystem.
@@ -90,6 +91,36 @@ with barney, use a regular expression:
 
 LONGCODE_BEGIN
 work_queue_pool -T condor -M barney.\* -c -t 300
+LONGCODE_END
+
+Use the configuration file BOLD(my_conf):
+
+LONGCODE_BEGIN
+work_queue_pool -Cmy_conf
+LONGCODE_END
+
+BOLD(my_conf) should be a proper JSON document, as:
+LONGCODE_BEGIN
+{
+        "master-name": "my_master.*",
+        "max-workers": 100,
+        "min-workers": 0
+}
+LONGCODE_END
+
+Valid configuration fields are:
+
+LONGCODE_BEGIN
+master-name
+foremen-name
+min-workers
+max-workers
+task-per-worker
+timeout
+worker-extra-options
+cores
+memory
+disk
 LONGCODE_END
 
 SECTION(KNOWN BUGS)

--- a/dttools/src/json_aux.c
+++ b/dttools/src/json_aux.c
@@ -1,9 +1,13 @@
 #include "buffer.h"
+#include "copy_stream.h"
 #include "json.h"
 #include "json_aux.h"
 
 #include <assert.h>
 #include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 const char json_type_str[][10] = {
 	"NONE",
@@ -73,6 +77,19 @@ int jsonA_escapestring(buffer_t *B, const char *str)
 		}
 	}
 	return 0;
+}
+
+json_value *jsonA_parse_file(const char *path) {
+	size_t size;
+	char *buffer;
+
+	if(copy_file_to_buffer(path, &buffer, &size) < 1)
+		return NULL;
+
+	json_value *J = json_parse(buffer, size);
+	free(buffer);
+
+	return J;
 }
 
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/json_aux.c
+++ b/dttools/src/json_aux.c
@@ -5,9 +5,6 @@
 
 #include <assert.h>
 #include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
 
 const char json_type_str[][10] = {
 	"NONE",

--- a/dttools/src/json_aux.c
+++ b/dttools/src/json_aux.c
@@ -18,15 +18,22 @@ const char json_type_str[][10] = {
 
 json_value *jsonA_getname (json_value *object, const char *name, json_type t)
 {
+	json_value *val = jsonA_getname_raw(object, name);
+
+	if(!val || !jistype(val, t)) {
+		return NULL;
+	} else {
+		return val;
+	}
+}
+
+json_value *jsonA_getname_raw (json_value *object, const char *name)
+{
 	unsigned int i;
 	assert(object->type == json_object);
 	for (i = 0; i < object->u.object.length; i++) {
 		if (strcmp(name, object->u.object.values[i].name) == 0) {
-			if (jistype(object->u.object.values[i].value, t)) {
-				return object->u.object.values[i].value;
-			} else {
-				return NULL;
-			}
+			return object->u.object.values[i].value;
 		}
 	}
 	return NULL;

--- a/dttools/src/json_aux.h
+++ b/dttools/src/json_aux.h
@@ -9,6 +9,7 @@
 json_value *jsonA_getname (json_value *object, const char *name, json_type t);
 json_value *jsonA_getname_raw (json_value *object, const char *name);
 int jsonA_escapestring(buffer_t *B, const char *str);
+json_value *jsonA_parse_file(const char *path);
 
 extern const char json_type_str[][10];
 

--- a/dttools/src/json_aux.h
+++ b/dttools/src/json_aux.h
@@ -7,6 +7,7 @@
 #define jistype(o,t) ((o)->type == (t))
 
 json_value *jsonA_getname (json_value *object, const char *name, json_type t);
+json_value *jsonA_getname_raw (json_value *object, const char *name);
 int jsonA_escapestring(buffer_t *B, const char *str);
 
 extern const char json_type_str[][10];

--- a/work_queue/src/batch_job.c
+++ b/work_queue/src/batch_job.c
@@ -10,6 +10,7 @@ See the file COPYING for details.
 
 #include "debug.h"
 #include "itable.h"
+#include "stringtools.h"
 #include "xxmalloc.h"
 
 #include <sys/stat.h>
@@ -138,6 +139,13 @@ void batch_queue_set_option (struct batch_queue *q, const char *what, const char
 		debug(D_BATCH, "cleared option `%s'", what);
 	}
 	q->module->option_update(q, what, value);
+}
+
+void batch_queue_set_int_option(struct batch_queue *q, const char *what, int value) {
+	char *str_value = string_format("%d", value);
+	batch_queue_set_option(q, what, str_value);
+
+	free(str_value);
 }
 
 batch_queue_type_t batch_queue_type_from_string(const char *str)

--- a/work_queue/src/batch_job.h
+++ b/work_queue/src/batch_job.h
@@ -143,6 +143,13 @@ the <tt>qsub</tt> command.  This call has no effect on other queue types.
 */
 void batch_queue_set_option(struct batch_queue *q, const char *what, const char *value);
 
+/** As @batch_queue_set_option, but allowing an integer argument.
+@param q The batch queue to adjust.
+@param what The key for option.
+@param value The value of the option.
+*/
+void batch_queue_set_int_option(struct batch_queue *q, const char *what, int value);
+
 /** Get batch queue options.
 This call returns the additional options to be passed to the batch system each
 time a job is submitted.

--- a/work_queue/src/work_queue_pool.c
+++ b/work_queue/src/work_queue_pool.c
@@ -52,6 +52,7 @@ static const char *resource_args=0;
 static int abort_flag = 0;
 static const char *scratch_dir = 0;
 static const char *password_file = 0;
+static const char *config_file = 0;
 
 /* -1 means 'not specified' */
 static int num_cores_option  = -1;
@@ -388,6 +389,7 @@ static void show_help(const char *cmd)
 	printf(" %-30s Foremen to serve, can be a regular expression.\n", "-F,--foremen-name=<project>");
 	printf(" %-30s Batch system type (required). One of: %s\n", "-T,--batch-type=<type>",batch_queue_type_string());
 	printf(" %-30s Password file for workers to authenticate to master.\n","-P,--password");
+	printf(" %-30s Use configuration file <file>.\n","-C,--config-file=<file>");
 	printf(" %-30s Minimum workers running.  (default=%d)\n", "-w,--min-workers", workers_min);
 	printf(" %-30s Maximum workers running.  (default=%d)\n", "-W,--max-workers", workers_max);
 	printf(" %-30s Average tasks per worker. (default=one task per core)\n", "--tasks-per-worker");
@@ -404,12 +406,13 @@ static void show_help(const char *cmd)
 	printf(" %-30s Show this screen.\n", "-h,--help");
 }
 
-enum { LONG_OPT_CORES = 255, LONG_OPT_MEMORY, LONG_OPT_DISK, LONG_OPT_GPUS, LONG_OPT_TASKS_PER_WORKER };
+enum { LONG_OPT_CORES = 255, LONG_OPT_MEMORY, LONG_OPT_DISK, LONG_OPT_GPUS, LONG_OPT_TASKS_PER_WORKER, LONG_OPT_CONF_FILE };
 static const struct option long_options[] = {
 	{"master-name", required_argument, 0, 'M'},
 	{"foremen-name", required_argument, 0, 'F'},
 	{"batch-type", required_argument, 0, 'T'},
 	{"password", required_argument, 0, 'P'},
+	{"config-file", required_argument, 0, 'C'},
 	{"min-workers", required_argument, 0, 'w'},
 	{"max-workers", required_argument, 0, 'W'},
 	{"tasks-per-worker", required_argument, 0, LONG_OPT_TASKS_PER_WORKER},
@@ -441,8 +444,11 @@ int main(int argc, char *argv[])
 
 	int c;
 
-	while((c = getopt_long(argc, argv, "F:N:M:T:t:w:W:E:P:S:cd:o:O:vh", long_options, NULL)) > -1) {
+	while((c = getopt_long(argc, argv, "C:F:N:M:T:t:w:W:E:P:S:cd:o:O:vh", long_options, NULL)) > -1) {
 		switch (c) {
+			case 'C':
+				config_file = xxstrdup(optarg);
+				break;
 			case 'F':
 				foremen_regex = optarg;
 				break;

--- a/work_queue/src/work_queue_pool.c
+++ b/work_queue/src/work_queue_pool.c
@@ -699,7 +699,9 @@ int main(int argc, char *argv[])
 
 	if(config_file) {
 		const char *base = path_basename(config_file);
-		char *cwd  = get_current_dir_name();
+		char *cwd = malloc(PATH_MAX * sizeof(char));
+		getcwd(cwd, PATH_MAX);
+
 		char *old_fullname = string_format("%s/%s", cwd, base);
 		char *new_fullname = string_format("%s/%s", scratch_dir, base);
 


### PR DESCRIPTION
As requested by @klannon, @matz-e, and @awoodard.

The configuration file is re-read if changed (at every cycle, that is
every 30 s). If an error is detected, the previous values are used.

The file should be proper json, as:

{
    "master-name": "my_master.*",
    "max-workers": 100,
    "min-workers": 0
}

Call as:

work_queue_pool -Cmy_conf_file

Valid fields are:

master-name:
foremen-name:
min-workers:
max-workers:
task-per-worker:
timeout:
worker-extra-options:
cores:
memory:
disk: