### PR TITLE
Log recovery silently resets nodes if cleaning

### DIFF
--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -198,7 +198,9 @@ static void makeflow_abort_all(struct dag *d)
 static void makeflow_node_force_rerun(struct itable *rerun_table, struct dag *d, struct dag_node *n);
 
 /*
-Decide whether to rerun a node based on batch and file system status.
+Decide whether to rerun a node based on batch and file system status. The silent
+option was added for to prevent confusing debug output when in clean mode. When
+clean_mode is not NONE we silence the node reseting output.
 */
 
 void makeflow_node_decide_rerun(struct itable *rerun_table, struct dag *d, struct dag_node *n, int silent)

--- a/makeflow/src/makeflow_log.c
+++ b/makeflow/src/makeflow_log.c
@@ -165,6 +165,9 @@ void makeflow_log_gc_event( struct dag *d, int collected, timestamp_t elapsed, i
 	makeflow_log_sync(d,0);
 }
 
+/** The clean_mode variable was added so that we could better print out error messages
+ * apply in the situation. Currently only used to silence node rerun checking.
+ */
 void makeflow_log_recover(struct dag *d, const char *filename, int verbose_mode, struct batch_queue *queue, makeflow_clean_depth clean_mode)
 {
 	char *line, *name, file[MAX_BUFFER_SIZE];

--- a/makeflow/src/makeflow_log.c
+++ b/makeflow/src/makeflow_log.c
@@ -86,7 +86,7 @@ timestamp - the unix time (in microseconds) when this line is written to the log
 These event types indicate that the workflow as a whole has started or completed in the indicated manner.
 */
 
-void makeflow_node_decide_rerun(struct itable *rerun_table, struct dag *d, struct dag_node *n );
+void makeflow_node_decide_rerun(struct itable *rerun_table, struct dag *d, struct dag_node *n, int silent );
 
 /*
 To balance between performance and consistency, we sync the log every 60 seconds
@@ -165,7 +165,7 @@ void makeflow_log_gc_event( struct dag *d, int collected, timestamp_t elapsed, i
 	makeflow_log_sync(d,0);
 }
 
-void makeflow_log_recover(struct dag *d, const char *filename, int verbose_mode, struct batch_queue *queue)
+void makeflow_log_recover(struct dag *d, const char *filename, int verbose_mode, struct batch_queue *queue, makeflow_clean_depth clean_mode)
 {
 	char *line, *name, file[MAX_BUFFER_SIZE];
 	int nodeid, state, jobid, file_state;
@@ -290,11 +290,12 @@ void makeflow_log_recover(struct dag *d, const char *filename, int verbose_mode,
 		}
 	}
 
+	int silent = clean_mode != MAKEFLOW_GC_NONE;
 	// Decide rerun tasks
 	if(!first_run) {
 		struct itable *rerun_table = itable_create(0);
 		for(n = d->nodes; n; n = n->next) {
-			makeflow_node_decide_rerun(rerun_table, d, n);
+			makeflow_node_decide_rerun(rerun_table, d, n, silent);
 		}
 		itable_delete(rerun_table);
 	}

--- a/makeflow/src/makeflow_log.h
+++ b/makeflow/src/makeflow_log.h
@@ -8,6 +8,7 @@ See the file COPYING for details.
 #define MAKEFLOW_LOG_H
 
 #include "dag.h"
+#include "makeflow_gc.h"
 #include "timestamp.h"
 
 /*
@@ -24,6 +25,6 @@ void makeflow_log_completed_event( struct dag *d );
 void makeflow_log_state_change( struct dag *d, struct dag_node *n, int newstate );
 void makeflow_log_file_state_change( struct dag *d, struct dag_file *f, int newstate );
 void makeflow_log_gc_event( struct dag *d, int collected, timestamp_t elapsed, int total_collected );
-void makeflow_log_recover( struct dag *d, const char *filename, int verbose_mode, struct batch_queue *queue );
+void makeflow_log_recover( struct dag *d, const char *filename, int verbose_mode, struct batch_queue *queue, makeflow_clean_depth clean_mode );
 
 #endif


### PR DESCRIPTION
We still reset the node state, we just don't report that we are retrying the node if we are cleaning.
Address #1003. @btovar 