### PR TITLE
do not use times to determine min number of cores

### DIFF
--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -69,7 +69,7 @@ struct category *category_lookup_or_create(struct hash_table *categories, const 
 
 	c->time_peak_independece = 0;
 
-	c->allocation_mode = CATEGORY_ALLOCATION_MODE_MAX_THROUGHPUT;
+	c->allocation_mode = CATEGORY_ALLOCATION_MODE_MAX;
 
 	hash_table_insert(categories, name, c);
 
@@ -350,15 +350,17 @@ int64_t category_first_allocation_max_throughput(struct itable *histogram, int64
 }
 
 int64_t category_first_allocation(struct itable *histogram, int assume_independence, category_mode_t mode,  int64_t top_resource) {
-	switch(mode) {
-		case CATEGORY_ALLOCATION_MODE_MIN_WASTE:
-			return category_first_allocation_min_waste(histogram, assume_independence, top_resource);
-			break;
-		case CATEGORY_ALLOCATION_MODE_MAX_THROUGHPUT:
-		default:
-			return category_first_allocation_max_throughput(histogram, top_resource);
-			break;
-	}
+    switch(mode) {
+        case CATEGORY_ALLOCATION_MODE_MIN_WASTE:
+            return category_first_allocation_min_waste(histogram, assume_independence, top_resource);
+            break;
+        case CATEGORY_ALLOCATION_MODE_MAX_THROUGHPUT:
+            return category_first_allocation_max_throughput(histogram, top_resource);
+            break;
+        default:
+            return top_resource;
+            break;
+    }
 }
 
 #define update_first_allocation_field(c, top, independence, field)\

--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -382,7 +382,7 @@ void category_update_first_allocation(struct hash_table *categories, const char 
 		c->first_allocation = rmsummary_create(-1);
 	}
 
-	c->first_allocation->cores          = c->max_allocation->cores;
+	c->first_allocation->cores = c->max_allocation->cores;
 
 	update_first_allocation_field(c, top, 1, cpu_time);
 	update_first_allocation_field(c, top, 1, wall_time);

--- a/dttools/src/category.h
+++ b/dttools/src/category.h
@@ -20,6 +20,7 @@ typedef enum {
 } category_allocation_t;
 
 typedef enum {
+    CATEGORY_ALLOCATION_MODE_MAX,
 	CATEGORY_ALLOCATION_MODE_MIN_WASTE = 0,
 	CATEGORY_ALLOCATION_MODE_MAX_THROUGHPUT
 } category_mode_t;
@@ -73,3 +74,4 @@ void categories_initialize(struct hash_table *categories, struct rmsummary *top,
 category_allocation_t category_next_label(struct hash_table *categories, const char *category, category_allocation_t current_label, int resource_overflow);
 
 #endif
+

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -2640,9 +2640,14 @@ static struct rmsummary *task_worker_box_size(struct work_queue *q, struct work_
 		limits->gpus   = MIN(label->gpus,   w->resources->gpus.total);
 	}
 
-	/* consider end time by itself, regardless of labeling. */
-	if(t->resources_requested && t->resources_requested->end > 0) {
-		limits->end = t->resources_requested->end;
+	/* consider times by themselves */
+	if(t->resources_requested) { 
+		
+		if(t->resources_requested->end > 0)
+			limits->end = t->resources_requested->end;
+
+		if(t->resources_requested->wall_time > 0)
+			limits->wall_time = t->resources_requested->wall_time;
 	}
 
 	return limits;
@@ -3604,7 +3609,7 @@ void work_queue_task_specify_max_retries( struct work_queue_task *t, int64_t max
 
 static void set_task_unlabel_flag( struct work_queue_task *t )
 {
-	if(t->resources_requested->cores < 0 && t->resources_requested->memory < 0 && t->resources_requested->disk < 0 && t->resources_requested->gpus < 0 && t->resources_requested->wall_time < 0)
+	if(t->resources_requested->cores < 0 && t->resources_requested->memory < 0 && t->resources_requested->disk < 0 && t->resources_requested->gpus)
 	{
 		if(t->resource_request == CATEGORY_ALLOCATION_USER)
 			t->resource_request = CATEGORY_ALLOCATION_UNLABELED;
@@ -3678,12 +3683,6 @@ void work_queue_task_specify_end_time( struct work_queue_task *t, int64_t usecon
 	else
 	{
 		t->resources_requested->end = useconds;
-
-		/* If end time is specified, assume at least one core is specified.
-		 * Otherwise, a single worker will get all the tasks. */
-		if(t->resources_requested->cores < 1) {
-			work_queue_task_specify_cores(t, 1);
-		}
 	}
 }
 
@@ -3696,12 +3695,6 @@ void work_queue_task_specify_running_time( struct work_queue_task *t, int64_t us
 	else
 	{
 		t->resources_requested->wall_time = useconds;
-
-		/* If wall time is specified, assume at least one core is specified.
-		 * Otherwise, a single worker will get all the tasks. */
-		if(t->resources_requested->cores < 1) {
-			work_queue_task_specify_cores(t, 1);
-		}
 	}
 }
 


### PR DESCRIPTION
As reported by @matze.

This is a left-over from the time we did not have categories. Specifying end time would set minimum cores to 1, so that a single worker did not get all of the tasks.