### PR TITLE
Supplementary groups

### DIFF
--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -1493,9 +1493,13 @@ static void decode_syscall( struct pfs_process *p, int entering )
 
 		case SYSCALL32_getgroups32:
 		case SYSCALL32_getgroups:
+			if (entering && pfs_fake_setgid)
+				divert_to_dummy(p,-EPERM);
+			break;
+
 		case SYSCALL32_setgroups32:
 		case SYSCALL32_setgroups:
-			if (entering && pfs_fake_setgid)
+			if (entering)
 				divert_to_dummy(p,-EPERM);
 			break;
 

--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -1285,8 +1285,6 @@ static void decode_syscall( struct pfs_process *p, int entering )
 		case SYSCALL32_set_thread_area:
 		case SYSCALL32_set_tid_address:
 		case SYSCALL32_setdomainname:
-		case SYSCALL32_setgroups32:
-		case SYSCALL32_setgroups:
 		case SYSCALL32_sethostname:
 		case SYSCALL32_setitimer:
 		case SYSCALL32_setpgid:
@@ -1493,6 +1491,12 @@ static void decode_syscall( struct pfs_process *p, int entering )
 					divert_to_dummy(p,-EPERM);
 				}
 			}
+			break;
+
+		case SYSCALL32_setgroups32:
+		case SYSCALL32_setgroups:
+			if (entering && pfs_fake_setgid)
+				divert_to_dummy(p,-EPERM);
 			break;
 
 		/* Here begin all of the I/O operations, given in the same order as in

--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -1221,8 +1221,6 @@ static void decode_syscall( struct pfs_process *p, int entering )
 		case SYSCALL32_get_robust_list:
 		case SYSCALL32_get_thread_area:
 		case SYSCALL32_getcpu:
-		case SYSCALL32_getgroups32:
-		case SYSCALL32_getgroups:
 		case SYSCALL32_getitimer:
 		case SYSCALL32_getpgid:
 		case SYSCALL32_getpgrp:
@@ -1493,6 +1491,8 @@ static void decode_syscall( struct pfs_process *p, int entering )
 			}
 			break;
 
+		case SYSCALL32_getgroups32:
+		case SYSCALL32_getgroups:
 		case SYSCALL32_setgroups32:
 		case SYSCALL32_setgroups:
 			if (entering && pfs_fake_setgid)

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -1002,7 +1002,6 @@ static void decode_syscall( struct pfs_process *p, int entering )
 		case SYSCALL64_get_robust_list:
 		case SYSCALL64_get_thread_area:
 		case SYSCALL64_getcpu:
-		case SYSCALL64_getgroups:
 		case SYSCALL64_getitimer:
 		case SYSCALL64_getpgid:
 		case SYSCALL64_getpgrp:
@@ -1251,6 +1250,7 @@ static void decode_syscall( struct pfs_process *p, int entering )
 			}
 			break;
 
+		case SYSCALL64_getgroups:
 		case SYSCALL64_setgroups:
 			if (entering && pfs_fake_setgid)
 				divert_to_dummy(p,-EPERM);

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -1251,8 +1251,12 @@ static void decode_syscall( struct pfs_process *p, int entering )
 			break;
 
 		case SYSCALL64_getgroups:
-		case SYSCALL64_setgroups:
 			if (entering && pfs_fake_setgid)
+				divert_to_dummy(p,-EPERM);
+			break;
+
+		case SYSCALL64_setgroups:
+			if (entering)
 				divert_to_dummy(p,-EPERM);
 			break;
 

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -1064,7 +1064,6 @@ static void decode_syscall( struct pfs_process *p, int entering )
 		case SYSCALL64_set_thread_area:
 		case SYSCALL64_set_tid_address:
 		case SYSCALL64_setdomainname:
-		case SYSCALL64_setgroups:
 		case SYSCALL64_sethostname:
 		case SYSCALL64_setitimer:
 		case SYSCALL64_setpgid:
@@ -1250,6 +1249,11 @@ static void decode_syscall( struct pfs_process *p, int entering )
 					divert_to_dummy(p,-EPERM);
 				}
 			}
+			break;
+
+		case SYSCALL64_setgroups:
+			if (entering && pfs_fake_setgid)
+				divert_to_dummy(p,-EPERM);
 			break;
 
 		/* Here begin all of the I/O operations, given in the same order as in


### PR DESCRIPTION
These should block `getgroups`/`setgroups` with `EPERM` when using `--fake-setuid`. If blocking `getgroups` is unnecessary, then a21e7a9701076aa2c94a7852e0c2e3eeab98cb7d just needs to be reverted.