### PR TITLE
Shell escape

### DIFF
--- a/dttools/src/stringtools.c
+++ b/dttools/src/stringtools.c
@@ -48,6 +48,12 @@ char *escape_shell_string(const char *str)
 }
 
 /*
+ * Based on opengroup.org's definition of the Shell Command Language (also gnu's)
+ * In section 2.2.3 on Double-Quoted Strings, it indicates you only need to
+ * escape dollar sign, backtick, and backslash. I also escape double quote as
+ * we are adding and exterior double quote around the string.
+ *
+ * [ $ \ ` " ] Are always escaped.
  * */
 char *string_escape_shell( const char *str )
 {

--- a/dttools/src/stringtools.c
+++ b/dttools/src/stringtools.c
@@ -61,7 +61,7 @@ char *string_escape_shell( const char *str )
 	buffer_init(B);
 	buffer_abortonfailure(B, 1);
 
-	char *s;
+	const char *s;
 	buffer_putliteral(B,"\"");
 	for(s=str;*s;s++) {
 		if(*s=='"' || *s=='\\' || *s=='$' || *s=='`')

--- a/dttools/src/stringtools.h
+++ b/dttools/src/stringtools.h
@@ -15,6 +15,14 @@ See the file COPYING for details.
 typedef char *(*string_subst_lookup_t) (const char *name, void *arg);
 
 char *escape_shell_string (const char *str);
+
+/** Takes a command string and escapes special characters in the Shell Command
+  language. Mallocs space for new string and does not modify original string.
+  Characters dollar-sign $, backtick `, backslash \, and double-quote " are
+  escaped.
+  @param str Command string presented to be escaped.
+  @return String with special characters escaped.
+  */
 char *string_escape_shell (const char *str);
 void string_from_ip_address(const unsigned char *ip_addr_bytes, char *str);
 int string_to_ip_address(const char *str, unsigned char *ip_addr_bytes);

--- a/dttools/src/stringtools.h
+++ b/dttools/src/stringtools.h
@@ -15,6 +15,7 @@ See the file COPYING for details.
 typedef char *(*string_subst_lookup_t) (const char *name, void *arg);
 
 char *escape_shell_string (const char *str);
+char *string_escape_shell (const char *str);
 void string_from_ip_address(const unsigned char *ip_addr_bytes, char *str);
 int string_to_ip_address(const char *str, unsigned char *ip_addr_bytes);
 int string_ip_subnet(const char *addr, char *subnet);


### PR DESCRIPTION
@btovar Take a look. Slightly confusing, but there was an older escape_shell_string that I am told is used for hadoop. Naming changes and whatnot can be addressed as needed just wanted to get this to you.