### PR TITLE
Update Chirp HDFS Docs (and maybe code)

### DIFF
--- a/doc/chirp.html
+++ b/doc/chirp.html
@@ -871,7 +871,8 @@ limitations, discussed below). Perhaps best of all, client jobs will no longer
 have any Hadoop or Java (version) dependencies.</p>
 
 <p>To run a Chirp server as a frontend to your HDFS filesystem,
-you will need to first set several environment variables which
+you will need to install the <tt>libhdfs-devel</tt> package
+and then set several environment variables which
 describe your Hadoop installation.  JAVA_HOME and HADOOP_HOME
 LIBHDFS_PATH should be set to indicate the location of the libhdfs library.
 Common values for the Cloudera Hadoop installation would be this:

--- a/doc/chirp.html
+++ b/doc/chirp.html
@@ -865,18 +865,26 @@ SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
 
 <p>The Chirp server is able to bind to backend filesystems besides the local
 filesystem. In particular, it is able to act as a frontend for the Hadoop HDFS
-filesystem. When used on top of Hadoop, Chirp gives you the benefit of a robust
+filesystem. When used on top of HDFS, Chirp gives you the benefit of a robust
 system of ACLs, simple userspace access and POSIX semantics (with some
 limitations, discussed below). Perhaps best of all, client jobs will no longer
 have any Hadoop or Java (version) dependencies.</p>
 
-<p>To run a Chirp server as a frontend to Hadoop use the
-<tt>chirp_server_hdfs</tt> command, which will set up a number of needed
-environment variables and then run <tt>chirp_server</tt> with the usual
-arguments.  Give the location of the root storage directory in HDFS with
-<tt>-r</tt> and a URL like so:</p>
+<p>To run a Chirp server as a frontend to your HDFS filesystem,
+you will need to first set several environment variables which
+describe your Hadoop installation.  JAVA_HOME and HADOOP_HOME
+LIBHDFS_PATH should be set to indicate the location of the libhdfs library.
+Common values for the Cloudera Hadoop installation would be this:
+</p>
+<code>setenv JAVA_HOME /usr/lib/jvm/java-openjdk
+setenv HADOOP_HOME /usr/lib/hadoop
+setenv LIBHDFS_PATH /usr/lib64/libhdfs.so
+</code>
 
-<code><span class="prompt">$ </span>chirp_server_hdfs -r hdfs://headnode.hadoop.domain.edu/mydata</code>
+Then, start <tt>chirp_server</tt> and indicate the
+root storage directory in HDFS with <tt>-r</tt> like this:
+
+<code><span class="prompt">$ </span>chirp_server -r hdfs://headnode.hadoop.domain.edu/mydata ...</code>
 
 <p>By default, chirp will use whatever default replication factor is defined by
 HDFS (typically 3).  To change the replication factor of a single file, use the


### PR DESCRIPTION
The world has changed somewhat since we originally did the code for these environment variables.  It seems that libhdfs is now a separate package, and the library usually appears in /usr/lib64/libhdfs.so.  So, I have changed the docs to reflect the more common situation.

If the user doesn't set `LIBHDFS_PATH`, our code will search for it in `HADOOP_HOME`, which I think is no longer a common configuration.

I suggest that we simplify that setup to be `dlopen` on either `$LIBHDFS_PATH` (if set) otherwise `libhdfs.so` and skip searching through `HADOOP_HOME`.

(But we still need to search `JAVA_HOME` for `libjvm.so`)

@batrick What do you think?
