### PR TITLE
DVDT resources mini-loop with makeflow

### DIFF
--- a/batch_job/src/batch_job_work_queue.c
+++ b/batch_job/src/batch_job_work_queue.c
@@ -230,6 +230,14 @@ static void batch_queue_wq_option_update (struct batch_queue *q, const char *wha
 			work_queue_master_preferred_connection(q->data, value);
 		else
 			work_queue_master_preferred_connection(q->data, "by_ip");
+	} else if(strcmp(what, "category-limits") == 0) {
+		struct rmsummary *s = rmsummary_parse_string(value);
+		if(s) {
+			work_queue_specify_max_category_resources(q->data, s->category, s);
+			rmsummary_delete(s);
+		} else {
+			debug(D_NOTICE, "Could no parse '%s' as a summary of resorces encoded in JSON\n", value);
+		}
 	}
 }
 

--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -172,8 +172,7 @@ int64_t category_first_allocation(struct itable *histogram, int64_t top_resource
 	return a_1;
 }
 
-void category_update_first_allocation(struct hash_table *categories, const char *category, struct rmsummary *top) {
-
+void category_update_first_allocation(struct hash_table *categories, const char *category) {
 	/* buffer used only for debug output. */
 	static buffer_t *b = NULL;
 	if(!b) {
@@ -182,8 +181,9 @@ void category_update_first_allocation(struct hash_table *categories, const char 
 	}
 
 	struct category *c = category_lookup_or_create(categories, category);
+	struct rmsummary *top = c->max_allocation;
 
-	if(!c->max_allocation)
+	if(!top)
 		return;
 
 	if(!c->first_allocation) {
@@ -272,7 +272,7 @@ void categories_initialize(struct hash_table *categories, struct rmsummary *top,
 
 	hash_table_firstkey(categories);
 	while(hash_table_nextkey(categories, &name, (void **) &c)) {
-		category_update_first_allocation(categories, name, top);
+		category_update_first_allocation(categories, name);
 		category_clear_histograms(c);
 	}
 }

--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -273,3 +273,35 @@ void categories_initialize(struct hash_table *categories, struct rmsummary *top,
 		category_clear_histograms(c);
 	}
 }
+
+/* returns the next allocation state. */
+category_allocation_t category_next_label(struct hash_table *categories, const char *category, category_allocation_t current_label, int resource_overflow) {
+
+	if(resource_overflow && (current_label == CATEGORY_ALLOCATION_USER || current_label == CATEGORY_ALLOCATION_UNLABELED || current_label == CATEGORY_ALLOCATION_AUTO_MAX)) {
+		return CATEGORY_ALLOCATION_ERROR;
+	}
+
+	/* If user specified resources manually, respect the label. */
+	if(current_label == CATEGORY_ALLOCATION_USER) {
+			return CATEGORY_ALLOCATION_USER;
+	}
+
+	struct category *c = category_lookup_or_create(categories, category);
+	/* If category is not labeling, and user is not labeling, return unlabeled. */
+	if(!c->max_allocation) {
+		return CATEGORY_ALLOCATION_UNLABELED;
+	}
+
+	/* Never downgrade max allocation */
+	if(current_label == CATEGORY_ALLOCATION_AUTO_MAX) {
+		return CATEGORY_ALLOCATION_AUTO_MAX;
+	}
+
+	if(c->first_allocation) {
+		/* Use first allocation when it is available. */
+		return CATEGORY_ALLOCATION_AUTO_FIRST;
+	} else {
+		/* Use default when no enough information is available. */
+		return CATEGORY_ALLOCATION_AUTO_ZERO;
+	}
+}

--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -183,6 +183,9 @@ void category_update_first_allocation(struct hash_table *categories, const char 
 
 	struct category *c = category_lookup_or_create(categories, category);
 
+	if(!c->max_allocation)
+		return;
+
 	if(!c->first_allocation) {
 		c->first_allocation = rmsummary_create(-1);
 	}

--- a/dttools/src/category.h
+++ b/dttools/src/category.h
@@ -38,6 +38,10 @@ struct category {
 	/* stats for wq */
 	uint64_t average_task_time;
 	struct work_queue_stats *wq_stats;
+
+	/* variables for makeflow */
+	/* Mappings between variable names defined in the makeflow file and their values. */
+	struct hash_table *mf_variables;
 };
 
 struct category *category_lookup_or_create(struct hash_table *categories, const char *name);

--- a/dttools/src/category.h
+++ b/dttools/src/category.h
@@ -10,6 +10,15 @@ See the file COPYING for details.
 #include "hash_table.h"
 #include "timestamp.h"
 
+typedef enum {
+	CATEGORY_ALLOCATION_UNLABELED = 0, /**< No resources are explicitely requested. */
+	CATEGORY_ALLOCATION_USER,          /**< Using values explicitely requested. */
+	CATEGORY_ALLOCATION_AUTO_ZERO,     /**< Pre-step for autolabeling, when the first allocation has not been computed. */
+	CATEGORY_ALLOCATION_AUTO_FIRST,    /**< Using first step value of the two-step policy. */
+	CATEGORY_ALLOCATION_AUTO_MAX,      /**< Using max of category. (2nd step of two-step policy) */
+	CATEGORY_ALLOCATION_ERROR          /**< No valid resources could be found. (E.g., after 2nd step fails) */
+} category_allocation_t;
+
 struct category {
 	char *name;
 	double fast_abort;
@@ -37,5 +46,6 @@ int64_t category_first_allocation(struct itable *histogram, int64_t top_resource
 void category_accumulate_summary(struct hash_table *categories, const char *category, struct rmsummary *rs);
 void category_update_first_allocation(struct hash_table *categories, const char *category, struct rmsummary *top);
 void categories_initialize(struct hash_table *categories, struct rmsummary *top, const char *summaries_file);
+category_allocation_t category_next_label(struct hash_table *categories, const char *category, category_allocation_t current_label, int resource_overflow);
 
 #endif

--- a/dttools/src/category.h
+++ b/dttools/src/category.h
@@ -48,7 +48,7 @@ struct category *category_lookup_or_create(struct hash_table *categories, const 
 void category_delete(struct hash_table *categories, const char *name);
 int64_t category_first_allocation(struct itable *histogram, int64_t top_resource);
 void category_accumulate_summary(struct hash_table *categories, const char *category, struct rmsummary *rs);
-void category_update_first_allocation(struct hash_table *categories, const char *category, struct rmsummary *top);
+void category_update_first_allocation(struct hash_table *categories, const char *category);
 void categories_initialize(struct hash_table *categories, struct rmsummary *top, const char *summaries_file);
 category_allocation_t category_next_label(struct hash_table *categories, const char *category, category_allocation_t current_label, int resource_overflow);
 

--- a/dttools/src/rmsummary.c
+++ b/dttools/src/rmsummary.c
@@ -384,6 +384,21 @@ struct rmsummary *rmsummary_parse_file_single(const char *filename)
 	return s;
 }
 
+struct rmsummary *rmsummary_parse_string(const char *str) {
+	if(!str)
+		return NULL;
+
+	struct jx *j = jx_parse_string(str);
+
+	if(!j)
+		return NULL;
+
+	struct rmsummary *s = json_to_rmsummary(j);
+
+	jx_delete(j);
+	return s;
+}
+
 
 /* Parse the file assuming there are multiple summaries in it. Summary
    boundaries are lines starting with # */

--- a/dttools/src/rmsummary.h
+++ b/dttools/src/rmsummary.h
@@ -83,6 +83,9 @@ int rmsummary_assign_char_field(struct rmsummary *s, const char *key, char *valu
 /**  Reads a single summary file from filename **/
 struct rmsummary *rmsummary_parse_file_single(const char *filename);
 
+/**  Reads a single summary file from string **/
+struct rmsummary *rmsummary_parse_string(const char *str);
+
 /**  Reads all summaries from filename **/
 struct list *rmsummary_parse_file_multiple(const char *filename);
 

--- a/makeflow/src/Makefile
+++ b/makeflow/src/Makefile
@@ -6,7 +6,7 @@ include ../../rules.mk
 LOCAL_LINKAGE=$(CCTOOLS_GLOBUS_LDFLAGS)
 
 EXTERNAL_DEPENDENCIES = ../../batch_job/src/libbatch_job.a ../../work_queue/src/libwork_queue.a ../../chirp/src/libchirp.a ../../dttools/src/libdttools.a
-OBJECTS = dag.o dag_node.o dag_file.o dag_variable.o dag_visitors.o lexer.o parser.o
+OBJECTS = dag.o dag_node.o dag_file.o dag_variable.o dag_visitors.o dag_resources.o lexer.o parser.o
 PROGRAMS = makeflow makeflow_viz makeflow_analyze makeflow_linker
 SCRIPTS = condor_submit_makeflow makeflow_graph_log makeflow_monitor starch makeflow_linker_perl_driver makeflow_linker_python_driver
 TARGETS = $(PROGRAMS)

--- a/makeflow/src/dag.c
+++ b/makeflow/src/dag.c
@@ -21,6 +21,7 @@ See the file COPYING for details.
 #include "rmsummary.h"
 
 #include "dag.h"
+#include "dag_resources.h"
 
 struct dag_variable *dag_variable_create(const char *name, const char *initial_value);
 
@@ -37,13 +38,14 @@ struct dag *dag_create()
 	d->files = hash_table_create(0, 0);
 	d->inputs = set_create(0);
 	d->outputs = set_create(0);
-	d->variables = hash_table_create(0, 0);
 	d->nodeid_counter = 0;
 	d->export_vars  = set_create(0);
 	d->special_vars = set_create(0);
-	d->task_categories = hash_table_create(0, 0);
 	d->completed_files = 0;
 	d->deleted_files = 0;
+
+	d->categories   = hash_table_create(0, 0);
+	d->default_category = makeflow_category_lookup_or_create(d, "default");
 
 	/* Add GC_*_LIST to variables table to ensure it is in
 	 * global DAG scope. /

--- a/makeflow/src/dag.h
+++ b/makeflow/src/dag.h
@@ -27,8 +27,8 @@ struct dag {
 	struct hash_table *files;           /* Maps every filename to a struct dag_file. */
 	struct set *inputs;                 /* Set of every struct dag_file specified as input. */
 	struct set *outputs;                /* Set of every struct dag_file specified as output. */
-	struct hash_table *variables;       /* Mappings between variable names defined in the makeflow file and their values. */
-	struct hash_table *task_categories; /* Mapping from labels to category structures. */
+	struct hash_table *categories;      /* Mapping from labels to category structures. */
+	struct category *default_category;  /* Default for all rules and variables without an explicit category. */
 	struct set *export_vars;            /* List of variables with prefix export. (these are setenv'ed eventually). */
 	struct set *special_vars;           /* List of special variables, such as category, cores, memory, etc. */
 

--- a/makeflow/src/dag_node.c
+++ b/makeflow/src/dag_node.c
@@ -42,6 +42,7 @@ struct dag_node *dag_node_create(struct dag *d, int linenum)
 	n->ancestor_depth = -1;
 
 	n->resources_needed = rmsummary_create(-1);
+	n->resources_measured = NULL;
 
 	n->resource_request = CATEGORY_ALLOCATION_UNLABELED;
 

--- a/makeflow/src/dag_node.c
+++ b/makeflow/src/dag_node.c
@@ -43,6 +43,8 @@ struct dag_node *dag_node_create(struct dag *d, int linenum)
 
 	n->resources = rmsummary_create(-1);
 
+	n->resource_request = CATEGORY_ALLOCATION_UNLABELED;
+
 	return n;
 }
 

--- a/makeflow/src/dag_node.h
+++ b/makeflow/src/dag_node.h
@@ -59,6 +59,7 @@ struct dag_node {
 
 	category_allocation_t resource_request;  /* type of allocation for the node (user, unlabeled, max, etc.) */
 	struct rmsummary *resources_needed;      /* resources required by this rule */
+	struct rmsummary *resources_measured;    /* resources measured on completion. */
 
 	/* Variables used in dag_width, dag_width_uniform_task, and dag_depth
 	* functions. Probably we should move them only to those functions, using

--- a/makeflow/src/dag_node.h
+++ b/makeflow/src/dag_node.h
@@ -88,7 +88,8 @@ const char *dag_node_get_local_name(struct dag_node *n, const char *filename );
 char *dag_node_resources_wrap_options(struct dag_node *n, const char *default_options, batch_queue_type_t batch_type);
 char *dag_node_resources_wrap_as_rmonitor_options(struct dag_node *n);
 
-void dag_node_fill_resources(struct dag_node *n);
+void dag_node_init_resources(struct dag_node *n);
+int dag_node_update_resources(struct dag_node *n, int overflow);
 void dag_node_print_debug_resources(struct dag_node *n);
 
 const char *dag_node_state_name(dag_node_state_t state);

--- a/makeflow/src/dag_node.h
+++ b/makeflow/src/dag_node.h
@@ -58,7 +58,7 @@ struct dag_node {
 	struct hash_table *variables;       /* This node settings for variables with @ syntax */
 
 	category_allocation_t resource_request;  /* type of allocation for the node (user, unlabeled, max, etc.) */
-	struct rmsummary *resources;             /* resources required by this rule */
+	struct rmsummary *resources_needed;      /* resources required by this rule */
 
 	/* Variables used in dag_width, dag_width_uniform_task, and dag_depth
 	* functions. Probably we should move them only to those functions, using

--- a/makeflow/src/dag_node.h
+++ b/makeflow/src/dag_node.h
@@ -8,6 +8,7 @@ See the file COPYING for details.
 #define DAG_NODE_H
 
 #include "batch_job.h"
+#include "category.h"
 #include "set.h"
 #include "hash_table.h"
 #include "itable.h"
@@ -55,7 +56,9 @@ struct dag_node {
 	struct category *category;          /* The set of task this node belongs too. Ideally, the makeflow
 										   file labeled which tasks have comparable resource usage. */
 	struct hash_table *variables;       /* This node settings for variables with @ syntax */
-	struct rmsummary *resources;        /* resources required by this rule */
+
+	category_allocation_t resource_request;  /* type of allocation for the node (user, unlabeled, max, etc.) */
+	struct rmsummary *resources;             /* resources required by this rule */
 
 	/* Variables used in dag_width, dag_width_uniform_task, and dag_depth
 	* functions. Probably we should move them only to those functions, using

--- a/makeflow/src/dag_resources.c
+++ b/makeflow/src/dag_resources.c
@@ -1,0 +1,19 @@
+/*
+Copyright (C) 2016- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include "category.h"
+#include "dag.h"
+#include "hash_table.h"
+
+struct category *makeflow_category_lookup_or_create(const struct dag *d, const char *name) {
+	struct category *c = category_lookup_or_create(d->categories, name);
+
+	if(!c->mf_variables) {
+		c->mf_variables = hash_table_create(0, 0);
+	}
+
+	return c;
+}

--- a/makeflow/src/dag_resources.h
+++ b/makeflow/src/dag_resources.h
@@ -1,0 +1,8 @@
+/*
+Copyright (C) 2016- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+
+struct category *makeflow_category_lookup_or_create(const struct dag *d, const char *name);

--- a/makeflow/src/dag_variable.c
+++ b/makeflow/src/dag_variable.c
@@ -6,6 +6,7 @@ See the file COPYING for details.
 
 #include "dag.h"
 #include "dag_variable.h"
+#include "dag_resources.h"
 #include "hash_table.h"
 #include "xxmalloc.h"
 #include "debug.h"
@@ -168,20 +169,10 @@ struct dag_variable_value *dag_variable_lookup(const char *name, struct dag_vari
 {
 	struct dag_variable_value *v;
 
-	int nodeid;
-	if(s->node)
-	{
-		nodeid = s->node->nodeid;
-	}
-	else if(s->dag)
-	{
-		nodeid = s->dag->nodeid_counter;
-	}
-
 	if(s) {
 		/* Try node variables table */
 		if(s->node) {
-			v = dag_variable_get_value(name, s->node->variables, nodeid);
+			v = dag_variable_get_value(name, s->node->variables, s->node->nodeid);
 			if(v) {
 				s->table = s->node->variables; //why this line?
 				return v;
@@ -190,9 +181,9 @@ struct dag_variable_value *dag_variable_lookup(const char *name, struct dag_vari
 
 		/* Try dag variables table */
 		if(s->dag) {
-			v = dag_variable_get_value(name, s->dag->variables, nodeid);
+			v = dag_variable_get_value(name, s->dag->default_category->mf_variables, s->dag->nodeid_counter);
 			if(v) {
-				s->table = s->dag->variables;
+				s->table = s->dag->default_category->mf_variables;
 				return v;
 			}
 		}

--- a/makeflow/src/dag_variable.c
+++ b/makeflow/src/dag_variable.c
@@ -169,27 +169,38 @@ struct dag_variable_value *dag_variable_lookup(const char *name, struct dag_vari
 {
 	struct dag_variable_value *v;
 
-	if(s) {
-		/* Try node variables table */
-		if(s->node) {
-			v = dag_variable_get_value(name, s->node->variables, s->node->nodeid);
-			if(v) {
-				s->table = s->node->variables; //why this line?
-				return v;
-			}
-		}
+	if(!s)
+		return NULL;
 
-		/* Try dag variables table */
-		if(s->dag) {
-			v = dag_variable_get_value(name, s->dag->default_category->mf_variables, s->dag->nodeid_counter);
-			if(v) {
-				s->table = s->dag->default_category->mf_variables;
-				return v;
-			}
+	/* Try node variables table */
+	if(s->node) {
+		v = dag_variable_get_value(name, s->node->variables, s->node->nodeid);
+		if(v) {
+			s->table = s->node->variables; //why this line?
+			return v;
 		}
 	}
 
-	/* Try environment */
+	if(!s->dag)
+		return NULL;
+
+	/* Try the category variables table */
+	if(s->category) {
+		v = dag_variable_get_value(name, s->category->mf_variables, s->dag->nodeid_counter);
+		if(v) {
+			s->table = s->dag->default_category->mf_variables;
+			return v;
+		}
+	}
+
+	/* Try dag variables table */
+	v = dag_variable_get_value(name, s->dag->default_category->mf_variables, s->dag->nodeid_counter);
+	if(v) {
+		s->table = s->dag->default_category->mf_variables;
+		return v;
+	}
+
+	/* Try the environment last. */
 	char *value = getenv(name);
 	if(value) {
 		return dag_variable_value_create(value);

--- a/makeflow/src/dag_visitors.c
+++ b/makeflow/src/dag_visitors.c
@@ -779,9 +779,9 @@ void dag_to_dot(struct dag *d, int condense_display, int change_size, int with_l
 			if(with_details) {
 				printf("subgraph cluster_S%d { \n", condense_display ? t->id : n->nodeid);
 				printf("\tstyle=unfilled;\n\tcolor=red\n");
-				printf("\tcores%d [style=filled, color=white, label=\"Cores: %"PRId64"\"]\n", condense_display ? t->id : n->nodeid, n->resources->cores);
-				printf("\tresMem%d [style=filled, color=white, label=\"Memory: %"PRId64" MB\"]\n", condense_display ? t->id : n->nodeid, n->resources->memory);
-				printf("\tworkDirFtprnt%d [style=filled, color=white, label=\"Footprint: %"PRId64" MB\"]\n", condense_display ? t->id : n->nodeid, n->resources->disk);
+				printf("\tcores%d [style=filled, color=white, label=\"Cores: %"PRId64"\"]\n", condense_display ? t->id : n->nodeid, n->resources_needed->cores);
+				printf("\tresMem%d [style=filled, color=white, label=\"Memory: %"PRId64" MB\"]\n", condense_display ? t->id : n->nodeid, n->resources_needed->memory);
+				printf("\tworkDirFtprnt%d [style=filled, color=white, label=\"Footprint: %"PRId64" MB\"]\n", condense_display ? t->id : n->nodeid, n->resources_needed->disk);
 				printf("\tcores%d -> resMem%d -> workDirFtprnt%d [color=white]", condense_display ? t->id : n->nodeid, condense_display ? t->id : n->nodeid, condense_display ? t->id : n->nodeid);
 
 				//Source Files

--- a/makeflow/src/dag_visitors.c
+++ b/makeflow/src/dag_visitors.c
@@ -27,6 +27,7 @@ See the file COPYING for details.
 #include "stringtools.h"
 
 #include "dag.h"
+#include "dag_resources.h"
 #include "dag_variable.h"
 #include "dag_visitors.h"
 #include "rmsummary.h"
@@ -71,7 +72,7 @@ int dag_to_file_exports(const struct dag *d, FILE * dag_stream, const char *pref
 	set_first_element(vars);
 	for(name = set_next_element(vars); name; name = set_next_element(vars))
 	{
-		v = hash_table_lookup(d->variables, name);
+		v = hash_table_lookup(d->default_category->mf_variables, name);
 		if(v)
 		{
 			fprintf(dag_stream, "%s%s=", prefix, name);
@@ -145,8 +146,8 @@ int dag_to_file_category(struct category *c, struct list *nodes, FILE * dag_stre
 	list_first_item(nodes);
 	while((n = list_next_item(nodes)))
 	{
-		dag_to_file_vars(n->d->special_vars, n->d->variables, n->nodeid, dag_stream, "");
-		dag_to_file_vars(n->d->export_vars,  n->d->variables, n->nodeid, dag_stream, "");
+		dag_to_file_vars(n->d->special_vars, n->d->default_category->mf_variables, n->nodeid, dag_stream, "");
+		dag_to_file_vars(n->d->export_vars,  n->d->default_category->mf_variables, n->nodeid, dag_stream, "");
 		dag_to_file_node(n, dag_stream, rename);
 	}
 
@@ -157,7 +158,7 @@ int dag_to_file_categories(const struct dag *d, FILE * dag_stream, char *(*renam
 {
 
 	//separate nodes per category
-	struct hash_table *nodes_of_category = hash_table_create(2*hash_table_size(d->task_categories), 0);
+	struct hash_table *nodes_of_category = hash_table_create(2*hash_table_size(d->categories), 0);
 
 	struct category *c;
 	struct list *ns;
@@ -177,7 +178,7 @@ int dag_to_file_categories(const struct dag *d, FILE * dag_stream, char *(*renam
 
 	hash_table_firstkey(nodes_of_category);
 	while(hash_table_nextkey(nodes_of_category, &name, (void **) &ns)) {
-		c = category_lookup_or_create(d->task_categories, name);
+		c = makeflow_category_lookup_or_create(d, name);
 		dag_to_file_category(c, ns, dag_stream, rename);
 	}
 
@@ -199,8 +200,8 @@ int dag_to_file(const struct dag *d, const char *dag_file, char *(*rename) (stru
 		return 1;
 
 	// For the collect list, use the their final value (the value at node with id nodeid_counter).
-	dag_to_file_var("GC_COLLECT_LIST", d->variables, d->nodeid_counter, dag_stream, "");
-	dag_to_file_var("GC_PRESERVE_LIST", d->variables, d->nodeid_counter, dag_stream, "");
+	dag_to_file_var("GC_COLLECT_LIST", d->default_category->mf_variables, d->nodeid_counter, dag_stream, "");
+	dag_to_file_var("GC_PRESERVE_LIST", d->default_category->mf_variables, d->nodeid_counter, dag_stream, "");
 
 	dag_to_file_exports(d, dag_stream, "");
 

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -501,7 +501,7 @@ static void makeflow_node_submit(struct dag *d, struct dag_node *n)
 	makeflow_log_file_expectation(d, output_list);
 
 	/* Now submit the actual job, retrying failures as needed. */
-	n->jobid = makeflow_node_submit_retry(queue,command,input_files,output_files,envlist,n->resources);
+	n->jobid = makeflow_node_submit_retry(queue,command,input_files,output_files,envlist,n->resources_needed);
 
 	/* Restore old batch job options. */
 	if(previous_batch_options) {

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -634,6 +634,20 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 	if(n->state != DAG_NODE_STATE_RUNNING)
 		return;
 
+	if(monitor) {
+		char *nodeid = string_format("%d",n->nodeid);
+		char *log_name_prefix = string_replace_percents(monitor->log_prefix, nodeid);
+		char *summary_name = string_format("%s.summary", log_name_prefix);
+
+		if(n->resources_measured)
+			rmsummary_delete(n->resources_measured);
+		n->resources_measured = rmsummary_parse_file_single(summary_name);
+
+		free(nodeid);
+		free(log_name_prefix);
+		free(summary_name);
+	}
+
 	struct list *outputs = makeflow_generate_output_files(n, wrapper, monitor);
 
 	if(info->exited_normally && info->exit_code == 0) {
@@ -669,16 +683,9 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 		if(monitor && info->exit_code == RM_OVERFLOW)
 		{
 			fprintf(stderr, "\nrule %d failed because it exceeded the resources limits.\n", n->nodeid);
-			char *nodeid = string_format("%d",n->nodeid);
-			char *log_name_prefix = string_replace_percents(monitor->log_prefix, nodeid);
-			free(nodeid);
-			char *summary_name = string_format("%s.summary", log_name_prefix);
-			struct rmsummary *s = rmsummary_parse_file_single(summary_name);
-
-			if(s)
+			if(n->resources_measured)
 			{
-				rmsummary_print(stderr, s, NULL);
-				rmsummary_delete(s);
+				rmsummary_print(stderr, n->resources_measured, NULL);
 				fprintf(stderr, "\n");
 			}
 
@@ -689,9 +696,6 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 			} else {
 				makeflow_failed_flag = 1;
 			}
-
-			free(log_name_prefix);
-			free(summary_name);
 		}
 		else if(makeflow_retry_flag || info->exit_code == 101) {
 			n->failure_count++;
@@ -710,13 +714,19 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 	} else {
 		/* Mark source files that have been used by this node */
 		list_first_item(n->source_files);
-		while((f = list_next_item(n->source_files))){
+		while((f = list_next_item(n->source_files))) {
 			f->ref_count+= -1;
 			if(f->ref_count == 0 && f->state == DAG_FILE_STATE_EXISTS)
 				makeflow_log_file_state_change(d, f, DAG_FILE_STATE_COMPLETE);
 		}
 
 		makeflow_log_state_change(d, n, DAG_NODE_STATE_COMPLETE);
+
+		if(monitor) {
+			category_accumulate_summary(d->categories, n->category->name, n->resources_measured);
+			if(d->node_states[DAG_NODE_STATE_COMPLETE] % 20 == 0)
+				category_update_first_allocation(d->categories, n->category->name);
+		}
 	}
 }
 

--- a/makeflow/src/makeflow_wrapper_monitor.c
+++ b/makeflow/src/makeflow_wrapper_monitor.c
@@ -99,7 +99,7 @@ char *makeflow_rmonitor_wrapper_command( struct makeflow_monitor *m, struct dag_
 
 	char * result = resource_monitor_write_command(executable,
 			m->log_prefix,
-			n->resources,
+			n->resources_needed,
 			extra_options,
 			m->enable_debug,
 			m->enable_time_series,

--- a/makeflow/src/parser.c
+++ b/makeflow/src/parser.c
@@ -478,7 +478,7 @@ static int dag_parse_node(struct lexer *bk)
 	itable_insert(bk->d->node_table, n->nodeid, n);
 
 	debug(D_MAKEFLOW_PARSER, "Setting resource category '%s' for rule %d.\n", n->category->name, n->nodeid);
-	dag_node_fill_resources(n);
+	dag_node_init_resources(n);
 	dag_node_print_debug_resources(n);
 
 	return 1;

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -5598,7 +5598,7 @@ void work_queue_category_accumulate_task(struct work_queue *q, struct work_queue
 
 				if(c->total_tasks % FIRST_ALLOCATION_EVERY_NTASKS == 0 && c->max_allocation) {
 					if(c->max_allocation) {
-						category_update_first_allocation(q->categories, t->category, c->max_allocation);
+						category_update_first_allocation(q->categories, t->category);
 					}
 				}
 			} else {

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -272,7 +272,7 @@ int relabel_task(struct work_queue *q, struct work_queue_task *t);
 const struct rmsummary *task_dynamic_label(struct work_queue *q, struct work_queue_task *t);
 
 void work_queue_category_accumulate_task(struct work_queue *q, struct work_queue_task *t);
-struct category *work_queue_category_lookup_or_create(struct hash_table *categories, const char *name);
+struct category *work_queue_category_lookup_or_create(struct work_queue *q, const char *name);
 
 /** Clone a @ref work_queue_file
 This performs a deep copy of the file struct.
@@ -1214,7 +1214,7 @@ void read_measured_resources(struct work_queue *q, struct work_queue_task *t) {
 		t->return_status = t->resources_measured->exit_status;
 	}
 
-	if(t->resource_request != WORK_QUEUE_ALLOCATION_USER)
+	if(t->resource_request != CATEGORY_ALLOCATION_USER)
 		rmsummary_merge_max(t->resources_requested, task_dynamic_label(q, t));
 
 	free(summary);
@@ -2525,7 +2525,7 @@ static struct rmsummary *task_worker_box_size(struct work_queue *q, struct work_
 
 	rmsummary_merge_max(limits, label);
 
-	if(t->resource_request == WORK_QUEUE_ALLOCATION_AUTO_ZERO) {
+	if(t->resource_request == CATEGORY_ALLOCATION_AUTO_ZERO) {
 		limits->cores  = MIN(label->cores,  w->resources->cores.total);
 		limits->memory = MIN(label->memory, w->resources->memory.total);
 		limits->disk   = MIN(label->disk,   w->resources->disk.total);
@@ -2690,7 +2690,7 @@ static int check_foreman_against_task(struct work_queue *q, struct work_queue_wo
 	int64_t cores_used, disk_used, mem_used, gpus_used;
 	int ok = 1;
 
-	if(t->resource_request == WORK_QUEUE_ALLOCATION_UNLABELED)
+	if(t->resource_request == CATEGORY_ALLOCATION_UNLABELED)
 	{
 		// Unlabeled tasks run alone in a worker. Return immediately if foreman
 		// does not have workers free.
@@ -2735,14 +2735,14 @@ static int check_worker_against_task(struct work_queue *q, struct work_queue_wor
 	int64_t cores_used, disk_used, mem_used, gpus_used;
 	int ok = 1;
 
-	if(t->resource_request != WORK_QUEUE_ALLOCATION_UNLABELED && w->resources->unlabeled.inuse > 0)
+	if(t->resource_request != CATEGORY_ALLOCATION_UNLABELED && w->resources->unlabeled.inuse > 0)
 	{
 		// Do not allow labeled/unlabeled mix at a regular worker.
 		ok = 0;
 		return ok;
 	}
 
-	if(t->resource_request == WORK_QUEUE_ALLOCATION_UNLABELED)
+	if(t->resource_request == CATEGORY_ALLOCATION_UNLABELED)
 	{
 		if(w->resources->unlabeled.inuse + 1 > overcommitted_resource_total(q, w->resources->workers.total, 1))
 		{
@@ -2752,7 +2752,7 @@ static int check_worker_against_task(struct work_queue *q, struct work_queue_wor
 	}
 
 	const struct rmsummary *label = task_dynamic_label(q, t);
-	if(t->resource_request == WORK_QUEUE_ALLOCATION_AUTO_ZERO) {
+	if(t->resource_request == CATEGORY_ALLOCATION_AUTO_ZERO) {
 		/* ZERO expands to the worker, except for cores. We always allocate the maximum cores. */
 
 		cores_used = MAX(label->cores, 1);
@@ -3026,7 +3026,7 @@ static void count_worker_resources(struct work_queue *q, struct work_queue_worke
 
 	itable_firstkey(w->current_tasks);
 	while(itable_nextkey(w->current_tasks, &taskid, (void **)&t)) {
-		if(t->resource_request == WORK_QUEUE_ALLOCATION_UNLABELED || t->resource_request == WORK_QUEUE_ALLOCATION_AUTO_ZERO)
+		if(t->resource_request == CATEGORY_ALLOCATION_UNLABELED || t->resource_request == CATEGORY_ALLOCATION_AUTO_ZERO)
 		{
 			cores_used = cores_avg;
 			mem_used  = mem_avg;
@@ -3043,7 +3043,7 @@ static void count_worker_resources(struct work_queue *q, struct work_queue_worke
 			gpus_used  = MAX(label->gpus, 0);
 		}
 
-		unlabeled_used = (t->resource_request == WORK_QUEUE_ALLOCATION_UNLABELED);
+		unlabeled_used = (t->resource_request == CATEGORY_ALLOCATION_UNLABELED);
 
 		w->resources->cores.inuse     += cores_used;
 		w->resources->memory.inuse    += mem_used;
@@ -3110,8 +3110,8 @@ static int send_one_task( struct work_queue *q )
 	list_first_item(q->ready_list);
 	while( (t = list_next_item(q->ready_list))) {
 
-		// Check whether a first-allocation is available for the task.
-		relabel_task(q, t);
+		// Assign the allocation type for the task.
+		t->resource_request = category_next_label(q->categories, t->category, t->resource_request, /*resource overflow*/ 0);
 
 		// Find the best worker for the task at the head of the list
 		w = find_best_worker(q,t);
@@ -3223,7 +3223,7 @@ static void abort_slow_workers(struct work_queue *q)
 	if(!fast_abort_flag)
 		return;
 
-	struct category *c_def = work_queue_category_lookup_or_create(q->categories, "default");
+	struct category *c_def = work_queue_category_lookup_or_create(q, "default");
 
 	timestamp_t current = timestamp_get();
 
@@ -3399,7 +3399,7 @@ struct work_queue_task *work_queue_task_create(const char *command_line)
 	t->total_cmd_execution_time = 0;
 	t->priority = 0;
 
-	t->resource_request   = WORK_QUEUE_ALLOCATION_UNLABELED;
+	t->resource_request   = CATEGORY_ALLOCATION_UNLABELED;
 	t->resources_measured = NULL;
 
 	/* In the absence of additional information, a task consumes an entire worker. */
@@ -3486,10 +3486,10 @@ static void set_task_unlabel_flag( struct work_queue_task *t )
 {
 	if(t->resources_requested->cores < 0 && t->resources_requested->memory < 0 && t->resources_requested->disk < 0 && t->resources_requested->gpus < 0 && t->resources_requested->wall_time < 0 && t->resources_requested->end < 0)
 	{
-		if(t->resource_request == WORK_QUEUE_ALLOCATION_USER)
-			t->resource_request = WORK_QUEUE_ALLOCATION_UNLABELED;
+		if(t->resource_request == CATEGORY_ALLOCATION_USER)
+			t->resource_request = CATEGORY_ALLOCATION_UNLABELED;
 	} else {
-		t->resource_request = WORK_QUEUE_ALLOCATION_USER;
+		t->resource_request = CATEGORY_ALLOCATION_USER;
 	}
 }
 
@@ -4771,6 +4771,9 @@ int work_queue_submit_internal(struct work_queue *q, struct work_queue_task *t)
 {
 	itable_insert(q->tasks, t->taskid, t);
 
+	/* Ensure category structure is created. */
+	work_queue_category_lookup_or_create(q, t->category);
+
 	change_task_state(q, t, WORK_QUEUE_TASK_READY);
 
 	t->time_task_submit = timestamp_get();
@@ -5083,9 +5086,10 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 		while((t = task_state_any(q, WORK_QUEUE_TASK_WAITING_RESUBMISSION))) {
 
 			if(t->result & WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION) {
-				int status = relabel_task(q, t);
-				if(status) {
-					debug(D_WQ, "Task %d resubmitted using max resources.\n", t->taskid);
+				category_allocation_t next = category_next_label(q->categories, t->category, t->resource_request, /* resource overflow */ 1);
+				if(next == CATEGORY_ALLOCATION_ERROR) {
+					debug(D_WQ, "Task %d resubmitted using new resource allocation.\n", t->taskid);
+					t->resource_request = next;
 					cancel_task_on_worker(q, t, WORK_QUEUE_TASK_READY);
 				} else {
 					debug(D_WQ, "Task %d failed given max resource exhaustion.\n", t->taskid);
@@ -5492,7 +5496,7 @@ void work_queue_get_stats_hierarchy(struct work_queue *q, struct work_queue_stat
 
 void work_queue_get_stats_category(struct work_queue *q, const char *category, struct work_queue_stats *s)
 {
-	struct category *c = work_queue_category_lookup_or_create(q->categories, category);
+	struct category *c = work_queue_category_lookup_or_create(q, category);
 	struct work_queue_stats *cs = c->wq_stats;
 	memcpy(s, cs, sizeof(*s));
 
@@ -5566,7 +5570,7 @@ void work_queue_category_accumulate_task(struct work_queue *q, struct work_queue
 	const char *name              = t->category ? t->category : "default";
 	work_queue_task_state_t state = (uintptr_t) itable_lookup(q->task_state_map, t->taskid);
 
-	struct category *c = work_queue_category_lookup_or_create(q->categories, name);
+	struct category *c = work_queue_category_lookup_or_create(q, name);
 
 	struct work_queue_stats *s = c->wq_stats;
 
@@ -5622,7 +5626,7 @@ void work_queue_specify_max_resources(struct work_queue *q,  const struct rmsumm
 }
 
 void work_queue_specify_max_category_resources(struct work_queue *q,  const char *category, const struct rmsummary *rm) {
-	struct category *c = work_queue_category_lookup_or_create(q->categories, category);
+	struct category *c = work_queue_category_lookup_or_create(q, category);
 
 	if(c->max_allocation) {
 		rmsummary_delete(c->max_allocation);
@@ -5640,62 +5644,21 @@ void work_queue_specify_max_category_resources(struct work_queue *q,  const char
 	}
 }
 
-/* returns: 1 relabel was possible, 0 already at max or no new label available. */
-int relabel_task(struct work_queue *q, struct work_queue_task *t) {
-	/* If user specified resources manually, respect the label. */
-	if(t->resource_request == WORK_QUEUE_ALLOCATION_USER)
-		return ~(t->result & WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION);
-
-	struct category *c = category_lookup_or_create(q->categories, t->category);
-
-	/* We return whether the task already failed because of resource
-	 * exhaustion. */
-	if(!c->max_allocation) {
-		t->resource_request = WORK_QUEUE_ALLOCATION_UNLABELED;
-		return ~(t->result & WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION);
-	}
-
-	if(t->result & WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION) {
-		/* We check whether the task already has the maximum resources. If it
-		 * does, we mark it as done. */
-		if(t->resource_request == WORK_QUEUE_ALLOCATION_AUTO_MAX) {
-			return 0;
-		} else {
-			debug(D_WQ, "Setting task %d to use maximum resources.", t->taskid);
-			t->resource_request = WORK_QUEUE_ALLOCATION_AUTO_MAX;
-		}
-	}
-
-	/* Never downgrade max allocation */
-	if(t->resource_request == WORK_QUEUE_ALLOCATION_AUTO_MAX)
-		return 1;
-
-	if(c->first_allocation) {
-		/* Use first allocation when it is available. */
-		t->resource_request = WORK_QUEUE_ALLOCATION_AUTO_FIRST;
-	} else {
-		/* Use default when no enough information is available. */
-		t->resource_request = WORK_QUEUE_ALLOCATION_AUTO_ZERO;
-	}
-
-	return 1;
-}
-
 const struct rmsummary *task_dynamic_label(struct work_queue *q, struct work_queue_task *t) {
 
-	struct category *c = work_queue_category_lookup_or_create(q->categories, t->category);
+	struct category *c = work_queue_category_lookup_or_create(q, t->category);
 	switch(t->resource_request) {
 		/* return the old cases when we are not autolabeling. */
-		case WORK_QUEUE_ALLOCATION_AUTO_ZERO:
-		case WORK_QUEUE_ALLOCATION_AUTO_MAX:
+		case CATEGORY_ALLOCATION_AUTO_ZERO:
+		case CATEGORY_ALLOCATION_AUTO_MAX:
 			return c->max_allocation;
 			break;
-		case WORK_QUEUE_ALLOCATION_AUTO_FIRST:
+		case CATEGORY_ALLOCATION_AUTO_FIRST:
 			return c->first_allocation;
 			break;
-		case WORK_QUEUE_ALLOCATION_USER:
+		case CATEGORY_ALLOCATION_USER:
 			return t->resources_requested;
-		case WORK_QUEUE_ALLOCATION_UNLABELED:
+		case CATEGORY_ALLOCATION_UNLABELED:
 		default:
 			if(c->max_allocation) {
 				return c->max_allocation;
@@ -5706,8 +5669,8 @@ const struct rmsummary *task_dynamic_label(struct work_queue *q, struct work_que
 	}
 }
 
-struct category *work_queue_category_lookup_or_create(struct hash_table *categories, const char *name) {
-	struct category *c = category_lookup_or_create(categories, name);
+struct category *work_queue_category_lookup_or_create(struct work_queue *q, const char *name) {
+	struct category *c = category_lookup_or_create(q->categories, name);
 
 	if(!c->wq_stats) {
 		c->wq_stats = calloc(1, sizeof(struct work_queue_stats));

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -19,6 +19,7 @@ See the file COPYING for details.
 
 #include <sys/types.h>
 #include "timestamp.h"
+#include "category.h"
 #include "rmsummary.h"
 
 #define WORK_QUEUE_DEFAULT_PORT 9123               /**< Default Work Queue port number. */
@@ -88,14 +89,6 @@ typedef enum {
 	WORK_QUEUE_URL                    /**< File-spec refers to an URL **/
 } work_queue_file_t;
 
-typedef enum {
-	WORK_QUEUE_ALLOCATION_UNLABELED = 0, /**< No resources are explicitely requested. */
-	WORK_QUEUE_ALLOCATION_USER,          /**< Using values from task->resources_requested. */
-	WORK_QUEUE_ALLOCATION_AUTO_ZERO,     /**< Pre-step for autolabeling, when the first allocation has not been computed. */
-	WORK_QUEUE_ALLOCATION_AUTO_FIRST,    /**< Using first step value of the two-step policy. */
-	WORK_QUEUE_ALLOCATION_AUTO_MAX       /**< Using max of category. (2nd step of two-step policy) */
-} work_queue_allocation_t;
-
 extern int wq_option_scheduler;	               /**< Initial setting for algorithm to assign tasks to
 												 workers upon creating queue . Change prior to
 												 calling work_queue_create, after queue is created
@@ -148,7 +141,7 @@ struct work_queue_task {
 	struct rmsummary *resources_measured;                  /**< When monitoring is enabled, it points to the measured resources used by the task. */
 	struct rmsummary *resources_requested;                 /**< Number of cores, disk, memory, time, etc. the task requires. */
 
-	work_queue_allocation_t resource_request;              /**< See @ref work_queue_allocation_t */
+	category_allocation_t resource_request;                /**< See @ref category_allocation_t */
 
 	char *category;                                        /**< User-provided label for the task. It is expected that all task with the same category will have similar resource usage. See @ref work_queue_task_specify_category. If no explicit category is given, the label "default" is used. **/
 


### PR DESCRIPTION
When a rule fails because of resources, it is then tried with the maximum allocation per category.
First allocation is computed automatically as jobs complete.

It works in all batch systems (not only wq).

(@dthain, @nhazekam, @charleszheng44)