### PR TITLE
Add dryrun mode + flat shell script output to Makeflow

### DIFF
--- a/batch_job/src/Makefile
+++ b/batch_job/src/Makefile
@@ -10,6 +10,7 @@ EXTERNAL_LIBRARIES = ../../work_queue/src/libwork_queue.a ../../chirp/src/libchi
 SOURCES = \
 	batch_job.c \
 	batch_job_amazon.c \
+	batch_job_dryrun.c \
 	batch_job_chirp.c \
 	batch_job_cluster.c \
 	batch_job_condor.c \

--- a/batch_job/src/batch_job.c
+++ b/batch_job/src/batch_job.c
@@ -29,6 +29,7 @@ extern const struct batch_queue_module batch_queue_pbs;
 extern const struct batch_queue_module batch_queue_torque;
 extern const struct batch_queue_module batch_queue_slurm;
 extern const struct batch_queue_module batch_queue_wq;
+extern const struct batch_queue_module batch_queue_dryrun;
 
 static struct batch_queue_module batch_queue_unknown = {
 	BATCH_QUEUE_TYPE_UNKNOWN, "unknown",
@@ -40,7 +41,7 @@ static struct batch_queue_module batch_queue_unknown = {
 	{NULL, NULL, NULL, NULL, NULL, NULL},
 };
 
-#define BATCH_JOB_SYSTEMS  "local, wq, condor, sge, torque, moab, slurm, chirp, amazon"
+#define BATCH_JOB_SYSTEMS  "local, wq, condor, sge, torque, moab, slurm, chirp, amazon, dryrun"
 
 const struct batch_queue_module * const batch_queue_modules[] = {
 	&batch_queue_amazon,
@@ -54,6 +55,7 @@ const struct batch_queue_module * const batch_queue_modules[] = {
 	&batch_queue_torque,
 	&batch_queue_slurm,
 	&batch_queue_wq,
+	&batch_queue_dryrun,
 	&batch_queue_unknown
 };
 

--- a/batch_job/src/batch_job.h
+++ b/batch_job/src/batch_job.h
@@ -43,6 +43,7 @@ typedef enum {
 	BATCH_QUEUE_TYPE_CLUSTER,             /**< Batch jobs will be sent to a user-defined cluster manager. */
 	BATCH_QUEUE_TYPE_WORK_QUEUE,          /**< Batch jobs will be sent to the Work Queue. */
 	BATCH_QUEUE_TYPE_CHIRP,               /**< Batch jobs will be sent to Chirp. */
+	BATCH_QUEUE_TYPE_DRYRUN,              /**< Batch jobs will not actually run. */
 	BATCH_QUEUE_TYPE_UNKNOWN = -1         /**< An invalid batch queue type. */
 } batch_queue_type_t;
 

--- a/batch_job/src/batch_job_dryrun.c
+++ b/batch_job/src/batch_job_dryrun.c
@@ -1,0 +1,223 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <signal.h>
+
+#include "batch_job.h"
+#include "batch_job_internal.h"
+#include "debug.h"
+#include "process.h"
+#include "macros.h"
+#include "stringtools.h"
+#include "path.h"
+#include "xxmalloc.h"
+
+static batch_job_id_t batch_job_dryrun_submit (struct batch_queue *q, const char *cmd, const char *extra_input_files, const char *extra_output_files, struct jx *envlist, struct rmsummary *resources )
+{
+	FILE *log;
+	char *escaped_cmd;
+	char *env_assignment;
+	char *escaped_env_assignment;
+	struct batch_job_info *info;
+	batch_job_id_t jobid = random();
+
+	fflush(NULL);
+
+	debug(D_BATCH, "started dry run of job %" PRIbjid ": %s", jobid, cmd);
+
+	if ((log = fopen(q->logfile, "a"))) {
+		if (!(info = calloc(sizeof(*info), 1))) {
+			fclose(log);
+			return -1;
+		}
+		info->submitted = time(0);
+		info->started = time(0);
+		itable_insert(q->job_table, jobid, info);
+
+		if(envlist && jx_istype(envlist, JX_OBJECT) && envlist->u.pairs) {
+			struct jx_pair *p;
+			fprintf(log, "env ");
+			for(p=envlist->u.pairs;p;p=p->next) {
+				if(p->key->type==JX_STRING && p->value->type==JX_STRING) {
+					env_assignment = string_format("%s=%s", p->key->u.string_value,p->value->u.string_value);
+					escaped_env_assignment = string_escape_shell(env_assignment);
+					fprintf(log, escaped_env_assignment);
+					fprintf(log, " ");
+					free(env_assignment);
+					free(escaped_env_assignment);
+				}
+			}
+		}
+		escaped_cmd = string_escape_shell(cmd);
+		fprintf(log, "sh -c %s\n", escaped_cmd);
+		free(escaped_cmd);
+		fclose(log);
+		return jobid;
+	} else {
+		return -1;
+	}
+}
+
+static batch_job_id_t batch_job_dryrun_wait (struct batch_queue * q, struct batch_job_info * info_out, time_t stoptime)
+{
+	struct batch_job_info *info;
+	UINT64_T jobid;
+
+	itable_firstkey(q->job_table);
+	if (itable_nextkey(q->job_table, &jobid, NULL)) {
+		info = itable_remove(q->job_table, jobid);
+		info->finished = time(0);
+		info->exited_normally = 1;
+		info->exit_code = 0;
+		memcpy(info_out, info, sizeof(*info));
+		free(info);
+		return jobid;
+	} else {
+		return 0;
+	}
+}
+
+static int batch_job_dryrun_remove (struct batch_queue *q, batch_job_id_t jobid)
+{
+	return 0;
+}
+
+static int batch_queue_dryrun_create (struct batch_queue *q)
+{
+	char *cwd = path_getcwd();
+
+	batch_queue_set_feature(q, "local_job_queue", NULL);
+	batch_queue_set_feature(q, "batch_log_name", "%s.sh");
+	batch_queue_set_option(q, "cwd", cwd);
+	return 0;
+}
+
+static int batch_fs_dryrun_stat (struct batch_queue *q, const char *path, struct stat *buf) {
+	struct stat dummy;
+	FILE *log;
+
+	if ((log = fopen(q->logfile, "a"))) {
+		char *escaped_path = string_escape_shell(path);
+		// Since Makeflow only calls stat *after* a file has been created,
+		// add a test here as a sanity check. If Makeflow e.g. tries to stat
+		// files before running rules to create them, these tests will
+		// cripple the shell script representation.
+		fprintf(log, "test -e %s\n", escaped_path);
+		free(escaped_path);
+		fclose(log);
+		dummy.st_size = 1;
+		memcpy(buf, &dummy, sizeof(dummy));
+		return 0;
+	} else {
+		return -1;
+	}
+}
+
+static int batch_fs_dryrun_mkdir (struct batch_queue *q, const char *path, mode_t mode, int recursive) {
+	FILE *log;
+
+	if ((log = fopen(q->logfile, "a"))) {
+		char *escaped_path = string_escape_shell(path);
+		if (recursive) {
+			fprintf(log, "mkdir -p -m %d %s\n", mode, escaped_path);
+		} else {
+			fprintf(log, "mkdir -m %d %s\n", mode, escaped_path);
+		}
+		fclose(log);
+		free(escaped_path);
+		return 0;
+	} else {
+		return -1;
+	}
+}
+
+static int batch_fs_dryrun_chdir (struct batch_queue *q, const char *path) {
+	FILE *log;
+
+	if ((log = fopen(q->logfile, "a"))) {
+		char *escaped_path = string_escape_shell(path);
+		batch_queue_set_option(q, "cwd", xxstrdup(path));
+
+		fprintf(log, "cd %s\n", escaped_path);
+
+		fclose(log);
+		free(escaped_path);
+		return 0;
+	} else {
+		return -1;
+	}
+}
+
+static int batch_fs_dryrun_getcwd (struct batch_queue *q, char *buf, size_t size) {
+	const char *cwd = batch_queue_get_option(q, "cwd");
+	size_t pathlength = strlen(cwd);
+	if (pathlength + 1 > size) {
+		errno = ERANGE;
+		return -1;
+	} else {
+		strcpy(buf, cwd);
+		return 0;
+	}
+}
+
+static int batch_fs_dryrun_unlink (struct batch_queue *q, const char *path) {
+	FILE *log;
+
+	if ((log = fopen(q->logfile, "a"))) {
+		char *escaped_path = string_escape_shell(path);
+		fprintf(log, "rm -r %s\n", escaped_path);
+		free(escaped_path);
+		fclose(log);
+		return 0;
+	} else {
+		return -1;
+	}
+}
+
+static int batch_fs_dryrun_putfile (struct batch_queue *q, const char *lpath, const char *rpath) {
+	FILE *log;
+
+	if ((log = fopen(q->logfile, "a"))) {
+		char *escaped_lpath = string_escape_shell(lpath);
+		char *escaped_rpath = string_escape_shell(rpath);
+		fprintf(log, "cp %s %s\n", escaped_lpath, escaped_rpath);
+		free(escaped_lpath);
+		free(escaped_rpath);
+		fclose(log);
+		return 0;
+	} else {
+		return -1;
+	}
+}
+
+batch_queue_stub_free(dryrun);
+batch_queue_stub_port(dryrun);
+batch_queue_stub_option_update(dryrun);
+
+const struct batch_queue_module batch_queue_dryrun = {
+	BATCH_QUEUE_TYPE_DRYRUN,
+	"dryrun",
+
+	batch_queue_dryrun_create,
+	batch_queue_dryrun_free,
+	batch_queue_dryrun_port,
+	batch_queue_dryrun_option_update,
+
+	{
+		batch_job_dryrun_submit,
+		batch_job_dryrun_wait,
+		batch_job_dryrun_remove,
+	},
+
+	{
+		batch_fs_dryrun_chdir,
+		batch_fs_dryrun_getcwd,
+		batch_fs_dryrun_mkdir,
+		batch_fs_dryrun_putfile,
+		batch_fs_dryrun_stat,
+		batch_fs_dryrun_unlink,
+	},
+};
+
+/* vim: set noexpandtab tabstop=4: */

--- a/doc/man/makeflow.m4
+++ b/doc/man/makeflow.m4
@@ -56,7 +56,7 @@ OPTION_ITEM(`-R, --retry')Automatically retry failed batch jobs up to 100 times.
 OPTION_TRIPLET(-r, retry-count, n)Automatically retry failed batch jobs up to n times.
 OPTION_PAIR(--wait-for-files-upto, #)Wait for output files to be created upto this many seconds (e.g., to deal with NFS semantics).
 OPTION_TRIPLET(-S, submission-timeout, timeout)Time to retry failed batch job submission. (default is 3600s)
-OPTION_TRIPLET(-T, batch-type, type)Batch system type: local, condor, sge, pbs, torque, slurm, moab, cluster, wq, amazon. (default is local)
+OPTION_TRIPLET(-T, batch-type, type)Batch system type: local, dryrun, condor, sge, pbs, torque, slurm, moab, cluster, wq, amazon. (default is local)
 OPTIONS_END
 
 SUBSECTION(Debugging Options)
@@ -117,6 +117,16 @@ OPTION_PAIR(--wrapper,script) Wrap all commands with this BOLD(script). Each rul
 OPTION_PAIR(--wrapper-input,file) Wrapper command requires this input file. This option may be specified more than once, defining an array of inputs. Additionally, each job executing a recipe has a unique integer identifier that replaces occurrences BOLD(%%) in BOLD(file).
 OPTION_PAIR(--wrapper-output,file) Wrapper command requires this output file. This option may be specified more than once, defining an array of outputs. Additionally, each job executing a recipe has a unique integer identifier that replaces occurrences BOLD(%%) in BOLD(file).
 OPTIONS_END
+
+SECTION(DRYRUN MODE)
+
+When the batch system is set to BOLD(-T) PARAM(dryrun), Makeflow runs as usual
+but does not actually execute jobs or modify the system. This is useful to
+check that wrappers and substitutions are applied as expected. In addition,
+Makeflow will write an equivalent shell script to the batch system log
+specified by BOLD(-L) PARAM(logfile). This script will run the commands in
+serial that Makeflow would have run. This shell script format may be useful
+for archival purposes, since it does not depend on Makeflow.
 
 SECTION(ENVIRONMENT VARIABLES)
 

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -1500,6 +1500,19 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	if(batch_queue_type == BATCH_QUEUE_TYPE_DRYRUN) {
+		int logfd;
+		if ((logfd = creat(batchlogfilename, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH)) < 0) {
+			fatal("unable to open log file %s\n", batchlogfilename);
+		} else {
+			dprintf(logfd, "#!/bin/sh\n");
+			dprintf(logfd, "set -x\n");
+			dprintf(logfd, "set -e\n");
+			dprintf(logfd, "\n# %s version %s (released %s)\n\n", argv[0], CCTOOLS_VERSION, CCTOOLS_RELEASE_DATE);
+			close(logfd);
+		}
+	}
+
 	batch_queue_set_logfile(remote_queue, batchlogfilename);
 	batch_queue_set_option(remote_queue, "batch-options", batch_submit_options);
 	batch_queue_set_option(remote_queue, "skip-afs-check", skip_afs_check ? "yes" : "no");


### PR DESCRIPTION
This is a first draft for #946. I added a new batch system, `dryrun`. If Makeflow is invoked as `makeflow -T dryrun`, it performs all validation, dependency checking, but instead of actually running jobs, it prints the command it would have used. Since issuing commands to the batch system is one of the last things Makeflow does, this will get wrappers or any other transformations that might be added.

In addition, this batch system's log is actually a flattened shell script that should generate the same results as running the makefile, albeit sequentially. Since it doesn't depend on Makeflow, the shell script from e.g. `makeflow -T dryrun -L archive.sh` can serve as an archival representation as in the issue. I'd like to try this out on a larger, more complex sample makefile, since I've just been testing simple things.