### PR TITLE
WQ categories

### DIFF
--- a/work_queue/src/perl/Work_Queue.pm
+++ b/work_queue/src/perl/Work_Queue.pm
@@ -111,6 +111,11 @@ sub activate_fast_abort {
 	return work_queue_activate_fast_abort($self->{_work_queue}, $multiplier);
 }
 
+sub activate_fast_abort_category {
+	my ($self, $name, $multiplier) = @_;
+	return work_queue_activate_fast_abort_category($self->{_work_queue}, $name, $multiplier);
+}
+
 sub empty {
 	my ($self) = @_;
 	return work_queue_empty($self->{_work_queue});
@@ -369,19 +374,45 @@ Returns 1 on success, 0 on failure (i.e., monitoring was not enabled).
 
 =back
 
+=head3 C<activate_fast_abort>
 
-=head3 C<fast_abort>
-
-Turn on or off fast abort functionality for a given queue.
+Turn on or off fast abort functionality for a given queue for tasks without
+an explicit category. Given the multiplier, abort a task which running time is
+larger than the average times the multiplier.  Fast-abort is computed per task
+category. The value specified here applies to all the categories for which @ref
+activate_fast_abort_category was not explicitely called.
 
 =over 12
 
 =item multiplier
 
-The multiplier of the average task time at which point to abort; if
-negative (the default) fast_abort is deactivated.
+The multiplier of the average task time at which point to abort; if less than zero, fast_abort is deactivated (the default).
 
 =back
+
+
+=head3 C<activate_fast_abort_category>
+
+Turn on or off fast abort functionality for a given category. Given the
+multiplier, abort a task which running time is larger than the average times
+the multiplier.  The value specified here applies only to tasks in the given
+category.  (Note: work_queue_activate_fast_abort_category(q, "default", n) is
+the same as work_queue_activate_fast_abort(q, n).)
+
+=over 12
+
+=item name
+
+The name of the category.
+
+=item multiplier
+
+The multiplier of the average task time at which point to abort; if zero,
+fast_abort is deactivated. If less than zero (default), use the fast abort of
+the "default" category.
+
+=back
+
 
 =head3 C<empty>
 

--- a/work_queue/src/perl/Work_Queue/Task.pm
+++ b/work_queue/src/perl/Work_Queue/Task.pm
@@ -54,6 +54,11 @@ sub specify_tag {
 	return work_queue_task_specify_tag($self->{_task}, $tag);;
 }
 
+sub specify_category {
+	my ($self, $name) = @_;
+	return work_queue_task_specify_category($self->{_task}, $name);;
+}
+
 sub clone {
 	my ($self) = @_;
 	my $copy = $self;
@@ -416,7 +421,20 @@ Attach a user defined logical name to the task.
 
 =item tag
 
-The tag to be executed.
+The tag to be assigned.
+
+=back
+
+=head3 C<specify_category>
+
+Label the task with the given category. It is expected that tasks with the same category
+have similar resources requirements (e.g. for fast abort).
+
+=over 12
+
+=item tag
+
+The name of the category.
 
 =back
 

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -94,6 +94,15 @@ class Task(_object):
         return work_queue_task_specify_tag(self._task, tag)
 
     ##
+    # Label the task with the given category. It is expected that tasks with the
+    # same category have similar resources requirements (e.g. for fast abort).
+    #
+    # @param self       Reference to the current task object.
+    # @param name       The name of the category
+    def specify_category(self, tag):
+        return work_queue_task_specify_category(self._task, name)
+
+    ##
     # Indicate that the task would be optimally run on a given host.
     #
     # @param self       Reference to the current task object.
@@ -723,12 +732,23 @@ class WorkQueue(_object):
         return work_queue_enable_monitoring_full(self._work_queue, dirname)
 
     ##
-    # Turn on or off fast abort functionality for a given queue.
+    # Turn on or off fast abort functionality for a given queue for tasks in
+    # the "default" category, and for task which category does not set an
+    # explicit multiplier.
     #
     # @param self       Reference to the current work queue object.
     # @param multiplier The multiplier of the average task time at which point to abort; if negative (the default) fast_abort is deactivated.
     def activate_fast_abort(self, multiplier):
         return work_queue_activate_fast_abort(self._work_queue, multiplier)
+
+    ##
+    # Turn on or off fast abort functionality for a given queue.
+    #
+    # @param self       Reference to the current work queue object.
+    # @param name       Name of the category.
+    # @param multiplier The multiplier of the average task time at which point to abort; if zero, deacticate for the category, negative (the default), use the one for the "default" category (see @ref fast_abort)
+    def activate_fast_abort_category(self, name, multiplier):
+        return work_queue_activate_fast_abort_category(self._work_queue, multiplier)
 
     ##
     # Determine whether there are any known tasks queued, running, or waiting to be collected.

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -153,10 +153,11 @@ struct work_queue_task {
 
 	struct rmsummary *resources_measured;                  /**< When monitoring is enabled, it points to the measured resources used by the task. */
 
-	timestamp_t time_app_delay;                            /**< @deprecated The time spent in upper-level application (outside of work_queue_wait). */
-
 	timestamp_t maximum_running_time;                      /**< Maximum time (microseconds) this task may run in a worker. If less than 1, no limit is enforced (default).*/
 
+	char *category;                                        /**< User-provided label for the task. It is expected that all task with the same category will have similar resource usage. See @ref work_queue_task_specify_category. If no explicit category is given, the label "default" is used. **/
+
+	timestamp_t time_app_delay;                            /**< @deprecated The time spent in upper-level application (outside of work_queue_wait). */
 };
 
 /** Statistics describing a work queue. */
@@ -370,6 +371,14 @@ in identifying tasks when they complete.
 */
 void work_queue_task_specify_tag(struct work_queue_task *t, const char *tag);
 
+/** Label the task with the given category. It is expected that tasks with the same category
+have similar resources requirements (e.g. for fast abort).
+@param q A work queue object.
+@param t A task object.
+@param category The name of the category to use.
+*/
+void work_queue_task_specify_category(struct work_queue_task *t, const char *category);
+
 /** Specify the priority of this task relative to others in the queue.
 Tasks with a higher priority value run first. If no priority is given, a task is placed at the end of the ready list, regardless of the priority.
 @param t A task object.
@@ -582,12 +591,28 @@ indicating how many from each worker pool are attached.
 */
 char * work_queue_get_worker_summary( struct work_queue *q );
 
-/** Turn on or off fast abort functionality for a given queue.
+/** Turn on or off fast abort functionality for a given queue for tasks without
+an explicit category. Given the multiplier, abort a task which running time is
+larger than the average times the multiplier.  Fast-abort is computed per task
+category. The value specified here applies to all the categories for which @ref
+work_queue_activate_fast_abort_category was not explicitely called.
 @param q A work queue object.
-@param multiplier The multiplier of the average task time at which point to abort; if negative (and by default) fast_abort is deactivated.
+@param multiplier The multiplier of the average task time at which point to abort; if less than 1 (and by default) fast_abort is deactivated.
 @returns 0 if activated or deactivated with an appropriate multiplier, 1 if deactivated due to inappropriate multiplier.
 */
 int work_queue_activate_fast_abort(struct work_queue *q, double multiplier);
+
+
+/** Turn on or off fast abort functionality for a given category. Given the
+multiplier, abort a task which running time is larger than the average times the
+multiplier.  The value specified here applies only to tasks in the given category.
+(Note: work_queue_activate_fast_abort_category(q, "default", n) is the same as work_queue_activate_fast_abort(q, n).)
+@param q A work queue object.
+@param category A category name.
+@param multiplier The multiplier of the average task time at which point to abort; if less than 1 (and by default) fast_abort is deactivated.
+@returns 0 if activated or deactivated with an appropriate multiplier, 1 if deactivated due to inappropriate multiplier.
+*/
+int work_queue_activate_fast_abort_category(struct work_queue *q, const char *category, double multiplier);
 
 
 /** Change the preference to send or receive tasks.

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -597,8 +597,8 @@ larger than the average times the multiplier.  Fast-abort is computed per task
 category. The value specified here applies to all the categories for which @ref
 work_queue_activate_fast_abort_category was not explicitely called.
 @param q A work queue object.
-@param multiplier The multiplier of the average task time at which point to abort; if less than 1 (and by default) fast_abort is deactivated.
-@returns 0 if activated or deactivated with an appropriate multiplier, 1 if deactivated due to inappropriate multiplier.
+@param multiplier The multiplier of the average task time at which point to abort; if less than zero, fast_abort is deactivated (the default).
+@returns 0 if activated, 1 if deactivated.
 */
 int work_queue_activate_fast_abort(struct work_queue *q, double multiplier);
 
@@ -609,8 +609,8 @@ multiplier.  The value specified here applies only to tasks in the given categor
 (Note: work_queue_activate_fast_abort_category(q, "default", n) is the same as work_queue_activate_fast_abort(q, n).)
 @param q A work queue object.
 @param category A category name.
-@param multiplier The multiplier of the average task time at which point to abort; if less than 1 (and by default) fast_abort is deactivated.
-@returns 0 if activated or deactivated with an appropriate multiplier, 1 if deactivated due to inappropriate multiplier.
+@param multiplier The multiplier of the average task time at which point to abort; if zero, fast_abort is deactivated. If less than zero (default), use the fast abort of the "default" category.
+@returns 0 if activated, 1 if deactivated.
 */
 int work_queue_activate_fast_abort_category(struct work_queue *q, const char *category, double multiplier);
 


### PR DESCRIPTION
Adds categories to work queue, with the API: work_queue_task_specify_category(t, "mycategory");

Tasks without an explicit category belong to "default".

Fast abort is computed per category with: work_queue_acitvate_fast_abort_category(q, "mycat", mult);

If fast abort for a category is not explicitly specified, the value from "default" (work_queue_acitvate_fast_abort) is used.

If a category has -1 as multiplier, use the default. If 0, deactivate for that category.


To do:
Compute first allocations per category to implement the whole resources loop.
Update with categories coming from makeflow.
Update with the batch options commit (dangling wq_fast_abort_option).

