### PR TITLE
Max task time

### DIFF
--- a/work_queue/src/perl/Work_Queue/Task.pm
+++ b/work_queue/src/perl/Work_Queue/Task.pm
@@ -205,8 +205,13 @@ sub specify_gpus {
 }
 
 sub specify_end_time {
-	my ($self, $seconds) = @_;
-	return work_queue_task_specify_end_time($self->{_task}, $seconds);
+	my ($self, $useconds) = @_;
+	return work_queue_task_specify_end_time($self->{_task}, $useconds);
+}
+
+sub specify_running_time {
+	my ($self, $useconds) = @_;
+	return work_queue_task_specify_running_time($self->{_task}, $useconds);
 }
 
 sub specify_priority {
@@ -693,14 +698,28 @@ Number of gpus.
 
 =head3 C<specify_end_time>
 
-Indicate the maximum end time (in seconds from the Epoch) of this
-task.
+Indicate the maximum end time (absolute, in microseconds from the Epoch) of
+this task.  This is useful, for example, when the task uses certificates that
+expire.  If less than 1, or not specified, no limit is imposed.
 
 =over 12
 
-=item seconds
+=item useconds
 
-Number of seconds.
+Number of microseconds.
+
+=back
+
+=head3 C<specify_running_time>
+
+Indicate the maximum running time for a task in a worker (relative to when the
+task starts to run).  If less than 1, or not specified, no limit is imposed.
+
+=over 12
+
+=item useconds
+
+Number of microseconds.
 
 =back
 

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -232,9 +232,17 @@ class Task(_object):
     def specify_priority( self, priority ):
         return work_queue_task_specify_priority(self._task,priority)
 
-    # Indicate the maximum end time (in seconds from the Epoch) of this task.
-    def specify_end_time( self, seconds ):
-        return work_queue_task_specify_end_time(self._task,seconds)
+    # Indicate the maximum end time (absolute, in microseconds from the Epoch) of this task.
+    # This is useful, for example, when the task uses certificates that expire.
+    # If less than 1, or not specified, no limit is imposed.
+    def specify_end_time( self, useconds ):
+        return work_queue_task_specify_end_time(self._task,useconds)
+
+    # Indicate the maximum running time for a task in a worker (relative to
+    # when the task starts to run).  If less than 1, or not specified, no limit
+    # is imposed.
+    def specify_running_time( self, useconds ):
+        return work_queue_task_specify_running_time(self._task,useconds)
 
     # Set this environment variable before running the task.
     # If value is None, then variable is unset.

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -3302,6 +3302,17 @@ void work_queue_task_specify_end_time( struct work_queue_task *t, timestamp_t us
 	}
 }
 
