### PR TITLE
Order pull transfers randomly.

### DIFF
--- a/chirp/src/chirp_fs_local_scheduler.c
+++ b/chirp/src/chirp_fs_local_scheduler.c
@@ -347,7 +347,7 @@ static int jbindfiles (sqlite3 *db, chirp_jobid_t id, const char *subject, const
 		"SELECT task_path, serv_path, binding, type"
 		"	FROM JobFile"
 		"	WHERE id = ?"
-		"	ORDER BY task_path;";
+		"	ORDER BY RANDOM();";
 
 	int rc;
 	sqlite3_stmt *stmt = NULL;


### PR DESCRIPTION
This prevents loading a single storage node with pulls due to the common
ordering of input files for jobs in a workflow. (e.g. all jobs specify the same
large database as the first input file.)