### PR TITLE
Umbrella destructive mode + ec2 execution engine

### DIFF
--- a/umbrella/example/cms_complex/README
+++ b/umbrella/example/cms_complex/README
@@ -22,3 +22,17 @@ umbrella \
 --log umbrella.log \
 --cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run
+
+umbrella \
+--spec cms_complex.umbrella \
+--meta http://ccl.cse.nd.edu/software/umbrella/database/packages.json \
+--localdir /tmp/umbrella_test/ \
+--output "/tmp/sim_job=/tmp/umbrella_test/ec2_cms_complex_output" \
+--sandbox_mode ec2 \
+--ec2_sshkey ~/bin/feb272015.pem \
+--ec2_key feb272015 \
+--ec2_instance_type m3.medium \
+--ec2_log umbrella.log.ec2 \
+--log umbrella.log \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
+run

--- a/umbrella/example/cms_complex/cms_complex.umbrella
+++ b/umbrella/example/cms_complex/cms_complex.umbrella
@@ -2,9 +2,9 @@
 	"comment": "a CMS application whose software dependencies are all from CVMFS, and whose data dependencies are not from CVMFS.",
 	"hardware": {
 		"arch": "x86_64",
-		"cores": "2",
-		"memory": "2GB",
-		"disk": "3GB"
+		"cores": "1",
+		"memory": "1GB",
+		"disk": "2GB"
 	},
 	"kernel" : {
 		"name": "linux",

--- a/umbrella/example/cms_opendata/README
+++ b/umbrella/example/cms_opendata/README
@@ -12,17 +12,6 @@ umbrella \
 --cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run
 
-#parrot execution engine test command - the umbrella specification is self-contained, so no metadata database is needed.
-umbrella \
---spec cms_opendata_S.umbrella \
---localdir /tmp/umbrella_test/ \
---output "/tmp/sim_job=/tmp/umbrella_test/parrot_cms_opendata_S_output" \
---sandbox_mode parrot \
---log umbrella.log \
---cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
-run
-
-
 #Docker execution engine test command. Don't do the docker test under your afs, it will fail due to the ACL of your afs.
 umbrella \
 --spec cms_opendata.umbrella \
@@ -34,12 +23,36 @@ umbrella \
 --cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run
 
+#parrot execution engine test command - the umbrella specification is self-contained, so no metadata database is needed.
+umbrella \
+--spec cms_opendata_S.umbrella \
+--localdir /tmp/umbrella_test/ \
+--output "/tmp/sim_job=/tmp/umbrella_test/parrot_cms_opendata_S_output" \
+--sandbox_mode parrot \
+--log umbrella.log \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
+run
+
 #Docker execution engine test command. Don't do the docker test under your afs, it will fail due to the ACL of your afs - the umbrella specification is self-contained, so no metadata database is needed.
 umbrella \
 --spec cms_opendata_S.umbrella \
 --localdir /tmp/umbrella_test/ \
 --output "/tmp/sim_job=/tmp/umbrella_test/docker_cms_opendata_S_output" \
 --sandbox_mode docker \
+--log umbrella.log \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
+run
+
+umbrella \
+--spec cms_opendata_S.umbrella \
+--localdir /tmp/umbrella_test/ \
+--output "/tmp/sim_job=/tmp/umbrella_test/ec2_cms_opendata_S_output" \
+--sandbox_mode ec2 \
+--ec2_sshkey ~/bin/feb272015.pem \
+--ec2_key feb272015 \
+--log umbrella.log \
+--ec2_instance_type m3.medium \
+--ec2_log umbrella.log.ec2 \
 --log umbrella.log \
 --cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run

--- a/umbrella/example/cms_opendata/cms_opendata_S.umbrella
+++ b/umbrella/example/cms_opendata/cms_opendata_S.umbrella
@@ -19,9 +19,9 @@
     "cmd": "/bin/sh /tmp/cms_opendata.sh", 
     "hardware": {
         "cores": "1", 
-        "disk": "3GB", 
+        "disk": "2GB", 
         "arch": "x86_64", 
-        "memory": "2GB"
+        "memory": "1GB"
     }, 
     "environ": {
         "PWD": "/tmp", 

--- a/umbrella/example/cms_opendata_git/README
+++ b/umbrella/example/cms_opendata_git/README
@@ -22,3 +22,18 @@ umbrella \
 --log umbrella.log \
 --cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run
+
+#ec2 execution engine
+umbrella \
+--spec cms_opendata_git.umbrella \
+--meta http://ccl.cse.nd.edu/software/umbrella/database/packages.json \
+--localdir /tmp/umbrella_test/ \
+--output "/tmp/CMSSW_4_2_8=/tmp/umbrella_test/ec2_cms_opendata_git_output" \
+--sandbox_mode ec2 \
+--ec2_sshkey ~/bin/feb272015.pem \
+--ec2_key feb272015 \
+--ec2_instance_type m3.medium \
+--ec2_log umbrella.log.ec2 \
+--log umbrella.log \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
+run

--- a/umbrella/example/cms_simple/README
+++ b/umbrella/example/cms_simple/README
@@ -25,6 +25,20 @@ umbrella \
 --cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run
 
+umbrella \
+--spec cms_simple.umbrella \
+--meta http://ccl.cse.nd.edu/software/umbrella/database/packages.json \
+--localdir /tmp/umbrella_test/ \
+--output "/tmp/cmsjob=/tmp/umbrella_test/ec2_cms_simple_output" \
+--sandbox_mode ec2 \
+--ec2_sshkey ~/bin/feb272015.pem \
+--ec2_key feb272015 \
+--ec2_instance_type m3.medium \
+--ec2_log umbrella.log.ec2 \
+--log umbrella.log \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
+run
+
 #expand cms_simple.umbrella into a self-contained spec
 umbrella \
 --spec cms_simple.umbrella \

--- a/umbrella/example/cms_simple/cms_simple.umbrella
+++ b/umbrella/example/cms_simple/cms_simple.umbrella
@@ -2,8 +2,8 @@
 	"comment": "a simple CMS application whose software and data dependencies are all from CVMFS.",
 	"hardware": {
 		"arch": "x86_64",
-		"cores": "2",
-		"memory": "2GB",
+		"cores": "1",
+		"memory": "1GB",
 		"disk": "3GB"
 	},
 	"kernel" : {

--- a/umbrella/example/git_protocol/README
+++ b/umbrella/example/git_protocol/README
@@ -22,3 +22,19 @@ umbrella \
 --log umbrella.log \
 --cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
 run
+
+#ec2 execution engine
+#currently, this module fails because the amazon ec2 instance by default has no git installed.
+umbrella \
+--spec git_protocol.umbrella \
+--meta http://ccl.cse.nd.edu/software/umbrella/database/packages.json \
+--localdir /tmp/umbrella_test/ \
+--output "/tmp/CMSSW_4_2_8=/tmp/umbrella_test/ec2_git_protocol_output" \
+--sandbox_mode ec2 \
+--ec2_sshkey ~/bin/feb272015.pem \
+--ec2_key feb272015 \
+--ec2_instance_type m3.medium \
+--ec2_log umbrella.log.ec2 \
+--log umbrella.log \
+--cvmfs_http_proxy http://cache01.hep.wisc.edu:3128 \
+run

--- a/umbrella/example/openmalaria/README
+++ b/umbrella/example/openmalaria/README
@@ -7,6 +7,19 @@ umbrella \
 --log umbrella.log \
 run
 
+#ec2
+umbrella \
+--spec openmalaria_S.umbrella \
+--localdir /tmp/umbrella_test/ \
+--output "/tmp/ctsout.txt=/tmp/umbrella_test/ec2_openmalaria/ctsout.txt, /tmp/output.txt=/tmp/umbrella_test/ec2_openmalaria/output.txt" \
+--sandbox_mode ec2 \
+--ec2_sshkey ~/bin/feb272015.pem \
+--ec2_key feb272015 \
+--ec2_instance_type m3.medium \
+--ec2_log umbrella.log.ec2 \
+--log umbrella.log \
+run
+
 umbrella \
 --spec openmalaria.umbrella \
 --meta file:///afs/crc.nd.edu/user/h/hmeng/git-development/cctools/umbrella/example/openmalaria/meta.json \

--- a/umbrella/example/povray/README
+++ b/umbrella/example/povray/README
@@ -52,3 +52,15 @@ umbrella \
 --sandbox_mode destructive \
 --log umbrella.log \
 run
+
+umbrella \
+--spec povray_S.umbrella \
+--localdir /tmp/umbrella_test/ \
+--output "/tmp/frame000.png=/tmp/umbrella_test/ec2_povray_S/output.png" \
+--sandbox_mode ec2 \
+--ec2_log umbrella.log.ec2 \
+--ec2_sshkey ~/bin/feb272015.pem \
+--ec2_key feb272015 \
+--ec2_instance_type m3.medium \
+--log umbrella.log \
+run

--- a/umbrella/example/povray/README
+++ b/umbrella/example/povray/README
@@ -43,3 +43,12 @@ umbrella \
 --sandbox_mode docker \
 --log umbrella.log \
 run
+
+umbrella \
+--spec povray_S.umbrella \
+--localdir /tmp/umbrella_test/ \
+--output /tmp/umbrella_test/destructive_povray_S \
+--output "/tmp/frame000.png=/tmp/umbrella_test/destructive_povray_S/output.png" \
+--sandbox_mode destructive \
+--log umbrella.log \
+run

--- a/umbrella/example/povray/povray_S.umbrella
+++ b/umbrella/example/povray/povray_S.umbrella
@@ -18,10 +18,10 @@
     }, 
     "cmd": "povray +I/tmp/4_cubes.pov +O/tmp/frame000.png +K.0  -H50 -W50", 
     "hardware": {
-        "cores": "2", 
-        "disk": "3GB", 
+        "cores": "1", 
+        "disk": "2GB", 
         "arch": "x86_64", 
-        "memory": "2GB"
+        "memory": "1GB"
     }, 
     "environ": {
         "PWD": "/tmp"

--- a/umbrella/src/umbrella.py
+++ b/umbrella/src/umbrella.py
@@ -2681,8 +2681,12 @@ def needCVMFS(spec_json, meta_json):
 	for sec_name in ["software", "data", "package_manager"]:
 		if spec_json.has_key(sec_name) and spec_json[sec_name]:
 			sec = spec_json[sec_name]
-			if sec_name == "package_manager" and sec.has_key("config") and sec["config"]:
-				sec = sec["config"]
+			if sec_name == "package_manager":
+				if sec.has_key("config") and sec["config"]:
+					sec = sec["config"]
+				else:
+					logging.debug("%s does not have config attribute!", sec_name)
+					break
 
 			for item in sec:
 				item_id = ""
@@ -2887,8 +2891,12 @@ def validate_spec(spec_json, meta_json = None):
 	for sec_name in ["software", "data", "package_manager"]:
 		if spec_json.has_key(sec_name) and spec_json[sec_name]:
 			sec = spec_json[sec_name]
-			if sec_name == "package_manager" and sec.has_key("config") and sec["config"]:
-				sec = sec["config"]
+			if sec_name == "package_manager":
+				if sec.has_key("config") and sec["config"]:
+					sec = sec["config"]
+				else:
+					logging.debug("%s does not have config attribute!", sec_name)
+					break
 			for item in sec:
 				if (sec[item].has_key("mountpoint") and sec[item]["mountpoint"]) \
 						or (sec[item].has_key("mount_env") and sec[item]["mount_env"]):


### PR DESCRIPTION
1. Add destructive mode into Umbrella, which directly modify the rootfs to run the task.
    
2. Tune the ec2 execution engine of Umbrella    
(2.1) Send umbrella job to ec2 instance, run umbrella destructive mode on the ec2 instance.    
(2.2) Add --ec2_instance_type option to umbrella
