### PR TITLE
Errors to terminal

### DIFF
--- a/dttools/src/debug.c
+++ b/dttools/src/debug.c
@@ -241,6 +241,17 @@ void warn(INT64_T flags, const char *fmt, ...)
 	errno = save_errno;
 }
 
+void notice(INT64_T flags, const char *fmt, ...)
+{
+	va_list args;
+
+	int save_errno = errno;
+	va_start(args, fmt);
+	do_debug(flags|D_NOTICE, fmt, args);
+	va_end(args);
+	errno = save_errno;
+}
+
 void fatal(const char *fmt, ...)
 {
 	struct fatal_callback *f;

--- a/dttools/src/debug.c
+++ b/dttools/src/debug.c
@@ -208,7 +208,7 @@ static void do_debug(INT64_T flags, const char *fmt, va_list args)
 			if(!terminal_f) {
 				if((terminal_f = fopen(terminal_path, "a")) == NULL) {
 					/* print to wherever stderr is pointing that we could not open the terminal. */
-					fprintf(stderr, "could not open '%s' for immediate error reporting.", terminal_path);
+					fprintf(stderr, "Could not open '%s' for immediate error reporting.\n", terminal_path);
 				}
 			}
 		}

--- a/dttools/src/debug.h
+++ b/dttools/src/debug.h
@@ -108,6 +108,7 @@ modify the linker namespace we are using.
 
 #define debug                  cctools_debug
 #define fatal                  cctools_fatal
+#define notice                 cctools_notice
 #define warn                   cctools_warn
 #define debug_config           cctools_debug_config
 #define debug_config_file      cctools_debug_config_file
@@ -156,6 +157,14 @@ Displays a printf-style message, and then forcibly exits the program.
 */
 
 void fatal(const char *fmt, ...);
+
+
+/** Emit a notice message.
+Logs a warning message, regardless of if given flags are active.
+@param flags Any of the standard debugging flags OR-ed together.
+@param fmt A printf-style formatting string, followed by the necessary arguments.
+  */
+void notice(INT64_T flags, const char *fmt, ...);
 
 /** Initialize the debugging system.
 Must be called before any other calls take place.


### PR DESCRIPTION
When stderr is redirected, D_{FATAL, NOTICE, WARN} are not printed to the terminal. The number one commit makes it so by printing such messages to /dev/tty if stderr is not a tty. The second commit simply adds notice as a function, similar to fatal and warn.

(@dthain: Adding these now so that students from the cloud computing class have friendlier messages.)
