### PR TITLE
Update to fix chirp local jobs

### DIFF
--- a/batch_job/src/batch_job.c
+++ b/batch_job/src/batch_job.c
@@ -71,6 +71,10 @@ struct batch_queue *batch_queue_create(batch_queue_type_t type)
 	q->output_table = itable_create(0);
 	q->data = NULL;
 
+	batch_queue_set_feature(q, "local_job_queue", "yes");
+	batch_queue_set_feature(q, "batch_log_name", "%s.batchlog");
+	batch_queue_set_feature(q, "gc_size", "yes");
+
 	q->module = NULL;
 	for (i = 0; batch_queue_modules[i]->type != BATCH_QUEUE_TYPE_UNKNOWN; i++)
 		if (batch_queue_modules[i]->type == type)
@@ -84,10 +88,6 @@ struct batch_queue *batch_queue_create(batch_queue_type_t type)
 		batch_queue_delete(q);
 		return NULL;
 	}
-
-	batch_queue_set_feature(q, "local_job_queue", "yes");
-	batch_queue_set_feature(q, "batch_log_name", "%s.batchlog");
-	batch_queue_set_feature(q, "gc_size", "yes");
 
 	debug(D_BATCH, "created queue %p (%s)", q, q->module->typestr);
 
@@ -166,7 +166,6 @@ void batch_queue_set_feature (struct batch_queue *q, const char *what, const cha
 	} else {
 		debug(D_BATCH, "cleared feature `%s'", what);
 	}
-	q->module->option_update(q, what, value);
 }
 
 void batch_queue_set_int_option(struct batch_queue *q, const char *what, int value) {


### PR DESCRIPTION
@btovar @batrick Please take a look to see if this addresses the issue in #1148 . The issue was that the default batch_job feature set was overriding the features defined in the batch_job_chirp.