### PR TITLE
adds stats for workers lost, fast aborted, or idled out

### DIFF
--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -166,8 +166,12 @@ struct work_queue_stats {
 	int workers_init;               /**< Number of workers initializing.*/
 	int workers_idle;               /**< Number of workers that are not running a task. */
 	int workers_busy;               /**< Number of workers that are running at least one task. */
+
 	int total_workers_joined;       /**< Total number of worker connections that were established to the master. */
-	int total_workers_removed;      /**< Total number of worker connections that were terminated by the master. */
+	int total_workers_removed;      /**< Total number of worker connections that were lost or terminated by the master. */
+	int total_workers_lost;         /**< Total number of worker connections that were unexpectedly lost. */
+	int total_workers_idled_out;    /**< Total number of worker that disconnected for being idle. */
+	int total_workers_fast_aborted; /**< Total number of worker connections terminated for being too slow. (see @ref work_queue_activate_fast_abort) */
 
 	int tasks_waiting;              /**< Number of tasks waiting to be run. */
 	int tasks_running;              /**< Number of tasks currently running. */

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -367,6 +367,9 @@ static void send_stats_update( struct link *master, int force_update)
 
 		send_master_message(master, "info total_workers_joined %lld\n", (long long) s.total_workers_joined);
 		send_master_message(master, "info total_workers_removed %lld\n", (long long) s.total_workers_removed);
+		send_master_message(master, "info total_workers_lost %lld\n", (long long) s.total_workers_lost);
+		send_master_message(master, "info total_workers_idled_out %lld\n", (long long) s.total_workers_idled_out);
+		send_master_message(master, "info total_workers_fast_aborted %lld\n", (long long) s.total_workers_fast_aborted);
 		send_master_message(master, "info total_send_time %lld\n", (long long) s.total_send_time);
 		send_master_message(master, "info total_receive_time %lld\n", (long long) s.total_receive_time);
 		send_master_message(master, "info total_execute_time %lld\n", (long long) s.total_execute_time);


### PR DESCRIPTION
As requested by @klannon to replace grep-fu with the debug output.

Adds as to the queue stats:

total_workers_lost                 (e.g., evicted)
total_workers_fast_aborted
total_workers_idled_out

