### PR TITLE
Less msgs to monitor

### DIFF
--- a/dttools/src/debug.c
+++ b/dttools/src/debug.c
@@ -49,6 +49,7 @@ static INT64_T debug_flags = D_NOTICE|D_ERROR|D_FATAL;
 
 static char *terminal_path = "/dev/tty";
 static FILE *terminal_f    = NULL;
+static int   did_terminal_notice = 0;
 
 struct flag_info {
 	const char *name;
@@ -203,12 +204,13 @@ static void do_debug(INT64_T flags, const char *fmt, va_list args)
 
 	debug_write(flags, buffer_tostring(&B));
 
-	if(flags & (D_ERROR | D_NOTICE | D_FATAL)) {
+	if(!did_terminal_notice && (flags & (D_ERROR | D_NOTICE | D_FATAL))) {
 		if(debug_write != debug_stderr_write || !isatty(STDERR_FILENO)) {
 			if(!terminal_f) {
 				if((terminal_f = fopen(terminal_path, "a")) == NULL) {
 					/* print to wherever stderr is pointing that we could not open the terminal. */
 					fprintf(stderr, "Could not open '%s' for immediate error reporting.\n", terminal_path);
+					did_terminal_notice = 1;
 				}
 			}
 		}


### PR DESCRIPTION
A couple of fixes as reported by lobster:

- Do not print debug message regarding /dev/tty more than once.
- Do not open/close the monitor socket every time there is a message. This worked when they were only very few messages to send (in most cases, only one). However, now that we track send/recv, write/read, the overhead was too big. Now we keep the socket open for the duration of the process.
 