### PR TITLE
Modify the Umbrella mechanisms for osf or s3 resources

### DIFF
--- a/umbrella/example/povray/README
+++ b/umbrella/example/povray/README
@@ -111,6 +111,14 @@ umbrella \
 upload s3 testhmeng public-read newspec.umbrella
 
 umbrella \
+--spec povray_S_osf.umbrella \
+--localdir /tmp/umbrella_test/ \
+--output "/tmp/frame000.png=/tmp/umbrella_test/parrot_povray_S_osf/output.png" \
+--sandbox_mode parrot \
+--log umbrella.log \
+run
+
+umbrella \
 --spec povray_S_s3.umbrella \
 --localdir /tmp/umbrella_test/ \
 --output "/tmp/frame000.png=/tmp/umbrella_test/parrot_povray_S_s3/output.png" \

--- a/umbrella/example/povray/povray_S_osf.umbrella
+++ b/umbrella/example/povray/povray_S_osf.umbrella
@@ -1,5 +1,6 @@
 {
     "comment": "A ray-tracing application which creates video frames. The dependencies are all from OSF.", 
+    "_comment": "osf project name: abc8",
     "kernel": {
         "version": ">=2.6.18", 
         "name": "linux"


### PR DESCRIPTION
	For deps from s3 or osf, first try to download it as a normal url using vanilla
	python. If failed, try to use python packages (boto3 or requests) and the user
	authentication to download deps.