### PR TITLE
Blacklist pool

### DIFF
--- a/work_queue/src/batch_job_condor.c
+++ b/work_queue/src/batch_job_condor.c
@@ -44,6 +44,11 @@ static char *blacklisted_expression(struct batch_queue *q) {
 	buffer_init(&b);
 
 	char *blist = xxstrdup(blacklisted);
+
+
+	/* strsep updates blist, so we keep the original pointer in binit so we can free it later */
+	char *binit = blist;
+
 	char *sep = "";
 	char *hostname;
 
@@ -56,6 +61,8 @@ static char *blacklisted_expression(struct batch_queue *q) {
 	buffer_printf(&b, ")");
 
 	char *result = xxstrdup(buffer_tostring(&b));
+
+	free(binit);
 	buffer_free(&b);
 
 	return result;

--- a/work_queue/src/batch_job_condor.c
+++ b/work_queue/src/batch_job_condor.c
@@ -36,9 +36,16 @@ static int setup_condor_wrapper(const char *wrapperfile)
 }
 
 static char *blacklisted_expression(struct batch_queue *q) {
-	const char *blacklisted = hash_table_lookup(q->options, "workers-blacklisted");
+	const char *blacklisted     = hash_table_lookup(q->options, "workers-blacklisted");
+	static char *last_blacklist = NULL;
+
 	if(!blacklisted)
 		return NULL;
+
+	/* print blacklist only when it changes. */
+	if(!last_blacklist || strcmp(last_blacklist, blacklisted) != 0) {
+		debug(D_BATCH, "Blacklisted hostnames: %s\n", blacklisted);
+	}
 
 	buffer_t b;
 	buffer_init(&b);
@@ -64,6 +71,12 @@ static char *blacklisted_expression(struct batch_queue *q) {
 
 	free(binit);
 	buffer_free(&b);
+
+	if(last_blacklist) {
+		free(last_blacklist);
+	}
+
+	last_blacklist = xxstrdup(blacklisted);
 
 	return result;
 }

--- a/work_queue/src/work_queue_pool.c
+++ b/work_queue/src/work_queue_pool.c
@@ -121,7 +121,9 @@ static int count_workers_needed( struct list *masters_list, int only_waiting )
 		masters++;
 	}
 
-	needed_workers = (int) ceil(needed_workers / tasks_per_worker);
+	if(tasks_per_worker > 0) {
+		needed_workers = (int) ceil(needed_workers / tasks_per_worker);
+	}
 
 	return needed_workers;
 }
@@ -427,6 +429,29 @@ int read_config_file(const char *config_file) {
 	last_time_modified = new_time_modified;
 	debug(D_NOTICE, "Configuration file '%s' has been loaded.", config_file);
 
+	debug(D_NOTICE, "master-name: %s\n", project_regex);
+	if(foremen_regex) {
+		debug(D_NOTICE, "foremen-name: %s\n", foremen_regex);
+	}
+	debug(D_NOTICE, "max-workers: %d\n", workers_max);
+	debug(D_NOTICE, "min-workers: %d\n", workers_min);
+
+	debug(D_NOTICE, "tasks-per-worker: %3.3lf\n", tasks_per_worker > 0 ? tasks_per_worker : (num_cores_option > 0 ? num_cores_option : 1));
+	debug(D_NOTICE, "timeout: %d s\n", worker_timeout);
+	debug(D_NOTICE, "cores: %d\n", num_cores_option > 0 ? num_cores_option : 1);
+
+	if(num_memory_option > -1) {
+		debug(D_NOTICE, "memory: %d MB\n", num_memory_option);
+	}
+
+	if(num_memory_option > -1) {
+		debug(D_NOTICE, "disk: %d MB\n", num_disk_option);
+	}
+
+	if(extra_worker_args) {
+		debug(D_NOTICE, "worker-extra-options: %s", extra_worker_args);
+	}
+
 end:
 	json_value_free(J);
 	return !error_found;
@@ -696,11 +721,6 @@ int main(int argc, char *argv[])
 	if(workers_min>workers_max) {
 		fprintf(stderr,"work_queue_pool: min workers (%d) is greater than max workers (%d)\n",workers_min, workers_max);
 		return 1;
-	}
-
-	if(tasks_per_worker < 1)
-	{
-		tasks_per_worker = num_cores_option > 0 ? num_cores_option : 1;
 	}
 
 	if(!scratch_dir) {


### PR DESCRIPTION
As request by @klannon, @matz-e, and @annawoodard.

Calls like:

q.blacklist("babadook.net")
q.blacklist("hello.com")

are converted in work queue pool with condor in the submit file to:

requirements = ((machine != "babadook.net") && (machine != "hello.com"))

This means that once the worker idles out, the pool request no to get that machine again.

@dthain, @nhazekam 

