### PR TITLE
Add permissions to parrot mountlist.

### DIFF
--- a/doc/parrot.html
+++ b/doc/parrot.html
@@ -231,10 +231,12 @@ that you specify.
 <p>
 The simplest name resolver is the <b>mountlist</b>, given
 by the <b>-m mountfile</b> option.  This file corresponds closely
-to <tt>/etc/ftsab</tt> in Unix.  A mountlist is simply a file with two
-columns.  The first column gives a logical directory or file name,
-while the second gives the physical path that it must be connected
-to.
+to <tt>/etc/fstab</tt> in Unix.  A mountlist is simply a file with one
+mount entry given per line. The first column is the path in Parrot's
+namespace. The next column can be either an access control specifier or
+a path in the host's filesystem. If two paths are given, then the third
+column can contain an optional access control specifier.
+
 <p>
 For example, if a database is stored at an FTP server under the
 path <tt>/anonftp/ftp.cs.wisc.edu/db</tt>, it may be spliced into the
@@ -245,6 +247,20 @@ Instruct Parrot to use the mountlist as follows:
 % cd /dbase
 % ls -la
 </code>
+
+<p>An <b>access control specifier</b> restricts the operations allowed under
+a given path. <tt>DENY</tt> blocks all operations, <tt>ENOENT</tt> makes
+operations fail as if nothing was present at the path, and <tt>LOCAL</tt> only
+allows operation on the local filesystem. For more fine-grained control,
+an access specifier can also be a combination of the letters <tt>r</tt>, <tt>w</tt>,
+and <tt>x</tt> to allow read, write, and execute/search, respectively.
+For example, a mountlist could contain the following entries
+<code>/     rX
+/home DENY
+/tmp  /tmp/sandbox
+/opt  /home/fred/project  xr
+</code></p>
+
 A single mount entry may be given on the command line
 with the <b>-M</b> option as follows:
 <code>% parrot_run -M /dbase=/anonftp/ftp.cs.wisc.edu/db tcsh</code>

--- a/doc/parrot.html
+++ b/doc/parrot.html
@@ -255,10 +255,10 @@ allows operation on the local filesystem. For more fine-grained control,
 an access specifier can also be a combination of the letters <tt>r</tt>, <tt>w</tt>,
 and <tt>x</tt> to allow read, write, and execute/search, respectively.
 For example, a mountlist could contain the following entries
-<code>/     rX
+<code>/     RX
 /home DENY
 /tmp  /tmp/sandbox
-/opt  /home/fred/project  xr
+/opt  /home/fred/project  RX
 </code></p>
 
 A single mount entry may be given on the command line

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -142,7 +142,6 @@ enum {
 	LONG_OPT_NO_SET_FOREGROUND,
 	LONG_OPT_SYSCALL_DISABLE_DEBUG,
 	LONG_OPT_VALGRIND,
-	LONG_OPT_WHITELIST,
 };
 
 static void get_linux_version(const char *cmd)
@@ -225,7 +224,6 @@ static void show_help( const char *cmd )
 	printf( " %-30s Record all the file names.\n", "-n,--name-list=<path>");
 	printf( " %-30s Disable changing the foreground process group of the session.\n","   --no-set-foreground");
 	printf( " %-30s Use this file as a mountlist.             (PARROT_MOUNT_FILE)\n", "-m,--ftab-file=<file>");
-	printf( " %-30s Only allow access to the paths in the given file.          (PARROT_WHITELIST)\n", "--whitelist=<file>");
 	printf( " %-30s Mount (redirect) /foo to /bar.          (PARROT_MOUNT_STRING)\n", "-M,--mount=/foo=/bar");
 	printf( " %-30s Pretend that this is my hostname.          (PARROT_HOST_NAME)\n", "-N,--hostname=<name>");
 	printf( " %-30s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal) (PARROT_DEBUG_FILE)\n", "-o,--debug-file=<file>");
@@ -625,7 +623,6 @@ int main( int argc, char *argv[] )
 		{"with-checksums", no_argument, 0, 'K'},
 		{"with-snapshots", no_argument, 0, 'F'},
 		{"work-dir", required_argument, 0, 'w'},
-		{"whitelist", required_argument, 0, LONG_OPT_WHITELIST},
 		{0,0,0,0}
 	};
 
@@ -692,9 +689,6 @@ int main( int argc, char *argv[] )
 			break;
 		case 'M':
 			pfs_resolve_manual_config(optarg);
