### PR TITLE
Parrot Self Detection

### DIFF
--- a/doc/man/parrot_run.m4
+++ b/doc/man/parrot_run.m4
@@ -57,6 +57,7 @@ OPTION_TRIPLET(-u, username, name)Use this extended username.
 OPTION_ITEM(`    --fake-setuid')Track changes from setuid and setgid.
 OPTION_ITEM(`    --valgrind')Enable valgrind support for Parrot.
 OPTION_ITEM(`-v, --version')Display version number.
+OPTION_ITEM(`    --is-running')Test is Parrot is already running.
 OPTION_TRIPLET(-w, work-dir, dir)Initial working directory.
 OPTION_ITEM(`-W, --syscall-table')Display table of system calls trapped.
 OPTION_ITEM(`-Y, --sync-write')Force synchronous disk writes.

--- a/doc/parrot.html
+++ b/doc/parrot.html
@@ -83,31 +83,38 @@ Now, you should be able to run any standard command using Parrot filenames.  Her
 % cat /anonftp/ftp.gnu.org/pub<b>[Press TAB here]</b>
 </code>
 
-<p>
-<center>
-<table width="75%" border=2>
-<tr bgcolor="#ffffaa">
-<td>
-Hint: You may find it useful to have some visual indication
-of when Parrot is active, so we recommend that you modify
-your shell startup scripts to change the prompt when Parrot is enabled.
-If you use <tt>tcsh</tt>, you might add something like this to your <tt>.cshrc</tt>:
-<code>if ( $?PARROT_ENABLED ) then
+<h3 id="interactive">Interactive Use of Parrot<a class="sectionlink" href="#interactive" title="Link to this section.">&#x21d7;</a></h3>
+
+<p>You may find it useful to have some visual indication of when Parrot is
+active, so we recommend that you modify your shell startup scripts to change
+the prompt when Parrot is enabled. Scripts may execute <tt>parrot_run
+--is-running</tt> to detect if Parrot is already running in the current
+session.</p>
+
+<ul>
+    <li>If you use <tt>tcsh</tt>, add to your <tt>.cshrc</tt>:
+        <code>which parrot_run &gt; /dev/null &amp;&amp; parrot_run --is-running &gt; /dev/null
+if ($? == 0) then
     set prompt = " (Parrot) %n@%m%~%# "
 else
     set prompt = " %n@%m%~%# "
-endif
-</code>
-</table>
-</center>
+endif</code>
+    </li>
+    <li>If you use <tt>bash</tt>, add to your <tt>.bashrc</tt>:
+        <code>if parrot_run --is-running &gt; /dev/null 2&gt; /dev/null; then
+    PS1="(Parrot) ${PS1}"
+fi</code>
+    </li>
+</ul>
 
-<p>
-We have limited the examples so far to HTTP and anonymous FTP, as they are
-the only services we know that absolutely everyone is familiar with.
-There are a number of other more powerful and secure remote services
-that you may be less familiar with.  Parrot supports them in the same form:
-The filename begins with the service type, then the host name,
-then the file name.  Here are all the currently supported services:
+<h2 id="protocols">Protocols<a class="sectionlink" href="#protocols" title="Link to this section.">&#x21d7;</a></h2>
+
+<p>We have limited the examples so far to HTTP and anonymous FTP, as they are
+the only services we know that absolutely everyone is familiar with.  There are
+a number of other more powerful and secure remote services that you may be less
+familiar with.  Parrot supports them in the same form: The filename begins with
+the service type, then the host name, then the file name.  Here are all the
+currently supported services:</p>
 
 <hr>
 <table>

--- a/parrot/src/Makefile
+++ b/parrot/src/Makefile
@@ -49,7 +49,7 @@ tracer.table.c: syscall_32.tbl
 tracer.table.h: syscall_32.tbl
 	cat $< syscall_parrot.tbl | perl tracer.table.pl header 32 > $@
 
-parrot_run: $(OBJECTS_PARROT_RUN)
+parrot_run: $(OBJECTS_PARROT_RUN) libparrot_client.a
 	$(CCTOOLS_LD) -o $@ $(CCTOOLS_INTERNAL_LDFLAGS) $^ $(CCTOOLS_IRODS_LDFLAGS) $(CCTOOLS_MYSQL_LDFLAGS) $(CCTOOLS_XROOTD_LDFLAGS) $(CCTOOLS_CVMFS_LDFLAGS) $(CCTOOLS_GLOBUS_LDFLAGS) $(CCTOOLS_EXTERNAL_LINKAGE)
 
 irods_reli.o: irods_reli.cc irods_reli.h

--- a/parrot/src/chroot_package_run
+++ b/parrot/src/chroot_package_run
@@ -178,8 +178,6 @@ export_env() {
 }
 export_env
 
-unset PARROT_ENABLED
-
 export PACKAGE_CHROOT_PWD="${PWD}"
 if [ -z "$1" ]; then
 	"${cmd_chroot}" "${package_path}" /bin/sh -c 'cd "${PACKAGE_CHROOT_PWD}"; exec /bin/sh'

--- a/parrot/src/parrot_client.c
+++ b/parrot/src/parrot_client.c
@@ -251,4 +251,14 @@ int parrot_unmount ( const char *path )
 #endif
 }
 
+ssize_t parrot_version ( char *buf, size_t len )
+{
+#ifdef CCTOOLS_CPU_I386
+	return syscall(SYSCALL32_parrot_version,buf,len);
+#else
+	return syscall(SYSCALL64_parrot_version,buf,len);
+#endif
+}
+
+
 /* vim: set noexpandtab tabstop=4: */

--- a/parrot/src/parrot_client.h
+++ b/parrot/src/parrot_client.h
@@ -31,5 +31,6 @@ int parrot_closesearch(SEARCH *search);
 int parrot_debug( const char *flags, const char *path, off_t size );
 int parrot_mount( const char *path, const char *destination, const char *mode );
 int parrot_unmount( const char *path );
+ssize_t parrot_version ( char *buf, size_t len );
 
 #endif

--- a/parrot/src/parrot_package_run
+++ b/parrot/src/parrot_package_run
@@ -93,8 +93,6 @@ export_env() {
 }
 export_env
 
-unset PARROT_ENABLED
-
 ldso_file="$(echo "$(pwd)/$(ldd ${cmd_parrot_run} | grep ld-linux | cut -d' ' -f1)" | sed -e 's/[ \t]//g')"
 
 #initialize the repeat process

--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -3363,6 +3363,22 @@ static void decode_syscall( struct pfs_process *p, int entering )
 			}
 			break;
 
+		case SYSCALL32_parrot_version:
+			if (entering) {
+				void *uaddr = POINTER(args[0]);
+				size_t len = args[1];
+
+				if (uaddr) {
+					char buffer[4096];
+					p->syscall_result = MIN((size_t)snprintf(buffer, sizeof(buffer), "%s", CCTOOLS_VERSION),len);
+					TRACER_MEM_OP(tracer_copy_out(p->tracer,buffer,uaddr,p->syscall_result,TRACER_O_ATOMIC));
+					divert_to_dummy(p,p->syscall_result);
+				} else {
+					divert_to_dummy(p,0);
+				}
+			}
+			break;
+
 		/* These things are not currently permitted.
 		 */
 

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -3053,6 +3053,22 @@ static void decode_syscall( struct pfs_process *p, int entering )
 			}
 			break;
 
