### PR TITLE
Use long timeout when first contacting master.

### DIFF
--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1698,7 +1698,7 @@ static int serve_master_by_hostport( const char *host, int port, const char *ver
 
 	reset_idle_timer();
 
-	struct link *master = link_connect(master_addr,port,time(0)+idle_stoptime);
+	struct link *master = link_connect(master_addr,port,idle_stoptime);
 	if(!master) {
 		fprintf(stderr,"couldn't connect to %s:%d: %s\n",master_addr,port,strerror(errno));
 		return 0;
@@ -1722,7 +1722,7 @@ static int serve_master_by_hostport( const char *host, int port, const char *ver
 		char line[WORK_QUEUE_LINE_MAX];
 		debug(D_WQ, "verifying master's project name");
 		send_master_message(master, "name\n");
-		if(!recv_master_message(master, line, sizeof(line), time(0) + idle_stoptime)) {
+		if(!recv_master_message(master,line,sizeof(line),idle_stoptime)) {
 			debug(D_WQ,"no response from master while verifying name");
 			link_close(master);
 			return 0;

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1687,8 +1687,13 @@ static int serve_master_by_hostport( const char *host, int port, const char *ver
 	}
 
 	/*
-	For the preliminary steps of password and project verification, we use the idle timeout,
-	because we have not yet been assigned any work and should leave if the master is not responsive.
+	For the preliminary steps of password and project verification, we use the
+	idle timeout, because we have not yet been assigned any work and should
+	leave if the master is not responsive.
+
+	It is tempting to use a short timeout here, but DON'T. The name and
+	password messages are ayncronous; if the master is busy handling other
+	workers, a short window is not enough for a response to come back.
 	*/
 
 	reset_idle_timer();

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -91,9 +91,6 @@ static time_t connect_stoptime = 0;
 // Maximum time to attempt connecting to all available masters before giving up.
 static int connect_timeout = 900;
 
-// Maximum time to attempt a single link_connect before trying other options.
-static int single_connect_timeout = 15;
-
 // Maximum time to attempt sending/receiving any given file or message.
 static const int active_timeout = 3600;
 
@@ -1720,7 +1717,7 @@ static int serve_master_by_hostport( const char *host, int port, const char *ver
 		char line[WORK_QUEUE_LINE_MAX];
 		debug(D_WQ, "verifying master's project name");
 		send_master_message(master, "name\n");
-		if(!recv_master_message(master, line, sizeof(line),time(0) + single_connect_timeout)) {
+		if(!recv_master_message(master, line, sizeof(line), time(0) + idle_stoptime)) {
 			debug(D_WQ,"no response from master while verifying name");
 			link_close(master);
 			return 0;


### PR DESCRIPTION
This reverts a change in which the first connection to the master used a short timeout. The idea was to make the worker more responsive. This, however, causes workers to repeatedly disconnect if the master does not immediately (i.e., 15 sec) confirms the connection.