-			break;
-		case LONG_OPT_WHITELIST:
-			pfs_resolve_whitelist_file(optarg);
 			break;
 		case 'n':
 			if(access(optarg, F_OK) != -1) {
@@ -870,9 +864,6 @@ int main( int argc, char *argv[] )
 
 	s = getenv("PARROT_MOUNT_STRING");
 	if(s) pfs_resolve_manual_config(s);
-
-	s = getenv("PARROT_WHITELIST");
-	if(s) pfs_resolve_whitelist_file(s);
 
 	s = getenv("PARROT_FORCE_STREAM");
 	if(s) pfs_force_stream = 1;

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -142,6 +142,7 @@ enum {
 	LONG_OPT_NO_SET_FOREGROUND,
 	LONG_OPT_SYSCALL_DISABLE_DEBUG,
 	LONG_OPT_VALGRIND,
+	LONG_OPT_WHITELIST,
 };
 
 static void get_linux_version(const char *cmd)
@@ -224,6 +225,7 @@ static void show_help( const char *cmd )
 	printf( " %-30s Record all the file names.\n", "-n,--name-list=<path>");
 	printf( " %-30s Disable changing the foreground process group of the session.\n","   --no-set-foreground");
 	printf( " %-30s Use this file as a mountlist.             (PARROT_MOUNT_FILE)\n", "-m,--ftab-file=<file>");
+	printf( " %-30s Only allow access to the paths in the given file.          (PARROT_WHITELIST)\n", "--whitelist=<file>");
 	printf( " %-30s Mount (redirect) /foo to /bar.          (PARROT_MOUNT_STRING)\n", "-M,--mount=/foo=/bar");
 	printf( " %-30s Pretend that this is my hostname.          (PARROT_HOST_NAME)\n", "-N,--hostname=<name>");
 	printf( " %-30s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal) (PARROT_DEBUG_FILE)\n", "-o,--debug-file=<file>");
@@ -623,6 +625,7 @@ int main( int argc, char *argv[] )
 		{"with-checksums", no_argument, 0, 'K'},
 		{"with-snapshots", no_argument, 0, 'F'},
 		{"work-dir", required_argument, 0, 'w'},
+		{"whitelist", required_argument, 0, LONG_OPT_WHITELIST},
 		{0,0,0,0}
 	};
 
@@ -689,6 +692,9 @@ int main( int argc, char *argv[] )
 			break;
 		case 'M':
 			pfs_resolve_manual_config(optarg);
+			break;
+		case LONG_OPT_WHITELIST:
+			pfs_resolve_whitelist_file(optarg);
 			break;
 		case 'n':
 			if(access(optarg, F_OK) != -1) {
@@ -864,6 +870,9 @@ int main( int argc, char *argv[] )
 
 	s = getenv("PARROT_MOUNT_STRING");
 	if(s) pfs_resolve_manual_config(s);
+
+	s = getenv("PARROT_WHITELIST");
+	if(s) pfs_resolve_whitelist_file(s);
 
 	s = getenv("PARROT_FORCE_STREAM");
 	if(s) pfs_force_stream = 1;

--- a/parrot/src/pfs_resolve.c
+++ b/parrot/src/pfs_resolve.c
@@ -30,7 +30,6 @@ struct mount_entry {
 };
 
 static struct mount_entry * mount_list = 0;
-static struct mount_entry * whitelist = 0;
 static struct hash_table *resolve_cache = 0;
 
 static void add_mount_entry( const char *prefix, const char *redirect )
@@ -40,15 +39,6 @@ static void add_mount_entry( const char *prefix, const char *redirect )
 	strcpy(m->redirect,redirect);
 	m->next = mount_list;
 	mount_list = m;
-}
-
-static void add_whitelist_entry( const char *path )
-{
-	struct mount_entry * m = xxmalloc(sizeof(*m));
-	strcpy(m->prefix,path);
-	strcpy(m->redirect,path);
-	m->next = whitelist;
-	whitelist = m;
 }
 
 void pfs_resolve_manual_config( const char *str )
@@ -98,63 +88,6 @@ void pfs_resolve_file_config( const char *filename )
 	}
 
 	fclose(file);
-}
-
-void pfs_resolve_whitelist_file( const char *filename )
-{
-	FILE *file;
-	struct mount_entry * m;
-	char line[PFS_LINE_MAX];
-	char path[PFS_LINE_MAX];
-	char * fake_root;
-	int fields;
-	int linenum=0;
-
-	file = fopen(filename,"r");
-	if(!file) fatal("couldn't open whitelist %s: %s\n",filename,strerror(errno));
-
-	fake_root = mkdtemp(xxstrdup("/tmp/parrot_fakeroot-XXXXXX"));
-	if(fake_root == NULL) fatal("couldn't create fake root: %s\n",strerror(errno));
-
-	m = xxmalloc(sizeof(*m));
-	strcpy(m->prefix, "/");
-	strcpy(m->redirect, fake_root);
-	m->next = 0;
-	whitelist = m;
-	free(fake_root);
-
-	while(1) {
-		if(!fgets(line,sizeof(line),file)) {
-			if(errno==EINTR) {
-				continue;
-			} else {
-				break;
-			}
-		}
-		linenum++;
-		if(line[0]=='#') continue;
-		string_chomp(line);
-		if(!line[0]) continue;
-		fields = sscanf(line,"%s",path);
-
-		if(fields==0) {
-			continue;
-		} else {
-			add_whitelist_entry(path);
-		}
-	}
-
-	fclose(file);
-
-	m = mount_list;
-	while(m && m->next) {
-		m = m->next;
-	}
-	if(m) {
-		m->next = whitelist;
-	} else {
-		mount_list = whitelist;
-	}
 }
 
 int pfs_resolve_external( const char *logical_name, const char *prefix, const char *redirect, char *physical_name )