+		case SYSCALL64_parrot_version:
+			if (entering) {
+				void *uaddr = POINTER(args[0]);
+				size_t len = args[1];
+
+				if (uaddr) {
+					char buffer[4096];
+					p->syscall_result = MIN((size_t)snprintf(buffer, sizeof(buffer), "%s", CCTOOLS_VERSION),len);
+					TRACER_MEM_OP(tracer_copy_out(p->tracer,buffer,uaddr,p->syscall_result,TRACER_O_ATOMIC));
+					divert_to_dummy(p,p->syscall_result);
+				} else {
+					divert_to_dummy(p,0);
+				}
+			}
+			break;
+
 		/* These things are not currently permitted.
 		 */
 

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -1170,6 +1170,7 @@ int main( int argc, char *argv[] )
 		if (!WIFCONTINUED(status))
 			fatal("child did not continue as expected!");
 	} else if(pid==0) {
+		setenv("PARROT_ENABLED", "TRUE", 1);
 		if (pfs_use_helper)
 			pfs_helper_init();
 		pfs_paranoia_payload();

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -151,7 +151,8 @@ enum {
 	LONG_OPT_SYSCALL_DISABLE_DEBUG,
 	LONG_OPT_VALGRIND,
 	LONG_OPT_FAKE_SETUID,
-	LONG_OPT_DYNAMIC_MOUNTS
+	LONG_OPT_DYNAMIC_MOUNTS,
+	LONG_OPT_IS_RUNNING,
 };
 
 static void get_linux_version(const char *cmd)
@@ -225,6 +226,7 @@ static void show_help( const char *cmd )
 	printf( " %-30s Rotate debug files of this size.     (PARROT_DEBUG_FILE_SIZE)\n", "-O,--debug-rotate-max=<bytes>");
 	printf( " %-30s     (default 10M, 0 disables)\n","");
 	printf( " %-30s Display version number.\n", "-v,--version");
+	printf( " %-30s Test if Parrot is already running.\n", "   --is-running");
 	printf( " %-30s Show most commonly used options.\n", "-h,--help");
 	printf("\n");
 	printf("Virtualization options:\n");
@@ -571,15 +573,6 @@ int main( int argc, char *argv[] )
 	int envdebug = 0;
 	int envauth = 0;
 
-	{
-		char buf[4096];
-		if (parrot_version(buf, sizeof(buf)) >= 0) {
-			fprintf(stderr, "sorry, parrot_run cannot be run inside of itself.\n");
-			fprintf(stderr, "version already running is %s.\n",buf);
-			exit(EXIT_FAILURE);
-		}
-	}
-
 	random_init();
 
 	debug_config(argv[0]);
@@ -826,6 +819,7 @@ int main( int argc, char *argv[] )
 		{"username", required_argument, 0, 'u'},
 		{"valgrind", no_argument, 0, LONG_OPT_VALGRIND},
 		{"version", no_argument, 0, 'v'},
+		{"is-running", no_argument, 0, LONG_OPT_IS_RUNNING},
 		{"with-checksums", no_argument, 0, 'K'},
 		{"with-snapshots", no_argument, 0, 'F'},
 		{"work-dir", required_argument, 0, 'w'},
@@ -1024,6 +1018,16 @@ int main( int argc, char *argv[] )
 		case LONG_OPT_DYNAMIC_MOUNTS:
 			pfs_allow_dynamic_mounts = 1;
 			break;
+		case LONG_OPT_IS_RUNNING: {
+			char buf[4096];
+			if (parrot_version(buf, sizeof(buf)) >= 0) {
+				printf("%s\n", buf);
+				exit(EXIT_SUCCESS);
+			} else {
+				exit(EXIT_FAILURE);
+			}
+			break;
+		}
 		default:
 			show_help(argv[0]);
 			break;
@@ -1031,6 +1035,15 @@ int main( int argc, char *argv[] )
 	}
 
 	if(optind>=argc) show_help(argv[0]);
