### PR TITLE
Computation overheads and waste table

### DIFF
--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -198,7 +198,7 @@ int64_t *category_sort_histogram(struct itable *histogram, int64_t *keys) {
 	return keys;
 }
 
-void category_first_allocation_accum_times(struct itable *histogram, int64_t *keys, int64_t *counts_accum, double *times_mean, double *times_accum) {
+void category_first_allocation_accum_times(struct itable *histogram, double *tau_mean, int64_t *keys, int64_t *counts_accum, double *times_mean, double *times_accum) {
 
 	int64_t n = itable_size(histogram);
 
@@ -224,6 +224,9 @@ void category_first_allocation_accum_times(struct itable *histogram, int64_t *ke
 		times_accum[i] = times_accum[i + 1] + times_mean[i+1] * ((double) p->count)/counts_accum[n-1];
 	}
 
+	p = itable_lookup(histogram, keys[0]);
+	*tau_mean = times_accum[0] + times_mean[0] * ((double) p->count)/counts_accum[n-1];
+
 	return;
 }
 
@@ -243,9 +246,9 @@ int64_t category_first_allocation(struct itable *histogram, int assume_independe
 	double  *times_mean   = malloc(n*sizeof(intptr_t));
 	double  *times_accum  = malloc(n*sizeof(intptr_t));
 
-	category_first_allocation_accum_times(histogram, keys, counts_accum, times_mean, times_accum);
+	double tau_mean;
 
-	double tau_mean = times_accum[0];
+	category_first_allocation_accum_times(histogram, &tau_mean, keys, counts_accum, times_mean, times_accum);
 
 	int64_t a_1 = top_resource;
 	int64_t a_m = top_resource;

--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -26,9 +26,9 @@ struct peak_count_time {
 	double  times;
 };
 
-static uint64_t memory_bucket_size    = 25;        /* MB */
-static uint64_t disk_bucket_size      = 25;        /* MB */
-static uint64_t time_bucket_size      = 30000000;  /*  1 s */
+static uint64_t memory_bucket_size    = 50;        /* MB */
+static uint64_t disk_bucket_size      = 50;        /* MB */
+static uint64_t time_bucket_size      = 60000000;  /* 1 minute */
 static uint64_t bytes_bucket_size     = MEGABYTE;  /* 1 M */
 static uint64_t bandwidth_bucket_size = 1000000;   /* 1 Mbit/s */
 

--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -26,9 +26,9 @@ struct peak_count_time {
 	int64_t times;
 };
 
-static uint64_t memory_bucket_size    = 100;       /* MB */
-static uint64_t disk_bucket_size      = 100;       /* MB */
-static uint64_t time_bucket_size      = 60000000;  /* 60 s */
+static uint64_t memory_bucket_size    = 25;        /* MB */
+static uint64_t disk_bucket_size      = 25;        /* MB */
+static uint64_t time_bucket_size      = 30000000;  /* 30 s */
 static uint64_t bytes_bucket_size     = MEGABYTE;  /* 1 M */
 static uint64_t bandwidth_bucket_size = 1000000;   /* 1 Mbit/s */
 

--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -349,7 +349,7 @@ int64_t category_first_allocation_max_throughput(struct itable *histogram, int64
 	return a_1;
 }
 
-int64_t category_first_allocation(struct itable *histogram, int assume_independence, category_allocation_t mode,  int64_t top_resource) {
+int64_t category_first_allocation(struct itable *histogram, int assume_independence, category_mode_t mode,  int64_t top_resource) {
 	switch(mode) {
 		case CATEGORY_ALLOCATION_MODE_MIN_WASTE:
 			return category_first_allocation_min_waste(histogram, assume_independence, top_resource);

--- a/dttools/src/category.h
+++ b/dttools/src/category.h
@@ -19,6 +19,11 @@ typedef enum {
 	CATEGORY_ALLOCATION_ERROR          /**< No valid resources could be found. (E.g., after 2nd step fails) */
 } category_allocation_t;
 
+typedef enum {
+	CATEGORY_ALLOCATION_MODE_MIN_WASTE = 0,
+	CATEGORY_ALLOCATION_MODE_MAX_THROUGHPUT
+} category_mode_t;
+
 struct category {
 	char *name;
 	double fast_abort;
@@ -43,6 +48,8 @@ struct category {
 	struct itable *bandwidth_histogram;
 	struct itable *total_files_histogram;
 	struct itable *disk_histogram;
+
+	category_mode_t allocation_mode;
 
 	uint64_t total_tasks;
 

--- a/dttools/src/category_internal.h
+++ b/dttools/src/category_internal.h
@@ -9,6 +9,7 @@ See the file COPYING for details.
 
 #include "category.h"
 
+void category_first_allocation_accum_times(struct itable *histogram, int64_t *keys, int64_t *counts_accum, double *times_mean, double *times_accum);
 void category_tune_bucket_size(const char *resource, uint64_t size);
 
 #endif

--- a/dttools/src/category_internal.h
+++ b/dttools/src/category_internal.h
@@ -9,7 +9,7 @@ See the file COPYING for details.
 
 #include "category.h"
 
-void category_first_allocation_accum_times(struct itable *histogram, int64_t *keys, int64_t *counts_accum, double *times_mean, double *times_accum);
+void category_first_allocation_accum_times(struct itable *histogram, double *tau_mean, int64_t *keys, int64_t *counts_accum, double *times_mean, double *times_accum);
 void category_tune_bucket_size(const char *resource, uint64_t size);
 
 #endif

--- a/resource_monitor/src/Makefile
+++ b/resource_monitor/src/Makefile
@@ -21,7 +21,7 @@ resource_monitor.o resource_monitor_pb.o: rmonitor_piggyback.h
 resource_monitor: rmonitor_helper_comm.o
 
 resource_monitor_histograms.o resource_monitor_cluster.o rmon_tools.o: %.o: %.c
-	$(CCTOOLS_CC) -fopenmp -o $@ -c $(CCTOOLS_INTERNAL_CCFLAGS) $(LOCAL_CCFLAGS) $<
+	$(CCTOOLS_CC) -fopenmp -O3 -o $@ -c $(CCTOOLS_INTERNAL_CCFLAGS) $(LOCAL_CCFLAGS) $<
 
 resource_monitor_histograms resource_monitor_cluster: %: rmon_tools.o %.o
 	$(CCTOOLS_LD) -fopenmp -O3 -o $@ $(CCTOOLS_INTERNAL_LDFLAGS) $^ $(LOCAL_LINKAGE) $(CCTOOLS_EXTERNAL_LINKAGE)

--- a/resource_monitor/src/resource_monitor_cluster.c
+++ b/resource_monitor/src/resource_monitor_cluster.c
@@ -30,7 +30,7 @@ See the file COPYING for details.
 #include "rmon_tools.h"
 
 
-#define DEFAULT_MAX_CLUSTERS 4
+#define DEFAULT_MAX_CLUSTERS 8
 
 static char *report_filename = "clusters.txt";
 struct rmDsummary *max_values;
@@ -439,8 +439,9 @@ struct cluster *nearest_neighbor_clustering(struct list *initial_clusters, doubl
 			list_push_head(stack, closest);
 		}
 
-		debug(D_DEBUG, "stack: %d  active: %d  closest: %lf subtop: %lf\n",
-				list_size(stack), itable_size(active_clusters), dclosest, dsubtop);
+		if((list_size(stack) + itable_size(active_clusters)) % 50 == 0) {
+			debug(D_DEBUG, "stack: %d  active: %d  closest: %lf subtop: %lf\n", list_size(stack), itable_size(active_clusters), dclosest, dsubtop);
+		}
 
 		/* If there are no more active_clusters, but there is not
 		 * a single cluster in the stack, we try again,
@@ -743,7 +744,6 @@ int main(int argc, char **argv)
 	freport = fopen(report_filename, "w");
 	if(!freport)
 		fatal("%s: %s\n", report_filename, strerror(errno));
-
 
 	struct rmDsummary_set *set = make_new_set("all");
 

--- a/resource_monitor/src/resource_monitor_cluster.c
+++ b/resource_monitor/src/resource_monitor_cluster.c
@@ -10,6 +10,7 @@ See the file COPYING for details.
 #include <string.h>
 #include <errno.h>
 #include <math.h>
+#include <float.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -210,7 +211,7 @@ struct cluster *cluster_nearest_neighbor(struct itable *active_clusters, struct 
 	uint64_t        ptr;
 	struct cluster *nearest = NULL;
 	struct cluster *other;
-	double         dmin, dtest;
+	double         dmin = DBL_MAX, dtest;
 
 	itable_firstkey(active_clusters);
 	while( itable_nextkey( active_clusters, &ptr, (void *) &other ) )

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -1608,7 +1608,7 @@ int main(int argc, char **argv)
 				break;
 			case 'm':
 				/* brute force, small bucket size */
-				category_tune_bucket_size("time",   USECOND);
+				category_tune_bucket_size("time",   2*USECOND);
 				category_tune_bucket_size("memory", 5);
 				category_tune_bucket_size("disk",   5);
 				break;

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -720,40 +720,40 @@ struct histogram *histogram_of_field(struct rmDsummary_set *source, struct field
 
 void write_histogram_stats_header(FILE *stream)
 {
-	fprintf(stream, "%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s\n",
-			"resource",
-			"count",
-			"mean", "std_dev",
-			"max", "min", "first_alloc_w_time", "first_alloc_wo_time", "first_alloc_bf",
-			"waste_max", "waste_w_time", "waste_wo_time", "waste_brute_force",
-			"p_25", "p_50", "p_75", "p_95", "p_99"
-		   );
+	fprintf(stream, "resource,");
+	fprintf(stream, "count,mean,std_dev,");
+	fprintf(stream, "min,");
+	fprintf(stream, "max,waste_max,");
+	fprintf(stream, "first_alloc_w_time,waste_w_time,");
+	fprintf(stream, "first_alloc_wo_time,waste_wo_time,");
+	fprintf(stream, "first_alloc_95,waste_95,");
+
+	if(brute_force) {
+		fprintf(stream, "first_alloc_bf,waste_brute_force,");
+	}
+
+	fprintf(stream, "p_25,p_50,p_75,p_99");
 }
 
 void write_histogram_stats(FILE *stream, struct histogram *h)
 {
-	char *resource_no_spaces = sanitize_path_name(h->resource->name);
-	fprintf(stream, "%s %d %.3lf %.3lf %.3lf %.3lf %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %g %g %g %g %g %.3lf %.3lf %.3lf %.3lf %.3lf\n",
-			resource_no_spaces,
-			h->total_count,
-			h->mean, h->std_dev,
-			h->max_value, h->min_value,
-			h->first_allocation_time_dependence,
-			h->first_allocation_time_independence,
-			h->first_allocation_95,
-			h->first_allocation_brute_force,
-			h->waste_max,
-			h->waste_time_dependence,
-			h->waste_time_independence,
-			h->waste_95,
-			h->waste_brute_force,
+	fprintf(stream, "%s,", sanitize_path_name(h->resource->name));
+	fprintf(stream, "%d,%.0lf,%.3lf,", h->total_count, ceil(h->mean), h->std_dev);
+	fprintf(stream, "%.0lf,", floor(h->min_value));
+	fprintf(stream, "%.0lf,%.0lf,", ceil(h->max_value), ceil(h->waste_max));
+	fprintf(stream, "%" PRId64 ",%.0lf,", h->first_allocation_time_dependence, ceil(h->waste_time_dependence));
+	fprintf(stream, "%" PRId64 ",%.0lf,", h->first_allocation_time_independence, ceil(h->waste_time_independence));
+	fprintf(stream, "%" PRId64 ",%.0lf,", h->first_allocation_95, ceil(h->waste_95));
+
+	if(brute_force) {
+		fprintf(stream, "%" PRId64 ",%.0lf,", h->first_allocation_brute_force, ceil(h->waste_brute_force));
+	}
+
+	fprintf(stream, "%.3lf,%.3lf,%.3lf,%.3lf\n",
 			value_of_p(h, 0.25),
 			value_of_p(h, 0.50),
 			value_of_p(h, 0.75),
-			value_of_p(h, 0.95),
 			value_of_p(h, 0.99));
-
-	free(resource_no_spaces);
 }
 
 void histograms_of_category(struct rmDsummary_set *ss)

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -1608,9 +1608,9 @@ int main(int argc, char **argv)
 				break;
 			case 'm':
 				/* brute force, small bucket size */
-				category_tune_bucket_size("time",   2*USECOND);
-				category_tune_bucket_size("memory", 5);
-				category_tune_bucket_size("disk",   5);
+				category_tune_bucket_size("time",   USECOND);
+				category_tune_bucket_size("memory", 1);
+				category_tune_bucket_size("disk",   1);
 				break;
 			case 'n':
 				webpage_mode = 0;

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -731,7 +731,7 @@ void write_histogram_stats_header(FILE *stream)
 		fprintf(stream, "first_alloc_bf,waste_brute_force,");
 	}
 
-	fprintf(stream, "p_25,p_50,p_75,p_99");
+	fprintf(stream, "p_25,p_50,p_75,p_99\n");
 }
 
 void write_histogram_stats(FILE *stream, struct histogram *h)

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -874,6 +874,7 @@ void set_first_allocation_time_dependence(struct rmDsummary_set *s, struct hash_
 		if(!f->active)
 			continue;
 
+
 		h = itable_lookup(s->histograms, (uint64_t) ((uintptr_t) f));
 
 		h->first_allocation_time_dependence = -1;
@@ -1040,7 +1041,7 @@ void write_stats_of_category(struct rmDsummary_set *s)
 	fclose(f_stats);
 }
 
-void write_limits_of_category(struct rmDsummary_set *s, double p_cut)
+void write_limits_of_category(struct rmDsummary_set *s)
 {
 
 	char *f_stats_raw   = sanitize_path_name(s->category);
@@ -1060,7 +1061,7 @@ void write_limits_of_category(struct rmDsummary_set *s, double p_cut)
 
 		h = itable_lookup(s->histograms, (uint64_t) ((uintptr_t) f));
 
-		fprintf(f_limits, "%s: %" PRIu64 "\n", f->name, (int64_t) ceil(value_of_p(h, p_cut)));
+		fprintf(f_limits, "%s: %" PRIu64 "\n", f->name, h->first_allocation_time_dependence);
 	}
 
 	fclose(f_limits);
@@ -1490,7 +1491,7 @@ int main(int argc, char **argv)
 			set_first_allocations_of_category(s, categories);
 
 			write_stats_of_category(s);
-			write_limits_of_category(s, 0.95);
+			write_limits_of_category(s);
 
 			if(webpage_mode)
 			{

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -1171,12 +1171,12 @@ void set_throughputs_of_category(struct rmDsummary_set *s, struct hash_table *ca
 
 void write_stats_of_category(struct rmDsummary_set *s)
 {
-	char *f_stats_raw   = sanitize_path_name(s->category);
-	char *filename      = string_format("%s/%s.stats", output_directory, f_stats_raw);
+	char *name_raw   = sanitize_path_name(s->category);
+	char *filename      = string_format("%s/%s.stats", output_directory, name_raw);
 
 	FILE *f_stats  = open_file(filename);
 
-	free(f_stats_raw);
+	free(name_raw);
 	free(filename);
 
 	write_histogram_stats_header(f_stats);
@@ -1198,13 +1198,13 @@ void write_stats_of_category(struct rmDsummary_set *s)
 void write_limits_of_category(struct rmDsummary_set *s)
 {
 
-	char *f_stats_raw   = sanitize_path_name(s->category);
-	char *filename      = string_format("%s/%s.limits", output_directory, f_stats_raw);
+	char *name_raw   = sanitize_path_name(s->category);
+	char *filename      = string_format("%s/%s.limits", output_directory, name_raw);
 
 	FILE *f_limits      = open_file(filename);
 
 	free(filename);
-	free(f_stats_raw);
+	free(name_raw);
 
 	struct field *f;
 	struct histogram *h;
@@ -1223,12 +1223,12 @@ void write_limits_of_category(struct rmDsummary_set *s)
 
 void write_overheads_of_category(struct rmDsummary_set *s)
 {
-	char *f_ovhs_raw   = sanitize_path_name(s->category);
-	char *filename      = string_format("%s/%s.overheads", output_directory, f_ovhs_raw);
+	char *name_raw   = sanitize_path_name(s->category);
+	char *filename   = string_format("%s/%s.overheads", output_directory, name_raw);
 
 	FILE *f_ovhs  = open_file(filename);
 
-	free(f_ovhs_raw);
+	free(name_raw);
 	free(filename);
 
 	fprintf(f_ovhs, "task_count,");
@@ -1608,7 +1608,7 @@ int main(int argc, char **argv)
 				break;
 			case 'm':
 				/* brute force, small bucket size */
-				category_tune_bucket_size("time",   USECOND);
+				category_tune_bucket_size("time",   10*USECOND);
 				category_tune_bucket_size("memory", 1);
 				category_tune_bucket_size("disk",   1);
 				break;

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -1221,6 +1221,54 @@ void write_limits_of_category(struct rmDsummary_set *s)
 	fclose(f_limits);
 }
 
+/*
+void write_scatters_of_category(struct category *c) {
+
+	char *name_raw   = sanitize_path_name(h->source->category);
+	char *filename   = string_format("%s/%s_scatter_%s_time.data", output_directory, name_raw, f->name);
+
+
+	FILE *f_rt = open_file(filename);
+
+
+	fclose(f_rt);
+}
+
+#define write_scatters_of_category(name) write_scatters_of_category_aux()
+
+void write_scatters_of_category(struct rmDsummary_set *s)
+{
+	struct category *c = category_lookup_or_create(categories, s->category);
+
+	c->cores_histogram          = itable_create(0);
+	c->wall_time_histogram      = itable_create(0);
+	c->cpu_time_histogram       = itable_create(0);
+	c->memory_histogram         = itable_create(0);
+	c->swap_memory_histogram    = itable_create(0);
+	c->virtual_memory_histogram = itable_create(0);
+	c->bytes_read_histogram     = itable_create(0);
+	c->bytes_written_histogram  = itable_create(0);
+	c->bytes_received_histogram = itable_create(0);
+	c->bytes_sent_histogram     = itable_create(0);
+	c->bandwidth_histogram      = itable_create(0);
+	c->total_files_histogram    = itable_create(0);
+	c->disk_histogram           = itable_create(0);
+	c->max_concurrent_processes_histogram = itable_create(0);
+	c->total_processes_histogram = itable_create(0);
+
+	struct field *f;
+	struct histogram *h;
+	for(f = &fields[WALL_TIME]; f->name != NULL; f++)
+	{
+		if(!f->active)
+			continue;
+
+		h = itable_lookup(s->histograms, (uint64_t) ((uintptr_t) f));
+		write_scatters_of_field(h, f);
+	}
+}
+*/
+
 void write_overheads_of_category(struct rmDsummary_set *s)
 {
 	char *name_raw   = sanitize_path_name(s->category);

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -650,8 +650,10 @@ void write_images(struct histogram *h)
 
 	if(pid == 0) {
 		char *path = string_format("%s/%s", output_directory, sanitize_path_name(h->source->category));
-		chdir(path);
-		execlp(gnuplot_path, "gnuplot", path_of_thumbnail_script(h, 1), NULL);
+		if(chdir(path) == 0) {
+			execlp(gnuplot_path, "gnuplot", path_of_thumbnail_script(h, 1), NULL);
+		}
+
 		fatal("Could not exec when creating thumbnail: %s\n", path_of_thumbnail_image(h, 0));
 	}
 

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -749,19 +749,16 @@ void write_histogram_stats(FILE *stream, struct histogram *h)
 	fprintf(stream, "%d,%.0lf,%.2lf,", h->total_count, ceil(h->mean), h->std_dev);
 	fprintf(stream, "%.0lf,", floor(h->min_value));
 
-	if(h->throughput_max < 1E-6)
-		h->throughput_max = 1;
-
-	fprintf(stream, "%.0lf,%.0lf,%.2lf,", ceil(h->max_value), ceil(h->waste_max), h->throughput_max/h->throughput_max);
-	fprintf(stream, "%" PRId64 ",%.0lf,%.2lf,", h->first_allocation_95, ceil(h->waste_95), h->throughput_95/h->throughput_max);
+	fprintf(stream, "%.0lf,%.0lf,%lf,", ceil(h->max_value), ceil(h->waste_max), h->throughput_max);
+	fprintf(stream, "%" PRId64 ",%.0lf,%lf,", h->first_allocation_95, ceil(h->waste_95), h->throughput_95);
 
 	if(brute_force) {
-		fprintf(stream, "%" PRId64 ",%.0lf,%.2lf,", h->first_allocation_brute_force,    ceil(h->waste_brute_force), h->throughput_brute_force/h->throughput_max);
-		fprintf(stream, "%" PRId64 ",%.0lf,%.2lf,", h->first_allocation_best_throughput, ceil(h->waste_best_throughput), h->throughput_best_throughput/h->throughput_max);
+		fprintf(stream, "%" PRId64 ",%.0lf,%lf,", h->first_allocation_brute_force,    ceil(h->waste_brute_force), h->throughput_brute_force);
+		fprintf(stream, "%" PRId64 ",%.0lf,%lf,", h->first_allocation_best_throughput, ceil(h->waste_best_throughput), h->throughput_best_throughput);
 	}
 
-	fprintf(stream, "%" PRId64 ",%.0lf,%.2lf,", h->first_allocation_time_dependence, ceil(h->waste_time_dependence), h->throughput_time_dependence/h->throughput_max);
-	fprintf(stream, "%" PRId64 ",%.0lf,%.2lf,", h->first_allocation_time_independence, ceil(h->waste_time_independence), h->throughput_time_independence/h->throughput_max);
+	fprintf(stream, "%" PRId64 ",%.0lf,%lf,", h->first_allocation_time_independence, ceil(h->waste_time_independence), h->throughput_time_independence);
+	fprintf(stream, "%" PRId64 ",%.0lf,%lf,", h->first_allocation_time_dependence, ceil(h->waste_time_dependence), h->throughput_time_dependence);
 
 	fprintf(stream, "%.2lf,%.2lf,%.2lf,%.2lf\n",
 			value_of_p(h, 0.25),
@@ -858,11 +855,11 @@ double throughput(struct histogram *h, struct field *f, uint64_t first_alloc) {
 		return 0;
 
 	struct histogram *all = itable_lookup(all_summaries->histograms, (uint64_t) ((uintptr_t) f));
-	if(!all)
+	if(!all) {
 		all = h;
+	}
 	double max_allocation  = all->max_value;
-
-	double current_task = max_allocation/first_alloc;
+	double current_task    = max_allocation/first_alloc;
 
 	int i;
 #pragma omp parallel for private(i) reduction(+: wall_time_accum, tasks_accum)
@@ -1611,9 +1608,9 @@ int main(int argc, char **argv)
 				break;
 			case 'm':
 				/* brute force, small bucket size */
-				category_tune_bucket_size("time",   5*USECOND);
-				category_tune_bucket_size("memory", 10);
-				category_tune_bucket_size("disk",   10);
+				category_tune_bucket_size("time",   USECOND);
+				category_tune_bucket_size("memory", 5);
+				category_tune_bucket_size("disk",   5);
 				break;
 			case 'n':
 				webpage_mode = 0;

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -38,6 +38,8 @@ int webpage_mode   = 1;
 
 char *output_directory = NULL;
 
+uint64_t input_overhead;
+
 struct histogram {
 	struct field *resource;
 	char *units;
@@ -1085,6 +1087,8 @@ void write_overheads_of_category(struct rmDsummary_set *s)
 	free(f_ovhs_raw);
 	free(filename);
 
+	fprintf(f_ovhs, "task_count,");
+	fprintf(f_ovhs, "input,");
 	fprintf(f_ovhs, "time_dependence,");
 	fprintf(f_ovhs, "time_independence,");
 
@@ -1094,6 +1098,8 @@ void write_overheads_of_category(struct rmDsummary_set *s)
 		fprintf(f_ovhs, "\n");
 	}
 
+	fprintf(f_ovhs, "%d,",  list_size(s->summaries));
+	fprintf(f_ovhs, "%lf,", rmsummary_to_external_unit("wall_time", input_overhead));
 	fprintf(f_ovhs, "%lf,", rmsummary_to_external_unit("wall_time", s->overhead_time_dependence));
 	fprintf(f_ovhs, "%lf,", rmsummary_to_external_unit("wall_time", s->overhead_time_independence));
 
@@ -1501,6 +1507,8 @@ int main(int argc, char **argv)
 	/* read and parse all input summaries */
 	all_summaries = make_new_set(ALL_SUMMARIES_CATEGORY);
 
+	input_overhead = timestamp_get();
+
 	if(input_directory)
 	{
 		parse_summary_recursive(all_summaries, input_directory, categories);
@@ -1510,6 +1518,8 @@ int main(int argc, char **argv)
 	{
 		parse_summary_from_filelist(all_summaries, input_list, categories);
 	}
+
+	input_overhead = timestamp_get() - input_overhead;
 
 	list_push_head(all_sets, all_summaries);
 

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -1221,53 +1221,67 @@ void write_limits_of_category(struct rmDsummary_set *s)
 	fclose(f_limits);
 }
 
-/*
-void write_scatters_of_category(struct category *c) {
+void write_scatters_of_category_aux(struct itable *hc, char *cat_name, char *field_name) {
 
-	char *name_raw   = sanitize_path_name(h->source->category);
-	char *filename   = string_format("%s/%s_scatter_%s_time.data", output_directory, name_raw, f->name);
+	int n = itable_size(hc);
+	if(n < 1)
+		return;
 
+	int64_t *keys         = malloc(n*sizeof(intptr_t));
+	int64_t *counts_accum = malloc(n*sizeof(intptr_t));
+	double  *times_mean   = malloc(n*sizeof(intptr_t));
+	double  *times_accum  = malloc(n*sizeof(intptr_t));
+	double tau_mean;
 
+	category_first_allocation_accum_times(hc, &tau_mean, keys, counts_accum, times_mean, times_accum);
+
+	char *name_raw   = sanitize_path_name(cat_name);
+	char *filename   = string_format("%s/%s/scatter_%s_time.data", output_directory, name_raw, field_name);
 	FILE *f_rt = open_file(filename);
 
+	fprintf(f_rt, "mean_time = %lf\n", tau_mean);
+	fprintf(f_rt, "# resource mean_time >mean_time\n");
+	fprintf(f_rt, "$DATA << EOD\n");
 
+	int i;
+	for(i = 0; i < n; i++) {
+		double Pa = 1 - ((double) counts_accum[i])/counts_accum[n-1];
+		double mean_rest = Pa > 0 ? times_accum[i]/Pa : 0;
+
+		fprintf(f_rt, "%" PRId64 " %lf %lf\n", keys[i], times_mean[i], mean_rest);
+	}
+
+	fprintf(f_rt, "EOD\n");
 	fclose(f_rt);
+
+	free(keys);
+	free(counts_accum);
+	free(times_mean);
+	free(times_accum);
 }
 
-#define write_scatters_of_category(name) write_scatters_of_category_aux()
+#define write_scatters_of_field(c, field) write_scatters_of_category_aux((c)->field##_histogram, c->name, #field)
 
 void write_scatters_of_category(struct rmDsummary_set *s)
 {
 	struct category *c = category_lookup_or_create(categories, s->category);
 
-	c->cores_histogram          = itable_create(0);
-	c->wall_time_histogram      = itable_create(0);
-	c->cpu_time_histogram       = itable_create(0);
-	c->memory_histogram         = itable_create(0);
-	c->swap_memory_histogram    = itable_create(0);
-	c->virtual_memory_histogram = itable_create(0);
-	c->bytes_read_histogram     = itable_create(0);
-	c->bytes_written_histogram  = itable_create(0);
-	c->bytes_received_histogram = itable_create(0);
-	c->bytes_sent_histogram     = itable_create(0);
-	c->bandwidth_histogram      = itable_create(0);
-	c->total_files_histogram    = itable_create(0);
-	c->disk_histogram           = itable_create(0);
-	c->max_concurrent_processes_histogram = itable_create(0);
-	c->total_processes_histogram = itable_create(0);
-
-	struct field *f;
-	struct histogram *h;
-	for(f = &fields[WALL_TIME]; f->name != NULL; f++)
-	{
-		if(!f->active)
-			continue;
-
-		h = itable_lookup(s->histograms, (uint64_t) ((uintptr_t) f));
-		write_scatters_of_field(h, f);
-	}
+	write_scatters_of_field(c, cores);
+	write_scatters_of_field(c, wall_time);
+	write_scatters_of_field(c, cpu_time);
+	write_scatters_of_field(c, memory);
+	write_scatters_of_field(c, swap_memory);
+	write_scatters_of_field(c, virtual_memory);
+	write_scatters_of_field(c, bytes_read);
+	write_scatters_of_field(c, bytes_written);
+	write_scatters_of_field(c, bytes_received);
+	write_scatters_of_field(c, bytes_sent);
+	write_scatters_of_field(c, bandwidth);
+	write_scatters_of_field(c, total_files);
+	write_scatters_of_field(c, disk);
+	write_scatters_of_field(c, max_concurrent_processes);
+	write_scatters_of_field(c, total_processes);
 }
-*/
 
 void write_overheads_of_category(struct rmDsummary_set *s)
 {
@@ -1743,6 +1757,7 @@ int main(int argc, char **argv)
 			write_stats_of_category(s);
 			write_limits_of_category(s);
 			write_overheads_of_category(s);
+			write_scatters_of_category(s);
 
 			if(webpage_mode)
 			{

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -1141,8 +1141,8 @@ void write_webpage_stats_header(FILE *stream, struct histogram *h)
 	fprintf(stream, "<td class=\"datahdr\" >mode <br> &#9653;</td>");
 	fprintf(stream, "<td class=\"datahdr\" >&mu; <br> &#9643; </td>");
 	fprintf(stream, "<td class=\"datahdr\" >1<sup>st</sup> alloc.<br> &#9663; </td>");
-	fprintf(stream, "<td class=\"datahdr\" >1<sup>st</sup> alloc. ind.<br> &#9663; </td>");
-	fprintf(stream, "<td class=\"datahdr\" >1<sup>st</sup> alloc. 0.95<br> &#9663; </td>");
+	fprintf(stream, "<td class=\"datahdr\" >1<sup>st</sup> alloc. ind.</td>");
+	fprintf(stream, "<td class=\"datahdr\" >1<sup>st</sup> alloc. 0.95</td>");
 
 	if(brute_force) {
 		fprintf(stream, "<td class=\"datahdr\" >1<sup>st</sup> alloc. b.f.</td>");
@@ -1174,20 +1174,20 @@ void write_webpage_stats(FILE *stream, struct histogram *h, char *prefix, int in
 	fprintf(stream, "%6.0lf\n", h->mean);
 	fprintf(stream, "</td>\n");
 
-	fprintf(stream, "<td class=\"data\"> (w: %lf) <br><br>\n", h->waste_time_dependence);
+	fprintf(stream, "<td class=\"data\"> (w: %.0lf) <br><br>\n", ceil(h->waste_time_dependence));
 	fprintf(stream, "%" PRId64 "\n", h->first_allocation_time_dependence);
 	fprintf(stream, "</td>\n");
 
-	fprintf(stream, "<td class=\"data\"> (w: %3.2lf ) <br><br>\n", h->waste_time_independence);
+	fprintf(stream, "<td class=\"data\"> (w: %.0lf ) <br><br>\n", ceil(h->waste_time_independence));
 	fprintf(stream, "%" PRId64 "\n", h->first_allocation_time_independence);
 	fprintf(stream, "</td>\n");
 
-	fprintf(stream, "<td class=\"data\"> (w: %3.2lf ) <br><br>\n", h->waste_95);
+	fprintf(stream, "<td class=\"data\"> (w: %.0lf ) <br><br>\n", ceil(h->waste_95));
 	fprintf(stream, "%" PRId64 "\n", h->first_allocation_95);
 	fprintf(stream, "</td>\n");
 
 	if(brute_force) {
-		fprintf(stream, "<td class=\"data\"> (w: %3.2lf) <br><br>\n", h->waste_brute_force);
+		fprintf(stream, "<td class=\"data\"> (w: %.0lf) <br><br>\n", ceil(h->waste_brute_force));
 		fprintf(stream, "%" PRId64 "\n", h->first_allocation_brute_force);
 		fprintf(stream, "</td>\n");
 	}

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -668,8 +668,9 @@ void write_images(struct histogram *h)
 
 	if(pid == 0) {
 		char *path = string_format("%s/%s", output_directory, sanitize_path_name(h->source->category));
-		chdir(path);
-		execlp(gnuplot_path, "gnuplot", path_of_image_script(h, 1), NULL);
+		if(chdir(path) == 0) {
+			execlp(gnuplot_path, "gnuplot", path_of_image_script(h, 1), NULL);
+		}
 		fatal("Could not exec when creating image: %s\n", path_of_image(h, 0));
 	}
 

--- a/resource_monitor/src/rmon_tools.c
+++ b/resource_monitor/src/rmon_tools.c
@@ -258,11 +258,12 @@ struct rmDsummary *parse_summary(FILE *stream, char *filename, struct hash_table
 	if(!so)
 		return NULL;
 
-	if(categories && so->category) {
-		category_accumulate_summary(categories, so->category, so);
+	if(categories) {
+		category_accumulate_summary(categories, ALL_SUMMARIES_CATEGORY, so);
+		if(so->category) {
+			category_accumulate_summary(categories, so->category, so);
+		}
 	}
-
-	category_accumulate_summary(categories, ALL_SUMMARIES_CATEGORY, so);
 
 	struct rmDsummary *s  = malloc(sizeof(struct rmDsummary));
 	bzero(s, sizeof(*s));

--- a/resource_monitor/src/rmon_tools.h
+++ b/resource_monitor/src/rmon_tools.h
@@ -85,10 +85,11 @@ struct rmDsummary_set
 	//per resource, address by field
 	struct itable *histograms;
 
-	uint64_t overhead_time_dependence;
-	uint64_t overhead_time_independence;
-	uint64_t overhead_brute_force;
-	uint64_t overhead_best_throughput;
+	uint64_t overhead_min_waste_time_dependence;
+	uint64_t overhead_min_waste_time_independence;
+	uint64_t overhead_min_waste_brute_force;
+	uint64_t overhead_max_throughput;
+	uint64_t overhead_max_throughput_brute_force;
 };
 
 struct field {

--- a/resource_monitor/src/rmon_tools.h
+++ b/resource_monitor/src/rmon_tools.h
@@ -84,6 +84,10 @@ struct rmDsummary_set
 
 	//per resource, address by field
 	struct itable *histograms;
+
+	uint64_t overhead_time_dependence;
+	uint64_t overhead_time_independence;
+	uint64_t overhead_brute_force;
 };
 
 struct field {

--- a/resource_monitor/src/rmon_tools.h
+++ b/resource_monitor/src/rmon_tools.h
@@ -88,6 +88,7 @@ struct rmDsummary_set
 	uint64_t overhead_time_dependence;
 	uint64_t overhead_time_independence;
 	uint64_t overhead_brute_force;
+	uint64_t overhead_best_throughput;
 };
 
 struct field {


### PR DESCRIPTION
Include time overhead for reading all summaries, and computing the first allocations.
Include waste for 0.95 allocation.