### PR TITLE
include limits exceeded in work queue measurement task report

### DIFF
--- a/dttools/src/rmsummary.c
+++ b/dttools/src/rmsummary.c
@@ -408,6 +408,16 @@ int rmsummary_assign_int_field(struct rmsummary *s, const char *key, int64_t val
 	return 0;
 }
 
+int rmsummary_assign_summary_field(struct rmsummary *s, char *key, struct jx *value) {
+
+	if(strcmp(key, "limits_exceeded") == 0) {
+		s->limits_exceeded = json_to_rmsummary(value);
+		return 1;
+	}
+
+	return 0;
+}
+
 
 #define field_to_json(o, s, f)\
 	if((s)->f > -1) {\
@@ -530,6 +540,8 @@ struct rmsummary *json_to_rmsummary(struct jx *j) {
 			if(status) {
 				rmsummary_assign_int_field(s, key, number);
 			}
+		} else if(jx_istype(value, JX_OBJECT)) {
+			rmsummary_assign_summary_field(s, key, value);
 		}
 
 		head = head->next;

--- a/dttools/src/rmsummary.h
+++ b/dttools/src/rmsummary.h
@@ -96,6 +96,7 @@ struct list *rmsummary_parse_file_multiple(const char *filename);
 struct rmsummary *rmsummary_parse_next(FILE *stream);
 
 struct jx *rmsummary_to_json(struct rmsummary *s, int only_resources);
+struct rmsummary *json_to_rmsummary(struct jx *j);
 
 struct rmsummary *rmsummary_create(signed char default_value);
 void rmsummary_delete(struct rmsummary *s);


### PR DESCRIPTION
As requested by @matz-e. Make resources exceeded per task API available.