### PR TITLE
More bug fixes for memory mappings

### DIFF
--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -2345,8 +2345,12 @@ static void decode_syscall( struct pfs_process *p, int entering )
 		 */
 
 		case SYSCALL32_munmap:
-			if(entering) {
-				pfs_mmap_delete(args[0],args[1]);
+			if(!entering) {
+				INT64_T actual;
+				tracer_result_get(p->tracer,&actual); /* check if kernel did the unmap... kernel does some error checking for us */
+				if (actual == 0) {
+					pfs_mmap_delete(args[0],args[1]);
+				}
 			}
 			break;
 

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -2035,8 +2035,12 @@ static void decode_syscall( struct pfs_process *p, int entering )
 		 */
 
 		case SYSCALL64_munmap:
-			if(entering) {
-				pfs_mmap_delete(args[0],args[1]);
+			if(!entering) {
+				INT64_T actual;
+				tracer_result_get(p->tracer,&actual); /* check if kernel did the unmap... kernel does some error checking for us */
+				if (actual == 0) {
+					pfs_mmap_delete(args[0],args[1]);
+				}
 			}
 			break;
 

--- a/parrot/test/TR_parrot_mmap.sh
+++ b/parrot/test/TR_parrot_mmap.sh
@@ -20,6 +20,15 @@ prepare()
 #include <stdlib.h>
 #include <string.h>
 
+void dumpmaps (void)
+{
+	char buf[4096];
+	int fd = open("/proc/self/maps", O_RDONLY);
+	read(fd, buf, sizeof(buf));
+	write(STDOUT_FILENO, buf, strlen(buf));
+	close(fd);
+}
+
 int main (int argc, char *argv[])
 {
 	int i;
@@ -50,10 +59,12 @@ int main (int argc, char *argv[])
 			ftruncate(fd, 0x2000);
 			uint8_t *addr = mmap(NULL, 0x2000, PROT_READ, MAP_SHARED, fd, 0);
 			close(fd);
+			dumpmaps();
 			if (addr != MAP_FAILED) {
 				munmap(addr+0x1000, 0x118);
 			}
 		}
+		dumpmaps();
 	}
 
 	/* after split */
@@ -65,10 +76,29 @@ int main (int argc, char *argv[])
 			ftruncate(fd, 0x2000);
 			uint8_t *addr = mmap(NULL, 0x2000, PROT_READ, MAP_SHARED, fd, 0);
 			close(fd);
+			dumpmaps();
 			if (addr != MAP_FAILED) {
 				munmap(addr, 0x118);
 			}
 		}
+		dumpmaps();
+	}
+
+	/* whole */
+	{
+		char f[PATH_MAX] = "/tmp/foo.XXXXXX";
+		int fd = mkstemp(f);
+		if (fd >= 0) {
+			unlink(f);
+			ftruncate(fd, 0x2000);
+			uint8_t *addr = mmap(NULL, 0x2000, PROT_READ, MAP_SHARED, fd, 0);
+			close(fd);
+			dumpmaps();
+			if (addr != MAP_FAILED) {
+				munmap(addr, 0x1118);
+			}
+		}
+		dumpmaps();
 	}
 	return 0;
 }


### PR DESCRIPTION
````
commit c7de11342b86a7e67f734aee11fac3ae478ffac4
Author: Patrick Donnelly <pdonnel3@nd.edu>
Date:   Fri Jan 15 12:28:31 2016 -0500

    Add more test code for mmap splits.

commit 949871994c000af2a556082b2e24d11b8745cdd8
Author: Patrick Donnelly <pdonnel3@nd.edu>
Date:   Fri Jan 15 12:27:30 2016 -0500

    Correct bug in after split size/file offset.
    
    Also add debug message for split.

commit 3d3649d6338a3f4498ad9414a202d6d208bedf38
Author: Patrick Donnelly <pdonnel3@nd.edu>
Date:   Fri Jan 15 12:25:37 2016 -0500

    Use a memfd for proc maps.
    
    This does away with the dependency on /dev/shm.

commit 5d85f5a9b636a36c30bef92afa8f7741b6cd9ef0
Author: Patrick Donnelly <pdonnel3@nd.edu>
Date:   Fri Jan 15 12:22:41 2016 -0500

    Only munmap if kernel succeeds.
    
    Our code was being more lenient with inputs and would perform an unmap when the
    kernel would fail. In particular, our code allowed the address to not be a
    multiple of the page size.
    
    The solution is to let the kernel try first and if it succeeds, then we do the
    unmap.
````