### PR TITLE
Fix maximum_end_time handling.

### DIFF
--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -583,7 +583,7 @@ static void expire_procs_running() {
 
 	itable_firstkey(procs_running);
 	while(itable_nextkey(procs_running, (uint64_t*)&pid, (void**)&p)) {
-		if(p->task->maximum_end_time > 0 && current_time - p->task->maximum_end_time > 0)
+		if(p->task->maximum_end_time > 0 && current_time > p->task->maximum_end_time)
 		{
 			p->task_status |= WORK_QUEUE_RESULT_TASK_TIMEOUT;
 			kill(pid, SIGKILL);


### PR DESCRIPTION
Fix overflow.  The altered conditional always results to true, I think this may be due to the subtraction of two `uint64_t`s?

Without this, tasks with a specified end time terminate immediately.