### PR TITLE
Linearish wq codes

### DIFF
--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -56,17 +56,17 @@ typedef enum {
 
 
 typedef enum {
-	WORK_QUEUE_RESULT_SUCCESS        = 0,       /**< The task ran successfully **/
-	WORK_QUEUE_RESULT_INPUT_MISSING  = 1,       /**< The task cannot be run due to a missing input file **/
-	WORK_QUEUE_RESULT_OUTPUT_MISSING = 2,       /**< The task ran but failed to generate a specified output file **/
-	WORK_QUEUE_RESULT_STDOUT_MISSING = 4,       /**< The task ran but its stdout has been truncated **/
-	WORK_QUEUE_RESULT_SIGNAL         = 8,       /**< The task was terminated with a signal **/
-	WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION = 16, /**< The task used more resources than requested **/
-	WORK_QUEUE_RESULT_TASK_TIMEOUT   = 32,      /**< The task ran after the specified (absolute since epoch) end time. **/
-	WORK_QUEUE_RESULT_UNKNOWN        = 64,      /**< The result could not be classified. **/
-	WORK_QUEUE_RESULT_FORSAKEN       = 128,     /**< The task failed, but it was neither a task or worker error **/
-	WORK_QUEUE_RESULT_MAX_RETRIES    = 256,     /**< The task could not be completed successfully in the given number of retries. **/
-	WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME = 512   /**< The task ran for more than the specified time (relative since running in a worker). **/
+	WORK_QUEUE_RESULT_SUCCESS             = 0,      /**< The task ran successfully **/
+	WORK_QUEUE_RESULT_INPUT_MISSING       = 1,      /**< The task cannot be run due to a missing input file **/
+	WORK_QUEUE_RESULT_OUTPUT_MISSING      = 2,      /**< The task ran but failed to generate a specified output file **/
+	WORK_QUEUE_RESULT_STDOUT_MISSING      = 4,      /**< The task ran but its stdout has been truncated **/
+	WORK_QUEUE_RESULT_SIGNAL              = 1 << 3, /**< The task was terminated with a signal **/
+	WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION = 2 << 3, /**< The task used more resources than requested **/
+	WORK_QUEUE_RESULT_TASK_TIMEOUT        = 3 << 3, /**< The task ran after the specified (absolute since epoch) end time. **/
+	WORK_QUEUE_RESULT_UNKNOWN             = 4 << 3, /**< The result could not be classified. **/
+	WORK_QUEUE_RESULT_FORSAKEN            = 5 << 3, /**< The task failed, but it was neither a task or worker error **/
+	WORK_QUEUE_RESULT_MAX_RETRIES         = 6 << 3, /**< The task could not be completed successfully in the given number of retries. **/
+	WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME   = 7 << 3, /**< The task ran for more than the specified time (relative since running in a worker). **/
 } work_queue_result_t;
 
 typedef enum {

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -575,7 +575,7 @@ static void expire_procs_running() {
 	while(itable_nextkey(procs_running, (uint64_t*)&pid, (void**)&p)) {
 		if(p->task->resources_requested->end > 0 && current_time > (uint64_t) p->task->resources_requested->end)
 		{
-			p->task_status |= WORK_QUEUE_RESULT_TASK_TIMEOUT;
+			p->task_status = WORK_QUEUE_RESULT_TASK_TIMEOUT;
 			kill(pid, SIGKILL);
 		}
 	}
@@ -1246,7 +1246,7 @@ static int enforce_processes_limits() {
 	while(itable_nextkey(procs_table,(uint64_t*)&pid,(void**)&p)) {
 		if(!enforce_process_limits(p)) {
 			finish_running_tasks(WORK_QUEUE_RESULT_FORSAKEN);
-			p->task_status |= WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION;
+			p->task_status = WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION;
 
 			/* we delete the sandbox, to free the exhausted resource. */
 			delete_dir(p->sandbox);
@@ -1275,7 +1275,7 @@ static void enforce_processes_max_running_time() {
 
 		if(now < p->execution_start + p->task->resources_requested->wall_time) {
 			debug(D_WQ,"Task %d went over its running time limit: %" PRId64 " us > %" PRIu64 " us\n", p->task->taskid, now - p->execution_start, p->task->resources_requested->wall_time);
-			p->task_status |= WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME;
+			p->task_status = WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME;
 			kill(pid, SIGKILL);
 		}
 	}


### PR DESCRIPTION
As requested by @matz-e.  task->result only returns a single error code, rather than an "or" of codes.

The only codes that are ever or-ed are missing stdout and missing output. This pr makes it so that if both are present, only missing output is returned.

Also, care was taken so that the older codes (missing input, output, stdout) may still be compared with & and ==, while newer codes can be compared with ==. With this, a simple switch case can be done on task->result, rather than multiple ifs with & in the condition.
