### PR TITLE
Specify monitor directory per task

### DIFF
--- a/work_queue/src/perl/Work_Queue/Task.pm
+++ b/work_queue/src/perl/Work_Queue/Task.pm
@@ -222,9 +222,15 @@ sub specify_priority {
 	return work_queue_task_specify_priority($self->{_task}, $priority);
 }
 
+
 sub specify_environment_variable {
 	my ($self, $name, $value) = @_;
 	return work_queue_task_specify_enviroment_variable($self->{_task}, $name, $value);
+}
+
+sub specify_monitor_output {
+	my ($self, $filename) = @_;
+	return work_queue_task_specify_monitor_output($self->{_task}, $filename);
 }
 
 sub tag {
@@ -773,6 +779,19 @@ Name of the environment variable.
 Value of the environment variable. Variable is unset if value is not given.
 
 =back
+
+=head3 C<specify_monitor_output>
+
+Set a name for the resource summary output from the monitor.
+
+=over 12
+
+=item filename
+
+Name of the resource summary.
+
+=back
+
 
 =head3 C<tag>
 

--- a/work_queue/src/perl/Work_Queue/Task.pm
+++ b/work_queue/src/perl/Work_Queue/Task.pm
@@ -229,8 +229,8 @@ sub specify_environment_variable {
 }
 
 sub specify_monitor_output {
-	my ($self, $filename) = @_;
-	return work_queue_task_specify_monitor_output($self->{_task}, $filename);
+	my ($self, $directory) = @_;
+	return work_queue_task_specify_monitor_output($self->{_task}, $directory);
 }
 
 sub tag {
@@ -782,13 +782,13 @@ Value of the environment variable. Variable is unset if value is not given.
 
 =head3 C<specify_monitor_output>
 
-Set a name for the resource summary output from the monitor.
+Set the directory name for the resource output from the monitor.
 
 =over 12
 
-=item filename
+=item directory
 
-Name of the resource summary.
+Name of the directory.
 
 =back
 

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -253,10 +253,16 @@ class Task(_object):
     def specify_running_time( self, useconds ):
         return work_queue_task_specify_running_time(self._task,useconds)
 
+    ##
     # Set this environment variable before running the task.
     # If value is None, then variable is unset.
     def specify_environment_variable( self, name, value = None ):
         return work_queue_task_specify_enviroment_variable(self._task,name,value)
+
+    ##
+    # Set a name for the resource summary output from the monitor.
+    def specify_monitor_output( self, filename ):
+        return work_queue_task_specify_monitor_output(self._task,filename)
 
     ##
     # Get the user-defined logical name for the task.

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -260,9 +260,9 @@ class Task(_object):
         return work_queue_task_specify_enviroment_variable(self._task,name,value)
 
     ##
-    # Set a name for the resource summary output from the monitor.
-    def specify_monitor_output( self, filename ):
-        return work_queue_task_specify_monitor_output(self._task,filename)
+    # Set a name for the resource summary output directory from the monitor.
+    def specify_monitor_output( self, directory ):
+        return work_queue_task_specify_monitor_output(self._task,directory)
 
     ##
     # Get the user-defined logical name for the task.

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -106,9 +106,9 @@ typedef enum {
 
 typedef enum {
 	MON_DISABLED = 0,
-	MON_SINGLE_FILE,
-	MON_SINGLE_FILE_NO_KEEP,
-	MON_FULL
+	MON_SINGLE_FILE,      /* accumulate all summary files to a single file. */
+	MON_NO_KEEP,          /* fill task->resources_measured, but delete summary file. */
+	MON_FULL              /* accumulate to a single file, and generate series and monitorin debug output. */
 } work_queue_monitoring_mode;
 
 // Threshold for available disk space (MB) beyond which files are not received from worker.
@@ -1205,8 +1205,18 @@ static void delete_uncacheable_files( struct work_queue *q, struct work_queue_wo
 	delete_worker_files(q, w, t->output_files, WORK_QUEUE_CACHE | WORK_QUEUE_PREEXIST);
 }
 
+char *monitor_file_name(struct work_queue *q, struct work_queue_task *t, const char *ext) {
+	if(t->monitor_output_file && strcmp(".summary", ext) == 0) {
+		return xxstrdup(t->monitor_output_file);
+	} else {
+		return string_format("%s/" RESOURCE_MONITOR_TASK_LOCAL_NAME "%s",
+				q->monitor_output_dirname, getpid(), t->taskid, ext ? ext : "");
+	}
+}
+
 void read_measured_resources(struct work_queue *q, struct work_queue_task *t) {
-	char *summary = string_format("%s/" RESOURCE_MONITOR_TASK_LOCAL_NAME ".summary", q->monitor_output_dirname, getpid(), t->taskid);
+
+	char *summary = monitor_file_name(q, t, ".summary");
 
 	if(t->resources_measured)
 		rmsummary_delete(t->resources_measured);
@@ -1229,12 +1239,12 @@ void resource_monitor_append_report(struct work_queue *q, struct work_queue_task
 	if(q->monitor_mode == MON_DISABLED)
 		return;
 
-	struct flock lock;
-	char        *summary = string_format("%s/" RESOURCE_MONITOR_TASK_LOCAL_NAME ".summary", q->monitor_output_dirname, getpid(), t->taskid);
+	char *summary = monitor_file_name(q, t, ".summary");
 
-	if(q->monitor_mode != MON_SINGLE_FILE_NO_KEEP) {
+	if(q->monitor_mode != MON_NO_KEEP) {
 		int monitor_fd = fileno(q->monitor_file);
 
+		struct flock lock;
 		lock.l_type   = F_WRLCK;
 		lock.l_start  = 0;
 		lock.l_whence = SEEK_SET;
@@ -1261,8 +1271,8 @@ void resource_monitor_append_report(struct work_queue *q, struct work_queue_task
 		fcntl(monitor_fd, F_SETLK, &lock);
 	}
 
-	/* Remove individual summary file if only keeping single file. */
-	if(q->monitor_mode != MON_FULL) {
+	/* Remove individual summary file unless it is named specifically. */
+	if(!t->monitor_output_file) {
 		unlink(summary);
 	}
 
@@ -1270,8 +1280,8 @@ void resource_monitor_append_report(struct work_queue *q, struct work_queue_task
 }
 
 void resource_monitor_compress_logs(struct work_queue *q, struct work_queue_task *t) {
-	char *series    = string_format("%s/" RESOURCE_MONITOR_TASK_LOCAL_NAME ".series", q->monitor_output_dirname, getpid(), t->taskid);
-	char *debug_log = string_format("%s/" RESOURCE_MONITOR_TASK_LOCAL_NAME ".debug", q->monitor_output_dirname, getpid(), t->taskid);
+	char *series    = monitor_file_name(q, t, ".series");
+	char *debug_log = monitor_file_name(q, t, ".debug");
 
 	char *command = string_format("gzip -9 -q %s %s", series, debug_log);
 
@@ -3494,6 +3504,8 @@ struct work_queue_task *work_queue_task_create(const char *command_line)
 	t->resource_request   = CATEGORY_ALLOCATION_UNLABELED;
 	t->resources_measured = NULL;
 
+	t->monitor_output_file = NULL;
+
 	/* In the absence of additional information, a task consumes an entire worker. */
 	t->resources_requested = rmsummary_create(-1);
 	t->resources_measured  = rmsummary_create(-1);
@@ -3532,6 +3544,10 @@ struct work_queue_task *work_queue_task_clone(const struct work_queue_task *task
   if(task->resources_measured) {
 	  new->resources_measured = malloc(sizeof(struct rmsummary));
 	  memcpy(new->resources_measured, task->resources_measured, sizeof(sizeof(struct rmsummary)));
+  }
+
+  if(task->monitor_output_file) {
+	new->monitor_output_file = xxstrdup(task->monitor_output_file);
   }
 
   if(task->output) {
@@ -4105,6 +4121,19 @@ void work_queue_task_specify_priority( struct work_queue_task *t, double priorit
 	t->priority = priority;
 }
 
+void work_queue_task_specify_monitor_output(struct work_queue_task *t, const char *monitor_output_file) {
+
+	if(!monitor_output_file) {
+		fatal("Error: no monitor_output_file was specified.");
+	}
+
+	if(t->monitor_output_file) {
+		free(t->monitor_output_file);
+	}
+
+	t->monitor_output_file = xxstrdup(monitor_output_file);
+}
+
 void work_queue_file_delete(struct work_queue_file *tf) {
 	if(tf->payload)
 		free(tf->payload);
@@ -4202,6 +4231,9 @@ void work_queue_task_delete(struct work_queue_task *t)
 			rmsummary_delete(t->resources_requested);
 		if(t->resources_measured)
 			rmsummary_delete(t->resources_measured);
+		if(t->monitor_output_file)
+			free(t->monitor_output_file);
+
 		free(t);
 	}
 }
@@ -4353,48 +4385,48 @@ struct work_queue *work_queue_create(int port)
 
 int work_queue_enable_monitoring(struct work_queue *q, char *monitor_output_directory)
 {
-  if(!q)
-	return 0;
+	if(!q)
+		return 0;
 
-  q->monitor_mode = MON_DISABLED;
-  q->monitor_exe = resource_monitor_locate(NULL);
+	q->monitor_mode = MON_DISABLED;
+	q->monitor_exe = resource_monitor_locate(NULL);
 
-  if(!q->monitor_exe)
-  {
-	warn(D_WQ, "Could not find the resource monitor executable. Disabling monitoring.\n");
-	return 0;
-  }
+	if(!q->monitor_exe)
+	{
+		warn(D_WQ, "Could not find the resource monitor executable. Disabling monitoring.\n");
+		return 0;
+	}
 
-  if(monitor_output_directory) {
-	  q->monitor_output_dirname = xxstrdup(monitor_output_directory);
-  } else {
-	  q->monitor_output_dirname = xxstrdup("./");
-  }
+	if(monitor_output_directory) {
+		q->monitor_output_dirname = xxstrdup(monitor_output_directory);
+	} else {
+		q->monitor_output_dirname = xxstrdup("./");
+	}
 
+	if(!create_dir(q->monitor_output_dirname, 0777)) {
+		fatal("Could not create monitor output directory - %s (%s)", q->monitor_output_dirname, strerror(errno));
+	}
 
-  if(!create_dir(q->monitor_output_dirname, 0777)) {
-	  fatal("Could not create monitor output directory - %s (%s)", q->monitor_output_dirname, strerror(errno));
-  }
+	if(q->measured_local_resources)
+		free(q->measured_local_resources);
 
-  if(q->measured_local_resources)
-	  free(q->measured_local_resources);
-  q->measured_local_resources = rmonitor_measure_process(getpid());
+	q->measured_local_resources = rmonitor_measure_process(getpid());
 
-  if(monitor_output_directory) {
-	  q->monitor_summary_filename = string_format("%s/wq-%d.summaries", q->monitor_output_dirname, getpid());
-	  q->monitor_file             = fopen(q->monitor_summary_filename, "a");
+	if(monitor_output_directory) {
+		q->monitor_summary_filename = string_format("%s/wq-%d.summaries", q->monitor_output_dirname, getpid());
+		q->monitor_file             = fopen(q->monitor_summary_filename, "a");
 
-	  if(!q->monitor_file)
-	  {
-		  fatal("Could not open monitor log file for writing: '%s'\n", q->monitor_summary_filename);
-	  }
+		if(!q->monitor_file)
+		{
+			fatal("Could not open monitor log file for writing: '%s'\n", q->monitor_summary_filename);
+		}
 
-	  q->monitor_mode = MON_SINGLE_FILE;
-  } else {
-	  q->monitor_mode = MON_SINGLE_FILE_NO_KEEP;
-  }
+		q->monitor_mode = MON_SINGLE_FILE;
+	} else {
+		q->monitor_mode = MON_NO_KEEP;
+	}
 
-  return 1;
+	return 1;
 }
 
 int work_queue_enable_monitoring_full(struct work_queue *q, char *monitor_output_directory) {
@@ -4628,7 +4660,7 @@ void work_queue_disable_monitoring(struct work_queue *q) {
 	if(!q->measured_local_resources->exit_type)
 		q->measured_local_resources->exit_type = xxstrdup("normal");
 
-	if(q->monitor_mode && q->monitor_mode != MON_SINGLE_FILE_NO_KEEP) {
+	if(q->monitor_mode && q->monitor_mode != MON_NO_KEEP) {
 		fclose(q->monitor_file);
 
 		char template[] = "rmonitor-summaries-XXXXXX";
@@ -4679,16 +4711,15 @@ void work_queue_disable_monitoring(struct work_queue *q) {
 }
 
 void work_queue_monitor_add_files(struct work_queue *q, struct work_queue_task *t) {
-	char *template = string_format("%s/" RESOURCE_MONITOR_TASK_LOCAL_NAME, q->monitor_output_dirname, getpid(), t->taskid);
 	work_queue_task_specify_file(t, q->monitor_exe, RESOURCE_MONITOR_REMOTE_NAME, WORK_QUEUE_INPUT, WORK_QUEUE_CACHE);
 
-	char *summary  = string_format("%s.summary", template);
+	char *summary  = monitor_file_name(q, t, ".summary");
 	work_queue_task_specify_file(t, summary, RESOURCE_MONITOR_REMOTE_NAME ".summary", WORK_QUEUE_OUTPUT, WORK_QUEUE_NOCACHE);
 	free(summary);
 
 	if(q->monitor_mode == MON_FULL) {
-		char *debug  = string_format("%s.debug",   template);
-		char *series = string_format("%s.series",  template);
+		char *debug  = monitor_file_name(q, t, ".debug");
+		char *series = monitor_file_name(q, t, ".series");
 
 		work_queue_task_specify_file(t, debug, RESOURCE_MONITOR_REMOTE_NAME ".debug",   WORK_QUEUE_OUTPUT, WORK_QUEUE_NOCACHE);
 		work_queue_task_specify_file(t, series, RESOURCE_MONITOR_REMOTE_NAME ".series", WORK_QUEUE_OUTPUT, WORK_QUEUE_NOCACHE);
@@ -4697,7 +4728,6 @@ void work_queue_monitor_add_files(struct work_queue *q, struct work_queue_task *
 		free(series);
 	}
 
-	free(template);
 }
 
 char *work_queue_monitor_wrap(struct work_queue *q, struct work_queue_worker *w, struct work_queue_task *t, struct rmsummary *limits)

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -145,7 +145,7 @@ struct work_queue_task {
 
 	char *category;                                        /**< User-provided label for the task. It is expected that all task with the same category will have similar resource usage. See @ref work_queue_task_specify_category. If no explicit category is given, the label "default" is used. **/
 
-	char *monitor_output_file;                             /**< Custom output name for the monitoring summary. If NULL, save to directory from @ref work_queue_enable_monitoring */
+	char *monitor_output_directory;                        /**< Custom output directory for the monitoring output files. If NULL, save to directory from @ref work_queue_enable_monitoring */
 
 	timestamp_t time_app_delay;                            /**< @deprecated The time spent in upper-level application (outside of work_queue_wait). */
 };
@@ -439,11 +439,12 @@ summaries into a single. If monitor_output_dirname is NULL, work_queue_task is
 updated with the resources measured, and no summary file is kept unless
 explicitely given by work_queue_task's monitor_output_file.
 @param q A work queue object.
-@param monitor_output_dirname The name of the output directory. If NULL, no
-summary file is kept, but resources_measured from work_queue_task is updated.
-@return 1 on success, 0 if monitoring was not enabled.
+@param monitor_output_dirname The name of the output directory. If NULL,
+summaries are kept only when monitor_output_directory is specify per task, but
+resources_measured from work_queue_task is updated.  @return 1 on success, 0 if
+monitoring was not enabled.
 */
-int work_queue_enable_monitoring(struct work_queue *q, char *monitor_output_dirname);
+int work_queue_enable_monitoring(struct work_queue *q, char *monitor_output_directory);
 
 /** Enables resource monitoring on the give work queue.
 As @ref work_queue_enable_monitoring, but it generates a time series and a

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -145,6 +145,8 @@ struct work_queue_task {
 
 	char *category;                                        /**< User-provided label for the task. It is expected that all task with the same category will have similar resource usage. See @ref work_queue_task_specify_category. If no explicit category is given, the label "default" is used. **/
 
+	char *monitor_output_file;                             /**< Custom output name for the monitoring summary. If NULL, save to directory from @ref work_queue_enable_monitoring */
+
 	timestamp_t time_app_delay;                            /**< @deprecated The time spent in upper-level application (outside of work_queue_wait). */
 };
 
@@ -393,6 +395,13 @@ To change the scheduling algorithm for all tasks, use @ref work_queue_specify_al
 */
 void work_queue_task_specify_algorithm(struct work_queue_task *t, work_queue_schedule_t algorithm);
 
+/** Specify a custom name for the monitoring summary. If @ref work_queue_enable_monitoring is also enabled, the summary is also written to that directory.
+@param t A task object.
+@param monitor_output Resource summary file.
+*/
+
+void work_queue_task_specify_monitor_output(struct work_queue_task *t, const char *monitor_output);
+
 /** Delete a task.
 This may be called on tasks after they are returned from @ref work_queue_wait.
 @param t The task to delete.
@@ -426,17 +435,21 @@ struct work_queue *work_queue_create(int port);
 /** Enables resource monitoring on the give work queue.
 It generates a resource summary per task, which is written to the given
 directory. It also creates all_summaries-PID.log, that consolidates all
-summaries into a single.
+summaries into a single. If monitor_output_dirname is NULL, work_queue_task is
+updated with the resources measured, and no summary file is kept unless
+explicitely given by work_queue_task's monitor_output_file.
 @param q A work queue object.
-@param monitor_output_dirname The name of the output directory.
+@param monitor_output_dirname The name of the output directory. If NULL, no
+summary file is kept, but resources_measured from work_queue_task is updated.
 @return 1 on success, 0 if monitoring was not enabled.
 */
-int work_queue_enable_monitoring(struct work_queue *q, char *monitor_summary_file);
-
+int work_queue_enable_monitoring(struct work_queue *q, char *monitor_output_dirname);
 
 /** Enables resource monitoring on the give work queue.
-As @ref work_queue_enable_monitoring, but it generates a time series and a monitor debug file (WARNING: for long running tasks these files may reach gigabyte sizes.)
-@param q A work queue object.
+As @ref work_queue_enable_monitoring, but it generates a time series and a
+monitor debug file (WARNING: for long running tasks these files may reach
+gigabyte sizes. This function is mostly used for debugging.) @param q A work
+queue object.
 @param monitor_output_dirname The name of the output directory.
 @return 1 on success, 0 if monitoring was not enabled.
 */

--- a/work_queue/src/work_queue_internal.h
+++ b/work_queue/src/work_queue_internal.h
@@ -50,3 +50,4 @@ void work_queue_broadcast_message(struct work_queue *q, const char *msg);
 
 /* shortcut to set cores, memory, disk, etc. from a single function. */
 void work_queue_task_specify_resources(struct work_queue_task *t, struct rmsummary *rm);
+


### PR DESCRIPTION
As requested by @klannon, let the user choose the name of the resource summary files.