### PR TITLE
Disk alloc fix

### DIFF
--- a/dttools/src/disk_alloc.c
+++ b/dttools/src/disk_alloc.c
@@ -163,13 +163,11 @@ int disk_alloc_delete(char *loc) {
 	int k;
 	int max_mount_path_length = 62;
 
-	//Copy only pathname of the mountpoint without extraneous characters
+	//Copy only pathname of the mountpoint without extraneous paretheses
 	for(k = 1; k < loop_dev_path_length; k++) {
 		loop_mountpoint_array[k-1] = loop_mount[k];
 	}
-	for(k; k < 128; k++) {
-		loop_mountpoint_array[k] = '\0';
-	}
+	loop_mountpoint_array[k] = '\0';
 
 	if(strncmp(loop_mountpoint_array, device_loc, max_mount_path_length) == 0) {
 

--- a/dttools/src/disk_alloc.c
+++ b/dttools/src/disk_alloc.c
@@ -131,7 +131,7 @@ int disk_alloc_delete(char *loc) {
 	//Find Used Device
 	char *dev_num = "-1";
 	device_loc = string_format("%s/alloc.img", loc);
-	
+
 	//Loop Device Unmounted
 	result = umount2(loc, MNT_FORCE);
 	if(result != 0) {

--- a/dttools/src/disk_alloc.c
+++ b/dttools/src/disk_alloc.c
@@ -149,16 +149,29 @@ int disk_alloc_delete(char *loc) {
 		}
 	}
 
+	//Find pathname of mountpoint associated with loop devide
 	char loop_dev[128], loop_info[128], loop_mount[128];
 	FILE *loop_find;
 	losetup_args = string_format("losetup -j %s", device_loc);
 	loop_find = popen(losetup_args, "r");
 	fscanf(loop_find, "%s %s %s", loop_dev, loop_info, loop_mount);
 	pclose(loop_find);
-	loop_mount[0] = '\0';
-	loop_mount[strlen(loop_mount) - 1] = '\0';
+	int loop_dev_path_length = strlen(loop_mount);
+	loop_mount[loop_dev_path_length - 1] = '\0';
 	loop_dev[strlen(loop_dev) - 1] = '\0';
-	if(strncmp(loop_mount, device_loc, 62) + 47 == 0) {
+	char loop_mountpoint_array[128];
+	int k;
+	int max_mount_path_length = 62;
+
+	//Copy only pathname of the mountpoint without extraneous characters
+	for(k = 1; k < loop_dev_path_length; k++) {
+		loop_mountpoint_array[k-1] = loop_mount[k];
+	}
+	for(k; k < 128; k++) {
+		loop_mountpoint_array[k] = '\0';
+	}
+
+	if(strncmp(loop_mountpoint_array, device_loc, max_mount_path_length) == 0) {
 
 		dev_num = loop_dev;
 	}

--- a/dttools/src/disk_alloc.c
+++ b/dttools/src/disk_alloc.c
@@ -139,6 +139,7 @@ int disk_alloc_delete(char *loc) {
 	char *losetup_args = NULL;
 	char *rm_args = NULL;
 	char *device_loc = NULL;
+	char *losetup_del_args = NULL;
 
 	//Find Used Device
 	char *dev_num = "-1";
@@ -186,7 +187,7 @@ int disk_alloc_delete(char *loc) {
 	}
 
 	rm_args = string_format("%s/alloc.img", loc);
-	losetup_args = string_format("losetup -d %s", dev_num);
+	losetup_del_args = string_format("losetup -d %s", dev_num);
 
 	//Loop Device Deleted
 	result = system(losetup_args);
@@ -212,6 +213,7 @@ int disk_alloc_delete(char *loc) {
 		goto error;
 	}
 
+	free(losetup_del_args);
 	free(losetup_args);
 	free(rm_args);
 	free(device_loc);
@@ -219,6 +221,9 @@ int disk_alloc_delete(char *loc) {
 	return 0;
 
 	error:
+		if(losetup_del_args) {
+			free(losetup_del_args);
+		}
 		if(losetup_args) {
 			free(losetup_args);
 		}

--- a/dttools/src/disk_alloc.c
+++ b/dttools/src/disk_alloc.c
@@ -164,11 +164,10 @@ int disk_alloc_delete(char *loc) {
 	else {
 		device_loc = string_format("%s/alloc.img", loc);
 	}
-	
 
 	//Find Used Device
 	char *dev_num = "-1";
-	
+
 	//Loop Device Unmounted
 	result = umount2(loc, MNT_FORCE);
 	if(result != 0) {

--- a/dttools/src/disk_alloc.c
+++ b/dttools/src/disk_alloc.c
@@ -32,15 +32,14 @@ int disk_alloc_create(char *loc, int64_t size) {
 	path_remove_trailing_slashes(loc);
 
 	int result;
-	char *device_loc, *dd_args, *losetup_args, *mk_args, *mount_args;
-	dd_args = string_format("junk");
-	losetup_args = string_format("junk");
-	mk_args = string_format("junk");
-	mount_args = string_format("junk");
+	char *device_loc = NULL;
+	char *dd_args = NULL;
+	char *losetup_args = NULL;
+	char *mk_args = NULL;
+	char *mount_args = NULL;
 
 	//Set Loopback Device Location
 	device_loc = string_format("%s/alloc.img", loc);
-
 	//Make Directory for Loop Device
 	if(mkdir(loc, 0777) != 0) {
 
@@ -108,11 +107,22 @@ int disk_alloc_create(char *loc, int64_t size) {
 	return 0;
 
 	error:
-		free(device_loc);
-		free(dd_args);
-		free(losetup_args);
-		free(mk_args);
-		free(mount_args);
+		if(device_loc) {
+			free(device_loc);
+		}
+		if(dd_args) {
+			free(dd_args);
+		}
+		if(losetup_args) {
+			free(losetup_args);
+		}
+		if(mk_args) {
+			free(mk_args);
+		}
+		if(mount_args) {
+			free(mount_args);
+		}
+
 		return -1;
 }
 
@@ -123,10 +133,9 @@ int disk_alloc_delete(char *loc) {
 	//Check for trailing '/'
 	path_remove_trailing_slashes(loc);
 
-	char *losetup_args, *rm_args, *device_loc;
-	losetup_args = string_format("junk");
-	rm_args = string_format("junk");
-	device_loc = string_format("junk");
+	char *losetup_args = NULL;
+	char *rm_args = NULL;
+	char *device_loc = NULL;
 
 	//Find Used Device
 	char *dev_num = "-1";
@@ -135,7 +144,6 @@ int disk_alloc_delete(char *loc) {
 	//Loop Device Unmounted
 	result = umount2(loc, MNT_FORCE);
 	if(result != 0) {
-
 		if(errno != ENOENT) {
 			goto error;
 		}
@@ -143,7 +151,6 @@ int disk_alloc_delete(char *loc) {
 
 	char loop_dev[128], loop_info[128], loop_mount[128];
 	FILE *loop_find;
-
 	losetup_args = string_format("losetup -j %s", device_loc);
 	loop_find = popen(losetup_args, "r");
 	fscanf(loop_find, "%s %s %s", loop_dev, loop_info, loop_mount);
@@ -194,10 +201,15 @@ int disk_alloc_delete(char *loc) {
 	return 0;
 
 	error:
-
-		free(losetup_args);
-		free(rm_args);
-		free(device_loc);
+		if(losetup_args) {
+			free(losetup_args);
+		}
+		if(rm_args) {
+			free(rm_args);
+		}
+		if(device_loc) {
+			free(device_loc);
+		}
 
 		return -1;
 }

--- a/dttools/src/disk_alloc.c
+++ b/dttools/src/disk_alloc.c
@@ -50,11 +50,11 @@ int disk_alloc_create(char *loc, int64_t size) {
 	dd_args = string_format("dd if=/dev/zero of=%s bs=1024 count=%"PRId64"", device_loc, size);
 	if(system(dd_args) != 0) {
 		debug(D_NOTICE, "Failed to allocate junk space for loop device image: %s.\n", strerror(errno));
-		if(unlink(device_loc)) {
+		if(unlink(device_loc) == -1) {
 			debug(D_NOTICE, "Failed to unlink loop device image while attempting to clean up after failure: %s.\n", strerror(errno));
 			goto error;
 		}
-		if(rmdir(loc)) {
+		if(rmdir(loc) == -1) {
 			debug(D_NOTICE, "Failed to remove directory of loop device image while attempting to clean up after failure: %s.\n", strerror(errno));
 		}
 		goto error;
@@ -81,11 +81,11 @@ int disk_alloc_create(char *loc, int64_t size) {
 
 	if(losetup_flag == 1) {
 		debug(D_NOTICE, "Failed to attach image to loop device: %s.\n", strerror(errno));
-		if(unlink(device_loc)) {
+		if(unlink(device_loc) == -1) {
 			debug(D_NOTICE, "Failed to unlink loop device image while attempting to clean up after failure: %s.\n", strerror(errno));
 			goto error;
 		}
-		if(rmdir(loc)) {
+		if(rmdir(loc) == -1) {
 			debug(D_NOTICE, "Failed to remove directory of loop device image while attempting to clean up after failure: %s.\n", strerror(errno));
 		}
 		goto error;


### PR DESCRIPTION
Fixes the way disk_alloc_delete finds and resolves the correct name of the mountpoint that is passed to losetup. This is necessary to de-allocate loop devices with a mountpoint pathname greater than 62 characters long.