### PR TITLE
Do not consider end time as a labeling resource

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -2586,6 +2586,11 @@ static struct rmsummary *task_worker_box_size(struct work_queue *q, struct work_
 		limits->gpus   = MIN(label->gpus,   w->resources->gpus.total);
 	}
 
+	/* consider end time by itself, regardless of labeling. */
+	if(t->resources_requested && t->resources_requested->end > 0) {
+		limits->end = t->resources_requested->end;
+	}
+
 	return limits;
 }
 
@@ -3539,7 +3544,7 @@ void work_queue_task_specify_max_retries( struct work_queue_task *t, int64_t max
 
 static void set_task_unlabel_flag( struct work_queue_task *t )
 {
-	if(t->resources_requested->cores < 0 && t->resources_requested->memory < 0 && t->resources_requested->disk < 0 && t->resources_requested->gpus < 0 && t->resources_requested->wall_time < 0 && t->resources_requested->end < 0)
+	if(t->resources_requested->cores < 0 && t->resources_requested->memory < 0 && t->resources_requested->disk < 0 && t->resources_requested->gpus < 0 && t->resources_requested->wall_time < 0)
 	{
 		if(t->resource_request == CATEGORY_ALLOCATION_USER)
 			t->resource_request = CATEGORY_ALLOCATION_UNLABELED;


### PR DESCRIPTION
If end time was specified, then autolabeling of other resources was not performed. This pr fixes that.