### PR TITLE
fix segfault when no masters appear in the list

### DIFF
--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -511,7 +511,7 @@ static void mainloop( struct batch_queue *queue, const char *project_regex, cons
 
 		masters_list = work_queue_catalog_query(catalog_host,catalog_port,project_regex);
 
-		if(list_size(masters_list) > 0)
+		if(masters_list && list_size(masters_list) > 0)
 		{
 			factory_timeout_start = time(0);
 		} else {


### PR DESCRIPTION
As reported by @annawoodard, the factory would segfault if no masters were found in the catalog.

This became evident given the recent cclweb00's catalog hiccup.
