### PR TITLE
Do not use kill to wake thread from initial stop.

### DIFF
--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -458,7 +458,6 @@ static void handle_event( pid_t pid, int status, struct rusage *usage )
 					if(p->nsyscalls == 0) { /* stop before we begin running the process */
 						debug(D_DEBUG, "suppressing bootstrap SIGSTOP for %d",pid);
 						signum = 0; /* suppress delivery */
-						kill(p->pid,SIGCONT);
 					}
 					break;
 				case SIGTSTP:


### PR DESCRIPTION
Oleg Nesterov noticed a bug [1] in this code where SIGCONT could wake multiple
newly cloned threads from their initial SIGSTOP. This would cause the threads
to continue executing without stopping at system calls. That is, they would
only stop at other ptrace events like PTRACE_EVENT_CLONE or PTRACE_EVENT_EXIT.
The only way to trace system calls on a new thread is to use PTRACE_SYSCALL
after receiving its stop signal.

Possible fix for #1207.

[1] https://lkml.org/lkml/2016/3/21/644