### PR TITLE
Worker categories

### DIFF
--- a/doc/man/work_queue_worker.m4
+++ b/doc/man/work_queue_worker.m4
@@ -57,6 +57,7 @@ OPTION_PAIR(--gpus, n)Set the number of GPUs this worker should use. (default=0)
 OPTION_PAIR(--memory, mb)Manually set the amount of memory (in MB) reported by this worker.
 OPTION_PAIR(--disk, mb)Manually set the amount of disk space (in MB) reported by this worker.
 OPTION_PAIR(--wall-time, s)Set the maximum number of seconds the worker may be active.
+OPTION_PAIR(--provides, feature)Specifies a user-defined feature the worker provides.
 OPTION_ITEM(-v, --version')Show version string.
 OPTION_ITEM(-h, --help')Show this help message.
 OPTION_PAIR(--docker, image) Enable the worker to run each task with a container based on this image.

--- a/work_queue/src/perl/Work_Queue/Task.pm
+++ b/work_queue/src/perl/Work_Queue/Task.pm
@@ -59,6 +59,11 @@ sub specify_category {
 	return work_queue_task_specify_category($self->{_task}, $name);;
 }
 
+sub specify_requirement {
+	my ($self, $name) = @_;
+	return work_queue_task_specify_requirement($self->{_task}, $name);;
+}
+
 sub clone {
 	my ($self) = @_;
 	my $copy = $self;
@@ -435,6 +440,18 @@ have similar resources requirements (e.g. for fast abort).
 =item tag
 
 The name of the category.
+
+=back
+
+=head3 C<specify_requirement>
+
+Label the task with the given user-defined requirement. The task will only run on a worker that provides (--provides option) such requirement.
+
+=over 12
+
+=item name
+
+The name of the required feature.
 
 =back
 

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -103,6 +103,16 @@ class Task(_object):
         return work_queue_task_specify_category(self._task, name)
 
     ##
+    # Label the task with the given user-defined requirement. Tasks with the
+    # requirement will only run on workers that provide it (see worker's
+    # --provides option).
+    #
+    # @param self       Reference to the current task object.
+    # @param name       The name of the requirement.
+    def specify_requirement(self, name):
+        return work_queue_task_specify_requirement(self._task, name)
+
+    ##
     # Indicate that the task would be optimally run on a given host.
     #
     # @param self       Reference to the current task object.

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -99,7 +99,7 @@ class Task(_object):
     #
     # @param self       Reference to the current task object.
     # @param name       The name of the category
-    def specify_category(self, tag):
+    def specify_category(self, name):
         return work_queue_task_specify_category(self._task, name)
 
     ##

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -5339,13 +5339,6 @@ void work_queue_get_stats_hierarchy(struct work_queue *q, struct work_queue_stat
 	}
 }
 
-/*
-This function is a little roundabout, because work_queue_resources_add
-updates the min and max of each value as it goes.  So, we set total
-to the value of the first item, then use work_queue_resources_add.
-If there are no items, we must manually return zero.
-*/
-
 void aggregate_workers_resources( struct work_queue *q, struct work_queue_resources *total )
 {
 	struct work_queue_worker *w;

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -5431,7 +5431,7 @@ void category_accumulate_task(struct work_queue *q, struct work_queue_task *t) {
 
 	const char *name = t->category ? t->category : "default";
 
-	struct work_queue_task_category *c = hash_table_lookup(q->categories, name);
+	struct work_queue_task_category *c = category_lookup_or_create(q, name);
 
 	if(t->result == WORK_QUEUE_RESULT_SUCCESS)
 	{

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -150,7 +150,7 @@ struct work_queue_task {
 
 	char *category;                                        /**< User-provided label for the task. It is expected that all task with the same category will have similar resource usage. See @ref work_queue_task_specify_category. If no explicit category is given, the label "default" is used. **/
 
-	struct list *required_features;                        /**< User-defined features this task requires. (See work_queue_worker's --provide option.) */
+	struct list *user_resources;                        /**< User-defined features this task requires. (See work_queue_worker's --provide option.) */
 
 	timestamp_t time_app_delay;                            /**< @deprecated The time spent in upper-level application (outside of work_queue_wait). */
 };
@@ -377,9 +377,10 @@ void work_queue_task_specify_category(struct work_queue_task *t, const char *cat
 /** Label the task with a user-defined requirement. The task will only run on a worker that provides (--provides option) such requirement.
 @param q A work queue object.
 @param t A task object.
+@param count The number of resources consumed. If 0, the task does not consume the resource, but the worker still needs to provide it.  
 @param category The name of the requirement.
 */
-void work_queue_task_specify_requirement(struct work_queue_task *t, const char *name);
+void work_queue_task_specify_resource(struct work_queue_task *t, const char *name, int64_t count);
 
 /** Specify the priority of this task relative to others in the queue.
 Tasks with a higher priority value run first. If no priority is given, a task is placed at the end of the ready list, regardless of the priority.

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -374,6 +374,13 @@ have similar resources requirements (e.g. for fast abort).
 */
 void work_queue_task_specify_category(struct work_queue_task *t, const char *category);
 
+/** Label the task with a user-defined requirement. The task will only run on a worker that provides (--provides option) such requirement.
+@param q A work queue object.
+@param t A task object.
+@param category The name of the requirement.
+*/
+void work_queue_task_specify_requirement(struct work_queue_task *t, const char *name);
+
 /** Specify the priority of this task relative to others in the queue.
 Tasks with a higher priority value run first. If no priority is given, a task is placed at the end of the ready list, regardless of the priority.
 @param t A task object.

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -150,6 +150,8 @@ struct work_queue_task {
 
 	char *category;                                        /**< User-provided label for the task. It is expected that all task with the same category will have similar resource usage. See @ref work_queue_task_specify_category. If no explicit category is given, the label "default" is used. **/
 
+	struct list *required_features;                        /**< User-defined features this task requires. (See work_queue_worker's --provide option.) */
+
 	timestamp_t time_app_delay;                            /**< @deprecated The time spent in upper-level application (outside of work_queue_wait). */
 };
 

--- a/work_queue/src/work_queue_internal.h
+++ b/work_queue/src/work_queue_internal.h
@@ -8,6 +8,7 @@ See the file COPYING for details.
 #include "work_queue_resources.h"
 
 #include "list.h"
+#include "hash_table.h"
 
 struct work_queue_file {
 	work_queue_file_t type;
@@ -23,7 +24,7 @@ struct work_queue_file {
 struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeout, struct link *foreman_uplink, int *foreman_uplink_active);
 
 /* Adds (arithmetically) all the workers resources (cores, memory, disk) */
-void aggregate_workers_resources( struct work_queue *q, struct work_queue_resources *r );
+void aggregate_workers_resources( struct work_queue *q, struct work_queue_resources *r, struct hash_table *categories );
 
 /** Enable use of the process module.
 This allows @ref work_queue_wait to call @ref process_pending from @ref process.h, exiting if a process has completed.

--- a/work_queue/src/work_queue_protocol.h
+++ b/work_queue/src/work_queue_protocol.h
@@ -17,7 +17,8 @@ This file should not be installed and should only be included by .c files.
 /* 4: added invalidate-file message, for cache management.    */
 /* 5: added wall_time, end_time messages, for task maximum running time. */
 /* 6: worker only report total, max, and min resources. */
-#define WORK_QUEUE_PROTOCOL_VERSION 6
+/* 7: worker send feature message. */
+#define WORK_QUEUE_PROTOCOL_VERSION 7
 
 #define WORK_QUEUE_LINE_MAX 4096       /**< Maximum length of a work queue message line. */
 #define WORK_QUEUE_POOL_NAME_MAX 128   /**< Maximum length of a work queue pool name. */

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -290,7 +290,7 @@ void measure_worker_resources()
 	measure_worker_disk();
 
 	if(worker_mode == WORKER_MODE_FOREMAN) {
-		aggregate_workers_resources(foreman_q, total_resources);
+		aggregate_workers_resources(foreman_q, total_resources, categories);
 	} else {
 		if(manual_cores_option > 0)
 			r->cores.total = manual_cores_option;

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -38,6 +38,7 @@ See the file COPYING for details.
 #include "random.h"
 #include "url_encode.h"
 #include "md5.h"
+#include "hash_table.h"
 
 #include <unistd.h>
 #include <dirent.h>
@@ -190,6 +191,9 @@ static struct list   *procs_waiting = NULL;
 // These are additional pointers into procs_table.
 static struct itable *procs_complete = NULL;
 
+//User specified categories this worker provides.
+static struct hash_table *categories = NULL;
+
 static int results_to_be_sent_msg = 0;
 
 static timestamp_t total_task_execution_time = 0;
@@ -319,6 +323,24 @@ void measure_worker_resources()
 	last_resources_measurement = time(0);
 }
 
+/*
+Send a message to the master with user defined features.
+*/
+static void send_categories(struct link *master) {
+	if(!categories)
+		return;
+
+	char *c;
+	void *dummy;
+	hash_table_firstkey(categories);
+
+	char cenc[WORK_QUEUE_LINE_MAX];
+	while(hash_table_nextkey(categories, &c, &dummy)) {
+		url_encode(c, cenc, WORK_QUEUE_LINE_MAX);
+		send_master_message(master, "category %s\n", cenc);
+	}
+}
+
 
 /*
 Send a message to the master with my current resources.
@@ -385,6 +407,7 @@ static void report_worker_ready( struct link *master )
 	char hostname[DOMAIN_NAME_MAX];
 	domain_name_cache_guess(hostname);
 	send_master_message(master,"workqueue %d %s %s %s %d.%d.%d\n",WORK_QUEUE_PROTOCOL_VERSION,hostname,os_name,arch_name,CCTOOLS_VERSION_MAJOR,CCTOOLS_VERSION_MINOR,CCTOOLS_VERSION_MICRO);
+	send_categories(master);
 	send_keepalive(master);
 }
 
@@ -1899,6 +1922,7 @@ static void show_help(const char *cmd)
 	printf( " %-30s Manually set the amount of memory (in MB) reported by this worker.\n", "--memory=<mb>           ");
 	printf( " %-30s Manually set the amount of disk (in MB) reported by this worker.\n", "--disk=<mb>");
 	printf( " %-30s Use loop devices for task sandboxes (default=disabled, requires root access).\n", "--disk-allocation");
+	printf( " %-30s Specifies a user-defined category the worker provides. May be specified several times.\n", "--category");
 	printf( " %-30s Set the maximum number of seconds the worker may be active. (in s).\n", "--wall-time=<s>");
 	printf( " %-30s Forbid the use of symlinks for cache management.\n", "--disable-symlinks");
 	printf(" %-30s Single-shot mode -- quit immediately after disconnection.\n", "--single-shot");
@@ -1909,10 +1933,12 @@ static void show_help(const char *cmd)
 }
 
 enum {LONG_OPT_DEBUG_FILESIZE = 256, LONG_OPT_VOLATILITY, LONG_OPT_BANDWIDTH,
-	  LONG_OPT_DEBUG_RELEASE, LONG_OPT_SPECIFY_LOG, LONG_OPT_CORES, LONG_OPT_MEMORY,
-	  LONG_OPT_DISK, LONG_OPT_GPUS, LONG_OPT_FOREMAN, LONG_OPT_FOREMAN_PORT, LONG_OPT_DISABLE_SYMLINKS,
-	  LONG_OPT_IDLE_TIMEOUT, LONG_OPT_CONNECT_TIMEOUT, LONG_OPT_RUN_DOCKER, LONG_OPT_RUN_DOCKER_PRESERVE,
-	  LONG_OPT_BUILD_FROM_TAR, LONG_OPT_SINGLE_SHOT, LONG_OPT_WALL_TIME, LONG_OPT_DISK_ALLOCATION};
+	LONG_OPT_DEBUG_RELEASE, LONG_OPT_SPECIFY_LOG, LONG_OPT_CORES, LONG_OPT_MEMORY,
+	LONG_OPT_DISK, LONG_OPT_GPUS, LONG_OPT_FOREMAN, LONG_OPT_FOREMAN_PORT, LONG_OPT_DISABLE_SYMLINKS,
+	LONG_OPT_IDLE_TIMEOUT, LONG_OPT_CONNECT_TIMEOUT, LONG_OPT_RUN_DOCKER, LONG_OPT_RUN_DOCKER_PRESERVE,
+	LONG_OPT_BUILD_FROM_TAR, LONG_OPT_SINGLE_SHOT, LONG_OPT_WALL_TIME, LONG_OPT_DISK_ALLOCATION,
+	LONG_OPT_CATEGORY
+};
 
 static const struct option long_options[] = {
 	{"advertise",           no_argument,        0,  'a'},
@@ -1955,6 +1981,7 @@ static const struct option long_options[] = {
 	{"docker",              required_argument,  0,  LONG_OPT_RUN_DOCKER},
 	{"docker-preserve",     required_argument,  0,  LONG_OPT_RUN_DOCKER_PRESERVE},
 	{"docker-tar",          required_argument,  0,  LONG_OPT_BUILD_FROM_TAR},
+	{"category",            required_argument,  0,  LONG_OPT_CATEGORY},
 	{0,0,0,0}
 };
 
@@ -2165,6 +2192,11 @@ int main(int argc, char *argv[])
 			break;
 		case LONG_OPT_DISK_ALLOCATION:
 			disk_allocation = 1;
+			break;
+		case LONG_OPT_CATEGORY:
+			if(!categories)
+				categories = hash_table_create(4, 0);
+			hash_table_insert(categories, optarg, (void **) 1);
 			break;
 		default:
 			show_help(argv[0]);


### PR DESCRIPTION
Adds feature labels to worker. This is an experimental feature for @asherkhb. Two interface additions:

--provides option for a worker. It may specified several times. 
t.specify_requirement(feature)

worker features are treated as any other resource. If a task specifies a feature requirement, it may only run in a worker labeled with that feature. A task without an explicit feature may run on any worker. In the future, we want to generalize this to user-defined resources (e.g., number of licenses).

Example:
ta.specify_requirement("analysis_local_data")
tb.specify_requirement("merge_local_data")
// tc does not specify requirement feature.

// worker 1
work_queue_worker --provides analysis_local_data ...
// worker 2
work_queue_worker --provides analysis_local_data --provides merge_local_data  ...
// worker 3
work_queue_worker ...

ta may run on workers 1 and 2. tb may run only on worker 2. tc may work on any worker.

@nhazekam 




