### PR TITLE
Also set timeout.usec = 0 on urgent messages.

### DIFF
--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -1504,6 +1504,7 @@ int wait_for_messages(int interval)
 					int urgent = rmonitor_dispatch_msg();
 					if(urgent) {
 						timeout.tv_sec  = 0;
+						timeout.tv_usec = 0;
 					}
 				}
 			}


### PR DESCRIPTION
Fix for #1220.

On urgent messages, such as from exiting processes, timeout.sec was set to 0, but not timeout.usec. This commit fixes that.