### PR TITLE
Use same field names in debug and standard output.

### DIFF
--- a/work_queue/src/work_queue_pool.c
+++ b/work_queue/src/work_queue_pool.c
@@ -513,8 +513,9 @@ static void mainloop( struct batch_queue *queue, const char *project_regex, cons
 
 		int new_workers_needed = workers_needed - workers_submitted;
 
-		debug(D_WQ,"workers needed: %d",workers_needed);
-		debug(D_WQ,"workers in queue: %d",workers_submitted);
+		debug(D_WQ,"workers needed: %d",    workers_needed);
+		debug(D_WQ,"workers submitted: %d", workers_submitted);
+		debug(D_WQ,"workers requested: %d", new_workers_needed);
 
 		print_stats(masters_list, foremen_list, workers_submitted, workers_needed, new_workers_needed);
 


### PR DESCRIPTION
Use "workers needed", "workers requested", and "workers submitted", rather than "raw needed",
"in queue", etc.

As requested by @matz-e.