### PR TITLE
Critical Fix to Parrot-Bxgrid support

### DIFF
--- a/dttools/src/random.h
+++ b/dttools/src/random.h
@@ -24,6 +24,12 @@ void    random_init (void);
  */
 #define random_int()   ((int) random_int64())
 
+/** Get a random unsigned int.
+ *
+ * @return a random unsigned int.
+ */
+#define random_uint()   ((unsigned) random_int64())
+
 /** Get a random int32_t.
  *
  * @return a random int32_t.

--- a/parrot/src/pfs_service_bxgrid.cc
+++ b/parrot/src/pfs_service_bxgrid.cc
@@ -329,7 +329,8 @@ const char *bxgrid_lookup_replicaid( MYSQL *mysql_cxn, const char *fileid, int n
 				strncpy(replicaid, replica_list->replicas[i], BXGRID_ID_MAX);
 				debug(D_BXGRID, "selecting closest replica %s", replicaid);
 			} else {
-				strncpy(replicaid, replica_list->replicas[random_int() % replica_list->nreplicas], BXGRID_ID_MAX);
+				// Careful, use UNSIGNED integer for array index!
+				strncpy(replicaid, replica_list->replicas[random_uint() % replica_list->nreplicas], BXGRID_ID_MAX);
 				debug(D_BXGRID, "selecting random replica %s", replicaid);
 			}
 		} else {
@@ -344,7 +345,7 @@ const char *bxgrid_lookup_replicaid( MYSQL *mysql_cxn, const char *fileid, int n
 
 		if (nreplicas == 0 || nid >= nreplicas) return NULL;
 		if (nid < 0) {
-			int i, ri = random_int() % nreplicas;
+			int i, ri = random_uint() % nreplicas;
 			BXGRID_FETCH_AND_CHECK(rep_row, rep_res, NULL);
 			for (i = 0; i < nreplicas; i++) {
 				if (ri == i)

--- a/parrot/src/pfs_service_lfc.cc
+++ b/parrot/src/pfs_service_lfc.cc
@@ -165,7 +165,7 @@ public:
 			debug(D_LFC,"replica: %s",replicas[n]);
 			n++;
 		}
-		return random_int()%n;
+		return random_uint()%n;
 	}
 
 	virtual pfs_file * open( pfs_name *name, int flags, mode_t mode ) {

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -602,7 +602,7 @@ pfs_file * pfs_table::open_object( const char *lname, int flags, mode_t mode, in
 					/* idea here is to not include a SPECIAL fd in this directory */
 					if (pointers[i] == NATIVE || PARROT_POINTER(pointers[i])) {
 						struct dirent dirent;
-						dirent.d_ino = random_int();
+						dirent.d_ino = random_uint();
 						dirent.d_off = 0;
 						dirent.d_reclen = sizeof(dirent);
 						snprintf(dirent.d_name, sizeof(dirent.d_name), "%d", i);


### PR DESCRIPTION
Use of signed random number when selecting replicas led crashes 50% of the time.
(This didn't come up until recently, b/c bxgrid was using an old parrot binary.)
