### PR TITLE
Split hostport on last : in chirp_client_connect

### DIFF
--- a/chirp/src/chirp_client.c
+++ b/chirp/src/chirp_client.c
@@ -70,6 +70,9 @@ See the file COPYING for details.
 /* The maximum chunk of memory the server will allocate to handle I/O */
 #define MAX_BUFFER_SIZE (16*1024*1024)
 
+/* Valid characters in an IPV6 address */
+#define IPV6_CHARS "0123456789abcdefABCDEF:"
+
 static int global_serial = 0;
 
 struct chirp_client {
@@ -349,7 +352,12 @@ struct chirp_client *chirp_client_connect(const char *hostport, int negotiate_au
 	int save_errno;
 	int port;
 
-	if(sscanf(hostport, "%[^:]:%d", host, &port) == 2) {
+	if(sscanf(hostport, "[%[" IPV6_CHARS "]]:%d", host, &port) == 2) {
+		/* IPV6 address with port */
+	} else if(sscanf(hostport, "[%[" IPV6_CHARS "]]", host) == 1) {
+		/* IPV6 address without port */
+		port = CHIRP_PORT;
+	} else if(sscanf(hostport, "%[^:]:%d", host, &port) == 2) {
 		/* use the split host and port */
 	} else {
 		strcpy(host, hostport);

--- a/chirp/src/chirp_client.c
+++ b/chirp/src/chirp_client.c
@@ -348,13 +348,9 @@ struct chirp_client *chirp_client_connect(const char *hostport, int negotiate_au
 	char host[DOMAIN_NAME_MAX];
 	int save_errno;
 	int port;
-	char *separator;
 
-	if((separator = strrchr(hostport, ':')) != NULL) {
+	if(sscanf(hostport, "%[^:]:%d", host, &port) == 2) {
 		/* use the split host and port */
-		strncpy(host, hostport, separator - hostport);
-		host[separator - hostport] = '\0';
-		port = atoi(separator + 1);
 	} else {
 		strcpy(host, hostport);
 		port = CHIRP_PORT;

--- a/chirp/src/chirp_client.c
+++ b/chirp/src/chirp_client.c
@@ -348,9 +348,13 @@ struct chirp_client *chirp_client_connect(const char *hostport, int negotiate_au
 	char host[DOMAIN_NAME_MAX];
 	int save_errno;
 	int port;
+	char *separator;
 
-	if(sscanf(hostport, "%[^:]:%d", host, &port) == 2) {
+	if((separator = strrchr(hostport, ':')) != NULL) {
 		/* use the split host and port */
+		strncpy(host, hostport, separator - hostport);
+		host[separator - hostport] = '\0';
+		port = atoi(separator + 1);
 	} else {
 		strcpy(host, hostport);
 		port = CHIRP_PORT;


### PR DESCRIPTION
This looks like it should address the case in the issue. Is an IP6 address without port allowed? This change would mangle that, and split the address itself