### PR TITLE
change default cvmfs uri from /opt/$VO to /cvmfs/$FQRN

### DIFF
--- a/apps/parrot_atlas/parrot.atlas.sh
+++ b/apps/parrot_atlas/parrot.atlas.sh
@@ -2,7 +2,7 @@
 
 export PARROT_ALLOW_SWITCHING_CVMFS_REPOSITORIES="yes"
 export HTTP_PROXY=http://cache01.hep.wisc.edu:3128
-export PARROT_CVMFS_REPO='*.cern.ch:pubkey=<BUILTIN-cern.ch.pub>,url=http://cvmfs-stratum-one.cern.ch/opt/*;http://cernvmfs.gridpp.rl.ac.uk/opt/*;http://cvmfs.racf.bnl.gov/opt/* atlas-nightlies.cern.ch:url=http://cvmfs-atlas-nightlies.cern.ch/cvmfs/atlas-nightlies.cern.ch,pubkey=<BUILTIN-cern.ch.pub>'
+export PARROT_CVMFS_REPO='*.cern.ch:pubkey=<BUILTIN-cern.ch.pub>,url=http://cvmfs-stratum-one.cern.ch/cvmfs/*.cern.ch;http://cernvmfs.gridpp.rl.ac.uk/cvmfs/*.cern.ch;http://cvmfs.racf.bnl.gov/cvmfs/*.cern.ch atlas-nightlies.cern.ch:url=http://cvmfs-atlas-nightlies.cern.ch/cvmfs/atlas-nightlies.cern.ch,pubkey=<BUILTIN-cern.ch.pub>'
 
 parrot_run ./atlas.sh
 

--- a/parrot/src/pfs_service_cvmfs.cc
+++ b/parrot/src/pfs_service_cvmfs.cc
@@ -644,10 +644,10 @@ cvmfs_filesystem *cvmfs_filesystem::createMatch(char const *repo_name) const
  * escaped with a backslash.
  *
  * Example for /cvmfs/cms.cern.ch:
- * cms.cern.ch:pubkey=/path/to/cern.ch.pub,url=http://cvmfs-stratum-one.cern.ch/opt/cms
+ * cms.cern.ch:pubkey=/path/to/cern.ch.pub,url=http://cvmfs-stratum-one.cern.ch/cvmfs/cms.cern.ch
  *
  * Example with wildcard (using <*> to avoid compiler warning about nested comment):
- * *.cern.ch:pubkey=/path/to/cern.ch.pub,url=http://cvmfs-stratum-one.cern.ch/opt/<*>
+ * *.cern.ch:pubkey=/path/to/cern.ch.pub,url=http://cvmfs-stratum-one.cern.ch/cvmfs/<*>.cern.ch
  */
 static void cvmfs_read_config()
 {

--- a/parrot/src/pfs_service_cvmfs.cc
+++ b/parrot/src/pfs_service_cvmfs.cc
@@ -59,7 +59,7 @@ static struct cvmfs_filesystem *cvmfs_active_filesystem = 0;
 static const char *default_cvmfs_repo =
 "*:try_local_filesystem \
 \
- *.cern.ch:pubkey=" CERN_KEY_PLACEHOLDER ",url=http://cvmfs-stratum-one.cern.ch/opt/*;http://cernvmfs.gridpp.rl.ac.uk/opt/*;http://cvmfs.racf.bnl.gov/opt/* \
+ *.cern.ch:pubkey=" CERN_KEY_PLACEHOLDER ",url=http://cvmfs-stratum-one.cern.ch/cvmfs/*.cern.ch;http://cernvmfs.gridpp.rl.ac.uk/cvmfs/*.cern.ch;http://cvmfs.racf.bnl.gov/cvmfs/*.cern.ch \
 \
  *.opensciencegrid.org:pubkey=" OASIS_KEY_PLACEHOLDER ",url=http://oasis-replica.opensciencegrid.org:8000/cvmfs/*;http://cvmfs.fnal.gov:8000/cvmfs/*;http://cvmfs.racf.bnl.gov:8000/cvmfs/*";
 

--- a/parrot/test/TR_parrot_cvmfs_access.sh
+++ b/parrot/test/TR_parrot_cvmfs_access.sh
@@ -4,7 +4,7 @@
 
 export PARROT_ALLOW_SWITCHING_CVMFS_REPOSITORIES="yes"
 export HTTP_PROXY=http://eddie.crc.nd.edu:3128
-export PARROT_CVMFS_REPO='*.cern.ch:pubkey=<BUILTIN-cern.ch.pub>,url=http://cvmfs-stratum-one.cern.ch/opt/*'
+export PARROT_CVMFS_REPO='*.cern.ch:pubkey=<BUILTIN-cern.ch.pub>,url=http://cvmfs-stratum-one.cern.ch/cvmfs/*.cern.ch'
 
 tmp_dir=${PWD}/parrot_temp_dir
 

--- a/parrot/test/TR_parrot_cvmfs_alien_cache.sh
+++ b/parrot/test/TR_parrot_cvmfs_alien_cache.sh
@@ -4,7 +4,7 @@
 
 export PARROT_ALLOW_SWITCHING_CVMFS_REPOSITORIES="yes"
 export HTTP_PROXY=http://eddie.crc.nd.edu:3128
-export PARROT_CVMFS_REPO='*.cern.ch:pubkey=<BUILTIN-cern.ch.pub>,url=http://cvmfs-stratum-one.cern.ch/opt/*'
+export PARROT_CVMFS_REPO='*.cern.ch:pubkey=<BUILTIN-cern.ch.pub>,url=http://cvmfs-stratum-one.cern.ch/cvmfs/*.cern.ch'
 
 tmp_dir_master=${PWD}/parrot_temp_dir
 tmp_dir_hitcher=${PWD}/parrot_temp_dir_hitcher


### PR DESCRIPTION
Original convention for web servers providing cvmfs repositories was to use 

    http://<HOSTNAME>/opt/<VIRTUAL ORGANIZATION>

like http://cvmfs-stratum-one.cern.ch/opt/atlas.  These URLs are still active on WLCG web servers but considered deprecated.  The URI scheme changed to

    http://<HOST NAME>/cvmfs/<FULLY QUALIFIED REPOSITORY NAME>

like http://cvmfs-stratum-one.cern.ch/cvmfs/atlas.cern.ch