### PR TITLE
Tiny update of Makeflow user manual

### DIFF
--- a/doc/makeflow.html
+++ b/doc/makeflow.html
@@ -678,7 +678,7 @@ Each line contains the following items:
 		<li> failed </li>
 		<li> aborted </li>
 	</ol>
-	the underline execution system is a batch system, such as Condor or SGE,
+	<li><b>job_id</b> - the underline execution system is a batch system, such as Condor or SGE,
 	the job id would be the job id assigned by the batch system when the task
 	was sent to the batch system for execution.</li>
 	<li><b>tasks_waiting</b> - the number of tasks are waiting to be executed.</li>


### PR DESCRIPTION
add a missing list item label for `job_id`