### PR TITLE
Add in-Parrot file copy via BTRFS_IOC_CLONE

### DIFF
--- a/doc/parrot.html
+++ b/doc/parrot.html
@@ -331,6 +331,23 @@ using the <tt>stat</tt> system call.</p>
 <p>You can also directly set your command as the arguments of <tt>parrot_package_run</tt>. In this case, <tt>parrot_package_run</tt> will exit automatically after the command is finished, and you do not need to use <tt>exit</tt> to exit. However, your command must belong to the original command set executed inside <tt>parrot_run</tt> and preserved by <tt>parrot_package_create</tt>.</p>
 <code>% parrot_package_run --package-path /tmp/package ls -al</code>
 
+<h2 id="reflink">Reflink Copy<a class="sectionlink" href="#reflink" title="Link to this section.">&#x21d7;</a></h2>
+<p>
+Parrot can take advantage of the reflink feature (added in coreutils 7.5) when using <tt>cp</tt>.
+To use this feature, invoke <tt>cp</tt> as
+<code>% cp --reflink foo bar</code>
+This works by intercepting <tt>BTRFS_IOC_CLONE</tt> to trigger an in-Parrot copy with no further
+interaction with <tt>cp</tt>, avoiding the overhead of moving data into the client's buffer and
+then immediately back to Parrot. When run in Parrot, <tt>cp --reflink</tt> is not restricted to
+files on the same BTRFS volume, and can be used for efficiently copying any regular file.
+</p>
+
+<p>
+As of coreutils 8.24, <tt>mv</tt> will automatically attempt a reflink copy when moving files
+across mount points. Parrot's reflink feature allows e.g. <tt>mv</tt>ing a file into a tmpfs
+like <tt>/tmp</tt> with minimal overhead.
+</p>
+
 <h2 id="parrot_cp">More Efficient Copies with <tt>parrot_cp</tt><a class="sectionlink" href="#parrot_cp" title="Link to this section.">&#x21d7;</a></h2>
 
 <p>

--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -43,6 +43,7 @@ extern "C" {
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <sys/wait.h>
+#include <sys/ioctl.h>
 
 #include <assert.h>
 #include <ctype.h>
@@ -99,6 +100,12 @@ extern "C" {
 #endif
 #ifndef UFFD_CLOEXEC
 #	define UFFD_CLOEXEC 02000000
+#endif
+#ifndef BTRFS_IOCTL_MAGIC
+#	define BTRFS_IOCTL_MAGIC 0x94
+#endif
+#ifndef BTRFS_IOC_CLONE
+#	define BTRFS_IOC_CLONE _IOW (BTRFS_IOCTL_MAGIC, 9, int)
 #endif
 
 extern struct pfs_process *pfs_current;
@@ -1976,12 +1983,22 @@ static void decode_syscall( struct pfs_process *p, int entering )
 			}
 			break;
 
-		/* ioctl is only for I/O streams which are never Parrot files. */
+		/* ioctl is only for I/O streams which are never Parrot files.
+		 * The exception is BTRFS_IOC_CLONE, which we use to trigger an
+		 * in-Parrot file copy.
+		 */
 
 		case SYSCALL32_ioctl:
 			if (entering) {
 				if (p->table->isparrot(args[0])) {
-					divert_to_dummy(p,-ENOTTY);
+					if (args[1] == BTRFS_IOC_CLONE) {
+						debug(D_DEBUG, "starting BTRFS_IOC_CLONE operation %" PRId64 "->%" PRId64, args[2], args[0]);
+						p->syscall_result = pfs_fcopyfile(args[2],args[0]);
+						if(p->syscall_result<0) p->syscall_result = -errno;
+						divert_to_dummy(p,p->syscall_result);
+					} else {
+						divert_to_dummy(p,-ENOTTY);
+					}
 				} else if (!p->table->isnative(args[0])) {
 					divert_to_dummy(p,-EBADF);
 				}

--- a/parrot/src/pfs_sys.cc
+++ b/parrot/src/pfs_sys.cc
@@ -500,6 +500,14 @@ int pfs_copyfile( const char *source, const char *target )
 	END
 }
 
+int pfs_fcopyfile( int srcfd, int dstfd )
+{
+	BEGIN
+	debug(D_LIBCALL,"fcopyfile %d %d",srcfd,dstfd);
+	result = pfs_current->table->fcopyfile(srcfd,dstfd);
+	END
+}
+
 int pfs_md5( const char *path, unsigned char *digest )
 {
 	BEGIN

--- a/parrot/src/pfs_sys.h
+++ b/parrot/src/pfs_sys.h
@@ -106,6 +106,7 @@ int		pfs_getacl( const char *path, char *buf, int size );
 int		pfs_setacl( const char *path, const char *subject, const char *rights );
 int		pfs_locate( const char *path, char* buf, int size );
 int		pfs_copyfile( const char *source, const char *target );
+int		pfs_fcopyfile( int srcfd, int dstfd );
 int		pfs_md5( const char *path, unsigned char *digest );
 int		pfs_timeout( const char *str );
 

--- a/parrot/src/pfs_table.h
+++ b/parrot/src/pfs_table.h
@@ -119,7 +119,8 @@ public:
 	int	setacl( const char *path, const char *subject, const char *rights );
 	int	locate( const char *path, char *buf, int size );
 	pfs_ssize_t copyfile( const char *source, const char *target );
-	pfs_ssize_t copyfile_slow( const char *source, const char *target );
+	pfs_ssize_t fcopyfile(int sourcefd, int targetfd);
+	pfs_ssize_t copyfile_slow( pfs_file *sourcefile, pfs_file *targetfile );
 	int	md5( const char *path, unsigned char *digest );
 	int	md5_slow( const char *path, unsigned char *digest );
 	int 	search( const char *paths, const char *pattern, int flags, char *buffer, size_t buffer_length, size_t *i);

--- a/parrot/src/syscall_parrot.tbl
+++ b/parrot/src/syscall_parrot.tbl
@@ -15,4 +15,3 @@
 1010 parrot parrot_debug sys_parrot_debug
 1011 parrot parrot_mount sys_parrot_mount
 1012 parrot parrot_unmount sys_parrot_unmount
-1013 parrot parrot_fcopyfile sys_parrot_fcopyfile

--- a/parrot/src/syscall_parrot.tbl
+++ b/parrot/src/syscall_parrot.tbl
@@ -15,3 +15,4 @@
 1010 parrot parrot_debug sys_parrot_debug
 1011 parrot parrot_mount sys_parrot_mount
 1012 parrot parrot_unmount sys_parrot_unmount
+1013 parrot parrot_fcopyfile sys_parrot_fcopyfile


### PR DESCRIPTION
This pull request adds handling of the `BTRFS_IOC_CLONE` ioctl to trigger an in-Parrot copy via `copyfile_slow`. With a recent version of coreutils, this functionality is available through `cp --reflink`. This feature masks the *real* BTRFS_IOC_CLONE, which might not be an issue. Also, I wasn't sure about the desired semantics for a clone operation. At the moment, this does not seek to the beginnings of files before copying.