### PR TITLE
Take into account shared memory when computing resident memory for the resource monitor

### DIFF
--- a/dttools/src/rmonitor_poll.c
+++ b/dttools/src/rmonitor_poll.c
@@ -571,8 +571,6 @@ int rmonitor_poll_maps_once(struct itable *processes, struct rmonitor_mem_info *
 	mem->private      = div_round_up(mem->private, 1024);
 	mem->resident     = div_round_up(mem->resident, 1024);
 
-	debug(D_NOTICE, "Resident per maps: resident %"PRId64", used with others %"PRId64"\n", mem->resident, mem->shared);
-
 	return 0;
 }
 

--- a/dttools/src/rmonitor_poll.c
+++ b/dttools/src/rmonitor_poll.c
@@ -389,7 +389,7 @@ struct rmonitor_mem_info *rmonitor_get_map_info(FILE *fmem, int rewind_flag) {
 		// 560019f25000-56001a127000 r-xp 00000000 08:01 266469                     /usr/bin/vim.basic
 
 		int n;
-		n = sscanf(map_info_line, "%lx-%lx %*s %lx %*s %*s %s", &(info->map_start), &(info->map_end), &offset, map_name_found);
+		n = sscanf(map_info_line, "%llx-%llx %*s %llx %*s %*s %s", (long long unsigned int *) &(info->map_start), (long long unsigned int *)  &(info->map_end), (long long unsigned int *) &offset, map_name_found);
 
 		/* continue if we do not get at least start, end, and offset */
 		if(n < 3)

--- a/dttools/src/rmonitor_poll_internal.h
+++ b/dttools/src/rmonitor_poll_internal.h
@@ -48,6 +48,7 @@ void rmonitor_poll_all_fss_once(      struct itable *filesysms, struct rmonitor_
 int rmonitor_poll_process_once(struct rmonitor_process_info *p);
 int rmonitor_poll_wd_once(     struct rmonitor_wdir_info    *d, int max_time_for_measurement);
 int rmonitor_poll_fs_once(     struct rmonitor_filesys_info *f);
+int rmonitor_poll_maps_once(   struct itable *processes, struct rmonitor_mem_info *mem);
 
 void rmonitor_info_to_rmsummary(struct rmsummary *tr, struct rmonitor_process_info *p, struct rmonitor_wdir_info *d, struct rmonitor_filesys_info *f, uint64_t start_time);
 

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -587,8 +587,8 @@ void rmonitor_collate_tree(struct rmsummary *tr, struct rmonitor_process_info *p
 	/* we use max here, as /proc/pid/smaps that fills *m is not always
 	 * available. This causes /proc/pid/status to become a conservative
 	 * fallback. */
-	if(m->resident + m->resident_shared > 0) {
-		tr->resident_memory   = (int64_t) (m->resident + m->resident_shared);
+	if(m->resident > 0) {
+		tr->resident_memory   = (int64_t) m->resident;
 		tr->swap_memory       = (int64_t) m->swap;
 	}
 	else {
@@ -931,12 +931,11 @@ struct rmsummary *rmonitor_rusage_tree(void)
         return NULL;
     }
 
-    /* Here we add the maximum recorded + the io from memory maps */
-    tr_usg->bytes_read     =  summary->bytes_read + usg.ru_majflt * sysconf(_SC_PAGESIZE);
-
-    tr_usg->resident_memory = (usg.ru_maxrss + ONE_MEGABYTE - 1) / ONE_MEGABYTE;
-
-    debug(D_RMON, "rusage faults: %ld resident memory: %ld.\n", usg.ru_majflt, usg.ru_maxrss);
+	if(usg.ru_majflt > 0) {
+		/* Here we add the maximum recorded + the io from memory maps */
+		tr_usg->bytes_read     =  summary->bytes_read + usg.ru_majflt * sysconf(_SC_PAGESIZE);
+		debug(D_RMON, "page faults: %ld.\n", usg.ru_majflt);
+	}
 
     return tr_usg;
 }

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -571,7 +571,7 @@ void rmonitor_summary_header()
     }
 }
 
-void rmonitor_collate_tree(struct rmsummary *tr, struct rmonitor_process_info *p, struct rmonitor_wdir_info *d, struct rmonitor_filesys_info *f)
+void rmonitor_collate_tree(struct rmsummary *tr, struct rmonitor_process_info *p, struct rmonitor_mem_info *m, struct rmonitor_wdir_info *d, struct rmonitor_filesys_info *f)
 {
 	tr->wall_time         = usecs_since_epoch() - summary->start;
 	tr->cpu_time          = p->cpu.delta + tr->cpu_time;
@@ -583,8 +583,18 @@ void rmonitor_collate_tree(struct rmsummary *tr, struct rmonitor_process_info *p
 	tr->total_processes     = summary->total_processes;
 
 	tr->virtual_memory    = (int64_t) p->mem.virtual;
-	tr->resident_memory   = (int64_t) p->mem.resident;
-	tr->swap_memory       = (int64_t) p->mem.swap;
+
+	/* we use max here, as /proc/pid/smaps that fills *m is not always
+	 * available. This causes /proc/pid/status to become a conservative
+	 * fallback. */
+	if(m->resident + m->resident_shared > 0) {
+		tr->resident_memory   = (int64_t) (m->resident + m->resident_shared);
+		tr->swap_memory       = (int64_t) m->swap;
+	}
+	else {
+		tr->resident_memory   = (int64_t) p->mem.resident;
+		tr->swap_memory       = (int64_t) p->mem.swap;
+	}
 
 	tr->bytes_read        = (int64_t) (p->io.delta_chars_read + tr->bytes_read);
 	tr->bytes_read       += (int64_t)  p->io.delta_bytes_faulted;
@@ -1394,6 +1404,7 @@ int rmonitor_resources(long int interval /*in microseconds */)
     struct rmonitor_process_info *p_acc = calloc(1, sizeof(struct rmonitor_process_info)); //Automatic zeroed.
     struct rmonitor_wdir_info    *d_acc = calloc(1, sizeof(struct rmonitor_wdir_info));
     struct rmonitor_filesys_info *f_acc = calloc(1, sizeof(struct rmonitor_filesys_info));
+    struct rmonitor_mem_info     *m_acc = calloc(1, sizeof(struct rmonitor_mem_info));
 
     struct rmsummary    *resources_now = calloc(1, sizeof(struct rmsummary));
 
@@ -1410,13 +1421,14 @@ int rmonitor_resources(long int interval /*in microseconds */)
 		ping_processes();
 
 		rmonitor_poll_all_processes_once(processes, p_acc);
+		rmonitor_poll_maps_once(processes, m_acc);
 
 		if(resources_flags->workdir_footprint)
 			rmonitor_poll_all_wds_once(wdirs, d_acc, MAX(1, interval/(ONE_SECOND*hash_table_size(wdirs))));
 
 		// rmonitor_fss_once(f); disabled until statfs fs id makes sense.
 
-		rmonitor_collate_tree(resources_now, p_acc, d_acc, f_acc);
+		rmonitor_collate_tree(resources_now, p_acc, m_acc, d_acc, f_acc);
 		rmonitor_find_max_tree(summary, resources_now);
 		rmonitor_log_row(resources_now);
 

--- a/resource_monitor/src/rmonitor_types.h
+++ b/resource_monitor/src/rmonitor_types.h
@@ -41,7 +41,13 @@ struct rmonitor_mem_info
 	uint64_t virtual;
 	uint64_t resident;
 	uint64_t swap;
-	uint64_t shared;
+	uint64_t resident_shared;
+	uint64_t swap_shared;
+
+	char    *map_name;
+	uint64_t map_start;
+	uint64_t map_end;
+
 	uint64_t text;
 	uint64_t data;
 };

--- a/resource_monitor/src/rmonitor_types.h
+++ b/resource_monitor/src/rmonitor_types.h
@@ -39,10 +39,13 @@ struct rmonitor_cpu_time_info
 struct rmonitor_mem_info
 {
 	uint64_t virtual;
+	uint64_t referenced;
 	uint64_t resident;
 	uint64_t swap;
-	uint64_t resident_shared;
-	uint64_t swap_shared;
+
+	/* resident values, itemized. */
+	uint64_t private;
+	uint64_t shared;
 
 	char    *map_name;
 	uint64_t map_start;


### PR DESCRIPTION
Accumulate the maps we just found per file. First, we merge together all the maps segment that overlap. With this, we do not overcount private segments, but do consider that segments are shared as little as possible.

After this merging, we determine upper bounds, such as: 
virtual >= referenced >= private >= referenced - private >= shared.

If swap size is zero, then virtual and private have the exact values, and we have worst case counts for referenced and shared.

When we accumulate resident for the result, we do it from private + shared, rather than the resident reported originally as this would overcount shared.

There could be a way to use Pss (proportional resident) to improve these bounds.

This should mitigate some obvious overcounting, as reported by @annawoodard.
 