+void work_queue_task_specify_running_time( struct work_queue_task *t, timestamp_t useconds )
+{
+	if(useconds < 1)
+	{
+		t->maximum_running_time = 0;
+	}
+	else
+	{
+		t->maximum_running_time = useconds;
+	}
+}
 
 void work_queue_task_specify_tag(struct work_queue_task *t, const char *tag)
 {

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1248,10 +1248,9 @@ static void expire_waiting_task(struct work_queue *q, struct work_queue_task *t)
 static void expire_waiting_tasks(struct work_queue *q)
 {
 	struct work_queue_task *t;
-	int64_t current_time;
 	int count;
 
-	current_time = time(0);
+	timestamp_t current_time = timestamp_get();
 	count = task_state_count(q, WORK_QUEUE_TASK_READY);
 
 	while(count > 0)
@@ -2385,6 +2384,8 @@ static work_queue_result_code_t start_one_task(struct work_queue *q, struct work
 	send_worker_msg(q,w, "memory %"PRId64"\n", t->memory );
 	send_worker_msg(q,w, "disk %"PRId64"\n",   t->disk );
 	send_worker_msg(q,w, "gpus %d\n",          t->gpus );
+	send_worker_msg(q,w, "end_time %"PRIu64"\n",  t->maximum_end_time );
+	send_worker_msg(q,w, "wall_time %"PRIu64"\n", t->maximum_running_time );
 
 	/* Note that even when environment variables after resources, values for
 	 * CORES, MEMORY, etc. will be set at the worker to the values of
@@ -3289,15 +3290,15 @@ void work_queue_task_specify_gpus( struct work_queue_task *t, int gpus )
 	set_task_unlabel_flag(t);
 }
 
-void work_queue_task_specify_end_time( struct work_queue_task *t, int64_t seconds )
+void work_queue_task_specify_end_time( struct work_queue_task *t, timestamp_t useconds )
 {
-	if(seconds < 1)
+	if(useconds < 1)
 	{
 		t->maximum_end_time = 0;
 	}
 	else
 	{
-		t->maximum_end_time = seconds;
+		t->maximum_end_time = useconds;
 	}
 }
 

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -2379,12 +2379,12 @@ static work_queue_result_code_t start_one_task(struct work_queue *q, struct work
 	t->hostname = xxstrdup(w->hostname);
 	t->host = xxstrdup(w->addrport);
 
-	send_worker_msg(q,w, "task %lld\n",  (long long) t->taskid);
-	send_worker_msg(q,w, "cmd %lld\n%s", (long long) strlen(t->command_line), t->command_line);
-	send_worker_msg(q,w, "cores %d\n",   t->cores );
-	send_worker_msg(q,w, "memory %"PRId64"\n",  t->memory );
-	send_worker_msg(q,w, "disk %"PRId64"\n",    t->disk );
-	send_worker_msg(q,w, "gpus %d\n",    t->gpus );
+	send_worker_msg(q,w, "task %lld\n",  (long long) t->taskid );
+	send_worker_msg(q,w, "cmd %lld\n%s", (long long) strlen(t->command_line), t->command_line );
+	send_worker_msg(q,w, "cores %d\n",         t->cores );
+	send_worker_msg(q,w, "memory %"PRId64"\n", t->memory );
+	send_worker_msg(q,w, "disk %"PRId64"\n",   t->disk );
+	send_worker_msg(q,w, "gpus %d\n",          t->gpus );
 
 	/* Note that even when environment variables after resources, values for
 	 * CORES, MEMORY, etc. will be set at the worker to the values of

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -139,7 +139,7 @@ struct work_queue_task {
 	int total_submissions;                                 /**< The number of times the task has been submitted. */
 	timestamp_t total_cmd_execution_time;                  /**< Time spent in microseconds for executing the command on any worker, including resubmittions of the task. */
 
-	int64_t maximum_end_time;                              /**< Maximum time (from epoch) this task may run. */
+	timestamp_t maximum_end_time;                               /**< Maximum time (microseconds from epoch) this is valid. If less than 1, then task is always valid (default).*/
 	int64_t memory;                                        /**< Memory required by the task. (MB) */
 	int64_t disk;                                          /**< Disk space required by the task. (MB) */
 	int cores;                                             /**< Number of cores required by the task. */
@@ -337,7 +337,9 @@ void work_queue_task_specify_cores( struct work_queue_task *t, int cores );
 
 void work_queue_task_specify_gpus( struct work_queue_task *t, int gpus );
 
-/** Specify the maximum end time allowed for the task (in seconds since the Epoch). If seconds less than 1, then no end time is specified.
+/** Specify the maximum end time allowed for the task (in microseconds since the
+ * Epoch). If less than 1, then no end time is specified (this is the default).
+This is useful, for example, when the task uses certificates that expire.
 @param t A task object.
 @param seconds Number of seconds since the Epoch.
 */

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -61,10 +61,11 @@ typedef enum {
 	WORK_QUEUE_RESULT_STDOUT_MISSING = 4,       /**< The task ran but its stdout has been truncated **/
 	WORK_QUEUE_RESULT_SIGNAL         = 8,       /**< The task was terminated with a signal **/
 	WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION = 16, /**< The task used more resources than requested **/
-	WORK_QUEUE_RESULT_TASK_TIMEOUT   = 32,      /**< The task ran after specified end time. **/
+	WORK_QUEUE_RESULT_TASK_TIMEOUT   = 32,      /**< The task ran after the specified (absolute since epoch) end time. **/
 	WORK_QUEUE_RESULT_UNKNOWN        = 64,      /**< The result could not be classified. **/
 	WORK_QUEUE_RESULT_FORSAKEN       = 128,     /**< The task failed, but it was neither a task or worker error **/
-	WORK_QUEUE_RESULT_MAX_RETRIES    = 256      /**< The task could not be completed succesfully in the given number of retries. **/
+	WORK_QUEUE_RESULT_MAX_RETRIES    = 256,     /**< The task could not be completed successfully in the given number of retries. **/
+	WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME = 512   /**< The task ran for more than the specified time (relative since running in a worker). **/
 } work_queue_result_t;
 
 typedef enum {
@@ -153,6 +154,8 @@ struct work_queue_task {
 	struct rmsummary *resources_measured;                  /**< When monitoring is enabled, it points to the measured resources used by the task. */
 
 	timestamp_t time_app_delay;                            /**< @deprecated The time spent in upper-level application (outside of work_queue_wait). */
+
+	timestamp_t maximum_running_time;                      /**< Maximum time (microseconds) this task may run in a worker. If less than 1, no limit is enforced (default).*/
 
 };
 
@@ -344,7 +347,16 @@ This is useful, for example, when the task uses certificates that expire.
 @param seconds Number of seconds since the Epoch.
 */
 
-void work_queue_task_specify_end_time( struct work_queue_task *t, int64_t seconds );
+void work_queue_task_specify_end_time( struct work_queue_task *t, timestamp_t useconds );
+
+/** Specify the maximum time (in microseconds) the task is allowed to run in a
+ * worker. This time is accounted since the the moment the task starts to run
+ * in a worker.  If less than 1, then no maximum time is specified (this is the default).
+@param t A task object.
+@param seconds Maximum number of seconds the task may run in a worker.
+*/
+
+void work_queue_task_specify_running_time( struct work_queue_task *t, timestamp_t useconds );
 
 /** Attach a user defined string tag to the task.
 This field is not interpreted by the work queue, but is provided for the user's convenience

--- a/work_queue/src/work_queue_protocol.h
+++ b/work_queue/src/work_queue_protocol.h
@@ -14,7 +14,9 @@ This file should not be installed and should only be included by .c files.
 #ifndef WORK_QUEUE_PROTOCOL_H
 #define WORK_QUEUE_PROTOCOL_H
 
-#define WORK_QUEUE_PROTOCOL_VERSION 4
+/* 4: added invalidate-file message, for cache management.    */
+/* 5: added wall_time, end_time messages, for task maximum running time. */
+#define WORK_QUEUE_PROTOCOL_VERSION 5
 
 #define WORK_QUEUE_LINE_MAX 4096       /**< Maximum length of a work queue message line. */
 #define WORK_QUEUE_POOL_NAME_MAX 128   /**< Maximum length of a work queue pool name. */

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -832,8 +832,11 @@ static int do_task( struct link *master, int taskid, time_t stoptime )
 	char localname[WORK_QUEUE_LINE_MAX];
 	char taskname[WORK_QUEUE_LINE_MAX];
 	char taskname_encoded[WORK_QUEUE_LINE_MAX];
-	int n, flags, length;
+	int flags, length;
+	int64_t n;
 	int disk_alloc = disk_allocation;
+
+	timestamp_t nt;
 
 	struct work_queue_task *task = work_queue_task_create(0);
 	task->taskid = taskid;
@@ -856,13 +859,13 @@ static int do_task( struct link *master, int taskid, time_t stoptime )
 			work_queue_task_specify_file(task, localname, taskname, WORK_QUEUE_OUTPUT, flags);
 		} else if(sscanf(line, "dir %s", filename)) {
 			work_queue_task_specify_directory(task, filename, filename, WORK_QUEUE_INPUT, 0700, 0);
-		} else if(sscanf(line,"cores %d",&n)) {
+		} else if(sscanf(line,"cores %" PRId64,&n)) {
 				work_queue_task_specify_cores(task, n);
-		} else if(sscanf(line,"memory %d",&n)) {
+		} else if(sscanf(line,"memory %" PRId64,&n)) {
 				work_queue_task_specify_memory(task, n);
-		} else if(sscanf(line,"disk %d",&n)) {
+		} else if(sscanf(line,"disk %" PRId64,&n)) {
 				work_queue_task_specify_disk(task, n);
-		} else if(sscanf(line,"gpus %d",&n)) {
+		} else if(sscanf(line,"gpus %" PRId64,&n)) {
 			work_queue_task_specify_gpus(task, n);
 		} else if(sscanf(line,"env %d",&length)==1) {
 			char *env = malloc(length+2); /* +2 for \n and \0 */


### PR DESCRIPTION
Fix for #966.
Adds:

work_queue_task_specify_running_time(t, useconds)

Also, standardizes  end_time (absolute from epoch) to useconds, so that all times required have the same units.  