### PR TITLE
Check CORES and MEMORY when starting allpairs_multicore

### DIFF
--- a/allpairs/src/allpairs_multicore.c
+++ b/allpairs/src/allpairs_multicore.c
@@ -28,6 +28,7 @@ See the file COPYING for details.
 #include "macros.h"
 #include "full_io.h"
 #include "getopt_aux.h"
+#include "rmsummary.h"
 
 static const char *progname = "allpairs_multicore";
 static const char *extra_arguments = "";
@@ -69,24 +70,27 @@ static int get_file_size( const char *path )
 
 /*
 block_size_estimate computes how many items we can effectively
-get in memory at once by measuring the first 100 elements of the set,
-and then choosing a number to fit within 1/2 of the available RAM.
+get in memory at once by measuring the first 100 elements of the set.
+If memory <= 0, then choose a number to fit within 1/2 of the available RAM.
 */
 
-int block_size_estimate( struct text_list *seta )
+int block_size_estimate( struct text_list *seta, UINT64_T memory )
 {
 	int count = MIN(100,text_list_size(seta));
 	int i;
 	UINT64_T total_data = 0,free_mem,total_mem;
 	int block_size;
 
-	host_memory_info_get(&free_mem, &total_mem);
-
 	for(i=0;i<count;i++) {
 		total_data += get_file_size(text_list_get(seta,i));
 	}
 
-	total_mem = total_mem/2;
+	if (memory > 0) {
+		total_mem = memory;
+	} else {
+		host_memory_info_get(&free_mem, &total_mem);
+		total_mem = total_mem/2;
+	}
 
 	if(total_data>=total_mem) {
 		block_size = text_list_size(seta) * total_mem / total_data;
@@ -317,6 +321,8 @@ int main(int argc, char *argv[])
 {
 	int c;
 	int result;
+	char *cores;
+	char *memory;
 
 	debug_config(progname);
 
@@ -392,10 +398,22 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	if(num_cores==0) num_cores = load_average_get_cpus();
+	if(num_cores==0) {
+		if ((cores = getenv(RESOURCES_CORES))) {
+			num_cores = atoi(cores);
+		} else {
+			num_cores = load_average_get_cpus();
+		}
+	}
 	debug(D_DEBUG,"num_cores: %d\n",num_cores);
 
-	if(block_size==0) block_size = block_size_estimate(seta);
+	if(block_size==0) {
+		if((memory = getenv(RESOURCES_MEMORY))) {
+			block_size = block_size_estimate(seta, atoi(memory) * MEGABYTE);
+		} else {
+			block_size = block_size_estimate(seta, -1);
+		}
+	}
 	debug(D_DEBUG,"block_size: %d elements",block_size);
 
 	allpairs_compare_t funcptr = allpairs_compare_function_get(funcpath);

--- a/allpairs/src/allpairs_multicore.c
+++ b/allpairs/src/allpairs_multicore.c
@@ -389,7 +389,7 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	struct rmsummary *tr = rmonitor_measure_host();
+	struct rmsummary *tr = rmonitor_measure_host(NULL);
 	if(num_cores==0) num_cores = tr->cores;
 	debug(D_DEBUG,"num_cores: %d\n",num_cores);
 

--- a/allpairs/src/allpairs_multicore.c
+++ b/allpairs/src/allpairs_multicore.c
@@ -23,11 +23,10 @@ See the file COPYING for details.
 #include "xxmalloc.h"
 #include "fast_popen.h"
 #include "text_list.h"
-#include "host_memory_info.h"
-#include "load_average.h"
 #include "macros.h"
 #include "full_io.h"
 #include "getopt_aux.h"
+#include "rmonitor_poll.h"
 
 static const char *progname = "allpairs_multicore";
 static const char *extra_arguments = "";
@@ -73,20 +72,18 @@ get in memory at once by measuring the first 100 elements of the set,
 and then choosing a number to fit within 1/2 of the available RAM.
 */
 
-int block_size_estimate( struct text_list *seta )
+int block_size_estimate( struct text_list *seta, struct rmsummary *tr )
 {
 	int count = MIN(100,text_list_size(seta));
 	int i;
-	UINT64_T total_data = 0,free_mem,total_mem;
+	UINT64_T total_data = 0,total_mem;
 	int block_size;
-
-	host_memory_info_get(&free_mem, &total_mem);
 
 	for(i=0;i<count;i++) {
 		total_data += get_file_size(text_list_get(seta,i));
 	}
 
-	total_mem = total_mem/2;
+	total_mem = tr->memory * MEGABYTE / 2;
 
 	if(total_data>=total_mem) {
 		block_size = text_list_size(seta) * total_mem / total_data;
@@ -392,11 +389,13 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	if(num_cores==0) num_cores = load_average_get_cpus();
+	struct rmsummary *tr = rmonitor_measure_host();
+	if(num_cores==0) num_cores = tr->cores;
 	debug(D_DEBUG,"num_cores: %d\n",num_cores);
 
-	if(block_size==0) block_size = block_size_estimate(seta);
+	if(block_size==0) block_size = block_size_estimate(seta, tr);
 	debug(D_DEBUG,"block_size: %d elements",block_size);
+	free(tr);
 
 	allpairs_compare_t funcptr = allpairs_compare_function_get(funcpath);
 	if(funcptr) {

--- a/dttools/src/rmonitor_poll.c
+++ b/dttools/src/rmonitor_poll.c
@@ -829,7 +829,7 @@ struct rmsummary *rmonitor_measure_host(char *path) {
 
 	if(path) {
 		path_disk_size_info_get(path, &total_disk, &file_count);
-		tr->disk = total_disk;
+		tr->disk = total_disk / MEGABYTE;
 		tr->total_files = file_count;
 	}
 	host_memory_info_get(&free_mem, &total_mem);

--- a/dttools/src/rmonitor_poll.c
+++ b/dttools/src/rmonitor_poll.c
@@ -20,6 +20,7 @@ See the file COPYING for details.
 
 #include "rmonitor_poll_internal.h"
 #include "host_memory_info.h"
+#include "path_disk_size_info.h"
 #include "load_average.h"
 
 /***
@@ -819,10 +820,18 @@ int rmonitor_measure_process_update_to_peak(struct rmsummary *tr, pid_t pid) {
 	return 1;
 }
 
-struct rmsummary *rmonitor_measure_host() {
-	uint64_t free_mem, total_mem;
+struct rmsummary *rmonitor_measure_host(char *path) {
+	uint64_t free_mem;
+	uint64_t total_mem;
+	int64_t total_disk;
+	int64_t file_count;
 	struct rmsummary *tr = rmsummary_create(-1);
 
+	if(path) {
+		path_disk_size_info_get(path, &total_disk, &file_count);
+		tr->disk = total_disk;
+		tr->total_files = file_count;
+	}
 	host_memory_info_get(&free_mem, &total_mem);
 	tr->memory = total_mem / MEGABYTE;
 	tr->cores = load_average_get_cpus();

--- a/dttools/src/rmonitor_poll.c
+++ b/dttools/src/rmonitor_poll.c
@@ -19,6 +19,8 @@ See the file COPYING for details.
 #include "xxmalloc.h"
 
 #include "rmonitor_poll_internal.h"
+#include "host_memory_info.h"
+#include "load_average.h"
 
 /***
  * Helper functions
@@ -815,6 +817,18 @@ int rmonitor_measure_process_update_to_peak(struct rmsummary *tr, pid_t pid) {
 	rmsummary_delete(now);
 
 	return 1;
+}
+
+struct rmsummary *rmonitor_measure_host() {
+	uint64_t free_mem, total_mem;
+	struct rmsummary *tr = rmsummary_create(-1);
+
+	host_memory_info_get(&free_mem, &total_mem);
+	tr->memory = total_mem / MEGABYTE;
+	tr->cores = load_average_get_cpus();
+	rmsummary_read_env_vars(tr);
+
+	return tr;
 }
 
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/rmonitor_poll.h
+++ b/dttools/src/rmonitor_poll.h
@@ -11,6 +11,6 @@ See the file COPYING for details.
 
 struct rmsummary *rmonitor_measure_process(pid_t pid);
 int rmonitor_measure_process_update_to_peak(struct rmsummary *tr, pid_t pid);
-struct rmsummary *rmonitor_measure_host();
+struct rmsummary *rmonitor_measure_host(char *);
 
 #endif

--- a/dttools/src/rmonitor_poll.h
+++ b/dttools/src/rmonitor_poll.h
@@ -11,5 +11,6 @@ See the file COPYING for details.
 
 struct rmsummary *rmonitor_measure_process(pid_t pid);
 int rmonitor_measure_process_update_to_peak(struct rmsummary *tr, pid_t pid);
+struct rmsummary *rmonitor_measure_host();
 
 #endif


### PR DESCRIPTION
I *think* the units are correct. `allpairs_multicore` appears to use bytes for calculating blocksize, while the environment variable seems to be in megabytes.