### PR TITLE
Fix segfault in work_queue_status

### DIFF
--- a/work_queue/src/work_queue_status.c
+++ b/work_queue/src/work_queue_status.c
@@ -235,7 +235,8 @@ int get_masters(time_t stoptime)
 		if(i == catalog_size)
 			resize_catalog( catalog_size * 2 );
 
-		if(strcmp(jx_lookup_string(j, "type"), "wq_master") == 0) {
+		const char *type = jx_lookup_string(j,"type");
+		if(type && !strcmp(type,"wq_master") == 0) {
 			global_catalog[i] = j; // make the global catalog point to this memory that j references
 			i++;                    // only increment i when a master jx is found
 		} else{


### PR DESCRIPTION
Crash only occurs when catalog has invalid expressions with null type.