### PR TITLE
Updated makeflow tests to use INPUTS/OUTPUTS

### DIFF
--- a/makeflow/test/TR_makeflow_023_export_wq.sh
+++ b/makeflow/test/TR_makeflow_023_export_wq.sh
@@ -17,6 +17,9 @@ prepare()
 	mkdir -p $TEST_DIR
 	cd $TEST_DIR
 	cat > test.mf <<EOF
+MAKEFLOW_INPUTS=""
+MAKEFLOW_OUTPUTS=output.txt
+
 export HELLO=hello makeflow
 export GOODBYE
 output.txt:

--- a/makeflow/test/TR_makeflow_030_gc_on_demand.sh
+++ b/makeflow/test/TR_makeflow_030_gc_on_demand.sh
@@ -13,9 +13,9 @@ prepare()
 	ln -sf ../syntax/collect.makeflow .
 cat > ../$test_output <<EOF
 7
-5
+8
 6
-5
+8
 EOF
 	exit 0
 }

--- a/makeflow/test/TR_makeflow_040_recursive.sh
+++ b/makeflow/test/TR_makeflow_040_recursive.sh
@@ -22,11 +22,17 @@ hello
 EOF
 
 cat > toplevel.makeflow <<EOF
+MAKEFLOW_INPUTS=input.txt
+MAKEFLOW_OUTPUTS=out.actual
+
 out.actual: input.txt
 	MAKEFLOW sublevel.makeflow
 EOF
 
 cat > sublevel.makeflow <<EOF
+MAKEFLOW_INPUTS=input.txt
+MAKEFLOW_OUTPUTS=out.actual
+
 out.1: input.txt
 	cat input.txt > out.1
 

--- a/makeflow/test/TR_makeflow_remote_naming.sh
+++ b/makeflow/test/TR_makeflow_remote_naming.sh
@@ -20,6 +20,9 @@ hello
 EOF
 
 cat > $MAKE_FILE <<EOF
+MAKEFLOW_INPUTS=input.txt
+MAKEFLOW_OUTPUTS=out.actual
+
 out.1 -> out.txt: input.txt -> input.1
 	cat input.1 > out.txt
 

--- a/makeflow/test/dirs/testcase.subdir.01.makeflow
+++ b/makeflow/test/dirs/testcase.subdir.01.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=input/hello
+MAKEFLOW_OUTPUTS=mydir
+
 # a single directory as a target
 mydir: input/hello
 	mkdir -p mydir; cp input/hello mydir/1.txt; cp input/hello mydir/2.txt

--- a/makeflow/test/dirs/testcase.subdir.02.makeflow
+++ b/makeflow/test/dirs/testcase.subdir.02.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=input/hello
+MAKEFLOW_OUTPUTS=mydir/1.txt mydir/2.txt
+
 # files as target files ( should create directories on their paths if not exist)
 mydir/1.txt mydir/2.txt: input/hello
 	mkdir -p mydir; cp input/hello mydir/1.txt; cp input/hello mydir/2.txt

--- a/makeflow/test/dirs/testcase.subdir.03.makeflow
+++ b/makeflow/test/dirs/testcase.subdir.03.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=input
+MAKEFLOW_OUTPUTS=mydir/1.txt mydir/2.txt
+
 # directory as input file
 mydir/1.txt mydir/2.txt: input
 	mkdir -p mydir; cp input/hello mydir/1.txt; cp input/hello mydir/2.txt

--- a/makeflow/test/dirs/testcase.subdir.04.makeflow
+++ b/makeflow/test/dirs/testcase.subdir.04.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=input
+MAKEFLOW_OUTPUTS=mydir
+
 # target and source files are both directories
 mydir: input
 	mkdir -p mydir; cp input/hello mydir/1.txt; cp input/hello mydir/2.txt

--- a/makeflow/test/dirs/testcase.subdir.05.makeflow
+++ b/makeflow/test/dirs/testcase.subdir.05.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=input
+MAKEFLOW_OUTPUTS=mydir mydir/1.txt mydir/2.txt
+
 # specify everything (directories and files) in the target file section
 mydir mydir/1.txt mydir/2.txt: input
 	mkdir -p mydir; cp input/hello mydir/1.txt; cp input/hello mydir/2.txt

--- a/makeflow/test/dirs/testcase.subdir.06.makeflow
+++ b/makeflow/test/dirs/testcase.subdir.06.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=input
+MAKEFLOW_OUTPUTS=mydir/1.txt mydir/2.txt mydir
+
 # specify everything (directories and files) in the target file section, but directory at the end (order of the targets creation is not as specified). This should work.
 mydir/1.txt mydir/2.txt mydir: input
 	mkdir -p mydir; cp input/hello mydir/1.txt; cp input/hello mydir/2.txt

