### PR TITLE
Stats per category

### DIFF
--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -39,9 +39,7 @@ struct category *category_lookup_or_create(struct hash_table *categories, const 
 	c->name       = xxstrdup(name);
 	c->fast_abort = -1;
 
-	c->total_tasks_complete     = 0;
-	c->total_good_execute_time  = 0;
-	c->total_good_transfer_time = 0;
+	c->total_tasks = 0;
 
 	c->first_allocation    = NULL;
 	c->max_allocation      = NULL;

--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -75,6 +75,9 @@ void category_delete(struct hash_table *categories, const char *name) {
 	if(c->name)
 		free(c->name);
 
+	if(c->wq_stats)
+		free(c->wq_stats);
+
 	itable_delete(c->cores_histogram);
 	itable_delete(c->memory_histogram);
 	itable_delete(c->disk_histogram);

--- a/dttools/src/category.h
+++ b/dttools/src/category.h
@@ -24,12 +24,11 @@ struct category {
 	struct itable *disk_histogram;
 	struct itable *wall_time_histogram;
 
-	/* stats for work queue */
-	timestamp_t average_task_time;
-	uint64_t total_tasks_complete;
-	uint64_t total_good_execute_time;
-	uint64_t total_good_transfer_time;
+	uint64_t total_tasks;
 
+	/* stats for wq */
+	uint64_t average_task_time;
+	struct work_queue_stats *wq_stats;
 };
 
 struct category *category_lookup_or_create(struct hash_table *categories, const char *name);

--- a/work_queue/src/perl/Work_Queue.pm
+++ b/work_queue/src/perl/Work_Queue.pm
@@ -15,8 +15,6 @@ use Carp qw(croak);
 use work_queue;
 use Work_Queue::Task;
 
-our $VERSION = 4.3.0;
-
 local $SIG{INT} = sub {
 	croak "Got terminate signal!\n";
 };
@@ -90,6 +88,14 @@ sub stats_hierarchy {
 	work_queue_get_stats_hierarchy($self->{_work_queue}, $self->{_stats_hierarchy});
 	return $self->{_stats_hierarchy};
 }
+
+sub stats_category {
+	my ($self, $category) = @_;
+	my $stats = work_queue::work_queue_stats->new();
+	work_queue_get_stats_category($self->{_work_queue}, $category, $stats);
+	return $stats;
+}
+
 
 sub task_state {
 	my ($self, $taskid) = @_;
@@ -361,6 +367,14 @@ Get the master's queue statistics.
 Get the queue statistics, including master and foremen.
 
 		 print $q->stats_hierarchy->{workers_busy};
+
+=head3 C<stats_category>
+
+Get the tasks statistics from the particular category.
+
+		 $s = $q->stats_category("my_category")
+		 print $s->{tasks_waiting}
+
 
 =head3 C<enable_monitoring($dir_name)>
 

--- a/work_queue/src/perl/Work_Queue/Task.pm
+++ b/work_queue/src/perl/Work_Queue/Task.pm
@@ -15,8 +15,6 @@ use work_queue;
 
 use Carp qw(croak);
 
-our $VERSION = 4.3.0;
-
 sub Work_Queue::Task::new {
 	my ($class, $command) = @_;
 	my $_task = work_queue_task_create($command);

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -700,7 +700,7 @@ class WorkQueue(_object):
     # @code
     # >>> print q.stats
     # @endcode
-    # The fields in @ref work_queue_stats can also be individually accessed through this call. For example:
+    # The fields in @ref stats can also be individually accessed through this call. For example:
     # @code
     # >>> print q.stats.workers_busy
     # @endcode
@@ -714,16 +714,35 @@ class WorkQueue(_object):
     # @a Note: This is defined using property decorator. So it must be called without parentheses
     # (). For example:
     # @code
-    # >>> print q.stats
+    # >>> print q.stats_hierarchy
     # @endcode
-    # The fields in @ref work_queue_stats can also be individually accessed through this call. For example:
+    # The fields in @ref stats_hierarchy can also be individually accessed through this call. For example:
     # @code
-    # >>> print q.stats.workers_busy
+    # >>> print q.stats_hierarchy.workers_busy
     # @endcode
     @property
     def stats_hierarchy(self):
         work_queue_get_stats_hierarchy(self._work_queue, self._stats_hierarchy)
         return self._stats_hierarchy
+
+    ##
+    # Get the task statistics for the given category.
+    #
+    # @param self 	Reference to the current work queue object.
+    # @param category   A category name.
+    # For example:
+    # @code
+    # s = q.stats_category("my_category")
+    # >>> print s
+    # @endcode
+    # The fields in @ref work_queue_stats can also be individually accessed through this call. For example:
+    # @code
+    # >>> print s.tasks_waiting
+    # @endcode
+    def stats_category(self, category):
+        stats = work_queue_stats()
+        work_queue_get_stats_category(self._work_queue, category, stats)
+        return stats
 
     ##
     # Get current task state. See @ref work_queue_task_state_t for possible values.

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -3108,6 +3108,10 @@ static int send_one_task( struct work_queue *q )
 	// Consider each task in the order of priority:
 	list_first_item(q->ready_list);
 	while( (t = list_next_item(q->ready_list))) {
+
+		// Check whether a first-allocation is available for the task.
+		relabel_task(q, t);
+
 		// Find the best worker for the task at the head of the list
 		w = find_best_worker(q,t);
 
@@ -5678,9 +5682,7 @@ int relabel_task(struct work_queue *q, struct work_queue_task *t) {
 
 const struct rmsummary *task_dynamic_label(struct work_queue *q, struct work_queue_task *t) {
 
-	relabel_task(q, t);
 	struct category *c = work_queue_category_lookup_or_create(q->categories, t->category);
-
 	switch(t->resource_request) {
 		/* return the old cases when we are not autolabeling. */
 		case WORK_QUEUE_ALLOCATION_AUTO_ZERO:

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -5482,6 +5482,18 @@ void work_queue_get_stats_hierarchy(struct work_queue *q, struct work_queue_stat
 	}
 }
 
+void work_queue_get_stats_category(struct work_queue *q, const char *category, struct work_queue_stats *s)
+{
+	struct category *c = work_queue_category_lookup_or_create(q->categories, category);
+	struct work_queue_stats *cs = c->wq_stats;
+	memcpy(s, cs, sizeof(*s));
+
+	//info about tasks
+	s->tasks_waiting = task_state_count(q, category, WORK_QUEUE_TASK_READY);
+	s->tasks_running = task_state_count(q, category, WORK_QUEUE_TASK_RUNNING) + task_state_count(q, category, WORK_QUEUE_TASK_WAITING_RETRIEVAL);
+	s->tasks_complete = task_state_count(q, category, WORK_QUEUE_TASK_RETRIEVED);
+}
+
 /*
 This function is a little roundabout, because work_queue_resources_add
 updates the min and max of each value as it goes.  So, we set total

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -2525,10 +2525,10 @@ static struct rmsummary *task_worker_box_size(struct work_queue *q, struct work_
 	rmsummary_merge_max(limits, label);
 
 	if(t->resource_request == WORK_QUEUE_ALLOCATION_AUTO_ZERO) {
-		limits->cores  = MIN(MAX(label->cores, 0),  w->resources->cores.total);
-		limits->memory = MIN(MAX(label->memory, 0), w->resources->memory.total);
-		limits->disk   = MIN(MAX(label->disk, 0),   w->resources->disk.total);
-		limits->gpus   = MIN(MAX(label->gpus, 0),   w->resources->gpus.total);
+		limits->cores  = MIN(label->cores,  w->resources->cores.total);
+		limits->memory = MIN(label->memory, w->resources->memory.total);
+		limits->disk   = MIN(label->disk,   w->resources->disk.total);
+		limits->gpus   = MIN(label->gpus,   w->resources->gpus.total);
 	}
 
 	return limits;

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -169,9 +169,12 @@ struct work_queue_stats {
 	int total_workers_idled_out;    /**< Total number of worker that disconnected for being idle. */
 	int total_workers_fast_aborted; /**< Total number of worker connections terminated for being too slow. (see @ref work_queue_activate_fast_abort) */
 
+	/* Stats for the current state of tasks: */
 	int tasks_waiting;              /**< Number of tasks waiting to be run. */
 	int tasks_running;              /**< Number of tasks currently running. */
 	int tasks_complete;             /**< Number of tasks waiting to be returned to user. */
+
+	/* Cummulative stats for tasks: */
 	int total_tasks_dispatched;     /**< Total number of tasks dispatch to workers. */
 	int total_tasks_complete;       /**< Total number of tasks completed and returned to user. */
 	int total_tasks_failed;         /**< Total number of tasks completed and returned to user with result other than WQ_RESULT_SUCCESS. */

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -561,6 +561,13 @@ void work_queue_get_stats(struct work_queue *q, struct work_queue_stats *s);
 */
 void work_queue_get_stats_hierarchy(struct work_queue *q, struct work_queue_stats *s);
 
+/** Get the task statistics for the given category.
+@param q A work queue object.
+@param c A category name.
+@param s A pointer to a buffer that will be filed with statistics.
+*/
+void work_queue_get_stats_category(struct work_queue *q, const char *c, struct work_queue_stats *s);
+
 
 /** Get the current state of the task.
 @param q A work queue object.


### PR DESCRIPTION
As requested by @matz-e. In python:

s = q.stats_category("my_category")
print s.tasks_waiting

Note that only stats relevant to tasks are included (bytes transfered, the different tasks counters etc.)

(EDIT: reorganized code to remove memory leaks.)