### PR TITLE
rmsummary follows naming conventions

### DIFF
--- a/batch_job/src/batch_job_work_queue.c
+++ b/batch_job/src/batch_job_work_queue.c
@@ -82,11 +82,11 @@ static void work_queue_task_specify_resources(struct work_queue_task *t, struct 
 		if(resources->cores > -1)
 			work_queue_task_specify_cores(t, resources->cores);
 
-		if(resources->resident_memory > -1)
-			work_queue_task_specify_memory(t, resources->resident_memory);
+		if(resources->memory > -1)
+			work_queue_task_specify_memory(t, resources->memory);
 
-		if(resources->workdir_footprint > -1)
-			work_queue_task_specify_disk(t, resources->workdir_footprint);
+		if(resources->disk > -1)
+			work_queue_task_specify_disk(t, resources->disk);
 }
 
 static batch_job_id_t batch_job_wq_submit (struct batch_queue * q, const char *cmd, const char *extra_input_files, const char *extra_output_files, struct jx *envlist )

--- a/dttools/src/rmonitor_poll.c
+++ b/dttools/src/rmonitor_poll.c
@@ -738,18 +738,18 @@ void rmonitor_info_to_rmsummary(struct rmsummary *tr, struct rmonitor_process_in
 	tr->total_processes          = -1;
 
 	tr->virtual_memory    = (int64_t) p->mem.virtual;
-	tr->resident_memory   = (int64_t) p->mem.resident;
+	tr->memory   = (int64_t) p->mem.resident;
 	tr->swap_memory       = (int64_t) p->mem.swap;
 
 	tr->bytes_read        = (int64_t)  p->io.chars_read;
 	tr->bytes_written     = (int64_t)  p->io.chars_written;
 
-	tr->workdir_num_files = -1;
-	tr->workdir_footprint = -1;
+	tr->total_files = -1;
+	tr->disk = -1;
 
 	if(d) {
-		tr->workdir_num_files = (int64_t) (d->files);
-		tr->workdir_footprint = (int64_t) (d->byte_count + ONE_MEGABYTE - 1) / ONE_MEGABYTE;
+		tr->total_files = (int64_t) (d->files);
+		tr->disk = (int64_t) (d->byte_count + ONE_MEGABYTE - 1) / ONE_MEGABYTE;
 	}
 
 	tr->fs_nodes = -1;

--- a/dttools/src/rmsummary.c
+++ b/dttools/src/rmsummary.c
@@ -9,7 +9,7 @@
    int64_t, with units in microseconds. Therefore we need to convert back
    and forth when reading/printing summaries.
 
-   Similarly, workdir_footprint is reported as double, in megabytes,
+   Similarly, disk is reported as double, in megabytes,
    but it is kept internally as int64_t, in bytes.*/
 
 #include <stdio.h>
@@ -65,12 +65,12 @@ int rmsummary_assign_field(struct rmsummary *s, char *key, char *value)
 	rmsummary_assign_as_int_field   (s, key, value, total_processes);
 	rmsummary_assign_as_time_field  (s, key, value, cpu_time);
 	rmsummary_assign_as_int_field   (s, key, value, virtual_memory);
-	rmsummary_assign_as_int_field   (s, key, value, resident_memory);
+	rmsummary_assign_as_int_field   (s, key, value, memory);
 	rmsummary_assign_as_int_field   (s, key, value, swap_memory);
 	rmsummary_assign_as_int_field   (s, key, value, bytes_read);
 	rmsummary_assign_as_int_field   (s, key, value, bytes_written);
-	rmsummary_assign_as_int_field   (s, key, value, workdir_num_files);
-	rmsummary_assign_as_int_field   (s, key, value, workdir_footprint);
+	rmsummary_assign_as_int_field   (s, key, value, total_files);
+	rmsummary_assign_as_int_field   (s, key, value, disk);
 	rmsummary_assign_as_int_field   (s, key, value, cores);
 	rmsummary_assign_as_int_field   (s, key, value, gpus);
 
@@ -134,7 +134,7 @@ struct rmsummary *rmsummary_parse_from_str(const char *buffer, const char separa
 
 	const char delim[] = { separator, '\n', '\0'};
 
-	struct rmsummary *s = make_rmsummary(-1);
+	struct rmsummary *s = rmsummary_create(-1);
 
 	/* if source have no last_error, we do not want the -1 from above */
 	s->last_error = 0;
@@ -259,8 +259,8 @@ void rmsummary_print_only_resources(FILE *stream, struct rmsummary *s, const cha
 	if(s->virtual_memory > -1)
 		fprintf(stream, "%s%-20s%20" PRId64 " MB\n",  prefix, "virtual_memory:", s->virtual_memory);
 
-	if(s->resident_memory > -1)
-		fprintf(stream, "%s%-20s%20" PRId64 " MB\n",  prefix, "resident_memory:", s->resident_memory);
+	if(s->memory > -1)
+		fprintf(stream, "%s%-20s%20" PRId64 " MB\n",  prefix, "memory:", s->memory);
 
 	if(s->swap_memory > -1)
 		fprintf(stream, "%s%-20s%20" PRId64 " MB\n",  prefix, "swap_memory:", s->swap_memory);
@@ -271,11 +271,11 @@ void rmsummary_print_only_resources(FILE *stream, struct rmsummary *s, const cha
 	if(s->bytes_written > -1)
 		fprintf(stream, "%s%-20s%20" PRId64 " B\n",  prefix, "bytes_written:", s->bytes_written);
 
-	if(s->workdir_num_files > -1)
-		fprintf(stream, "%s%-20s%20" PRId64 " files+dirs\n",  prefix, "workdir_num_files:", s->workdir_num_files);
+	if(s->total_files > -1)
+		fprintf(stream, "%s%-20s%20" PRId64 " files+dirs\n",  prefix, "total_files:", s->total_files);
 
-	if(s->workdir_footprint > -1)
-		fprintf(stream, "%s%-20s%20" PRId64 " MB\n", prefix, "workdir_footprint:", s->workdir_footprint);
+	if(s->disk > -1)
+		fprintf(stream, "%s%-20s%20" PRId64 " MB\n", prefix, "disk:", s->disk);
 }
 /* Parse the file assuming there are multiple summaries in it. Summary
    boundaries are lines starting with # */
@@ -329,8 +329,8 @@ struct rmsummary *rmsummary_parse_limits_exceeded(char *limits_exceeded)
 
 
 /* Create summary filling all numeric fields with default_value, and
-all string fields with NULL. Usual values are 0, or -1. */
-struct rmsummary *make_rmsummary(signed char default_value)
+   all string fields with NULL. Usual values are 0, or -1. */
+struct rmsummary *rmsummary_create(signed char default_value)
 {
 	struct rmsummary *s = malloc(sizeof(struct rmsummary));
 	memset(s, default_value, sizeof(struct rmsummary));
@@ -340,7 +340,30 @@ struct rmsummary *make_rmsummary(signed char default_value)
 	s->exit_type = NULL;
 	s->limits_exceeded = NULL;
 
+	s->last_error  = 0;
+	s->exit_status = 0;
+
 	return s;
+}
+
+void rmsummary_delete(struct rmsummary *s)
+{
+	if(!s)
+		return;
+
+	if(s->command)
+		free(s->command);
+
+	if(s->category)
+		free(s->category);
+
+	if(s->exit_type)
+		free(s->exit_type);
+
+	if(s->limits_exceeded)
+		free(s->limits_exceeded);
+
+	free(s);
 }
 
 void rmsummary_read_env_vars(struct rmsummary *s)
@@ -349,9 +372,9 @@ void rmsummary_read_env_vars(struct rmsummary *s)
 	if((value = getenv( RESOURCES_CORES  )))
 		s->cores           = atoi(value);
 	if((value = getenv( RESOURCES_MEMORY )))
-		s->resident_memory = atoi(value);
+		s->memory = atoi(value);
 	if((value = getenv( RESOURCES_DISK )))
-		s->workdir_footprint = atoi(value);
+		s->disk = atoi(value);
 }
 
 #define rmsummary_apply_op(dest, src, fn, field) (dest)->field = fn((dest)->field, (src)->field)
@@ -368,12 +391,12 @@ void rmsummary_bin_op(struct rmsummary *dest, struct rmsummary *src, rm_bin_op f
 	rmsummary_apply_op(dest, src, fn, total_processes);
 	rmsummary_apply_op(dest, src, fn, cpu_time);
 	rmsummary_apply_op(dest, src, fn, virtual_memory);
-	rmsummary_apply_op(dest, src, fn, resident_memory);
+	rmsummary_apply_op(dest, src, fn, memory);
 	rmsummary_apply_op(dest, src, fn, swap_memory);
 	rmsummary_apply_op(dest, src, fn, bytes_read);
 	rmsummary_apply_op(dest, src, fn, bytes_written);
-	rmsummary_apply_op(dest, src, fn, workdir_num_files);
-	rmsummary_apply_op(dest, src, fn, workdir_footprint);
+	rmsummary_apply_op(dest, src, fn, total_files);
+	rmsummary_apply_op(dest, src, fn, disk);
 
 	rmsummary_apply_op(dest, src, fn, cores);
 	rmsummary_apply_op(dest, src, fn, fs_nodes);
@@ -420,18 +443,18 @@ void rmsummary_debug_report(struct rmsummary *s)
 		debug(D_DEBUG, "max resource %-18s  s: %lf\n", "cpu_time",  ((double) s->cpu_time  / 1000000));
 	if(s->virtual_memory != -1)
 		debug(D_DEBUG, "max resource %-18s MB: %" PRId64 "\n", "virtual_memory", s->virtual_memory);
-	if(s->resident_memory != -1)
-		debug(D_DEBUG, "max resource %-18s MB: %" PRId64 "\n", "resident_memory", s->resident_memory);
+	if(s->memory != -1)
+		debug(D_DEBUG, "max resource %-18s MB: %" PRId64 "\n", "memory", s->memory);
 	if(s->swap_memory != -1)
 		debug(D_DEBUG, "max resource %-18s MB: %" PRId64 "\n", "swap_memory", s->swap_memory);
 	if(s->bytes_read != -1)
 		debug(D_DEBUG, "max resource %-18s   : %" PRId64 "\n", "bytes_read", s->bytes_read);
 	if(s->bytes_written != -1)
 		debug(D_DEBUG, "max resource %-18s   : %" PRId64 "\n", "bytes_written", s->bytes_written);
-	if(s->workdir_num_files != -1)
-		debug(D_DEBUG, "max resource %-18s   : %" PRId64 "\n", "workdir_num_files", s->workdir_num_files);
-	if(s->workdir_footprint != -1)
-		debug(D_DEBUG, "max resource %-18s MB: %" PRId64 "\n", "workdir_footprint", s->workdir_footprint);
+	if(s->total_files != -1)
+		debug(D_DEBUG, "max resource %-18s   : %" PRId64 "\n", "total_files", s->total_files);
+	if(s->disk != -1)
+		debug(D_DEBUG, "max resource %-18s MB: %" PRId64 "\n", "disk", s->disk);
 }
 
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/rmsummary.h
+++ b/dttools/src/rmsummary.h
@@ -40,12 +40,12 @@ struct rmsummary
 	int64_t  max_concurrent_processes;
 	int64_t  cpu_time;
 	int64_t  virtual_memory;
-	int64_t  resident_memory;
+	int64_t  memory;
 	int64_t  swap_memory;
 	int64_t  bytes_read;
 	int64_t  bytes_written;
-	int64_t  workdir_num_files;
-	int64_t  workdir_footprint;
+	int64_t  total_files;
+	int64_t  disk;
 
 	int64_t  cores;
 	int64_t  gpus;
@@ -81,7 +81,9 @@ struct rmsummary *rmsummary_parse_from_str(const char *buffer, const char separa
 /**  Reads a single summary from stream. summaries are separated by '#' or '\n'. **/
 struct rmsummary *rmsummary_parse_next(FILE *stream);
 
-struct rmsummary *make_rmsummary(signed char default_value);
+struct rmsummary *rmsummary_create(signed char default_value);
+void rmsummary_delete(struct rmsummary *s);
+
 void rmsummary_read_env_vars(struct rmsummary *s);
 
 

--- a/makeflow/src/dag_visitors.c
+++ b/makeflow/src/dag_visitors.c
@@ -760,8 +760,8 @@ void dag_to_dot(struct dag *d, int condense_display, int change_size, int with_l
 				printf("subgraph cluster_S%d { \n", condense_display ? t->id : n->nodeid);
 				printf("\tstyle=unfilled;\n\tcolor=red\n");
 				printf("\tcores%d [style=filled, color=white, label=\"Cores: %"PRId64"\"]\n", condense_display ? t->id : n->nodeid, n->resources->cores);
-				printf("\tresMem%d [style=filled, color=white, label=\"Memory: %"PRId64" MB\"]\n", condense_display ? t->id : n->nodeid, n->resources->resident_memory);
-				printf("\tworkDirFtprnt%d [style=filled, color=white, label=\"Footprint: %"PRId64" MB\"]\n", condense_display ? t->id : n->nodeid, n->resources->workdir_footprint);
+				printf("\tresMem%d [style=filled, color=white, label=\"Memory: %"PRId64" MB\"]\n", condense_display ? t->id : n->nodeid, n->resources->memory);
+				printf("\tworkDirFtprnt%d [style=filled, color=white, label=\"Footprint: %"PRId64" MB\"]\n", condense_display ? t->id : n->nodeid, n->resources->disk);
 				printf("\tcores%d -> resMem%d -> workDirFtprnt%d [color=white]", condense_display ? t->id : n->nodeid, condense_display ? t->id : n->nodeid, condense_display ? t->id : n->nodeid);
 
 				//Source Files

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -676,7 +676,7 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 			if(s)
 			{
 				rmsummary_print(stderr, s, NULL, NULL, NULL);
-				free(s);
+				rmsummary_delete(s);
 				fprintf(stderr, "\n");
 			}
 

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -277,7 +277,7 @@ void parse_limits_file(struct rmsummary *limits, char *path)
 
 	rmsummary_merge_override(limits, s);
 
-	free(s);
+	rmsummary_delete(s);
 }
 
 
@@ -618,15 +618,15 @@ void rmonitor_summary_header()
 	    fprintf(log_series, " %20s", "cpu_time");
 	    fprintf(log_series, " %25s", "max_concurrent_processes");
 	    fprintf(log_series, " %25s", "virtual_memory");
-	    fprintf(log_series, " %25s", "resident_memory");
+	    fprintf(log_series, " %25s", "memory");
 	    fprintf(log_series, " %25s", "swap_memory");
 	    fprintf(log_series, " %25s", "bytes_read");
 	    fprintf(log_series, " %25s", "bytes_written");
 
-	    if(resources_flags->workdir_footprint)
+	    if(resources_flags->disk)
 	    {
-		    fprintf(log_series, " %25s", "workdir_num_files");
-		    fprintf(log_series, " %25s", "workdir_footprint");
+		    fprintf(log_series, " %25s", "total_files");
+		    fprintf(log_series, " %25s", "disk");
 	    }
 
 	    fprintf(log_series, "\n");
@@ -649,12 +649,12 @@ void rmonitor_collate_tree(struct rmsummary *tr, struct rmonitor_process_info *p
 	 * fallback. */
 	if(m->resident > 0) {
 		tr->virtual_memory    = (int64_t) m->virtual;
-		tr->resident_memory   = (int64_t) m->resident;
+		tr->memory   = (int64_t) m->resident;
 		tr->swap_memory       = (int64_t) m->swap;
 	}
 	else {
 		tr->virtual_memory    = (int64_t) p->mem.virtual;
-		tr->resident_memory   = (int64_t) p->mem.resident;
+		tr->memory   = (int64_t) p->mem.resident;
 		tr->swap_memory       = (int64_t) p->mem.swap;
 	}
 
@@ -662,8 +662,8 @@ void rmonitor_collate_tree(struct rmsummary *tr, struct rmonitor_process_info *p
 	tr->bytes_read       += (int64_t)  p->io.delta_bytes_faulted;
 	tr->bytes_written     = (int64_t) (p->io.delta_chars_written + tr->bytes_written);
 
-	tr->workdir_num_files = (int64_t) d->files;
-	tr->workdir_footprint = (int64_t) (d->byte_count + ONE_MEGABYTE - 1) / ONE_MEGABYTE;
+	tr->total_files = (int64_t) d->files;
+	tr->disk = (int64_t) (d->byte_count + ONE_MEGABYTE - 1) / ONE_MEGABYTE;
 
 	tr->fs_nodes          = (int64_t) f->disk.f_ffree;
 }
@@ -689,15 +689,15 @@ void rmonitor_log_row(struct rmsummary *tr)
 		fprintf(log_series, " %18" PRId64, tr->cpu_time);
 		fprintf(log_series, " %20" PRId64, tr->max_concurrent_processes);
 		fprintf(log_series, " %20" PRId64, tr->virtual_memory);
-		fprintf(log_series, " %20" PRId64, tr->resident_memory);
+		fprintf(log_series, " %20" PRId64, tr->memory);
 		fprintf(log_series, " %20" PRId64, tr->swap_memory);
 		fprintf(log_series, " %20" PRId64, tr->bytes_read);
 		fprintf(log_series, " %20" PRId64, tr->bytes_written);
 
-		if(resources_flags->workdir_footprint)
+		if(resources_flags->disk)
 		{
-			fprintf(log_series, " %20" PRId64, tr->workdir_num_files);
-			fprintf(log_series, " %20" PRId64, tr->workdir_footprint);
+			fprintf(log_series, " %20" PRId64, tr->total_files);
+			fprintf(log_series, " %20" PRId64, tr->disk);
 		}
 
 		fprintf(log_series, "\n");
@@ -706,7 +706,7 @@ void rmonitor_log_row(struct rmsummary *tr)
 		// fprintf(log_series "%" PRId64 "\n", tr->fs_nodes);
 	}
 
-	debug(D_RMON, "resources: %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 "% " PRId64 "\n", tr->wall_time + summary->start, tr->cpu_time, tr->max_concurrent_processes, tr->virtual_memory, tr->resident_memory, tr->swap_memory, tr->bytes_read, tr->bytes_written, tr->workdir_num_files, tr->workdir_footprint);
+	debug(D_RMON, "resources: %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 "% " PRId64 "\n", tr->wall_time + summary->start, tr->cpu_time, tr->max_concurrent_processes, tr->virtual_memory, tr->memory, tr->swap_memory, tr->bytes_read, tr->bytes_written, tr->total_files, tr->disk);
 
 }
 
@@ -1195,12 +1195,12 @@ int rmonitor_check_limits(struct rmsummary *tr)
 	over_limit_check(tr, max_concurrent_processes,   1, PRId64);
 	over_limit_check(tr, total_processes,   1, PRId64);
 	over_limit_check(tr, virtual_memory,  1, PRId64);
-	over_limit_check(tr, resident_memory, 1, PRId64);
+	over_limit_check(tr, memory, 1, PRId64);
 	over_limit_check(tr, swap_memory,     1, PRId64);
 	over_limit_check(tr, bytes_read,      1, PRId64);
 	over_limit_check(tr, bytes_written,   1, PRId64);
-	over_limit_check(tr, workdir_num_files, 1, PRId64);
-	over_limit_check(tr, workdir_footprint, 1, PRId64);
+	over_limit_check(tr, total_files, 1, PRId64);
+	over_limit_check(tr, disk, 1, PRId64);
 
 	if(tr->limits_exceeded)
 		return 0;
@@ -1532,7 +1532,7 @@ int rmonitor_resources(long int interval /*in microseconds */)
 		rmonitor_poll_all_processes_once(processes, p_acc);
 		rmonitor_poll_maps_once(processes, m_acc);
 
-		if(resources_flags->workdir_footprint)
+		if(resources_flags->disk)
 			rmonitor_poll_all_wds_once(wdirs, d_acc, MAX(1, interval/(ONE_SECOND*hash_table_size(wdirs))));
 
 		// rmonitor_fss_once(f); disabled until statfs fs id makes sense.
@@ -1560,7 +1560,7 @@ int rmonitor_resources(long int interval /*in microseconds */)
 		round++;
 	}
 
-    free(resources_now);
+    rmsummary_delete(resources_now);
     free(p_acc);
     free(m_acc);
     free(d_acc);
@@ -1595,8 +1595,8 @@ int main(int argc, char **argv) {
     signal(SIGTERM, rmonitor_final_cleanup);
 
     summary          = calloc(1, sizeof(struct rmsummary));
-    resources_limits = make_rmsummary(-1);
-    resources_flags  = make_rmsummary(0);
+    resources_limits = rmsummary_create(-1);
+    resources_flags  = rmsummary_create(0);
 
     rmsummary_read_env_vars(resources_limits);
 
@@ -1650,7 +1650,7 @@ int main(int argc, char **argv) {
 
 
 	/* By default, measure working directory. */
-	resources_flags->workdir_footprint = 1;
+	resources_flags->disk = 1;
 
 	/* Used in LONG_OPT_MEASURE_DIR */
 	char measure_dir_name[PATH_MAX];
@@ -1706,7 +1706,7 @@ int main(int argc, char **argv) {
 				use_inotify = 1;
 				break;
 			case LONG_OPT_NO_DISK_FOOTPRINT:
-				resources_flags->workdir_footprint = 0;
+				resources_flags->disk = 0;
 				break;
 			case LONG_OPT_FOLLOW_CHDIR:
 				follow_chdir = 1;

--- a/resource_monitor/src/rmon_tools.c
+++ b/resource_monitor/src/rmon_tools.c
@@ -4,12 +4,12 @@ struct field fields[NUM_FIELDS + 1] = {
 	[WALL_TIME] = {"t", "wall time",      "s",      1, offsetof(struct rmDsummary, wall_time)},
 	[CPU_TIME]  = {"c", "cpu time",        "s",     1, offsetof(struct rmDsummary, cpu_time)},
 	[VIRTUAL  ] = {"v", "virtual memory",  "MB",    1, offsetof(struct rmDsummary, virtual_memory)},
-	[RESIDENT ] = {"m", "resident memory", "MB",    1, offsetof(struct rmDsummary, resident_memory)},
+	[RESIDENT ] = {"m", "resident memory", "MB",    1, offsetof(struct rmDsummary, memory)},
 	[SWAP     ] = {"s", "swap memory",     "MB",    1, offsetof(struct rmDsummary, swap_memory)},
 	[B_READ   ] = {"r", "read bytes",      "MB",    1, offsetof(struct rmDsummary, bytes_read)},
 	[B_WRITTEN] = {"w", "written bytes",   "MB",    1, offsetof(struct rmDsummary, bytes_written)},
-	[FILES    ] = {"n", "num files",       "files", 1, offsetof(struct rmDsummary, workdir_num_files)},
-	[FOOTPRINT] = {"z", "footprint",       "MB",    1, offsetof(struct rmDsummary, workdir_footprint)},
+	[FILES    ] = {"n", "num files",       "files", 1, offsetof(struct rmDsummary, total_files)},
+	[FOOTPRINT] = {"z", "footprint",       "MB",    1, offsetof(struct rmDsummary, disk)},
 	[CORES    ] = {"C", "cores",           "cores", 0, offsetof(struct rmDsummary, cores)},
 	[MAX_PROCESSES]   = {"p", "max processes",   "procs", 0, offsetof(struct rmDsummary, max_concurrent_processes)},
 	[TOTAL_PROCESSES] = {"P", "total processes", "procs", 0, offsetof(struct rmDsummary, total_processes)},
@@ -268,14 +268,14 @@ struct rmDsummary *parse_summary(FILE *stream, char *filename)
 	s->max_concurrent_processes = so->max_concurrent_processes;
 
 	s->virtual_memory = so->virtual_memory;
-	s->resident_memory = so->resident_memory;
+	s->memory = so->memory;
 	s->swap_memory = so->swap_memory;
 
 	s->bytes_read    = bytes_to_Mbytes(so->bytes_read);
 	s->bytes_written = bytes_to_Mbytes(so->bytes_written);
 
-	s->workdir_num_files = so->workdir_num_files;
-	s->workdir_footprint = so->workdir_footprint;
+	s->total_files = so->total_files;
+	s->disk = so->disk;
 
 	s->task_id = so->task_id;
 	if(s->task_id < 0)

--- a/resource_monitor/src/rmon_tools.h
+++ b/resource_monitor/src/rmon_tools.h
@@ -58,12 +58,12 @@ struct rmDsummary
 	double  max_concurrent_processes;
 	double  cpu_time;
 	double  virtual_memory;
-	double  resident_memory;
+	double  memory;
 	double  swap_memory;
 	double  bytes_read;
 	double  bytes_written;
-	double  workdir_num_files;
-	double  workdir_footprint;
+	double  total_files;
+	double  disk;
 	double  cores;
 
 };

--- a/resource_monitor/src/rmonitor_poll_example.c
+++ b/resource_monitor/src/rmonitor_poll_example.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
 			resources.wall_time/1000000.0);
 
 	fprintf(stdout, "total memory used (MB): %" PRId64 ", ",
-			resources.resident_memory + resources.swap_memory);
+			resources.memory + resources.swap_memory);
 
 	fprintf(stdout, "total cores used: %" PRId64 "\n",
 			resources.cores);

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -3970,7 +3970,7 @@ void work_queue_task_delete(struct work_queue_task *t)
 		if(t->host)
 			free(t->host);
 		if(t->resources_measured)
-			free(t->resources_measured);
+			rmsummary_delete(t->resources_measured);
 		free(t);
 	}
 }
@@ -4356,6 +4356,10 @@ void work_queue_delete(struct work_queue *q)
 		if(q->logfile) {
 			fclose(q->logfile);
 		}
+
+		if(q->measured_local_resources)
+			rmsummary_delete(q->measured_local_resources);
+
 		free(q);
 	}
 }


### PR DESCRIPTION
Rename make_rmsummary to rmsummary_create.
Rename resident_memory to memory, workdir_footprint to disk, and workdir_num_files to total_files.
Add rmsummary_delete.