--- a/makeflow/test/dirs/testcase.subdir.07.makeflow
+++ b/makeflow/test/dirs/testcase.subdir.07.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=input
+MAKEFLOW_OUTPUTS=mydir mydir/1.txt mydir/3.txt
+
 # second rule should not have to create 'mydir' in its command
 mydir mydir/1.txt: input
 	mkdir -p mydir; cp input/hello mydir/1.txt; cp input/hello mydir/2.txt

--- a/makeflow/test/dirs/testcase.subdir.08.makeflow
+++ b/makeflow/test/dirs/testcase.subdir.08.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=input
+MAKEFLOW_OUTPUTS=mydir/mysubdir/1.txt
+
 # dir depth larger than 2. target is a file
 mydir/mysubdir/1.txt: input
 	mkdir -p mydir; mkdir -p mydir/mysubdir; cp input/hello mydir/mysubdir/1.txt

--- a/makeflow/test/dirs/testcase.subdir.09.makeflow
+++ b/makeflow/test/dirs/testcase.subdir.09.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=input
+MAKEFLOW_OUTPUTS=mydir
+
 # dir depth larger than 2. Target is the root directory
 mydir: input
 	mkdir -p mydir; mkdir -p mydir/mysubdir; cp input/hello mydir/mysubdir/1.txt

--- a/makeflow/test/dirs/testcase.subdir.10.makeflow
+++ b/makeflow/test/dirs/testcase.subdir.10.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=input
+MAKEFLOW_OUTPUTS=mydir
+
 # dir depth larger than 2. Target is the sub-directory 'mysubdir'.
 mydir: input
 	mkdir -p mydir; mkdir -p mydir/mysubdir; cp input/hello mydir/mysubdir/1.txt

--- a/makeflow/test/dirs/testcase.subdir.11.makeflow
+++ b/makeflow/test/dirs/testcase.subdir.11.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=input
+MAKEFLOW_OUTPUTS=1.txt mydir mydir.txt mydir/1.txt mydir/2.txt mydir/1 mydir/1/a.txt mydir/1/b.txt mydir/1/haha/lala.txt mydir/1/haha/wawa.txt
+
 # many directories. Prove on redundant transfer with debug on!
 1.txt mydir mydir.txt mydir/1.txt mydir/2.txt mydir/1 mydir/1/a.txt mydir/1/b.txt mydir/1/haha/lala.txt mydir/1/haha/wawa.txt: input
 	echo top > 1.txt; echo level > mydir.txt; mkdir -p mydir; cp input/hello mydir/1.txt; cp input/hello mydir/2.txt; mkdir -p mydir/1;cp input/hello mydir/1/a.txt; cp input/hello mydir/1/b.txt; mkdir -p mydir/1/haha; echo hello > mydir/1/haha/lala.txt; echo world > mydir/1/haha/wawa.txt

--- a/makeflow/test/syntax/Makeflow
+++ b/makeflow/test/syntax/Makeflow
@@ -1,6 +1,9 @@
 CP=/bin/cp
 BASEDIR=../../src/
 
+MAKEFLOW_INPUTS=$BASEDIR/makeflow.c
+MAKEFLOW_OUTPUTS=total_line_count.txt
+
 makeflow.c: $BASEDIR/makeflow.c
 	$CP $BASEDIR/makeflow.c makeflow.c
 

--- a/makeflow/test/syntax/collect.makeflow
+++ b/makeflow/test/syntax/collect.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=""
+MAKEFLOW_OUTPUTS="_collect.7"
+
 _collect.0:
 	touch _collect.0 ; ls | wc -l > _collect.0 
 

--- a/makeflow/test/syntax/export.external.makeflow
+++ b/makeflow/test/syntax/export.external.makeflow
@@ -1,6 +1,9 @@
 export ECHOB=echob
 export ECHOC=$ECHOA
 
+MAKEFLOW_INPUTS=$ECHOA $ECHOC
+MAKEFLOW_OUTPUTS="out.all"
+
 out.all: $ECHOA $ECHOC
 	$ECHOA $ECHOA $ECHOB > out.all; $ECHOC $ECHOC $ECHOB >> out.all	
 

--- a/makeflow/test/syntax/export.makeflow
+++ b/makeflow/test/syntax/export.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=""
+MAKEFLOW_OUTPUTS="out.all"
+
 VAR0=0
 VAR1=1
 export VAR1

