### PR TITLE
Show all compiled-in services under /

### DIFF
--- a/parrot/src/pfs_dir.cc
+++ b/parrot/src/pfs_dir.cc
@@ -28,9 +28,30 @@ extern "C" {
 pfs_dir::pfs_dir( pfs_name *n ) : pfs_file(n)
 {
 	iterations = 0;
-	/* FIXME This should include all services, not just Chirp. See issue #1107. */
 	if(strcmp(n->path, "/") == 0) {
 		append("chirp");
+		append("multi");
+		append("anonftp");
+		append("ftp");
+		append("http");
+		append("grow");
+#ifdef HAS_GLOBUS_GSS
+		append("gsiftp");
+		append("gridftp");
+#endif
+#ifdef HAS_IRODS
+		append("irods");
+#endif
+		append("hdfs");
+#ifdef HAS_BXGRID
+		append("bxgrid");
+#endif
+#ifdef HAS_XROOTD
+		append("xrootd");
+#endif
+#ifdef HAS_CVMFS
+		append("cvmfs");
+#endif
 	}
 }
 

--- a/parrot/src/pfs_dir.cc
+++ b/parrot/src/pfs_dir.cc
@@ -29,29 +29,13 @@ pfs_dir::pfs_dir( pfs_name *n ) : pfs_file(n)
 {
 	iterations = 0;
 	if(strcmp(n->path, "/") == 0) {
-		append("chirp");
-		append("multi");
-		append("anonftp");
-		append("ftp");
-		append("http");
-		append("grow");
-#ifdef HAS_GLOBUS_GSS
-		append("gsiftp");
-		append("gridftp");
-#endif
-#ifdef HAS_IRODS
-		append("irods");
-#endif
-		append("hdfs");
-#ifdef HAS_BXGRID
-		append("bxgrid");
-#endif
-#ifdef HAS_XROOTD
-		append("xrootd");
-#endif
-#ifdef HAS_CVMFS
-		append("cvmfs");
-#endif
+		extern struct hash_table *available_services;
+		char *key;
+		void *value;
+		hash_table_firstkey(available_services);
+		while(hash_table_nextkey(available_services, &key, &value)) {
+			append(key);
+		}
 	}
 }
 

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -76,6 +76,7 @@ int wait_barrier = 0;
 int pfs_master_timeout = 300;
 struct file_cache *pfs_file_cache = 0;
 struct password_cache *pfs_password_cache = 0;
+struct hash_table *available_services;
 int pfs_force_stream = 0;
 int pfs_force_cache = 0;
 int pfs_force_sync = 0;
@@ -280,13 +281,12 @@ static void show_help( const char *cmd )
 	printf( "\n\n");
 	printf( "Enabled filesystems are:");
 
-	const char *driver_list[] = {"http","grow","ftp","anonftp","gsiftp","nest","chirp","gfal","rfio","dcap","glite","lfc","irods","hdfs","bxgrid","s3","rootd","xrootd","cvmfs",0};
-
-	int i;
-
-	for(i=0;driver_list[i];i++) {
-		if(pfs_service_lookup(driver_list[i])) {
-			printf(" %s",driver_list[i]);
+	{
+		char *key;
+		void *value;
+		hash_table_firstkey(available_services);
+		while(hash_table_nextkey(available_services, &key, &value)) {
+			printf(" %s", key);
 		}
 	}
 
@@ -627,6 +627,43 @@ int main( int argc, char *argv[] )
 
 	pfs_uid = getuid();
 	pfs_gid = getgid();
+
+	available_services = hash_table_create(0, 0);
+	extern pfs_service *pfs_service_chirp;
+	hash_table_insert(available_services, "chirp", pfs_service_chirp);
+	extern pfs_service *pfs_service_multi;
+	hash_table_insert(available_services, "multi", pfs_service_multi);
+	extern pfs_service *pfs_service_anonftp;
+	hash_table_insert(available_services, "anonftp", pfs_service_anonftp);
+	extern pfs_service *pfs_service_ftp;
+	hash_table_insert(available_services, "ftp", pfs_service_ftp);
+	extern pfs_service *pfs_service_http;
+	hash_table_insert(available_services, "http", pfs_service_http);
+	extern pfs_service *pfs_service_grow;
+	hash_table_insert(available_services, "grow", pfs_service_grow);
+	extern pfs_service *pfs_service_hdfs;
+	hash_table_insert(available_services, "hdfs", pfs_service_hdfs);
+#ifdef HAS_GLOBUS_GSS
+	extern pfs_service *pfs_service_gsiftp;
+	hash_table_insert(available_services, "gsiftp", pfs_service_gsiftp);
+	hash_table_insert(available_services, "gridftp", pfs_service_gsiftp);
+#endif
+#ifdef HAS_IRODS
+	extern pfs_service *pfs_service_irods;
+	hash_table_insert(available_services, "irods", pfs_service_irods);
+#endif
+#ifdef HAS_BXGRID
+	extern pfs_service *pfs_service_bxgrid;
+	hash_table_insert(available_services, "bxgrid", pfs_service_bxgrid);
+#endif
+#ifdef HAS_XROOTD
+	extern pfs_service *pfs_service_xrootd;
+	hash_table_insert(available_services, "xrootd", pfs_service_xrootd);
+#endif
+#ifdef HAS_CVMFS
+	extern pfs_service *pfs_service_cvmfs;
+	hash_table_insert(available_services, "cvmfs", pfs_service_cvmfs);
+#endif
 
 	{
 		const char *s;

--- a/parrot/src/pfs_service.cc
+++ b/parrot/src/pfs_service.cc
@@ -348,55 +348,17 @@ int pfs_service::md5( pfs_name *source, unsigned char *digest )
 
 pfs_service * pfs_service_lookup( const char *name )
 {
-	if(!strcmp(name,"chirp")) {
-		extern pfs_service *pfs_service_chirp;
-		return pfs_service_chirp;
-	} else if(!strcmp(name,"multi")) {
-		extern pfs_service *pfs_service_multi;
-		return pfs_service_multi;
-	} else if(!strcmp(name,"anonftp")) {
-		extern pfs_service *pfs_service_anonftp;
-		return pfs_service_anonftp;
-	} else if(!strcmp(name,"ftp")) {
-		extern pfs_service *pfs_service_ftp;
-		return pfs_service_ftp;
-	} else if(!strcmp(name,"http")) {
-		extern pfs_service *pfs_service_http;
-		return pfs_service_http;
-	} else if(!strcmp(name,"grow")) {
-		extern pfs_service *pfs_service_grow;
-		return pfs_service_grow;
-#ifdef HAS_GLOBUS_GSS
-	} else if(!strcmp(name,"gsiftp") || !strcmp(name,"gridftp") ) {
-		extern pfs_service *pfs_service_gsiftp;
-		return pfs_service_gsiftp;
-#endif
-#ifdef HAS_IRODS
-	} else if(!strcmp(name,"irods")) {
-		extern pfs_service *pfs_service_irods;
-		return pfs_service_irods;
-#endif
-	} else if(!strcmp(name,"hdfs")) {
-		extern pfs_service *pfs_service_hdfs;
-		return pfs_service_hdfs;
-#ifdef HAS_BXGRID
-	} else if(!strcmp(name,"bxgrid")) {
-		extern pfs_service *pfs_service_bxgrid;
-		return pfs_service_bxgrid;
-#endif
-#ifdef HAS_XROOTD
-	} else if(!strcmp(name,"xrootd")) {
-		extern pfs_service *pfs_service_xrootd;
-		return pfs_service_xrootd;
-#endif
-#ifdef HAS_CVMFS
-	} else if(!strcmp(name,"cvmfs")) {
-		extern pfs_service *pfs_service_cvmfs;
-		return pfs_service_cvmfs;
-#endif
-	} else {
-		return 0;
+	extern struct hash_table *available_services;
+	char *key;
+	void *value;
+	hash_table_firstkey(available_services);
+	while(hash_table_nextkey(available_services, &key, &value)) {
+		if(!strcmp(name, key)) {
+			return (pfs_service *) value;
+		}
 	}
+
+	return 0;
 }
 
 pfs_service * pfs_service_lookup_default()


### PR DESCRIPTION
I *think* this should resolve #1107. This adds entries under / for all services compiled into Parrot