### PR TITLE
Add positional parameters to starch run.sh

### DIFF
--- a/doc/man/starch.m4
+++ b/doc/man/starch.m4
@@ -44,7 +44,7 @@ Once a CODE(SFX) is generated, you can use it as a normal executable.
 
 SECTION(CONFIGURATION FILE)
 The command line options may be stored in a configuration file and passed to
-starch using the CODE(-C) option.  The format of the configuration file is as
+starch using the CODE(starch -C) option.  The format of the configuration file is as
 follows:
 LONGCODE_BEGIN
 [starch]
@@ -86,13 +86,14 @@ SECTION(EXAMPLES)
 
 Package the date program:
 LONGCODE_BEGIN
-    $ starch -x date date.sfx
+    $ starch -c date -x date date.sfx
 LONGCODE_END
 
 Package the date program using a configuration file:
 LONGCODE_BEGIN
     $ cat data.cfg
     [starch]
+    executables = date
     command = date
     $ starch -C date.cfg date.sfx
 LONGCODE_END
@@ -119,7 +120,7 @@ LONGCODE_END
 
 Advanced example involving a complex shell command:
 LONGCODE_BEGIN
-    $ starch -v -x tar -x rm extract_and_remove.sfx 'for f in $@; do if ! tar xvf $f; then exit 1; fi; done; rm $@'
+    $ starch -v -x tar -x rm  -c 'tar_test() { for f in $@; do if ! tar xvf $f; then exit 1; fi; done; rm $@'; }; tar_test' extract_and_remove.sfx
     $ ./extract_and_remove.sfx *.tar.gz
 LONGCODE_END
 

--- a/makeflow/src/starch
+++ b/makeflow/src/starch
@@ -138,7 +138,7 @@ if [ -d "$SFX_DIR/lib" ]; then
         fi
     fi
 fi
-%s
+%s "$@"
 '''
 
 # Create SFX

--- a/makeflow/test/TR_starch_date.sh
+++ b/makeflow/test/TR_starch_date.sh
@@ -11,7 +11,7 @@ prepare()
 
 run()
 {
-	../src/starch -x date $sfxfile
+	../src/starch -c date -x date $sfxfile
 	exec ./$sfxfile
 }
 

--- a/makeflow/test/TR_starch_date_config.sh
+++ b/makeflow/test/TR_starch_date_config.sh
@@ -15,7 +15,7 @@ EOF
 
 run()
 {
-	../src/starch -C $cfgfile $sfxfile
+	../src/starch -c date -C $cfgfile $sfxfile
 	exec ./$sfxfile
 }
 

--- a/makeflow/test/TR_starch_extract_and_remove.sh
+++ b/makeflow/test/TR_starch_extract_and_remove.sh
@@ -13,7 +13,7 @@ prepare()
 
 run()
 {
-	../src/starch -v -x tar -x rm -c 'for f in $@; do if ! tar xvf $f; then exit 1; fi ; done; rm $@' $sfxfile
+	../src/starch -v -x tar -x rm -c 'tar_test() { for f in $@; do if ! tar xvf $f; then exit 1; fi ; done; rm $@; }; tar_test' $sfxfile
 	exec ./$sfxfile $tarfile
 }
 


### PR DESCRIPTION
	Currently, `starch` assumes that the whole command is provided by its `-c` option.
	This would fail if the provided `-c` option is incomplete or the user wants to
	add more parameters to the command during runtime.

	The change here allows the user to provide more parameters during runtime.