### PR TITLE
Skip process if an error is found

### DIFF
--- a/dttools/src/rmonitor_poll.c
+++ b/dttools/src/rmonitor_poll.c
@@ -456,6 +456,9 @@ int rmonitor_get_mmaps_usage(pid_t pid, struct hash_table *maps)
 }
 
 int rmonitor_poll_maps_once(struct itable *processes, struct rmonitor_mem_info *mem) {
+	/* set result to 0. */
+	bzero(mem, sizeof(struct rmonitor_mem_info));
+
 	struct hash_table *maps_per_file = hash_table_create(0, 0);
 
 	uint64_t pid;
@@ -485,14 +488,8 @@ int rmonitor_poll_maps_once(struct itable *processes, struct rmonitor_mem_info *
 	 * bounds.
 	 */
 
-	if(mem->map_name)
-		free(mem->map_name);
-
-	/* set result to 0. */
-	bzero(mem, sizeof(struct rmonitor_mem_info));
-
-	struct list *infos;
 	char *map_name;
+	struct list *infos;
 
 	hash_table_firstkey(maps_per_file);
 	while(hash_table_nextkey(maps_per_file, &map_name, (void *) &infos )) {

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -1522,6 +1522,7 @@ int rmonitor_resources(long int interval /*in microseconds */)
 
     free(resources_now);
     free(p_acc);
+    free(m_acc);
     free(d_acc);
     free(f_acc);
 


### PR DESCRIPTION
Before, we would report the previous correct value per resource. Now they are reported by sets.