### PR TITLE
use category as fall-back to user labeling

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1205,7 +1205,7 @@ void read_measured_resources(struct work_queue *q, struct work_queue_task *t) {
 	char *summary = string_format("%s/" RESOURCE_MONITOR_TASK_LOCAL_NAME ".summary", q->monitor_output_dirname, getpid(), t->taskid);
 
 	if(t->resources_measured)
-		free(t->resources_measured);
+		rmsummary_delete(t->resources_measured);
 
 	t->resources_measured = rmsummary_parse_file_single(summary);
 


### PR DESCRIPTION
As reported by @matz-e:


I currently am processing stuff with one category, with the following passed to WQ:

2016-02-04 05:24:18 [DEBUG] lobster.core: Category merge: {'cores': 1, 'memory': 900}
2016-02-04 05:24:18 [DEBUG] lobster.core: Category processing: {'wall_time': 1800000000, 'cores': 1, 'memory': 1500}
…
        queue.specify_max_category_resources(category, constraints)
        logger.debug('Category {0}: {1}'.format(category,constraints))

Yet I have a task that’s running for 3 hours right now? I also don’t see these constraints passed along:

2016/02/05 01:36:29.79 work_queue_python[1696366] wq: tx to dev4.crc.nd.edu (129.74.85.17:57466): task 8592
2016/02/05 01:36:29.79 work_queue_python[1696366] wq: tx to dev4.crc.nd.edu (129.74.85.17:57466): cmd 192
./cctools-monitor --with-output-files=cctools-monitor -L 'end: 1455011436.000000' -L 'cores: 1' -V 'task_id: 8592' -V 'category: processing' --sh "sh wrapper.sh python task.py parameters.json"


The issue here is that specifying "end" marked the task as user labeled, ignoring the other resources specified from the category.

