### PR TITLE
First draft of JSON export for Makeflow

### DIFF
--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -216,6 +216,26 @@ int jx_insert( struct jx *j, struct jx *key, struct jx *value )
 	return 1;
 }
 
+int jx_insert_unless_empty( struct jx *object, struct jx *key, struct jx *value ) {
+	switch(value->type) {
+		case JX_OBJECT:
+		case JX_ARRAY:
+			/* C99 says union members have the same start address, so
+			 * just pick one, they're both pointers. */
+			if(value->u.pairs == NULL) {
+				jx_delete(key);
+				jx_delete(value);
+				return -1;
+			} else {
+				return jx_insert(object, key, value);
+			}
+			break;
+		default:
+			return jx_insert(object, key, value);
+			break;
+	}
+}
+
 void jx_insert_integer( struct jx *j, const char *key, jx_int_t value )
 {
 	jx_insert(j,jx_string(key),jx_integer(value));

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -176,6 +176,9 @@ struct jx * jx_remove( struct jx *object, struct jx *key );
 /** Insert a key-value pair into an object.  @param object The object.  @param key The key.  @param value The value. @return True on success, false on failure.  Failure can only occur if the object is not a @ref JX_OBJECT. */
 int jx_insert( struct jx *object, struct jx *key, struct jx *value );
 
+/** Insert a key-value pair into an object, unless the value is an empty collection, in which case delete the key and value.  @param key The key.  @param value The value. @return 1 on success, -1 on empty value, 0 on failure.  Failure can only occur if the object is not a @ref JX_OBJECT. */
+int jx_insert_unless_empty( struct jx *object, struct jx *key, struct jx *value );
+
 /** Insert an integer value into an object @param object The object @param key The key represented as a C string  @param value The integer value. */
 void jx_insert_integer( struct jx *object, const char *key, jx_int_t value );
 

--- a/makeflow/src/dag_visitors.c
+++ b/makeflow/src/dag_visitors.c
@@ -1238,8 +1238,8 @@ struct jx *dag_nodes_to_json(struct dag_node *node) {
 		jx_insert(rule, jx_string("category"), jx_string(n->category->name));
 		jx_insert_unless_empty(rule, jx_string("variables"), variables_to_json(n->variables));
 		jx_insert_unless_empty(rule, jx_string("resources_needed"), resources_to_json(n->resources_needed));
-		jx_insert(rule, jx_string("source_files"), files_to_json(n->source_files));
-		jx_insert(rule, jx_string("target_files"), files_to_json(n->target_files));
+		jx_insert(rule, jx_string("inputs"), files_to_json(n->source_files));
+		jx_insert(rule, jx_string("outputs"), files_to_json(n->target_files));
 		jx_insert_unless_empty(rule, jx_string("remote_names"), remote_names_to_json(n->remote_names));
 		jx_insert(rule, jx_string("allocation"), category_allocation_to_json(n->resource_request));
 
@@ -1264,7 +1264,6 @@ struct jx *dag_to_json(struct dag *d) {
 	void *value;
 	struct jx *result = jx_object(NULL);
 	struct jx *categories = jx_object(NULL);
-	jx_insert(result, jx_string("filename"), jx_string(d->filename));
 	jx_insert_unless_empty(result, jx_string("environment"), env_to_json(d));
 	jx_insert(result, jx_string("rules"), dag_nodes_to_json(d->nodes));
 	hash_table_firstkey(d->categories);

--- a/makeflow/src/dag_visitors.h
+++ b/makeflow/src/dag_visitors.h
@@ -8,6 +8,7 @@ See the file COPYING for details.
 #define DAG_VISITORS_H
 
 #include "dag.h"
+#include "jx.h"
 
 /* The dag_to_file function write a struct dag in memory to a
  * file, using the remotename names generated from
@@ -34,5 +35,9 @@ void dag_to_ppm(struct dag *d, int ppm_mode, char *ppm_option);
  * file, giving a graphical presentation of the makeflow for use in Cytoscape
  */
 void dag_to_cyto(struct dag *d, int condense_display, int change_size);
+
+/* Generate a JSON representation of the given DAG.
+ */
+struct jx *dag_to_json(struct dag *d);
 
 #endif

--- a/makeflow/src/makeflow_analyze.c
+++ b/makeflow/src/makeflow_analyze.c
@@ -40,6 +40,7 @@ See the file COPYING for details.
 #include "rmonitor.h"
 #include "random.h"
 #include "path.h"
+#include "jx_pretty_print.h"
 
 #include "dag.h"
 #include "dag_visitors.h"
@@ -49,6 +50,7 @@ See the file COPYING for details.
 enum { SHOW_INPUT_FILES = 2,
 	   SHOW_OUTPUT_FILES,
 	   SHOW_MAKEFLOW_ANALYSIS,
+	   SHOW_JSON,
 	   SHOW_DAG_FILE
 };
 
@@ -190,6 +192,10 @@ void dag_show_output_files(struct dag *d)
 	}
 }
 
+void dag_show_json(struct dag *d) {
+	jx_pretty_print_stream(dag_to_json(d), stdout);
+}
+
 static void show_help_analyze(const char *cmd)
 {
 	fprintf(stdout, "Use: %s [options] <dagfile>\n", cmd);
@@ -199,6 +205,7 @@ static void show_help_analyze(const char *cmd)
 	fprintf(stdout, " %-30s Show input files.\n", "-I,--show-input");
 	fprintf(stdout, " %-30s Syntax check.\n", "-k,--syntax-check");
 	fprintf(stdout, " %-30s Show output files.\n", "-O,--show-output");
+	fprintf(stdout, " %-30s Translate workflow JSON representation.\n", "-J,--json");
 	fprintf(stdout, " %-30s Show version string\n", "-v,--version");
 }
 
@@ -222,10 +229,11 @@ int main(int argc, char *argv[])
 		{"show-input", no_argument, 0, 'I'},
 		{"syntax-check", no_argument, 0, 'k'},
 		{"show-output", no_argument, 0, 'O'},
+		{"json", no_argument, 0, 'J'},
 		{"version", no_argument, 0, 'v'},
 		{0, 0, 0, 0}
 	};