+
+	{
+		char buf[4096];
+		if (parrot_version(buf, sizeof(buf)) >= 0) {
+			fprintf(stderr, "sorry, parrot_run cannot be run inside of itself.\n");
+			fprintf(stderr, "version already running is %s.\n",buf);
+			exit(EXIT_FAILURE);
+		}
+	}
 
 	cctools_version_debug(D_DEBUG, argv[0]);
 

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -15,6 +15,10 @@ See the file COPYING for details.
 #include "pfs_table.h"
 #include "ptrace.h"
 
+extern "C" {
+#include "parrot_client.h"
+}
+
 #ifndef PTRACE_EVENT_STOP
 #  define PTRACE_EVENT_STOP 128
 #endif
@@ -567,9 +571,13 @@ int main( int argc, char *argv[] )
 	int envdebug = 0;
 	int envauth = 0;
 
-	if(getenv("PARROT_ENABLED")) {
-		fprintf(stderr,"sorry, parrot_run cannot be run inside of itself.\n");
-		exit(EXIT_FAILURE);
+	{
+		char buf[4096];
+		if (parrot_version(buf, sizeof(buf)) >= 0) {
+			fprintf(stderr, "sorry, parrot_run cannot be run inside of itself.\n");
+			fprintf(stderr, "version already running is %s.\n",buf);
+			exit(EXIT_FAILURE);
+		}
 	}
 
 	random_init();
@@ -1149,7 +1157,6 @@ int main( int argc, char *argv[] )
 		if (!WIFCONTINUED(status))
 			fatal("child did not continue as expected!");
 	} else if(pid==0) {
-		setenv("PARROT_ENABLED", "TRUE", 1);
 		if (pfs_use_helper)
 			pfs_helper_init();
 		pfs_paranoia_payload();

--- a/parrot/src/syscall_parrot.tbl
+++ b/parrot/src/syscall_parrot.tbl
@@ -15,3 +15,4 @@
 1010 parrot parrot_debug sys_parrot_debug
 1011 parrot parrot_mount sys_parrot_mount
 1012 parrot parrot_unmount sys_parrot_unmount
+1013 parrot parrot_version sys_parrot_version


### PR DESCRIPTION
    Test if Parrot is running using parrot_version.
    
    Environment variables are not the right mechanism for testing if Parrot is
    already running. In #1203, the PARROT_ENABLED environment variable would be
    sent along with jobs to remote systems which would prevent Parrot from running.
    Instead, just try a Parrot system call to see if we're already running Parrot.
    
    Fixes #1203.