### PR TITLE
Monitor cleanup/manually add dirs.

### DIFF
--- a/doc/man/resource_monitor.m4
+++ b/doc/man/resource_monitor.m4
@@ -99,6 +99,7 @@ OPTION_TRIPLET(-O,with-output-files,template)Specify template for log files (def
 OPTION_ITEM(--with-time-series)Write resource time series to <template>.series.
 OPTION_ITEM(--with-inotify)Write inotify statistics to <template>.files.
 OPTION_TRIPLET(-V,verbatim-to-summary,str)Include this string verbatim in a line in the summary. (Could be specified multiple times.)
+OPTION_ITEM(--follow-chdir)Follow processes' current working directories.
 OPTION_ITEM(--without-time-series)Do not write the time-series log file.
 OPTION_ITEM(--without-opened-files)Do not write the list of opened files.
 OPTION_ITEM(--without-disk-footprint)Do not measure working directory footprint (default).

--- a/doc/man/resource_monitor.m4
+++ b/doc/man/resource_monitor.m4
@@ -100,6 +100,7 @@ OPTION_ITEM(--with-time-series)Write resource time series to <template>.series.
 OPTION_ITEM(--with-inotify)Write inotify statistics to <template>.files.
 OPTION_TRIPLET(-V,verbatim-to-summary,str)Include this string verbatim in a line in the summary. (Could be specified multiple times.)
 OPTION_ITEM(--follow-chdir)Follow processes' current working directories.
+OPTION_ITEM(--measure-dir=<dir>)Follow the size of <dir>. If not specified, follow the current directory. Can be specified multiple times.
 OPTION_ITEM(--without-time-series)Do not write the time-series log file.
 OPTION_ITEM(--without-opened-files)Do not write the list of opened files.
 OPTION_ITEM(--without-disk-footprint)Do not measure working directory footprint (default).

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -1395,10 +1395,13 @@ static void show_help(const char *cmd)
     fprintf(stdout, "\n");
     fprintf(stdout, "%-30s Use maxfile with list of var: value pairs for resource limits.\n", "-l,--limits-file=<maxfile>");
     fprintf(stdout, "%-30s Use string of the form \"var: value, var: value\" to specify.\n", "-L,--limits=<string>");
-    fprintf(stdout, "%-30s resource limits. (Could be specified multiple times.)\n", "");
+    fprintf(stdout, "%-30s resource limits. Can be specified multiple times.\n", "");
     fprintf(stdout, "\n");
     fprintf(stdout, "%-30s Keep the monitored process in foreground (for interactive use).\n", "-f,--child-in-foreground");
-    fprintf(stdout, "%-30s Follow processes' current working directories. \n", "--follow-chdir");
+    fprintf(stdout, "\n");
+    fprintf(stdout, "%-30s Follow the size of processes' current working directories. \n", "--follow-chdir");
+    fprintf(stdout, "%-30s Follow the size of <dir>. If not specified, follow the current directory.\n", "--measure-dir");
+    fprintf(stdout, "%-30s Can be specified multiple times.\n", "");
     fprintf(stdout, "\n");
     fprintf(stdout, "%-30s Specify filename template for log files (default=resource-pid-<pid>)\n", "-O,--with-output-files=<file>");
     fprintf(stdout, "%-30s Write resource time series to <template>.series\n", "--with-time-series");
@@ -1503,7 +1506,17 @@ int main(int argc, char **argv) {
 
     rmsummary_read_env_vars(resources_limits);
 
+    processes = itable_create(0);
+    wdirs     = hash_table_create(0,0);
+    filesysms = itable_create(0);
+    files     = hash_table_create(0,0);
+
+    wdirs_rc   = itable_create(0);
+    filesys_rc = itable_create(0);
+
 	verbatim_summary_lines = list_create(0);
+
+	char *cwd = getcwd(NULL, 0);
 
 	enum {
 		LONG_OPT_TIME_SERIES = UCHAR_MAX+1,
@@ -1512,7 +1525,8 @@ int main(int argc, char **argv) {
 		LONG_OPT_NO_DISK_FOOTPRINT,
 		LONG_OPT_SH_CMDLINE,
 		LONG_OPT_WORKING_DIRECTORY,
-		LONG_OPT_FOLLOW_CHDIR
+		LONG_OPT_FOLLOW_CHDIR,
+		LONG_OPT_MEASURE_DIR
 	};
 
     static const struct option long_options[] =
@@ -1530,6 +1544,7 @@ int main(int argc, char **argv) {
 		    {"verbatim-to-summary",required_argument, 0, 'V'},
 
 		    {"follow-chdir", no_argument, 0,  LONG_OPT_FOLLOW_CHDIR},
+		    {"measure-dir", required_argument, 0,  LONG_OPT_MEASURE_DIR},
 
 		    {"with-output-files",   required_argument, 0,  'O'},
 		    {"with-time-series",    no_argument, 0, LONG_OPT_TIME_SERIES},
@@ -1542,6 +1557,9 @@ int main(int argc, char **argv) {
 
 	/* By default, measure working directory. */
 	resources_flags->workdir_footprint = 1;
+
+	/* Used in LONG_OPT_MEASURE_DIR */
+	char measure_dir_name[PATH_MAX];
 
     while((c = getopt_long(argc, argv, "c:d:fhi:L:l:o:O:vV:", long_options, NULL)) >= 0)
     {
@@ -1597,12 +1615,22 @@ int main(int argc, char **argv) {
 			case LONG_OPT_FOLLOW_CHDIR:
 				follow_chdir = 1;
 				break;
+			case LONG_OPT_MEASURE_DIR:
+				path_absolute(optarg, measure_dir_name, 0);
+				if(!lookup_or_create_wd(NULL, measure_dir_name))
+					fatal("Directory '%s' does not exist.", optarg);
+				break;
 			default:
 				show_help(argv[0]);
 				return 1;
 				break;
 		}
 	}
+
+	if( follow_chdir && hash_table_size(wdirs) > 0) {
+		fatal("Options --follow-chdir and --measure-dir as mutually exclusive.");
+	}
+
 
     rmsummary_debug_report(resources_limits);
 
@@ -1661,14 +1689,6 @@ int main(int argc, char **argv) {
     rmonitor_helper_init(lib_helper_name, &rmonitor_queue_fd);
 #endif
 
-    processes = itable_create(0);
-    wdirs     = hash_table_create(0,0);
-    filesysms = itable_create(0);
-    files     = hash_table_create(0,0);
-
-    wdirs_rc   = itable_create(0);
-    filesys_rc = itable_create(0);
-
 	summary_path = default_summary_name(template_path);
 
     if(use_series)
@@ -1697,9 +1717,7 @@ int main(int argc, char **argv) {
 
 	/* if we are not following changes in directory, and no directory was manually added, we follow the current working directory. */
 	if(!follow_chdir || hash_table_size(wdirs) == 0) {
-		char *newpath = getcwd(NULL, 0);
-		lookup_or_create_wd(NULL, newpath);
-		free(newpath);
+		lookup_or_create_wd(NULL, cwd);
 	}
 
 	executable = xxstrdup(argv[optind]);

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -582,16 +582,16 @@ void rmonitor_collate_tree(struct rmsummary *tr, struct rmonitor_process_info *p
 	tr->max_concurrent_processes     = (int64_t) itable_size(processes);
 	tr->total_processes     = summary->total_processes;
 
-	tr->virtual_memory    = (int64_t) p->mem.virtual;
-
 	/* we use max here, as /proc/pid/smaps that fills *m is not always
 	 * available. This causes /proc/pid/status to become a conservative
 	 * fallback. */
 	if(m->resident > 0) {
+		tr->virtual_memory    = (int64_t) m->virtual;
 		tr->resident_memory   = (int64_t) m->resident;
 		tr->swap_memory       = (int64_t) m->swap;
 	}
 	else {
+		tr->virtual_memory    = (int64_t) p->mem.virtual;
 		tr->resident_memory   = (int64_t) p->mem.resident;
 		tr->swap_memory       = (int64_t) p->mem.swap;
 	}

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -618,19 +618,19 @@ void rmonitor_log_row(struct rmsummary *tr)
 {
 	if(log_series)
 	{
-		fprintf(log_series,  "%-20" PRId64, tr->wall_time + summary->start);
-		fprintf(log_series, " %20" PRId64, tr->cpu_time);
-		fprintf(log_series, " %25" PRId64, tr->max_concurrent_processes);
-		fprintf(log_series, " %25" PRId64, tr->virtual_memory);
-		fprintf(log_series, " %25" PRId64, tr->resident_memory);
-		fprintf(log_series, " %25" PRId64, tr->swap_memory);
-		fprintf(log_series, " %25" PRId64, tr->bytes_read);
-		fprintf(log_series, " %25" PRId64, tr->bytes_written);
+		fprintf(log_series,  "%-18" PRId64, tr->wall_time + summary->start);
+		fprintf(log_series, " %18" PRId64, tr->cpu_time);
+		fprintf(log_series, " %20" PRId64, tr->max_concurrent_processes);
+		fprintf(log_series, " %20" PRId64, tr->virtual_memory);
+		fprintf(log_series, " %20" PRId64, tr->resident_memory);
+		fprintf(log_series, " %20" PRId64, tr->swap_memory);
+		fprintf(log_series, " %20" PRId64, tr->bytes_read);
+		fprintf(log_series, " %20" PRId64, tr->bytes_written);
 
 		if(resources_flags->workdir_footprint)
 		{
-			fprintf(log_series, " %25" PRId64, tr->workdir_num_files);
-			fprintf(log_series, " %25" PRId64, tr->workdir_footprint);
+			fprintf(log_series, " %20" PRId64, tr->workdir_num_files);
+			fprintf(log_series, " %20" PRId64, tr->workdir_footprint);
 		}
 
 		fprintf(log_series, "\n");
@@ -638,6 +638,9 @@ void rmonitor_log_row(struct rmsummary *tr)
 		/* are we going to keep monitoring the whole filesystem? */
 		// fprintf(log_series "%" PRId64 "\n", tr->fs_nodes);
 	}
+
+	debug(D_RMON, "resources: %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 "% " PRId64 "\n", tr->wall_time + summary->start, tr->cpu_time, tr->max_concurrent_processes, tr->virtual_memory, tr->resident_memory, tr->swap_memory, tr->bytes_read, tr->bytes_written, tr->workdir_num_files, tr->workdir_footprint);
+
 }
 
 void decode_zombie_status(struct rmsummary *summary, int wait_status)
@@ -1539,6 +1542,7 @@ int main(int argc, char **argv) {
 				break;
 			case 'o':
 				debug_config_file(optarg);
+				debug_config_file_size(0);
 				break;
 			case 'h':
 				show_help(argv[0]);

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -788,20 +788,12 @@ int rmonitor_final_summary()
 	char *monitor_self_info = string_format("monitor_version:%9s %d.%d.%d.%.8s", "", CCTOOLS_VERSION_MAJOR, CCTOOLS_VERSION_MINOR, CCTOOLS_VERSION_MICRO, CCTOOLS_COMMIT);
 	list_push_tail(verbatim_summary_lines, monitor_self_info);
 
-	rmonitor_find_files_final_sizes();
-	rmonitor_add_files_to_summary("input_files:",  0);
-	rmonitor_add_files_to_summary("output_files:", 1);
-
-	char *epilogue = rmonitor_consolidate_verbatim_lines();
-	rmsummary_print(log_summary, summary, resources_limits, NULL, epilogue);
-
-	if(monitor_self_info)
-		free(monitor_self_info);
-	if(epilogue)
-		free(epilogue);
-
 	if(log_inotify)
 	{
+		rmonitor_find_files_final_sizes();
+		rmonitor_add_files_to_summary("input_files:",  0);
+		rmonitor_add_files_to_summary("output_files:", 1);
+
         int nfds = rmonitor_inotify_fd + 1;
         int count = 0;
 
@@ -823,6 +815,14 @@ int rmonitor_final_summary()
 
 		rmonitor_file_io_summaries();
 	}
+
+	char *epilogue = rmonitor_consolidate_verbatim_lines();
+	rmsummary_print(log_summary, summary, resources_limits, NULL, epilogue);
+
+	if(monitor_self_info)
+		free(monitor_self_info);
+	if(epilogue)
+		free(epilogue);
 
 	return summary->exit_status;
 }
@@ -1548,7 +1548,7 @@ int main(int argc, char **argv) {
 
 		    {"with-output-files",   required_argument, 0,  'O'},
 		    {"with-time-series",    no_argument, 0, LONG_OPT_TIME_SERIES},
-		    {"with-opened-files",   no_argument, 0, LONG_OPT_OPENED_FILES},
+		    {"with-inotify",   no_argument, 0, LONG_OPT_OPENED_FILES},
 		    {"without-disk-footprint", no_argument, 0, LONG_OPT_NO_DISK_FOOTPRINT},
 
 		    {0, 0, 0, 0}

--- a/resource_monitor/src/rmonitor_helper.c
+++ b/resource_monitor/src/rmonitor_helper.c
@@ -173,6 +173,10 @@ FILE *fopen(const char *path, const char *mode)
 		file = original_fopen(path, mode);
 	POP_ERRNO(msg)
 
+	/* With ENOENT we do not send a message, simply to reduce spam. */
+	if(msg.error == ENOENT)
+		return file;
+
 	/* Consider file as input by default. */
 	msg.type   = OPEN_INPUT;
 
@@ -208,6 +212,10 @@ int open(const char *path, int flags, ...)
 		fd = original_open(path, flags, mode);
 	POP_ERRNO(msg)
 
+	/* With ENOENT we do not send a message, simply to reduce spam. */
+	if(msg.error == ENOENT)
+		return fd;
+
 	/* Consider file as input by default. */
 	msg.type   = OPEN_INPUT;
 
@@ -236,6 +244,10 @@ FILE *fopen64(const char *path, const char *mode)
 	PUSH_ERRNO
 		file = original_fopen64(path, mode);
 	POP_ERRNO(msg)
+
+	/* With ENOENT we do not send a message, simply to reduce spam. */
+	if(msg.error == ENOENT)
+		return file;
 
 	/* Consider file as input by default. */
 	msg.type   = OPEN_INPUT;
@@ -271,6 +283,10 @@ int open64(const char *path, int flags, ...)
 	PUSH_ERRNO
 		fd = original_open64(path, flags, mode);
 	POP_ERRNO(msg)
+
+	/* With ENOENT we do not send a message, simply to reduce spam. */
+	if(msg.error == ENOENT)
+		return fd;
 
 	/* Consider file as input by default. */
 	msg.type   = OPEN_INPUT;


### PR DESCRIPTION
Adds: --follow-chdir (disable by default) and --measure-dir=<dir> (can be specified multiple times).

Cleans debug output and memory measurements on error.

Does not print opened files to summary if inotify is not active.

Fixes #1017.