-	const char *option_string_analyze = "b:hiIkOd:v";
+	const char *option_string_analyze = "b:hiIkOJd:v";
 
 	while((c = getopt_long(argc, argv, option_string_analyze, long_options_analyze, NULL)) >= 0) {
 		switch (c) {
@@ -246,6 +254,9 @@ int main(int argc, char *argv[])
 				break;
 			case 'O':
 				display_mode = SHOW_OUTPUT_FILES;
+				break;
+			case 'J':
+				display_mode = SHOW_JSON;
 				break;
 			case 'd':
 				debug_flags_set(optarg);
@@ -310,6 +321,10 @@ int main(int argc, char *argv[])
 
 			case SHOW_MAKEFLOW_ANALYSIS:
 				dag_show_analysis(d);
+				break;
+
+			case SHOW_JSON:
+				dag_show_json(d);
 				break;
 
 			default:

--- a/makeflow/src/makeflow_analyze.c
+++ b/makeflow/src/makeflow_analyze.c
@@ -40,7 +40,6 @@ See the file COPYING for details.
 #include "rmonitor.h"
 #include "random.h"
 #include "path.h"
-#include "jx_pretty_print.h"
 
 #include "dag.h"
 #include "dag_visitors.h"
@@ -50,7 +49,6 @@ See the file COPYING for details.
 enum { SHOW_INPUT_FILES = 2,
 	   SHOW_OUTPUT_FILES,
 	   SHOW_MAKEFLOW_ANALYSIS,
-	   SHOW_JSON,
 	   SHOW_DAG_FILE
 };
 
@@ -192,10 +190,6 @@ void dag_show_output_files(struct dag *d)
 	}
 }
 
-void dag_show_json(struct dag *d) {
-	jx_pretty_print_stream(dag_to_json(d), stdout);
-}
-
 static void show_help_analyze(const char *cmd)
 {
 	fprintf(stdout, "Use: %s [options] <dagfile>\n", cmd);
@@ -205,7 +199,6 @@ static void show_help_analyze(const char *cmd)
 	fprintf(stdout, " %-30s Show input files.\n", "-I,--show-input");
 	fprintf(stdout, " %-30s Syntax check.\n", "-k,--syntax-check");
 	fprintf(stdout, " %-30s Show output files.\n", "-O,--show-output");
-	fprintf(stdout, " %-30s Translate workflow JSON representation.\n", "-J,--json");
 	fprintf(stdout, " %-30s Show version string\n", "-v,--version");
 }
 
