### PR TITLE
Support curateND URLs in Umbrella

### DIFF
--- a/umbrella/example/openmalaria/openmalaria.umbrella
+++ b/umbrella/example/openmalaria/openmalaria.umbrella
@@ -31,6 +31,7 @@
 				"id": "4cd77946d1b5176987036e8fb382ce2d",
 				"mountpoint": "/etc/yum.repo.d/epel.repo",
 				"source": [
+					"https://curate.nd.edu/downloads/fx719k4458m",
 					"http://ccl.cse.nd.edu/research/data/hep-case-study/4cd77946d1b5176987036e8fb382ce2d/epel.repo"
 				],
 				"format": "plain",
@@ -43,6 +44,7 @@
 		"openMalaria-32-centos6-x86_64": {
 			"id": "97cff84e58a4172fd8e9d1cb25c6047c",
 			"source": [
+				"https://curate.nd.edu/downloads/h702q526t1v",
 				"http://ccl.cse.nd.edu/research/data/hep-case-study/97cff84e58a4172fd8e9d1cb25c6047c/openMalaria-32-centos6-x86_64.tar.gz"
 			],
 			"format": "tgz",
@@ -57,6 +59,7 @@
 			"id": "54ea34d38d96c311122642aec045bc40",
 			"mountpoint": "/tmp/densities.csv",
 			"source": [
+				"https://curate.nd.edu/downloads/hx11xd09r8t",
 				"http://ccl.cse.nd.edu/research/data/hep-case-study/54ea34d38d96c311122642aec045bc40/densities.csv"
 			],
 			"format": "plain",
@@ -67,6 +70,7 @@
 			"id": "bef8a475dbd3765b61995f36b11b0672",
 			"mountpoint": "/tmp/scenario_32.xsd",
 			"source": [
+				"https://curate.nd.edu/downloads/hq37vm43660",
 				"http://ccl.cse.nd.edu/research/data/hep-case-study/bef8a475dbd3765b61995f36b11b0672/scenario_32.xsd"
 			],
 			"format": "plain",
@@ -77,6 +81,7 @@
 			"id": "e28c0c145c801789b0919d175f0afa9c",
 			"mountpoint": "/tmp/scenario.xml",
 			"source": [
+				"https://curate.nd.edu/downloads/hd76rx93c3q",
 				"http://ccl.cse.nd.edu/research/data/hep-case-study/e28c0c145c801789b0919d175f0afa9c/scenario.xml"
 			],
 			"format": "plain",

--- a/umbrella/example/povray/README
+++ b/umbrella/example/povray/README
@@ -21,3 +21,24 @@ umbrella \
 --sandbox_mode docker \
 --log umbrella.log \
 run
+
+umbrella \
+--spec povray.umbrella \
+--meta http://ccl.cse.nd.edu/software/umbrella/database/packages.json \
+expand povray_S.umbrella
+
+umbrella \
+--spec povray_S.umbrella \
+--localdir /tmp/umbrella_test/ \
+--output /tmp/umbrella_test/parrot_povray_S \
+--sandbox_mode parrot \
+--log umbrella.log \
+run
+
+umbrella \
+--spec povray_S.umbrella \
+--localdir /tmp/umbrella_test/ \
+--output /tmp/umbrella_test/docker_povray_S \
+--sandbox_mode docker \
+--log umbrella.log \
+run

--- a/umbrella/example/povray/povray_S.umbrella
+++ b/umbrella/example/povray/povray_S.umbrella
@@ -1,0 +1,68 @@
+{
+	"comment": "A ray-tracing application which creates video frames.", 
+	"kernel": {
+		"version": ">=2.6.18", 
+		"name": "linux"
+	}, 
+	"os": {
+		"name": "Redhat", 
+		"format": "tgz", 
+		"checksum": "669ab5ef94af84d273f8f92a86b7907a", 
+		"source": [
+			"http://ccl.cse.nd.edu/research/data/hep-case-study/669ab5ef94af84d273f8f92a86b7907a/redhat-6.5-x86_64.tar.gz"
+		], 
+		"version": "6.5", 
+		"uncompressed_size": "1743656960", 
+		"id": "669ab5ef94af84d273f8f92a86b7907a", 
+		"size": "633848940"
+	}, 
+	"cmd": "povray +I/tmp/4_cubes.pov +O/tmp/frame000.png +K.0  -H50 -W50", 
+	"hardware": {
+		"cores": "2", 
+		"disk": "3GB", 
+		"arch": "x86_64", 
+		"memory": "2GB"
+	}, 
+	"environ": {
+		"PWD": "/tmp"
+	}, 
+	"data": {
+		"4_cubes.pov": {
+			"format": "plain", 
+			"checksum": "c65266cd2b672854b821ed93028a877a", 
+			"source": [
+				"http://ccl.cse.nd.edu/research/data/hep-case-study/c65266cd2b672854b821ed93028a877a/4_cubes.pov"
+			], 
+			"action": "none", 
+			"mountpoint": "/tmp/4_cubes.pov", 
+			"id": "c65266cd2b672854b821ed93028a877a", 
+			"size": "1757"
+		}, 
+		"WRC_RubiksCube.inc": {
+			"format": "plain", 
+			"checksum": "2f8afdd09fc3a6177c6f1977bb3bdae7", 
+			"source": [
+				"https://curate.nd.edu/downloads/gt54kk93p78",
+				"http://ccl.cse.nd.edu/research/data/hep-case-study/2f8afdd09fc3a6177c6f1977bb3bdae7/WRC_RubiksCube.inc"
+			], 
+			"action": "none", 
+			"mountpoint": "/tmp/WRC_RubiksCube.inc", 
+			"id": "2f8afdd09fc3a6177c6f1977bb3bdae7", 
+			"size": "28499"
+		}
+	}, 
+	"software": {
+		"povray-3.6.1-redhat6-x86_64": {
+			"format": "tgz", 
+			"checksum": "b02ba86dd3081a703b4b01dc463e0499", 
+			"source": [
+				"https://curate.nd.edu/downloads/h128nc60795",
+				"http://ccl.cse.nd.edu/research/data/hep-case-study/b02ba86dd3081a703b4b01dc463e0499/povray-3.6.1-redhat6-x86_64.tar.gz"
+			], 
+			"mountpoint": "/software/povray-3.6.1-redhat6-x86_64", 
+			"uncompressed_size": "3010560", 
+			"id": "b02ba86dd3081a703b4b01dc463e0499", 
+			"size": "1471452"
+		}
+	}
+}

--- a/umbrella/src/umbrella.py
+++ b/umbrella/src/umbrella.py
@@ -1646,7 +1646,7 @@ def workflow_repeat(cwd_setting, sandbox_dir, sandbox_mode, output_dir, input_di
 				subprocess_error(cmd, rc, stdout, stderr)
 
 			logging.debug("Rename the sandbox dir(%s) to the output directory(%s)", sandbox_dir, output_dir)
-			os.rmdir(output_dir)
+			shutil.rmtree(output_dir)
 			os.renames(sandbox_dir, output_dir)
 			print "The output has been put into the output dir: %s" % output_dir
 		else:


### PR DESCRIPTION
This branch allows the user to specified urls of data from curateND in Umbrella specs.

urls from curateND does not include the file names, instead use a random name for each file. For example, 
The download url from curateND for a file named `scenario.xml.tar.gz` is                            `https://curate.nd.edu/downloads/hd76rx93c3q`.

Umbrella specs should keep record of both the compressed file name (if compressed) `scenario.xml.tar.gz` and uncompressed file name `scenario.xml` to ease the resource existence checking.