### PR TITLE
umbrella communicates with s3

### DIFF
--- a/umbrella/example/povray/README
+++ b/umbrella/example/povray/README
@@ -101,3 +101,19 @@ umbrella \
 --sandbox_mode parrot \
 --log umbrella.log \
 run
+
+#The interaction between Umbrella and the Amazon S3 uses the boto3 package which is not included in Python by default. Please install boto3 first.
+#upload the dependencies to S3.
+umbrella \
+--spec povray_S_local.umbrella \
+--localdir /tmp/umbrella_test/ \
+--log umbrella.log \
+upload s3 testhmeng public-read newspec.umbrella
+
+umbrella \
+--spec povray_S_s3.umbrella \
+--localdir /tmp/umbrella_test/ \
+--output "/tmp/frame000.png=/tmp/umbrella_test/parrot_povray_S_s3/output.png" \
+--sandbox_mode parrot \
+--log umbrella.log \
+run

--- a/umbrella/example/povray/povray_S_s3.umbrella
+++ b/umbrella/example/povray/povray_S_s3.umbrella
@@ -1,0 +1,72 @@
+{
+    "comment": "A ray-tracing application which creates video frames. The dependencies are all from local dirs /tmp/local_data", 
+    "kernel": {
+        "version": ">=2.6.18", 
+        "name": "linux"
+    }, 
+    "data": {
+        "4_cubes.pov": {
+            "format": "plain", 
+            "checksum": "c65266cd2b672854b821ed93028a877a", 
+            "source": [
+                "s3+https://s3.amazonaws.com/testhmeng/4_cubes.pov"
+            ], 
+            "action": "none", 
+            "mountpoint": "/tmp/4_cubes.pov", 
+            "id": "c65266cd2b672854b821ed93028a877a", 
+            "size": "1757"
+        }, 
+        "WRC_RubiksCube.inc": {
+            "format": "plain", 
+            "checksum": "2f8afdd09fc3a6177c6f1977bb3bdae7", 
+            "source": [
+                "s3+https://s3.amazonaws.com/testhmeng/WRC_RubiksCube.inc"
+            ], 
+            "action": "none", 
+            "mountpoint": "/tmp/WRC_RubiksCube.inc", 
+            "id": "2f8afdd09fc3a6177c6f1977bb3bdae7", 
+            "size": "28499"
+        }
+    }, 
+    "cmd": "povray +I/tmp/4_cubes.pov +O/tmp/frame000.png +K.0  -H50 -W50", 
+    "hardware": {
+        "cores": "1", 
+        "disk": "2GB", 
+        "arch": "x86_64", 
+        "memory": "1GB"
+    }, 
+    "environ": {
+        "PWD": "/tmp"
+    }, 
+    "output": {
+        "files": [
+            "/tmp/frame000.png"
+        ], 
+        "dirs": []
+    }, 
+    "os": {
+        "name": "Redhat", 
+        "format": "tgz", 
+        "checksum": "669ab5ef94af84d273f8f92a86b7907a", 
+        "source": [
+            "s3+https://s3.amazonaws.com/testhmeng/redhat-6.5-x86_64.tar.gz"
+        ], 
+        "version": "6.5", 
+        "size": "633848940", 
+        "id": "669ab5ef94af84d273f8f92a86b7907a", 
+        "uncompressed_size": "1743656960"
+    }, 
+    "software": {
+        "povray-3.6.1-redhat6-x86_64": {
+            "format": "tgz", 
+            "checksum": "b02ba86dd3081a703b4b01dc463e0499", 
+            "source": [
+                "s3+https://s3.amazonaws.com/testhmeng/povray-3.6.1-redhat6-x86_64.tar.gz"
+            ], 
+            "mountpoint": "/software/povray-3.6.1-redhat6-x86_64", 
+            "size": "1471452", 
+            "id": "b02ba86dd3081a703b4b01dc463e0499", 
+            "uncompressed_size": "3010560"
+        }
+    }
+}


### PR DESCRIPTION
	1) Upload the dependencies of one umbrella spec to the Amazon s3; and create a
	new umbrella spec with data dependencies from s3; Upload this new umbrella spec
	to s3

	2) Support dependencies from s3 during runtime