### PR TITLE
moving ec2 ami info into umbrella spec

### DIFF
--- a/umbrella/example/cms_complex/cms_complex.umbrella
+++ b/umbrella/example/cms_complex/cms_complex.umbrella
@@ -11,6 +11,11 @@
 		"version": ">=2.6.32"
 	},
 	"os": {
+		"ec2": {
+			"ami": "ami-2cf8901c",
+			"region": "us-west-2",
+			"user": "ec2-user"
+		},
 		"id": "669ab5ef94af84d273f8f92a86b7907a",
 		"name": "Redhat",
 		"version": "6.5"

--- a/umbrella/example/cms_complex/cms_complex_S.umbrella
+++ b/umbrella/example/cms_complex/cms_complex_S.umbrella
@@ -5,6 +5,11 @@
         "name": "linux"
     }, 
     "os": {
+        "ec2": {
+            "ami": "ami-2cf8901c",
+            "region": "us-west-2",
+            "user": "ec2-user"
+        },
         "name": "Redhat", 
         "format": "tgz", 
         "checksum": "669ab5ef94af84d273f8f92a86b7907a", 

--- a/umbrella/example/cms_complex/cms_complex_S_osf.umbrella
+++ b/umbrella/example/cms_complex/cms_complex_S_osf.umbrella
@@ -48,6 +48,11 @@
         ]
     }, 
     "os": {
+        "ec2": {
+            "ami": "ami-2cf8901c",
+            "region": "us-west-2",
+            "user": "ec2-user"
+        },
         "name": "Redhat", 
         "format": "tgz", 
         "checksum": "669ab5ef94af84d273f8f92a86b7907a", 

--- a/umbrella/example/cms_complex/cms_complex_S_s3.umbrella
+++ b/umbrella/example/cms_complex/cms_complex_S_s3.umbrella
@@ -48,6 +48,11 @@
         ]
     }, 
     "os": {
+        "ec2": {
+            "ami": "ami-2cf8901c",
+            "region": "us-west-2",
+            "user": "ec2-user"
+        },
         "name": "Redhat", 
         "format": "tgz", 
         "checksum": "669ab5ef94af84d273f8f92a86b7907a", 

--- a/umbrella/example/openmalaria/openmalaria.umbrella
+++ b/umbrella/example/openmalaria/openmalaria.umbrella
@@ -15,6 +15,11 @@
         "name": "yum"
     }, 
     "os": {
+        "ec2": {
+            "ami": "ami-0b06483b",
+            "region": "us-west-2",
+            "user": "root"
+        },
         "name": "CentOS", 
         "version": "6.6", 
         "id": "902703f016e0f930a870eaf9cb31640b"

--- a/umbrella/example/openmalaria/openmalaria_S.umbrella
+++ b/umbrella/example/openmalaria/openmalaria_S.umbrella
@@ -12,6 +12,11 @@
 		"version": ">=2.6.18"
 	},
 	"os": {
+		"ec2": {
+			"ami": "ami-0b06483b",
+			"region": "us-west-2",
+			"user": "root"
+		},
 		"id": "902703f016e0f930a870eaf9cb31640b",
 		"name": "CentOS",
 		"version": "6.6",

--- a/umbrella/example/povray/povray.umbrella
+++ b/umbrella/example/povray/povray.umbrella
@@ -11,6 +11,11 @@
 		"version": ">=2.6.18"
 	},
 	"os": {
+		"ec2": {
+			"ami": "ami-2cf8901c",
+			"region": "us-west-2",
+			"user": "ec2-user"
+		},
 		"id": "669ab5ef94af84d273f8f92a86b7907a",
 		"name": "Redhat",
 		"version": "6.5"

--- a/umbrella/example/povray/povray_S.umbrella
+++ b/umbrella/example/povray/povray_S.umbrella
@@ -5,6 +5,11 @@
         "name": "linux"
     }, 
     "os": {
+        "ec2": {
+            "ami": "ami-2cf8901c",
+            "region": "us-west-2",
+            "user": "ec2-user"
+        },
         "name": "Redhat", 
         "format": "tgz", 
         "checksum": "669ab5ef94af84d273f8f92a86b7907a", 

--- a/umbrella/example/povray/povray_S_local+osf.umbrella
+++ b/umbrella/example/povray/povray_S_local+osf.umbrella
@@ -47,6 +47,11 @@
         "dirs": []
     }, 
     "os": {
+        "ec2": {
+            "ami": "ami-2cf8901c",
+            "region": "us-west-2",
+            "user": "ec2-user"
+        },
         "name": "Redhat", 
         "format": "tgz", 
         "checksum": "669ab5ef94af84d273f8f92a86b7907a", 

--- a/umbrella/example/povray/povray_S_local.umbrella
+++ b/umbrella/example/povray/povray_S_local.umbrella
@@ -5,6 +5,11 @@
         "name": "linux"
     }, 
     "os": {
+        "ec2": {
+            "ami": "ami-2cf8901c",
+            "region": "us-west-2",
+            "user": "ec2-user"
+        },
         "name": "Redhat", 
         "format": "tgz", 
         "checksum": "669ab5ef94af84d273f8f92a86b7907a", 

--- a/umbrella/example/povray/povray_S_osf.umbrella
+++ b/umbrella/example/povray/povray_S_osf.umbrella
@@ -45,6 +45,11 @@
         "dirs": []
     }, 
     "os": {
+        "ec2": {
+            "ami": "ami-2cf8901c",
+            "region": "us-west-2",
+            "user": "ec2-user"
+        },
         "name": "Redhat", 
         "format": "tgz", 
         "checksum": "669ab5ef94af84d273f8f92a86b7907a", 

--- a/umbrella/example/povray/povray_S_s3.umbrella
+++ b/umbrella/example/povray/povray_S_s3.umbrella
@@ -45,6 +45,11 @@
         "dirs": []
     }, 
     "os": {
+        "ec2": {
+            "ami": "ami-2cf8901c",
+            "region": "us-west-2",
+            "user": "ec2-user"
+        },
         "name": "Redhat", 
         "format": "tgz", 
         "checksum": "669ab5ef94af84d273f8f92a86b7907a", 

--- a/umbrella/example/povray/povray_base_local.umbrella
+++ b/umbrella/example/povray/povray_base_local.umbrella
@@ -5,6 +5,11 @@
         "name": "linux"
     },
     "os": {
+        "ec2": {
+            "ami": "ami-2cf8901c",
+            "region": "us-west-2",
+            "user": "ec2-user"
+        },
         "name": "Redhat",
         "format": "tgz",
         "source": [

--- a/umbrella/src/umbrella.py
+++ b/umbrella/src/umbrella.py
@@ -680,8 +680,6 @@ def dependency_process(name, id, action, meta_json, sandbox_dir, osf_auth):
 	if source[:4] == "git+":
 		dest = git_dependency_parser(item, source[4:], sandbox_dir)
 		mount_value = dest
-		cleanup(tempfile_list, tempdir_list)
-		sys.exit("this is git source, can not support")
 	elif source[:4] == "osf+":
 		checksum = attr_check(name, item, "checksum")
 		form = attr_check(name, item, "format")
@@ -2156,7 +2154,7 @@ def ec2_process(spec_path, spec_json, meta_option, meta_path, ssh_key, ec2_key_p
 		meta_path: the path of the json file including all the metadata information.
 		ssh_key: the name the private key file to use when connecting to an instance.
 		ec2_key_pair: the path of the key-pair to use when launching an instance.
-		ec2_security_group: the security group within which the EC2 instance should be run.
+		ec2_security_group: the security group id within which the EC2 instance should be run.
 		ec2_instance_type: the type of an Amazone ec2 instance
 		sandbox_dir: the sandbox dir for temporary files like Parrot mountlist file.
 		output_f_dict: the mappings of output files (key is the file path used by the application; value is the file path the user specifies.)
@@ -2208,38 +2206,29 @@ def ec2_process(spec_path, spec_json, meta_option, meta_path, ssh_key, ec2_key_p
 		logging.critical("%s is not in the ec2 json file (%s).", name, ec2_path)
 		sys.exit("%s is not in the ec2 json file (%s).\n" % (name, ec2_path))
 
+	#here we should judge the os type, yum is used by Fedora, CentOS, and REHL.
+	if distro_name not in ["fedora", "centos", "redhat"]:
+			cleanup(tempfile_list, tempdir_list)
+			logging.critical("Currently the supported Linux distributions are redhat, centos and fedora.\n")
+			sys.exit("Currently the supported Linux distributions are redhat, centos and fedora.\n")
+
 	#start the instance and obtain the instance id
 	print "Starting an Amazon EC2 instance ..."
-	instance_id = get_instance_id(ami, ec2_instance_type, ec2_key_pair, ec2_security_group)
-	logging.debug("Start the instance and obtain the instance id: %s", instance_id)
+	instance = launch_ec2_instance(ami, ec2_instance_type, ec2_key_pair, ec2_security_group)
+	logging.debug("Start the instance and obtain the instance id: %s", instance)
 
-	#get the public DNS of the instance_id
-	print "Obtaining the public DNS of the Amazon EC2 instance ..."
-	public_dns = get_public_dns(instance_id)
-	logging.debug("Get the public DNS of the instance_id: %s", public_dns)
-
-	'''
-
-	#instance_id = "<instance_id>"
-	#public_dns = "<public_dns>"
-
-	instance_id = "i-e61ad13c"
-	public_dns = "ec2-52-26-177-97.us-west-2.compute.amazonaws.com"
-	'''
+	#get the public DNS of the instance
+	public_ip = instance.public_ip_address
+	logging.debug("Get the public IP of the instance: %s", public_ip)
 
 	#install wget on the instance
 	print "Installing wget on the EC2 instance ..."
 	logging.debug("Install wget on the instance")
-	#here we should judge the os type, yum is used by Fedora, CentOS, and REHL.
-	if distro_name not in ["fedora", "centos", "redhat"]:
-			cleanup(tempfile_list, tempdir_list)
-			sys.exit("Currently the supported Linux distributions are redhat, centos and fedora.\n")
-
 	#ssh exit code 255: the remote node is down or unavailable
 	rc = 300
 	while rc != 0:
 		#without `-t` option of ssh, if the username is not root, `ssh + sudo` will get the following error: sudo: sorry, you must have a tty to run sudo.
-		cmd = 'ssh -t -o ConnectionAttempts=5 -o StrictHostKeyChecking=no -o ConnectTimeout=60 -i %s %s@%s \'sudo yum -y install wget\'' % (ssh_key, user_name, public_dns)
+		cmd = 'ssh -t -o ConnectionAttempts=5 -o StrictHostKeyChecking=no -o ConnectTimeout=60 -i %s %s@%s \'sudo yum -y install wget\'' % (ssh_key, user_name, public_ip)
 		rc, stdout, stderr = func_call(cmd)
 		if rc != 0:
 			logging.debug("`%s` fails with the return code of %d, \nstdout: %s, \nstderr: %s" % (cmd, rc, stdout, stderr))
@@ -2252,10 +2241,10 @@ def ec2_process(spec_path, spec_json, meta_option, meta_path, ssh_key, ec2_key_p
 	python_url = "http://ccl.cse.nd.edu/research/data/hep-case-study/python-2.6.9-%s-%s.tar.gz" % (linux_distro, hardware_platform)
 	scheme, netloc, path, query, fragment = urlparse.urlsplit(python_url)
 	python_url_filename = os.path.basename(path)
-	cmd = 'ssh -t -o ConnectionAttempts=5 -o StrictHostKeyChecking=no -o ConnectTimeout=60 -i %s %s@%s \'sudo wget %s && sudo tar zxvf %s\'' % (ssh_key, user_name, public_dns, python_url, python_url_filename)
+	cmd = 'ssh -t -o ConnectionAttempts=5 -o StrictHostKeyChecking=no -o ConnectTimeout=60 -i %s %s@%s \'sudo wget %s && sudo tar zxvf %s\'' % (ssh_key, user_name, public_ip, python_url, python_url_filename)
 	rc, stdout, stderr = func_call(cmd)
 	if rc != 0:
-		terminate_instance(instance_id)
+		terminate_instance(instance)
 		subprocess_error(cmd, rc, stdout, stderr)
 
 	#scp umbrella, meta.json and input files to the instance
@@ -2267,17 +2256,24 @@ def ec2_process(spec_path, spec_json, meta_option, meta_path, ssh_key, ec2_key_p
 
 	#here meta_path may start with http so need a special treatement
 	umbrella_fullpath = which_exec("umbrella")
+	if umbrella_fullpath == None:
+		cleanup(tempfile_list, tempdir_list)
+		terminate_instance(instance)
+		logging.critical("Failed to find the executable umbrella. Please modify your $PATH.")
+		sys.exit("Failed to find the executable umbrella. Please modify your $PATH.\n")
+
+	logging.debug("The full path of umbrella is: %s" % umbrella_fullpath)
 
 	if meta_option:
 		meta_option = " --meta ~%s/%s " % (user_name, os.path.basename(meta_path))
-		cmd = 'scp -i %s %s %s %s %s %s@%s:' % (ssh_key, umbrella_fullpath, spec_path, meta_path, input_file_string, user_name, public_dns)
+		cmd = 'scp -i %s %s %s %s %s %s@%s:' % (ssh_key, umbrella_fullpath, spec_path, meta_path, input_file_string, user_name, public_ip)
 	else:
 		meta_option = ""
-		cmd = 'scp -i %s %s %s %s %s@%s:' % (ssh_key, umbrella_fullpath, spec_path, input_file_string, user_name, public_dns)
+		cmd = 'scp -i %s %s %s %s %s@%s:' % (ssh_key, umbrella_fullpath, spec_path, input_file_string, user_name, public_ip)
 
 	rc, stdout, stderr = func_call(cmd)
 	if rc != 0:
-		terminate_instance(instance_id)
+		terminate_instance(instance)
 		subprocess_error(cmd, rc, stdout, stderr)
 
 	#change the --inputs option to put all the inputs directory in the home dir of the instance
@@ -2300,6 +2296,7 @@ def ec2_process(spec_path, spec_json, meta_option, meta_path, ssh_key, ec2_key_p
 	cmd = 'which cctools_python'
 	rc, stdout, stderr = func_call(cmd)
 	if rc != 0:
+		terminate_instance(instance)
 		subprocess_error(cmd, rc, stdout, stderr)
 	cctools_python_path = stdout[:-1]
 
@@ -2316,45 +2313,54 @@ def ec2_process(spec_path, spec_json, meta_option, meta_path, ssh_key, ec2_key_p
 	if output_option:
 		ec2_output_option = " -o '%s'" % output_option
 
-	cmd = 'ssh -t -o ConnectionAttempts=5 -o StrictHostKeyChecking=no -o ConnectTimeout=60 -i %s %s@%s "sudo %s/bin/python ~%s/umbrella %s -s destructive --spec ~%s/%s %s --log ~%s/ec2_umbrella.log -l ec2_umbrella %s %s %s run \'%s\'"' % (ssh_key, user_name, public_dns, python_name, user_name, cvmfs_http_proxy_option, user_name, os.path.basename(spec_path), meta_option, user_name, ec2_output_option, new_input_options, env_option, user_cmd[0])
+	if not env_option:
+		env_option = ''
+
+	cmd = 'ssh -t -o ConnectionAttempts=5 -o StrictHostKeyChecking=no -o ConnectTimeout=60 -i %s %s@%s "sudo %s/bin/python ~%s/umbrella %s -s destructive --spec ~%s/%s %s --log ~%s/ec2_umbrella.log -l ec2_umbrella %s %s %s run \'%s\'"' % (ssh_key, user_name, public_ip, python_name, user_name, cvmfs_http_proxy_option, user_name, os.path.basename(spec_path), meta_option, user_name, ec2_output_option, new_input_options, env_option, user_cmd[0])
 	rc, stdout, stderr = func_call(cmd)
 	if rc != 0:
-		terminate_instance(instance_id)
+		terminate_instance(instance)
 		subprocess_error(cmd, rc, stdout, stderr)
+
+	print "\n********** STDOUT of the command **********"
+	print stdout
+
+	print "\n********** STDERR of the command **********"
+	print stderr
 
 	#postprocessing
 	print "Transferring the output of the user's task from the EC2 instance back to the local machine ..."
 	logging.debug("Create a tarball for the output dir on the instance.")
 
 	output = '%s %s' % (' '.join(output_f_dict.values()), ' '.join(output_d_dict.values()))
-	cmd = 'ssh -t -o ConnectionAttempts=5 -o StrictHostKeyChecking=no -o ConnectTimeout=60 -i %s %s@%s \'sudo tar cvzf ~%s/output.tar.gz %s && sudo chown %s:%s ~%s/output.tar.gz ~%s/ec2_umbrella.log\'' % (ssh_key, user_name, public_dns, user_name, output, user_name, user_name, user_name, user_name)
+	cmd = 'ssh -t -o ConnectionAttempts=5 -o StrictHostKeyChecking=no -o ConnectTimeout=60 -i %s %s@%s \'sudo tar cvzf ~%s/output.tar.gz %s && sudo chown %s:%s ~%s/output.tar.gz ~%s/ec2_umbrella.log\'' % (ssh_key, user_name, public_ip, user_name, output, user_name, user_name, user_name, user_name)
 	rc, stdout, stderr = func_call(cmd)
 	if rc != 0:
-		terminate_instance(instance_id)
+		terminate_instance(instance)
 		subprocess_error(cmd, rc, stdout, stderr)
 
 	logging.debug("The instance returns the output.tar.gz to the local machine.")
-	cmd = 'scp -i %s %s@%s:output.tar.gz %s/' % (ssh_key, user_name, public_dns, sandbox_dir)
+	cmd = 'scp -i %s %s@%s:output.tar.gz %s/' % (ssh_key, user_name, public_ip, sandbox_dir)
 	rc, stdout, stderr = func_call(cmd)
 	if rc != 0:
-		terminate_instance(instance_id)
+		terminate_instance(instance)
 		subprocess_error(cmd, rc, stdout, stderr)
 
 	logging.debug("The instance returns the remote umbrella log file to the local machine.")
-	cmd = 'scp -i %s %s@%s:ec2_umbrella.log %s' % (ssh_key, user_name, public_dns, ec2log_path)
+	cmd = 'scp -i %s %s@%s:ec2_umbrella.log %s' % (ssh_key, user_name, public_ip, ec2log_path)
 	rc, stdout, stderr = func_call(cmd)
 	if rc != 0:
-		terminate_instance(instance_id)
+		terminate_instance(instance)
 		subprocess_error(cmd, rc, stdout, stderr)
 
 	cmd = 'tar zxvf %s/output.tar.gz -C /' % (sandbox_dir)
 	rc, stdout, stderr = func_call(cmd)
 	if rc != 0:
-		terminate_instance(instance_id)
+		terminate_instance(instance)
 		subprocess_error(cmd, rc, stdout, stderr)
 
 	print "Terminating the EC2 instance ..."
-	terminate_instance(instance_id)
+	terminate_instance(instance)
 
 def obtain_package(spec_json):
 	"""Check whether this spec includes a package_manager section, which in turn includes a list attr.
@@ -2628,83 +2634,50 @@ def dependency_check(item):
 		print "Find the executable `%s` through $PATH." % item
 		return 0
 
-def get_instance_id(image_id, instance_type, ec2_key_pair, ec2_security_group):
+def launch_ec2_instance(image_id, instance_type, ec2_key_pair, ec2_security_group):
 	""" Start one VM instance through Amazon EC2 command line interface and return the instance id.
 
 	Args:
 		image_id: the Amazon Image Identifier.
 		instance_type: the Amazon EC2 instance type used for the task.
 		ec2_key_pair: the path of the key-pair to use when launching an instance.
-		ec2_security_group: the security group within which the EC2 instance should be run.
+		ec2_security_group: the security group id within which the EC2 instance should be run.
 
 	Returns:
-		If no error happens, returns the id of the started instance.
+		If no error happens, returns an EC2.Instance object.
 		Otherwise, directly exit.
 	"""
-	sg_option = ''
-	if ec2_security_group:
-		sg_option = ' -g ' + ec2_security_group
-	cmd = 'ec2-run-instances %s -t %s -k %s %s --associate-public-ip-address true' % (image_id, instance_type, ec2_key_pair, sg_option)
-	logging.debug("Starting an instance: %s", cmd)
-	p = subprocess.Popen(cmd, stdout = subprocess.PIPE, shell = True)
-	(stdout, stderr) = p.communicate()
-	rc = p.returncode
-	logging.debug("returncode: %d\nstdout: %s\nstderr: %s", rc, stdout, stderr)
-	if rc != 0:
-		subprocess_error(cmd, rc, stdout, stderr)
-	str = "\nINSTANCE"
-	index = stdout.find(str)
-	if index == -1:
-		cleanup(tempfile_list, tempdir_list)
-		sys.exit("Fail to get the instance id!")
-	else:
-		instance_id = stdout[(index+9):(index+20)]
-		return instance_id
+	ec2 = boto3.resource('ec2')
 
-def terminate_instance(instance_id):
+	if ec2_security_group and ec2_security_group != '':
+		instances = ec2.create_instances(ImageId=image_id, MinCount=1, MaxCount=1, KeyName=ec2_key_pair, SecurityGroupIds=[ec2_security_group], InstanceType=instance_type)
+	else:
+		instances = ec2.create_instances(ImageId=image_id, MinCount=1, MaxCount=1, KeyName=ec2_key_pair, InstanceType=instance_type)
+
+	if len(instances) <= 0:
+		logging.critical("No instance was launched!")
+		sys.exit("No instance was launched!")
+
+	instance = instances[0]
+	instance.wait_until_running()
+
+	# Calls EC2.Client.describe_instances() to update the attributes of the Instance resource
+	instance.load()
+
+	return instance
+
+def terminate_instance(instance):
 	"""Terminate an instance.
 
 	Args:
-		instance_id: the id of the VM instance.
+		instance_id: an ec2.Instance object
 
 	Returns:
 		None.
 	"""
-	logging.debug("Terminate the ec2 instance: %s", instance_id)
-	cmd = 'ec2-terminate-instances %s' % instance_id
-	p = subprocess.Popen(cmd, stdout = subprocess.PIPE, shell = True)
-
-def get_public_dns(instance_id):
-	"""Get the public dns of one VM instance from Amazon EC2.
-	`ec2-run-instances` can not directly return the public dns of the instance, so this function is needed to check the result of `ec2-describe-instances` to obtain the public dns of the instance.
-
-	Args:
-		instance_id: the id of the VM instance.
-
-	Returns:
-		If no error happens, returns the public dns of the instance.
-		Otherwise, directly exit.
-	"""
-	public_dns = ''
-	while public_dns == None or public_dns == '' or public_dns == 'l':
-		cmd = 'ec2-describe-instances ' + instance_id
-		p = subprocess.Popen(cmd, stdout = subprocess.PIPE, shell = True)
-		(stdout, stderr) = p.communicate()
-		rc = p.returncode
-		logging.debug("returncode: %d\nstdout: %s\nstderr: %s", rc, stdout, stderr)
-		if rc != 0:
-			subprocess_error(cmd, rc, stdout, stderr)
-
-		str = "\nPRIVATEIPADDRESS"
-		index = stdout.find(str)
-		if index >= 0:
-			index1 = stdout.find("ec2", index + 1)
-			if index1 == -1:
-				time.sleep(5)
-				continue
-			public_dns = stdout[index1:-1]
-			break
-	return public_dns
+	logging.debug("Terminate the ec2 instance:")
+	instance.terminate()
+	instance.wait_until_terminated()
 
 def add2spec(item, source_dict, target_dict):
 	"""Abstract the metadata information (source format checksum size) from source_dict (metadata database) and add these information into target_dict (umbrella spec).
@@ -3835,7 +3808,7 @@ To check the help doc for a specific behavoir, use: %prog <behavior> help""",
 					help="The path of the ec2 umbrella log file. Required for ec2 execution engines.",)
 	parser.add_option("-g", "--ec2_group",
 					action="store",
-					help="the security group within which an Amazon EC2 instance should be run. (only for ec2)",)
+					help="the security group id within which an Amazon EC2 instance should be run. (only for ec2)",)
 	parser.add_option("-k", "--ec2_key",
 					action="store",
 					help="the name of the key pair to use when launching an Amazon EC2 instance. (only for ec2)",)
@@ -4242,6 +4215,13 @@ To check the help doc for a specific behavoir, use: %prog <behavior> help""",
 				logging.critical("The ssh key file (%s) does not exists!", ssh_key)
 				sys.exit("The ssh key file (%s) does not exists!\n" % ssh_key)
 
+			if not found_boto3 or not found_botocore:
+				cleanup(tempfile_list, tempdir_list)
+				logging.critical("\nUsing the Amazon EC2 resources requires a python package - boto3. Please check the installation page of boto3:\n\n\thttps://boto3.readthedocs.org/en/latest/guide/quickstart.html#installation\n")
+				sys.exit("\nUsing the Amazon EC2 resources requires a python package - boto3. Please check the installation page of boto3:\n\n\thttps://boto3.readthedocs.org/en/latest/guide/quickstart.html#installation\n")
+
+			# Here the security group id, instead of the security group name, is used to allow an instance to be launched into a nondefault VPC.
+			# the security group name can only be used to launch an instance into EC2-Classic or default VPC.
 			ec2_security_group = options.ec2_group
 			ec2_key_pair = options.ec2_key
 			ec2_instance_type = options.ec2_instance_type


### PR DESCRIPTION
    1) Use python boto3 to communicate with EC2 instead of CLI

    2) moving ec2 ami info into umbrella spec
    
        Originally, Umbrella used a dict to maintain the mapping between the os
        name and the EC2 AMI info. This solution requires update the dict every time a
        new mapping entry is added.