### PR TITLE
Monitor add debug, series files  to wq

### DIFF
--- a/dttools/src/rmonitor.c
+++ b/dttools/src/rmonitor.c
@@ -98,9 +98,7 @@ char *resource_monitor_locate(const char *path_from_cmdline)
 
 //Using default sampling interval. We may want to add an option
 //to change it.
-char *resource_monitor_write_command(const char *monitor_path, const char *template_filename, const char *limits_filename,
-					   const char *extra_monitor_options,
-					   int time_series, int inotify_stats)
+char *resource_monitor_write_command(const char *monitor_path, const char *template_filename, const char *limits_filename, const char *extra_monitor_options, int debug_output, int time_series, int inotify_stats)
 {
 
 
@@ -112,6 +110,9 @@ char *resource_monitor_write_command(const char *monitor_path, const char *templ
 
 	buffer_printf(&cmd_builder, "%s", monitor_path);
 	buffer_printf(&cmd_builder, " --with-output-files=%s", template_filename);
+
+	if(debug_output)
+		buffer_printf(&cmd_builder, " -dall -o %s.debug", template_filename);
 
 	if(time_series)
 		buffer_printf(&cmd_builder, " --with-time-series");

--- a/dttools/src/rmonitor.h
+++ b/dttools/src/rmonitor.h
@@ -24,9 +24,7 @@ the corresponding log file options.
 @return A wrapper command line for string_wrap_command to wrap original command line with the resource monitor.
 */
 
-char *resource_monitor_write_command(const char *monitor_path, const char *template_filename, const char *limits_filename,
-					   const char *extra_monitor_options,
-					   int time_series, int opened_files);
+char *resource_monitor_write_command(const char *monitor_path, const char *template_filename, const char *limits_filename, const char *extra_monitor_options, int debug_output, int time_series, int opened_files);
 
 /** Looks for a resource monitor executable, and makes a copy in
 current working directory.

--- a/makeflow/src/makeflow_wrapper_monitor.c
+++ b/makeflow/src/makeflow_wrapper_monitor.c
@@ -19,6 +19,7 @@ struct makeflow_monitor * makeflow_monitor_create()
 {
 	struct makeflow_monitor *m = malloc(sizeof(*m));
 	m->wrapper = makeflow_wrapper_create();
+	m->enable_debug       = 0;
 	m->enable_time_series = 0;
 	m->enable_list_files  = 0;
 
@@ -90,6 +91,7 @@ char *makeflow_rmonitor_wrapper_command( struct makeflow_monitor *m, struct dag_
 			m->log_prefix,
 			m->limits_name,
 			extra_options,
+			m->enable_debug,
 			m->enable_time_series,
 			m->enable_list_files);
 

--- a/makeflow/src/makeflow_wrapper_monitor.h
+++ b/makeflow/src/makeflow_wrapper_monitor.h
@@ -16,6 +16,7 @@ may be removed, according to a variety of criteria.
 
 struct makeflow_monitor {
 	struct makeflow_wrapper *wrapper;
+	int enable_debug;
 	int enable_time_series;
 	int enable_list_files;
 

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -1559,33 +1559,12 @@ int main(int argc, char **argv) {
 			case 'O':
 				if(template_path)
 					free(template_path);
-				if(summary_path)
-				{
-					free(summary_path);
-					summary_path = NULL;
-				}
-				if(series_path)
-				{
-					free(series_path);
-					series_path = NULL;
-				}
-				if(opened_path)
-				{
-					free(opened_path);
-					opened_path = NULL;
-				}
 				template_path = xxstrdup(optarg);
 				break;
 			case  LONG_OPT_TIME_SERIES:
-				if(series_path)
-					free(series_path);
-				series_path = xxstrdup(optarg);
 				use_series  = 1;
 				break;
 			case  LONG_OPT_OPENED_FILES:
-				if(opened_path)
-					free(opened_path);
-				opened_path = xxstrdup(optarg);
 				use_inotify = 1;
 				break;
 			case LONG_OPT_NO_DISK_FOOTPRINT:

--- a/work_queue/src/perl/Work_Queue.pm
+++ b/work_queue/src/perl/Work_Queue.pm
@@ -101,6 +101,11 @@ sub enable_monitoring {
 	return work_queue_enable_monitoring($self->{_work_queue}, $summary_file);
 }
 
+sub enable_monitoring_full {
+	my ($self, $dir_name) = @_;
+	return work_queue_enable_monitoring_full($self->{_work_queue}, $dir_name);
+}
+
 sub activate_fast_abort {
 	my ($self, $multiplier) = @_;
 	return work_queue_activate_fast_abort($self->{_work_queue}, $multiplier);
@@ -337,20 +342,33 @@ Get the queue statistics, including master and foremen.
 
 		 print $q->stats_hierarchy->{workers_busy};
 
-=head3 C<enable_monitoring($summary_file)>
+=head3 C<enable_monitoring($dir_name)>
 
-Enables resource monitoring of tasks in the queue. And writes a
-summary of the monitored information to a file.
+Enables resource monitoring of tasks in the queue, and writes a summary per
+task to the directory given. Additionally, all summaries are consolidate into
+the file all_summaries-PID.log
 
- Returns 1 on success, 0 on failure (i.e., monitoring was not enabled).
+Returns 1 on success, 0 on failure (i.e., monitoring was not enabled).
 
 =over 12
 
-=item summaryfile
-
-Filename for the summary log (If NULL, writes to wq-\<pid\>-resource-usage).
+=item dirname    Directory name for the monitor output.
 
 =back
+
+=head3 C<enable_monitoring_full($dir_name)>
+
+As @ref enable_monitoring, but it also generates a time series and a debug
+file.  WARNING: Such files may reach gigabyte sizes for long running tasks.
+
+Returns 1 on success, 0 on failure (i.e., monitoring was not enabled).
+
+=over 12
+
+=item dirname    Directory name for the monitor output.
+
+=back
+
 
 =head3 C<fast_abort>
 

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -698,14 +698,26 @@ class WorkQueue(_object):
     def task_state(self, taskid):
         return work_queue_task_state(self._work_queue, taskid)
 
-    ## Enables resource monitoring of tasks in the queue. And writes a summary of the monitored information to a file.
+    ## Enables resource monitoring of tasks in the queue, and writes a summary
+    #  per task to the directory given. Additionally, all summaries are
+    #  consolidate into the file all_summaries-PID.log
     #
     #  Returns 1 on success, 0 on failure (i.e., monitoring was not enabled).
     #
     # @param self 	Reference to the current work queue object.
-    # @param summaryfile Filename for the summary log (If NULL, writes to wq-\<pid\>-resource-usage).
-    def enable_monitoring(self, summaryfile):
-        return work_queue_enable_monitoring(self._work_queue, summaryfile)
+    # @param dirname    Directory name for the monitor output.
+    def enable_monitoring(self, dirname):
+        return work_queue_enable_monitoring(self._work_queue, dirname)
+
+    ## As @ref enable_monitoring, but it also generates a time series and a debug file.
+    #  WARNING: Such files may reach gigabyte sizes for long running tasks.
+    #
+    #  Returns 1 on success, 0 on failure (i.e., monitoring was not enabled).
+    #
+    # @param self 	Reference to the current work queue object.
+    # @param dirname    Directory name for the monitor output.
+    def enable_monitoring_full(self, dirname):
+        return work_queue_enable_monitoring_full(self._work_queue, dirname)
 
     ##
     # Turn on or off fast abort functionality for a given queue.

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -420,13 +420,23 @@ the <b>CATALOG_HOST</b> and <b>CATALOG_PORT</b> environmental variables as descr
 struct work_queue *work_queue_create(int port);
 
 /** Enables resource monitoring on the give work queue.
-It generates the log file indicated by monitor_summary_file with all the
-summaries of the resources used by each task.
+It generates a resource summary per task, which is written to the given
+directory. It also creates all_summaries-PID.log, that consolidates all
+summaries into a single.
 @param q A work queue object.
-@param monitor_summary_file The filename of the log (If NULL, it defaults to wq-pid-resource-usage).
+@param monitor_output_dirname The name of the output directory.
 @return 1 on success, 0 if monitoring was not enabled.
 */
 int work_queue_enable_monitoring(struct work_queue *q, char *monitor_summary_file);
+
+
+/** Enables resource monitoring on the give work queue.
+As @ref work_queue_enable_monitoring, but it generates a time series and a monitor debug file (WARNING: for long running tasks these files may reach gigabyte sizes.)
+@param q A work queue object.
+@param monitor_output_dirname The name of the output directory.
+@return 1 on success, 0 if monitoring was not enabled.
+*/
+int work_queue_enable_monitoring_full(struct work_queue *q, char *monitor_output_directory);
 
 /** Submit a task to a queue.
 Once a task is submitted to a queue, it is not longer under the user's


### PR DESCRIPTION
Adds work_queue_enable_monitoring_full which also generates debug monitor output and time series. Should be used judiciously, as these files are in the order of gigabytes for long running tasks.

Also, enable_monitoring asks now for a directory, rather than a filename. This is to be consistent with makeflow.