### PR TITLE
Immediately wait for tracee on wait barrier.

### DIFF
--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -103,7 +103,7 @@ extern char *pfs_false_uname;
 extern uid_t pfs_uid;
 extern gid_t pfs_gid;
 
-extern pid_t trace_this_pid;
+extern int wait_barrier;
 
 extern INT64_T pfs_syscall_count;
 extern INT64_T pfs_read_count;
@@ -182,7 +182,7 @@ static void divert_to_parrotfd( struct pfs_process *p, INT64_T fd, char *path, c
 
 	p->syscall_args_changed = 1;
 	p->syscall_parrotfd = fd;
-	trace_this_pid = p->pid; /* this handles two processes racing to create the same file, also see comment for pfs_table::setparrot. */
+	wait_barrier = 1; /* this handles two processes racing to create the same file, also see comment for pfs_table::setparrot. */
 }
 
 static void handle_parrotfd( struct pfs_process *p )
@@ -1331,7 +1331,7 @@ static void decode_syscall( struct pfs_process *p, int entering )
 				 * we can determine the child pid before seeing any events from
 				 * the child.
 				 */
-				trace_this_pid = p->pid;
+				wait_barrier = 1;
 			}
 			break;
 

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -112,7 +112,7 @@ extern char *pfs_false_uname;
 extern uid_t pfs_uid;
 extern gid_t pfs_gid;
 
-extern pid_t trace_this_pid;
+extern int wait_barrier;
 
 extern INT64_T pfs_syscall_count;
 extern INT64_T pfs_read_count;
@@ -191,7 +191,7 @@ static void divert_to_parrotfd( struct pfs_process *p, INT64_T fd, char *path, c
 
 	p->syscall_args_changed = 1;
 	p->syscall_parrotfd = fd;
-	trace_this_pid = p->pid; /* this handles two processes racing to create the same file, also see comment for pfs_table::setparrot. */
+	wait_barrier = 1; /* this handles two processes racing to create the same file, also see comment for pfs_table::setparrot. */
 }
 
 static void handle_parrotfd( struct pfs_process *p )
@@ -1100,7 +1100,7 @@ static void decode_syscall( struct pfs_process *p, int entering )
 				 * we can determine the child pid before seeing any events from
 				 * the child.
 				 */
-				trace_this_pid = p->pid;
+				wait_barrier = 1;
 			}
 			break;
 

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -73,7 +73,7 @@ static const int _SENTINEL2 = 0;
 
 #define PARROT_POINTER(pointer) (!(pointer == NATIVE || pointer == SPECIAL || pointer == NULL))
 
-#define VALID_FD(fd) (0 <= fd && fd <= pointer_count)
+#define VALID_FD(fd) (0 <= fd && fd < pointer_count)
 #define PARROT_FD(fd) (VALID_FD(fd) && PARROT_POINTER(pointers[fd]))
 
 #define CHECK_FD(fd) \

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -669,7 +669,7 @@ int pfs_table::open( const char *lname, int flags, mode_t mode, int force_cache,
 		if(file) {
 			if(path && file->canbenative(path, len)) {
 				file->close();
-				return -2;
+				result = -2;
 			} else {
 				pointers[result] = new pfs_pointer(file,flags,mode);
 				fd_flags[result] = 0;
@@ -679,13 +679,13 @@ int pfs_table::open( const char *lname, int flags, mode_t mode, int force_cache,
 			}
 		} else if (errno == ECHILD /* hack: indicates to open natively */) {
 			snprintf(path, len, "%s", lname);
-			return -2;
+			result = -2;
 		} else {
 			result = -1;
 		}
 	} else {
-		result = -1;
 		errno = EMFILE;
+		result = -1;
 	}
 
 	return result;

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -150,6 +150,7 @@ void pfs_table::setparrot(int fd, int rfd, struct stat *buf)
 {
 	if (!PARROT_FD(fd))
 		fatal("fd %d is not an open parrotfd", fd);
+	assert(fd == rfd || (VALID_FD(rfd) && pointers[rfd] == NULL));
 
 	/* It's possible for another thread to create a native fd which is equal to
 	 * the parrot fd. If that happens we change the parrot fd to what the
@@ -221,6 +222,7 @@ to this physical file descriptor in the tracing process.
 
 void pfs_table::attach( int logical, int physical, int flags, mode_t mode, const char *name, struct stat *buf )
 {
+	assert(VALID_FD(logical) && pointers[logical] == NULL);
 	pointers[logical] = new pfs_pointer(pfs_file_bootstrap(physical,name),flags,mode);
 	fd_flags[logical] = 0;
 	setparrot(logical, logical, buf);
@@ -229,6 +231,7 @@ void pfs_table::attach( int logical, int physical, int flags, mode_t mode, const
 void pfs_table::setnative( int fd, int fdflags )
 {
 	debug(D_DEBUG, "setting fd %d as native%s", fd, fdflags & FD_CLOEXEC ? " (FD_CLOEXEC)" : "");
+	assert(VALID_FD(fd) && (pointers[fd] == NULL || pointers[fd] == NATIVE));
 	pointers[fd] = NATIVE;
 	fd_flags[fd] = fdflags;
 }
@@ -236,6 +239,7 @@ void pfs_table::setnative( int fd, int fdflags )
 void pfs_table::setspecial( int fd )
 {
 	debug(D_DEBUG, "setting fd %d as special", fd);
+	assert(VALID_FD(fd) && pointers[fd] == NULL);
 	pointers[fd] = SPECIAL;
 	fd_flags[fd] = 0;
 }


### PR DESCRIPTION
Commit 50200922bb94e4a11743561ac84ae5f1ba90b08b introduced an error where
events for other tracees would be handled after setting trace_this_pid. The
intent of trace_this_pid is to setup a barrier preventing handling of other
events until the current two stage operation completes (clone or open).
    
Now Parrot immediately waits again for a tracee that sets up such a barrier.
I've corrected the variable name to make this intent more clear.
    
Fixes #986.