### PR TITLE
Fix space and : parsing error.

### DIFF
--- a/makeflow/src/lexer.c
+++ b/makeflow/src/lexer.c
@@ -1161,6 +1161,7 @@ int lexer_read_line(struct lexer * lx)
 		return 1;
 		break;
 	case '\t':
+	case  ' ': /* A command starting with a space.. for backwards compatibility. */
 		return lexer_read_command(lx);
 		break;
 	case '\n':
@@ -1184,10 +1185,6 @@ int lexer_read_line(struct lexer * lx)
 		 * equal sign read the line as a file list. */
 		if((colon != -1) && (equal == -1 || colon < equal)) {
 			lexer_read_file_list(lx);
-		}
-		else if(c == ' ' && equal == -1) {
-			/* A command starting with a space.. for backwards compatibility. */
-			return lexer_read_command(lx);
 		}
 		else {
 			lexer_read_syntax_or_variable(lx);


### PR DESCRIPTION
If a command line started with " " and also contained : (such as
http://...), the line was read as a file specification. This commit
treats space as tab, to signify the start of rule.

Also @nhazekam 