--- a/makeflow/test/syntax/line_continuation.makeflow
+++ b/makeflow/test/syntax/line_continuation.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=
+MAKEFLOW_OUTPUTS=out2
+
 out1:
 	echo "One" "Two" \
     "Three" > out1

--- a/makeflow/test/syntax/meta.makeflow
+++ b/makeflow/test/syntax/meta.makeflow
@@ -9,6 +9,9 @@
 # Copyright 2010 The University of Notre Dame. All rights reserved. See file
 # COPYING for details.
 
+MAKEFLOW_INPUTS="typo.makeflow"
+MAKEFLOW_OUTPUTS="correct.makeflow"
+
 correct.makeflow: typo.makeflow
 	LOCAL < typo.makeflow > correct.makeflow sed "s!capital!capitol!g"
 

--- a/makeflow/test/syntax/meta2.makeflow
+++ b/makeflow/test/syntax/meta2.makeflow
@@ -9,6 +9,9 @@
 # Copyright 2010 The University of Notre Dame. All rights reserved. See file
 # COPYING for details.
 
+MAKEFLOW_INPUTS="typo.makeflow"
+MAKEFLOW_OUTPUTS="correct.makeflow"
+
 correct.makeflow: typo.makeflow
 	LOCAL <typo.makeflow >correct.makeflow sed "s!capital!capitol!g"
 

--- a/makeflow/test/syntax/options.makeflow
+++ b/makeflow/test/syntax/options.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=""
+MAKEFLOW_OUTPUTS=""
+
 uname.disc:
 BATCH_OPTIONS='requirements = MachineGroup == "disc"'
 	uname -a > uname.disc

--- a/makeflow/test/syntax/recursive.makeflow
+++ b/makeflow/test/syntax/recursive.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS=options.makeflow test.makeflow
+MAKEFLOW_OUTPUTS=uname.append.0 uname.append.1 capitol.montage.gif
+
 uname.append.0 uname.append.1: options.makeflow
 BATCH_LOCAL=1
 	MAKEFLOW options.makeflow

--- a/makeflow/test/syntax/remote_name.makeflow
+++ b/makeflow/test/syntax/remote_name.makeflow
@@ -1,3 +1,7 @@
+
+MAKEFLOW_INPUTS="curl"
+MAKEFLOW_OUTPUTS="capitol.diff"
+
 URL=http://ccl.cse.nd.edu/images/capitol.jpg
 
 capitol.diff: capitol.0.jpg capitol.270.jpg

--- a/makeflow/test/syntax/test.makeflow
+++ b/makeflow/test/syntax/test.makeflow
@@ -10,6 +10,9 @@ CURL=/usr/bin/curl
 CONVERT=/usr/bin/convert
 URL=http://ccl.cse.nd.edu/images/capitol.jpg
 
+MAKEFLOW_INPUTS=$CURL
+MAKEFLOW_OUTPUTS="capitol.montage.gif"
+
 capitol.montage.gif: capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg $CONVERT
 	$CONVERT -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.montage.gif
 

--- a/makeflow/test/syntax/typo.makeflow
+++ b/makeflow/test/syntax/typo.makeflow
@@ -7,6 +7,9 @@
 # Copyright 2010 The University of Notre Dame. All rights reserved. See file
 # COPYING for details.
 
+MAKEFLOW_INPUTS=""
+MAKEFLOW_OUTPUTS="capitol.montage.gif"
+
 CURL=/usr/bin/curl
 CONVERT=/usr/bin/convert
 URL=http://ccl.cse.nd.edu/images/capitol.jpg

--- a/makeflow/test/syntax/variable_issues.makeflow
+++ b/makeflow/test/syntax/variable_issues.makeflow
@@ -5,6 +5,9 @@
 # Created by K. Partington, 28 February 2010.
 # Copyright University of Notre Dame, 2010. See file COPYING for details.
 
+MAKEFLOW_INPUTS=""
+MAKEFLOW_OUTPUTS="output"
+
 VAR=cool
 VAR="ultra-cool"
 =bad

--- a/makeflow/test/syntax/variable_scope.makeflow
+++ b/makeflow/test/syntax/variable_scope.makeflow
@@ -1,4 +1,8 @@
 # Global
+
+MAKEFLOW_INPUTS=""
+MAKEFLOW_OUTPUTS="out.all"
+
 VAR1 = 1
 
 out.0:


### PR DESCRIPTION
Fixes failure in Makeflow GC on-demand test and adds INTPUTS and OUTPUTS line to test makeflows so as to eliminate the notice lines printed during testing.