### PR TITLE
Add jx.h into the public library list, which is required by work_queue.h

### DIFF
--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -108,6 +108,7 @@ HEADERS_PUBLIC = \
 	auth_kerberos.h \
 	auth_ticket.h \
 	auth_unix.h \
+    jx.h\
 	buffer.h \
 	debug.h \
 	int_sizes.h \


### PR DESCRIPTION
Solve the issue #1111 