@@ -229,11 +222,10 @@ int main(int argc, char *argv[])
 		{"show-input", no_argument, 0, 'I'},
 		{"syntax-check", no_argument, 0, 'k'},
 		{"show-output", no_argument, 0, 'O'},
-		{"json", no_argument, 0, 'J'},
 		{"version", no_argument, 0, 'v'},
 		{0, 0, 0, 0}
 	};
-	const char *option_string_analyze = "b:hiIkOJd:v";
+	const char *option_string_analyze = "b:hiIkOd:v";
 
 	while((c = getopt_long(argc, argv, option_string_analyze, long_options_analyze, NULL)) >= 0) {
 		switch (c) {
@@ -254,9 +246,6 @@ int main(int argc, char *argv[])
 				break;
 			case 'O':
 				display_mode = SHOW_OUTPUT_FILES;
-				break;
-			case 'J':
-				display_mode = SHOW_JSON;
 				break;
 			case 'd':
 				debug_flags_set(optarg);
@@ -321,10 +310,6 @@ int main(int argc, char *argv[])
 
 			case SHOW_MAKEFLOW_ANALYSIS:
 				dag_show_analysis(d);
-				break;
-
-			case SHOW_JSON:
-				dag_show_json(d);
 				break;
 
 			default:

--- a/makeflow/src/makeflow_viz.c
+++ b/makeflow/src/makeflow_viz.c
@@ -39,6 +39,7 @@ See the file COPYING for details.
 #include "getopt_aux.h"
 #include "random.h"
 #include "path.h"
+#include "jx_pretty_print.h"
 
 #include "dag.h"
 #include "dag_visitors.h"
@@ -49,6 +50,7 @@ enum {
 	   SHOW_DAG_DOT,
 	   SHOW_DAG_PPM,
 	   SHOW_DAG_CYTO,
+	   SHOW_DAG_JSON,
 	   SHOW_DAG_DAX
 };
 
@@ -76,6 +78,7 @@ static void show_help_viz(const char *cmd)
 	fprintf(stdout, " %-35s ppm      PPM file format for rapid iconic display\n","");
 	fprintf(stdout, " %-35s cyto     Cytoscape format for browsing and customization.\n","");
 	fprintf(stdout, " %-35s dax      DAX format for use by the Pegasus workflow manager.\n","");
+	fprintf(stdout, " %-35s json     JSON representation of the DAG.\n","");
 	fprintf(stdout, "\n");
 	fprintf(stdout, " %-30s Condense similar boxes.\n", "--dot-merge-similar");
 	fprintf(stdout, " %-30s Change the size of the boxes proportional to file size.\n", "--dot-proportional");
@@ -135,6 +138,8 @@ int main(int argc, char *argv[])
 					display_mode = SHOW_DAG_CYTO;
 				} else if (strcasecmp(optarg, "dax") ==0 ) {
 					display_mode = SHOW_DAG_DAX;
+				} else if(strcasecmp(optarg, "json") == 0) {
+					display_mode = SHOW_DAG_JSON;
 				} else {
 					fatal("Unknown display option: %s\n", optarg);
 				}
@@ -221,6 +226,9 @@ int main(int argc, char *argv[])
 				break;
 			case SHOW_DAG_DAX:
 				dag_to_dax(d, path_basename(dagfile) );
+				break;
+			case SHOW_DAG_JSON:
+				jx_pretty_print_stream(dag_to_json(d), stdout);
 				break;
 			default:
 				fatal("Unknown display option.");


### PR DESCRIPTION
For #1178 

I added a new option `makeflow_analyze -J` that reads the DAG from the given makeflow and prints a JSON representation. The output for the example included with Makeflow is [attached](https://github.com/cooperative-computing-lab/cctools/files/178743/example.json.txt). The JSON DAG object has a few main keys:

- `categories` associates variables, resource limits, etc. with category names
- `environment` is a set of environment variables to be sent with a makeflow when run
- `rules` is a list (in no particular order) of the rules that make up the makeflow

Each rule is an object that stores

- `command`
- lists of input and output filenames
- the category for that rule

I also attached [another example](https://github.com/cooperative-computing-lab/cctools/files/178744/example2.json.txt) that shows how some of the more advanced features (e.g. remote renaming, sub-makeflows, resource limits) show up.

@btovar @dthain what do you think of this format?