--- a/parrot/src/pfs_resolve.c
+++ b/parrot/src/pfs_resolve.c
@@ -280,9 +280,9 @@ pfs_resolve_t pfs_resolve( const char *logical_name, char *physical_name, mode_t
 	pfs_resolve_t result = PFS_RESOLVE_UNCHANGED;
 	struct mount_entry *e;
 	const char *t;
-	char lookup_key[PFS_PATH_MAX + sizeof(int)];
+	char lookup_key[PFS_PATH_MAX + 3 * sizeof(int) + 1];
 
-	sprintf(lookup_key, "%o%s", mode, logical_name); /* Hack: write string key */
+	sprintf(lookup_key, "%o|%s", mode, logical_name);
 
 	if(!resolve_cache) resolve_cache = hash_table_create(0,0);
 

--- a/parrot/src/pfs_resolve.c
+++ b/parrot/src/pfs_resolve.c
@@ -251,10 +251,13 @@ pfs_resolve_t pfs_resolve( const char *logical_name, char *physical_name, mode_t
 	pfs_resolve_t result = PFS_RESOLVE_UNCHANGED;
 	struct mount_entry *e;
 	const char *t;
+	char lookup_key[PFS_PATH_MAX + sizeof(int)];
+
+	sprintf(lookup_key, "%o%s", mode, logical_name); // Hack: write string key
 
 	if(!resolve_cache) resolve_cache = hash_table_create(0,0);
 
-	t = hash_table_lookup(resolve_cache,logical_name);
+	t = hash_table_lookup(resolve_cache,lookup_key);
 	if(t) {
 		strcpy(physical_name,t);
 		result = PFS_RESOLVE_CHANGED;
@@ -291,8 +294,8 @@ pfs_resolve_t pfs_resolve( const char *logical_name, char *physical_name, mode_t
 
 	if(result==PFS_RESOLVE_UNCHANGED || result==PFS_RESOLVE_CHANGED) {
 		debug(D_RESOLVE,"%s = %s,%o",logical_name,physical_name,mode);
-		if(!hash_table_lookup(resolve_cache,logical_name)) {
-			hash_table_insert(resolve_cache,logical_name,xxstrdup(physical_name));
+		if(!hash_table_lookup(resolve_cache,lookup_key)) {
+			hash_table_insert(resolve_cache,lookup_key,xxstrdup(physical_name));
 		}
 	}
 

--- a/parrot/src/pfs_resolve.h
+++ b/parrot/src/pfs_resolve.h
@@ -20,7 +20,6 @@ typedef enum {
 
 void pfs_resolve_file_config( const char *mountfile );
 void pfs_resolve_manual_config( const char *string );
-void pfs_resolve_whitelist_file( const char *filename );
 
 pfs_resolve_t pfs_resolve( const char *logical_name, char *physical_name, time_t stoptime );
 

--- a/parrot/src/pfs_resolve.h
+++ b/parrot/src/pfs_resolve.h
@@ -9,6 +9,7 @@ See the file COPYING for details.
 #define PFS_RESOLVE
 
 #include <time.h>
+#include "pfs_types.h"
 
 typedef enum {
 	PFS_RESOLVE_UNCHANGED,
@@ -21,6 +22,6 @@ typedef enum {
 void pfs_resolve_file_config( const char *mountfile );
 void pfs_resolve_manual_config( const char *string );
 
-pfs_resolve_t pfs_resolve( const char *logical_name, char *physical_name, time_t stoptime );
+pfs_resolve_t pfs_resolve( const char *logical_name, char *physical_name, mode_t mode, time_t stoptime );
 
 #endif

--- a/parrot/src/pfs_resolve.h
+++ b/parrot/src/pfs_resolve.h
@@ -20,6 +20,7 @@ typedef enum {
 
 void pfs_resolve_file_config( const char *mountfile );
 void pfs_resolve_manual_config( const char *string );
+void pfs_resolve_whitelist_file( const char *filename );
 
 pfs_resolve_t pfs_resolve( const char *logical_name, char *physical_name, time_t stoptime );
 

--- a/parrot/src/pfs_sys.cc
+++ b/parrot/src/pfs_sys.cc
@@ -533,7 +533,7 @@ int pfs_get_local_name( const char *rpath, char *lpath, char *firstline, size_t 
 
 int pfs_resolve_name(int is_special_syscall, const char *path, struct pfs_name *pname )
 {
-	return pfs_current->table->resolve_name(is_special_syscall,path,pname);
+	return pfs_current->table->resolve_name(is_special_syscall,path,pname,F_OK); //TODO check this
 }
 
 /*

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -184,7 +184,7 @@ int pfs_table::bind( int fd, char *lpath, size_t len )
 
 	/* Resolve the path... */
 	struct pfs_name pname;
-	if (!resolve_name(1, lpath, &pname, F_OK)) //TODO check this
+	if (!resolve_name(1, lpath, &pname, F_OK))
 		return -1;
 
 	if (!pname.is_local)
@@ -389,7 +389,7 @@ void pfs_table::follow_symlink( struct pfs_name *pname, int depth )
 				name_to_resolve = absolute_link_target;
 			}
 		}
-		if (resolve_name(0, name_to_resolve, &new_pname, X_OK, true, depth + 1)) { //TODO check this
+		if (resolve_name(0, name_to_resolve, &new_pname, X_OK, true, depth + 1)) {
 			*pname = new_pname;
 		}
 	}
@@ -1171,7 +1171,7 @@ int pfs_table::access( const char *n, mode_t mode )
 	pfs_name pname;
 	int result = -1;
 
-	if(resolve_name(0,n,&pname,X_OK)) {
+	if(resolve_name(0,n,&pname,X_OK | mode)) {
 		result = pname.service->access(&pname,mode);
 	}
 
@@ -1183,7 +1183,7 @@ int pfs_table::chmod( const char *n, mode_t mode )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,X_OK|W_OK)) {
+	if(resolve_name(0,n,&pname,W_OK)) {
 		result = pname.service->chmod(&pname,mode);
 	}
 
@@ -1195,7 +1195,7 @@ int pfs_table::chown( const char *n, uid_t uid, gid_t gid )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,X_OK|W_OK)) {
+	if(resolve_name(0,n,&pname,W_OK)) {
 		result = pname.service->chown(&pname,uid,gid);
 	}
 
@@ -1216,7 +1216,7 @@ int pfs_table::lchown( const char *n, uid_t uid, gid_t gid )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,X_OK|W_OK,false)) {
+	if(resolve_name(0,n,&pname,W_OK,false)) {
 		result = pname.service->lchown(&pname,uid,gid);
 	}
 
@@ -1228,7 +1228,7 @@ int pfs_table::truncate( const char *n, pfs_off_t offset )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(1,n,&pname,X_OK|W_OK)) {
+	if(resolve_name(1,n,&pname,W_OK)) {
 		result = pname.service->truncate(&pname,offset);
 	}
 
@@ -1240,7 +1240,7 @@ ssize_t pfs_table::getxattr (const char *path, const char *name, void *value, si
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,path,&pname,X_OK)) {
+	if(resolve_name(0,path,&pname,R_OK)) {
 		result = pname.service->getxattr(&pname,name,value,size);
 	}
 
@@ -1252,7 +1252,7 @@ ssize_t pfs_table::lgetxattr (const char *path, const char *name, void *value, s
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,path,&pname,X_OK,false)) {
+	if(resolve_name(0,path,&pname,R_OK,false)) {
 		result = pname.service->lgetxattr(&pname,name,value,size);
 	}
 
@@ -1271,7 +1271,7 @@ ssize_t pfs_table::listxattr (const char *path, char *list, size_t size)
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,path,&pname,X_OK)) {
+	if(resolve_name(0,path,&pname,R_OK)) {
 		result = pname.service->listxattr(&pname,list,size);
 	}
 
@@ -1283,7 +1283,7 @@ ssize_t pfs_table::llistxattr (const char *path, char *list, size_t size)
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,path,&pname,X_OK,false)) {
+	if(resolve_name(0,path,&pname,R_OK,false)) {
 		result = pname.service->llistxattr(&pname,list,size);
 	}
 
@@ -1302,7 +1302,7 @@ int pfs_table::setxattr (const char *path, const char *name, const void *value, 
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,path,&pname,X_OK|W_OK)) {
+	if(resolve_name(0,path,&pname,W_OK)) {
 		result = pname.service->setxattr(&pname,name,value,size,flags);
 	}
 
@@ -1314,7 +1314,7 @@ int pfs_table::lsetxattr (const char *path, const char *name, const void *value,
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,path,&pname,X_OK|W_OK,false)) {
+	if(resolve_name(0,path,&pname,W_OK,false)) {
 		result = pname.service->lsetxattr(&pname,name,value,size,flags);
 	}
 
@@ -1333,7 +1333,7 @@ int pfs_table::removexattr (const char *path, const char *name)
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,path,&pname,X_OK|W_OK)) {
+	if(resolve_name(0,path,&pname,W_OK)) {
 		result = pname.service->removexattr(&pname,name);
 	}
 
@@ -1345,7 +1345,7 @@ int pfs_table::lremovexattr (const char *path, const char *name)
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,path,&pname,X_OK|W_OK,false)) {
+	if(resolve_name(0,path,&pname,W_OK,false)) {
 		result = pname.service->lremovexattr(&pname,name);
 	}
 
@@ -1364,7 +1364,7 @@ int pfs_table::utime( const char *n, struct utimbuf *buf )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,X_OK|W_OK)) {
+	if(resolve_name(0,n,&pname,W_OK)) {
 		result = pname.service->utime(&pname,buf);
 	}
 
@@ -1376,7 +1376,7 @@ int pfs_table::utimens( const char *n, const struct timespec times[2] )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,X_OK|W_OK)) {
+	if(resolve_name(0,n,&pname,W_OK)) {
 		result = pname.service->utimens(&pname,times);
 	}
 
@@ -1388,7 +1388,7 @@ int pfs_table::lutimens( const char *n, const struct timespec times[2] )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,X_OK|W_OK,false)) {
+	if(resolve_name(0,n,&pname,W_OK,false)) {
 		result = pname.service->lutimens(&pname,times);
 	}
 
@@ -1401,7 +1401,7 @@ int pfs_table::unlink( const char *n )
 	pfs_name pname;
 	int result = -1;
 
-	if(resolve_name(0,n,&pname,X_OK|W_OK|E_OK,false)) {
+	if(resolve_name(0,n,&pname,W_OK|E_OK,false)) {
 		result = pname.service->unlink(&pname);
 		if(result==0) {
 			pfs_cache_invalidate(&pname);
@@ -1417,7 +1417,7 @@ int pfs_table::stat( const char *n, struct pfs_stat *b )
 	pfs_name pname;
 	int result = -1;
 
-	if(resolve_name(0,n,&pname,X_OK|E_OK)) {
+	if(resolve_name(0,n,&pname,E_OK)) {
 		result = pname.service->stat(&pname,b);
 		if(result>=0) {
 			b->st_blksize = pname.service->get_block_size();
@@ -1436,7 +1436,7 @@ int pfs_table::statfs( const char *n, struct pfs_statfs *b )
 	pfs_name pname;
 	int result = -1;
 
-	if(resolve_name(0,n,&pname,X_OK)) {
+	if(resolve_name(0,n,&pname,F_OK)) {
 		result = pname.service->statfs(&pname,b);
 	}
 
@@ -1448,7 +1448,7 @@ int pfs_table::lstat( const char *n, struct pfs_stat *b )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,X_OK|E_OK,false)) {
+	if(resolve_name(0,n,&pname,E_OK,false)) {
 		result = pname.service->lstat(&pname,b);
 		if(result>=0) {
 			b->st_blksize = pname.service->get_block_size();
@@ -1467,7 +1467,7 @@ int pfs_table::rename( const char *n1, const char *n2 )
 	pfs_name p1, p2;
 	int result = -1;
 
-	if(resolve_name(0,n1,&p1,X_OK|W_OK|E_OK,false) && resolve_name(0,n2,&p2,X_OK|W_OK|E_OK,false)) {
+	if(resolve_name(0,n1,&p1,W_OK|E_OK,false) && resolve_name(0,n2,&p2,W_OK|E_OK,false)) {
 		if(p1.service==p2.service) {
 			result = p1.service->rename(&p1,&p2);
 			if(result==0) {
@@ -1490,7 +1490,7 @@ int pfs_table::link( const char *n1, const char *n2 )
 
 	// Require write on the target to prevent linking into a RW directory
 	// and bypassing restrictions
-	if(resolve_name(0,n1,&p1,X_OK|W_OK,false) && resolve_name(0,n2,&p2,X_OK|W_OK|E_OK,false)) {
+	if(resolve_name(0,n1,&p1,W_OK,false) && resolve_name(0,n2,&p2,W_OK|E_OK,false)) {
 		if(p1.service==p2.service) {
 			result = p1.service->link(&p1,&p2);
 		} else {
@@ -1515,7 +1515,7 @@ int pfs_table::symlink( const char *n1, const char *n2 )
 	verbatim down to the needed driver.
 	*/
 
-	if(resolve_name(0,n2,&pname,X_OK|W_OK|E_OK,false)) {
+	if(resolve_name(0,n2,&pname,W_OK|E_OK,false)) {
 		result = pname.service->symlink(n1,&pname);
 	}
 
@@ -1540,7 +1540,7 @@ int pfs_table::readlink( const char *n, char *buf, pfs_size_t size )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,X_OK,false)) {
+	if(resolve_name(0,n,&pname,R_OK,false)) {
 		char *pid = NULL, *fd = NULL;
 		if(pattern_match(pname.path, "^/proc/(%d+)/fd/(%d+)$",&pid,&fd) >= 0) {
 			struct pfs_process *target = pfs_process_lookup(atoi(pid));
@@ -1586,7 +1586,7 @@ int pfs_table::mknod( const char *n, mode_t mode, dev_t dev )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,X_OK|W_OK|E_OK)) {
+	if(resolve_name(0,n,&pname,W_OK|E_OK)) {
 		result = pname.service->mknod(&pname,mode,dev);
 	}
 
@@ -1598,7 +1598,7 @@ int pfs_table::mkdir( const char *n, mode_t mode )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,X_OK|W_OK|E_OK)) {
+	if(resolve_name(0,n,&pname,W_OK|E_OK)) {
 		result = pname.service->mkdir(&pname,mode);
 	}
 
@@ -1610,7 +1610,7 @@ int pfs_table::rmdir( const char *n )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,X_OK|W_OK|E_OK,false)) {
+	if(resolve_name(0,n,&pname,W_OK|E_OK,false)) {
 		result = pname.service->rmdir(&pname);
 	}
 
@@ -1636,7 +1636,7 @@ int pfs_table::mkalloc( const char *n, pfs_ssize_t size, mode_t mode )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,X_OK|W_OK|E_OK)) { //TODO check this
+	if(resolve_name(0,n,&pname,W_OK|E_OK)) {
 		result = pname.service->mkalloc(&pname,size,mode);
 	}
 
@@ -1648,7 +1648,7 @@ int pfs_table::lsalloc( const char *n, char *a, pfs_ssize_t *total, pfs_ssize_t 
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(1,n,&pname,X_OK)) { //TODO check this
+	if(resolve_name(1,n,&pname,R_OK)) {
 		result = pname.service->lsalloc(&pname,a,total,avail);
 		if(result==0) {
 			strcpy(a,pname.path);
@@ -1663,7 +1663,7 @@ int pfs_table::whoami( const char *n, char *buf, int length )
 	pfs_name pname;
 	int result = -1;
 
-	if(resolve_name(1,n,&pname,X_OK)) { //TODO check this
+	if(resolve_name(1,n,&pname,F_OK)) {
 		result = pname.service->whoami(&pname,buf,length);
 	}
 
@@ -2035,7 +2035,7 @@ int pfs_table::search( const char *paths, const char *patt, int flags, char *buf
 			}
 		} else {
 			/* Check to see if search is implemented in the service */
-			if(resolve_name(0,path, &pname, X_OK)) { //TODO check this
+			if(resolve_name(0,path, &pname, X_OK)) {
 				debug(D_DEBUG, "attempting service `%s' search routine for path `%s'", pname.service_name, pname.path);
 				if ((result = pname.service->search(&pname, pattern, flags, buffer, buffer_length, i))==-1 && errno == ENOSYS) {
 					debug(D_DEBUG, "no service to search found: falling back to manual search `%s'", directory);
@@ -2062,7 +2062,7 @@ int pfs_table::getacl( const char *n, char *buf, int length )
 	pfs_name pname;
 	int result = -1;
 
-	if(resolve_name(0,n,&pname,X_OK)) { //TODO check this
+	if(resolve_name(0,n,&pname,R_OK)) {
 		result = pname.service->getacl(&pname,buf,length);
 	}
 
@@ -2074,7 +2074,7 @@ int pfs_table::setacl( const char *n, const char *subject, const char *rights )
 	pfs_name pname;
 	int result = -1;
 
-	if(resolve_name(0,n,&pname,X_OK|W_OK)) { //TODO check this
+	if(resolve_name(0,n,&pname,W_OK)) {
 		result = pname.service->setacl(&pname,subject,rights);
 	}
 
@@ -2092,7 +2092,7 @@ int pfs_table::locate( const char *n, char *buf, int length )
 		if(loc) delete(loc);
 		loc = 0;
 
-		if(resolve_name(0, n, &pname, X_OK)) { //TODO check this
+		if(resolve_name(0, n, &pname, X_OK)) {
 			loc = pname.service->locate(&pname);
 		}
 	}
@@ -2123,8 +2123,8 @@ pfs_ssize_t pfs_table::copyfile( const char *source, const char *target )
 		return -1;
 	}
 
-	if(resolve_name(1,source,&psource,X_OK|R_OK)<0) return -1; //TODO check this
-	if(resolve_name(1,target,&ptarget,X_OK|W_OK|E_OK)<0) return -1; //TODO check this
+	if(resolve_name(1,source,&psource,R_OK)<0) return -1;
+	if(resolve_name(1,target,&ptarget,W_OK|E_OK)<0) return -1;
 
 	if(psource.service == ptarget.service) {
 		result = ptarget.service->thirdput(&psource,&ptarget);
@@ -2220,7 +2220,7 @@ int pfs_table::md5( const char *path, unsigned char *digest )
 		return -1;
 	}
 
-	if(resolve_name(1,path,&pname,X_OK|R_OK)<0) return -1; //TODO check this
+	if(resolve_name(1,path,&pname,R_OK)<0) return -1;
 
 	result = pname.service->md5(&pname,digest);
 

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -1191,7 +1191,7 @@ int pfs_table::lchown( const char *n, uid_t uid, gid_t gid )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,false,W_OK)) {
+	if(resolve_name(0,n,&pname,W_OK,false)) {
 		result = pname.service->lchown(&pname,uid,gid);
 	}
 
@@ -1227,7 +1227,7 @@ ssize_t pfs_table::lgetxattr (const char *path, const char *name, void *value, s
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,path,&pname,false,R_OK)) {
+	if(resolve_name(0,path,&pname,R_OK,false)) {
 		result = pname.service->lgetxattr(&pname,name,value,size);
 	}
 
@@ -1258,7 +1258,7 @@ ssize_t pfs_table::llistxattr (const char *path, char *list, size_t size)
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,path,&pname,false,R_OK)) {
+	if(resolve_name(0,path,&pname,R_OK,false)) {
 		result = pname.service->llistxattr(&pname,list,size);
 	}
 
@@ -1289,7 +1289,7 @@ int pfs_table::lsetxattr (const char *path, const char *name, const void *value,
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,path,&pname,false,W_OK)) {
+	if(resolve_name(0,path,&pname,W_OK,false)) {
 		result = pname.service->lsetxattr(&pname,name,value,size,flags);
 	}
 
@@ -1320,7 +1320,7 @@ int pfs_table::lremovexattr (const char *path, const char *name)
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,path,&pname,false,W_OK)) {
+	if(resolve_name(0,path,&pname,W_OK,false)) {
 		result = pname.service->lremovexattr(&pname,name);
 	}
 
@@ -1363,7 +1363,7 @@ int pfs_table::lutimens( const char *n, const struct timespec times[2] )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,false,R_OK)) {
+	if(resolve_name(0,n,&pname,R_OK,false)) {
 		result = pname.service->lutimens(&pname,times);
 	}
 
@@ -1376,7 +1376,7 @@ int pfs_table::unlink( const char *n )
 	pfs_name pname;
 	int result = -1;
 
-	if(resolve_name(0,n,&pname,false,W_OK)) {
+	if(resolve_name(0,n,&pname,W_OK,false)) {
 		result = pname.service->unlink(&pname);
 		if(result==0) {
 			pfs_cache_invalidate(&pname);
@@ -1423,7 +1423,7 @@ int pfs_table::lstat( const char *n, struct pfs_stat *b )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,false,F_OK)) {
+	if(resolve_name(0,n,&pname,F_OK,false)) {
 		result = pname.service->lstat(&pname,b);
 		if(result>=0) {
 			b->st_blksize = pname.service->get_block_size();
@@ -1442,7 +1442,7 @@ int pfs_table::rename( const char *n1, const char *n2 )
 	pfs_name p1, p2;
 	int result = -1;
 
-	if(resolve_name(0,n1,&p1,false,W_OK) && resolve_name(0,n2,&p2,false,W_OK)) {
+	if(resolve_name(0,n1,&p1,W_OK,false) && resolve_name(0,n2,&p2,W_OK,false)) {
 		if(p1.service==p2.service) {
 			result = p1.service->rename(&p1,&p2);
 			if(result==0) {
@@ -1463,7 +1463,7 @@ int pfs_table::link( const char *n1, const char *n2 )
 	pfs_name p1, p2;
 	int result = -1;
 
-	if(resolve_name(1,n1,&p1,false,X_OK) && resolve_name(0,n2,&p2,false,W_OK)) {
+	if(resolve_name(1,n1,&p1,X_OK,false) && resolve_name(0,n2,&p2,W_OK,false)) {
 		if(p1.service==p2.service) {
 			result = p1.service->link(&p1,&p2);
 		} else {
@@ -1488,7 +1488,7 @@ int pfs_table::symlink( const char *n1, const char *n2 )
 	verbatim down to the needed driver.
 	*/
 
-	if(resolve_name(0,n2,&pname,false,W_OK)) {
+	if(resolve_name(0,n2,&pname,W_OK,false)) {
 		result = pname.service->symlink(n1,&pname);
 	}
 
@@ -1513,7 +1513,7 @@ int pfs_table::readlink( const char *n, char *buf, pfs_size_t size )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,false,X_OK)) {
+	if(resolve_name(0,n,&pname,X_OK,false)) {
 		char *pid = NULL, *fd = NULL;
 		if(pattern_match(pname.path, "^/proc/(%d+)/fd/(%d+)$",&pid,&fd) >= 0) {
 			struct pfs_process *target = pfs_process_lookup(atoi(pid));
@@ -1583,7 +1583,7 @@ int pfs_table::rmdir( const char *n )
 	pfs_name pname;
 	int result=-1;
 
-	if(resolve_name(0,n,&pname,false,W_OK)) {
+	if(resolve_name(0,n,&pname,W_OK,false)) {
 		result = pname.service->rmdir(&pname);
 	}
 

--- a/parrot/src/pfs_table.h
+++ b/parrot/src/pfs_table.h
@@ -124,7 +124,7 @@ public:
 	int 	search( const char *paths, const char *pattern, int flags, char *buffer, size_t buffer_length, size_t *i);
 
 	void	follow_symlink( struct pfs_name *pname, int depth = 0 );
-	int	resolve_name( int is_special_syscall, const char *cname, pfs_name *pname, bool do_follow_symlink = true, int depth = 0 );
+	int	resolve_name( int is_special_syscall, const char *cname, pfs_name *pname, mode_t mode, bool do_follow_symlink = true, int depth = 0 );
 
 	/* mmap operations */
 	pfs_size_t  mmap_create( int fd, pfs_size_t file_offset, pfs_size_t length, int prot, int flags );

--- a/parrot/test/TR_parrot_permissions.sh
+++ b/parrot/test/TR_parrot_permissions.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+. ../../dttools/test/test_runner_common.sh
+
+PARROT_MOUNTFILE=$PWD/parrot_mount.$PPID
+PARROT_TMPDIR=$PWD/parrot_tmp.$PPID
+
+prepare()
+{
+  mkdir -p "$PARROT_TMPDIR/subdir"
+  mkdir -p "$PARROT_TMPDIR/rw"
+  touch "$PARROT_TMPDIR/file1"
+  touch "$PARROT_TMPDIR/rw/file2"
+  touch "$PARROT_TMPDIR/subdir/file3"
+
+  cat > "$PARROT_MOUNTFILE" <<EOF
+/                  rx
+/dev/null          rwx
+/var               DENY
+$PARROT_TMPDIR/rw  rwx
+EOF
+}
+
+run()
+{
+  ../src/parrot_run -m "$PARROT_MOUNTFILE" -- sh -c "ls /var/log" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then echo 'ignored DENY'; return 1; fi
+
+  ../src/parrot_run -m "$PARROT_MOUNTFILE" -- sh -c "rm $PARROT_TMPDIR/file1" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then echo 'ignored read only path'; return 1; fi
+
+  ../src/parrot_run -m "$PARROT_MOUNTFILE" -- sh -c "mv $PARROT_TMPDIR/rw/file2 $PARROT_TMPDIR" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then echo 'ignored read only target dir'; return 1; fi
+
+  ../src/parrot_run -m "$PARROT_MOUNTFILE" -- sh -c "echo test >> $PARROT_TMPDIR/file1" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then echo 'ignored read only file'; return 1; fi
+
+  ../src/parrot_run -m "$PARROT_MOUNTFILE" -- sh -c "touch $PARROT_TMPDIR/subdir/file3" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then echo 'ignored read only subdirectory'; return 1; fi
+
+  ../src/parrot_run -m "$PARROT_MOUNTFILE" -- sh -c "ln /etc/passwd $PARROT_TMPDIR/rw/document" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then echo 'allowed potentially dangerous hard link'; return 1; fi
+
+  ../src/parrot_run -m "$PARROT_MOUNTFILE" -- sh -c "echo test >> $PARROT_TMPDIR/rw/file4" >/dev/null 2>&1
+  if [ $? -ne 0 ]; then echo 'blocked write'; return 1; fi
+
+  ../src/parrot_run -m "$PARROT_MOUNTFILE" -- sh -c "mkdir $PARROT_TMPDIR/rw/subdir2" >/dev/null 2>&1
+  if [ $? -ne 0 ]; then echo 'blocked mkdir'; return 1; fi
+
+  ../src/parrot_run -m "$PARROT_MOUNTFILE" -- sh -c "mv $PARROT_TMPDIR/rw/file4 $PARROT_TMPDIR/rw/subdir2/file4" >/dev/null 2>&1
+  if [ $? -ne 0 ]; then echo 'blocked mv'; return 1; fi
+
+  ../src/parrot_run -m "$PARROT_MOUNTFILE" -- sh -c "cp -v $PARROT_TMPDIR/subdir/file3 $PARROT_TMPDIR/rw" >/dev/null 2>&1
+  if [ $? -ne 0 ]; then echo 'blocked cp'; return 1; fi
+
+
+  return 0
+}
+
+clean()
+{
+  rm -rf "$PARROT_TMPDIR"
+  rm -f "$PARROT_MOUNTFILE"
+  return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:
+


### PR DESCRIPTION
This feature just sets up some mounts behind the scenes to prevent access to paths not explicitly listed in the whitelist file it's given. I've tested it with user-defined mounts (via mountfile and via command line option) and everything seems to work as expected. The executable being run has to be in one of the allowed paths, and will most probably require some libraries. A minimal whitelist like the following is enough to run simple programs, e.g. dash.

/bin
/lib
/lib64
/usr/bin
/usr/lib
/usr/lib64