### PR TITLE
Backup catalog server

### DIFF
--- a/chirp/src/chirp_global.c
+++ b/chirp/src/chirp_global.c
@@ -123,10 +123,10 @@ static int server_table_load(time_t stoptime)
 		jx_delete(item);
 	}
 
-	debug(D_CHIRP, "querying catalog at %s:%d", CATALOG_HOST, CATALOG_PORT);
+	debug(D_CHIRP, "querying catalog at %s", CATALOG_HOST);
 
 	struct jx *jexpr = jx_parse_string("type==\"chirp\"");
-	q = catalog_query_create(CATALOG_HOST, CATALOG_PORT, jexpr, stoptime);
+	q = catalog_query_create(CATALOG_HOST, jexpr, stoptime);
 
 	if(!q) {
 		jx_delete(jexpr);

--- a/chirp/src/chirp_server.c
+++ b/chirp/src/chirp_server.c
@@ -88,7 +88,6 @@ static char        address[LINK_ADDRESS_MAX];
 static time_t      advertise_alarm = 0;
 static int         advertise_timeout = 300; /* five minutes */
 static int         config_pipe[2] = {-1, -1};
-static struct      datagram *catalog_port;
 static char        hostname[DOMAIN_NAME_MAX];
 static int         idle_timeout = 60; /* one minute */
 static UINT64_T    minimum_space_free = 0;
@@ -135,16 +134,6 @@ static int space_available(INT64_T amount)
 		errno = ENOSPC;
 		return 0;
 	}
-}
-
-int update_one_catalog(void *catalog_host, const void *text)
-{
-	char addr[DATAGRAM_ADDRESS_MAX];
-	if(domain_name_cache_lookup(catalog_host, addr)) {
-		debug(D_DEBUG, "sending update to %s:%d", (char*) catalog_host, CATALOG_PORT);
-		datagram_send(catalog_port, text, strlen(text), addr, CATALOG_PORT);
-	}
-	return 1;
 }
 
 static void downgrade (void)
@@ -253,7 +242,7 @@ static int update_all_catalogs(const char *url)
 
 	char *message = jx_print_string(j);
 
-	list_iterate(catalog_host_list, update_one_catalog, message);
+	list_iterate(catalog_host_list, (int (*) (void *, const void *)) catalog_query_send_update, message);
 
 	free(message);
 	jx_delete(j);
@@ -2219,7 +2208,6 @@ int main(int argc, char *argv[])
 		opts_write_port_file(port_file, chirp_port);
 
 	starttime = time(0);
-	catalog_port = datagram_create(0);
 	if(manual_hostname) {
 		strcpy(hostname, manual_hostname);
 	} else {

--- a/chirp/src/chirp_server.c
+++ b/chirp/src/chirp_server.c
@@ -242,7 +242,7 @@ static int update_all_catalogs(const char *url)
 
 	char *message = jx_print_string(j);
 
-	list_iterate(catalog_host_list, (int (*) (void *, const void *)) catalog_query_send_update, message);
+	list_iterate(catalog_host_list, (list_op_t) catalog_query_send_update, message);
 
 	free(message);
 	jx_delete(j);

--- a/chirp/src/chirp_status.c
+++ b/chirp/src/chirp_status.c
@@ -218,7 +218,7 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	q = catalog_query_create(catalog_host, 0, jexpr, stoptime);
+	q = catalog_query_create(catalog_host, jexpr, stoptime);
 	if(!q) {
 		fprintf(stderr, "couldn't query catalog: %s\n", strerror(errno));
 		return 1;

--- a/chirp/src/confuga_fs.h
+++ b/chirp/src/confuga_fs.h
@@ -27,8 +27,7 @@ struct confuga {
 	int scheduler;
 	uint64_t scheduler_n;
 
-	char     catalog_host[256]; /* FQDN is max 255 bytes */
-	uint16_t catalog_port;
+	const char *catalog_hosts;
 
 	unsigned char ticket[20]; /* SHA1 of ticket */
 

--- a/chirp/src/confuga_node.c
+++ b/chirp/src/confuga_node.c
@@ -33,19 +33,9 @@ CONFUGA_IAPI int confugaS_catalog (confuga *C, const char *catalog)
 	int rc;
 
 	if (catalog) {
-		char *port;
-		snprintf(C->catalog_host, sizeof(C->catalog_host), "%s", catalog);
-		port = strchr(C->catalog_host, ':');
-		if (port) {
-			*port = '\0';
-			port += 1;
-			C->catalog_port = strtoul(port, NULL, 10);
-		} else {
-			C->catalog_port = CATALOG_PORT_DEFAULT;
-		}
+		C->catalog_hosts = catalog;
 	} else {
-		snprintf(C->catalog_host, sizeof(C->catalog_host), "%s", CATALOG_HOST_DEFAULT);
-		C->catalog_port = CATALOG_PORT_DEFAULT;
+		C->catalog_hosts = CATALOG_HOST;
 	}
 
 	rc = 0;
@@ -108,7 +98,7 @@ CONFUGA_IAPI int confugaS_catalog_sync (confuga *C)
 
 	debug(D_DEBUG|D_CONFUGA, "syncing with catalog");
 
-	Q = catalog_query_create(C->catalog_host, C->catalog_port, 0, stoptime);
+	Q = catalog_query_create(C->catalog_hosts, 0, stoptime);
 	CATCH(Q == NULL ? errno : 0);
 
 	/* FIXME sqlcatch is silent about EAGAIN, what should we do? */

--- a/doc/catalog.html
+++ b/doc/catalog.html
@@ -1,0 +1,82 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en">
+
+<head>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+<link rel="stylesheet" type="text/css" href="manual.css">
+<title>Chirp Protocol Version 2</title>
+<style type="text/css">
+.command {
+    margin: 10px;
+    border: 1px solid black;
+    font-weight: bold;
+}
+</style>
+</head>
+
+<body>
+
+<div id="manual">
+<h1>Catalog Servers</h1>
+
+<p style="text-align: right;"><b>Last edited: 12 April 2016</b></p>
+
+<p>To check the status of all of the Chirp servers that are available for use,
+consult the Chirp <a href="http://catalog.cse.nd.edu:9097">storage catalog</a>.
+This web page is a list of all known Chirp servers and their locations.</p>
+
+<h2 id="specifying">Specifying Catalog Servers<a class="sectionlink" href="#specifying" title="Link to this section.">&#x21d7;</a></h2>
+
+<p>Many of the tools accept command line arguments or environment variables to specify the catalog server(s) to use. The catalog host is specified as a semicolon delimited list of servers to use. Each may optionally include a port number. If no port is specified, the value of the environment variable <tt>CATALOG_PORT</tt> is used, or the default of port 9097. If no catalog server is given on the command line, the <tt>CATALOG_HOST</tt> environment variable is used. If that is unset, the default of
+<code>catalog.cse.nd.edu;backup-catalog.cse.nd.edu</code>
+This could be written more verbosely as
+<code>catalog.cse.nd.edu:9097;backup-catalog.cse.nd.edu:9097</code>
+assuming the catalog port was not set in the environment.</p>
+
+<h2 id="updates">Updates<a class="sectionlink" href="#updates" title="Link to this section.">&#x21d7;</a></h2>
+
+<p>When any program is sending catalog updates, it will examine the environment and/or configuration options to get a list of catalog servers in use. Updates are then sent to every server listed. The program will consider it a success if at least one update can be sent successfully. If DNS resolution fails for every catalog server, for example, the program will report a failed update.</p>
+
+<h2 id="queries">Querying Catalog Servers<a class="sectionlink" href="#queries" title="Link to this section.">&#x21d7;</a></h2>
+
+<p>When a program making catalog queries is configured with multiple servers, the program will try each in succession until receiving an answer. If no servers give valid responses, the query as a whole fails. The order in which servers are listed sets the initial query order. If a server fails to respond, it will be marked as down before trying the next server in the list. On subsequent queries, servers that were down will not be tried unless every other server is non-responsive. If in this scenario the previously down server answers the query, it will be marked as up again and used with normal priority in future queries.</p>
+
+<h2 id="running">Running a Catalog Server<a class="sectionlink" href="#running" title="Link to this section.">&#x21d7;</a></h2>
+<p>You may want to establish your own catalog server.  This can be
+useful for keeping your systems logically distinct from the main storage pool,
+but can also help performance and availability if your catalog is close to your
+Chirp servers.  The catalog server is installed in the same place as the Chirp
+server.  Simply run it on any machine that you like and then direct your Chirp
+servers to update the new catalog with the -u option.  The catalog will be
+published via HTTP on port 9097 of the catalog machine.</p>
+
+<p>For example, suppose that you wish to run a catalog server on a machine
+named <tt>dopey</tt> and a Chirp server on a machine named <tt>sneezy</tt>:</p>
+
+<code>dopey<span class="prompt">$ </span>catalog_server
+...
+sneezy<span class="prompt">$ </span>chirp_server -u dopey [more options]
+</code>
+
+<p>Finally, point your web browser to: <tt>http://dopey:9097</tt></p>
+
+<p>Or, set an environment variable and use Parrot:</p>
+
+<code><span class="prompt">$ </span>setenv CATALOG_HOST dopey
+<span class="prompt">$ </span>parrot_run tcsh
+<span class="prompt">$ </span>ls /chirp
+</code>
+
+<p>And you will see <a href="http://catalog.cse.nd.edu:9097">something like
+this.</a> You may easily run multiple catalogs for either scalability or fault
+tolerance.  Simply give each Chirp server the name of each
+running catalog separated by semicolons, e.g.
+<code><span class="prompt">$ </span>chirp_server -u 'dopey;happy:9000;grumpy'</code>
+</p>
+
+<p>(Hint: If you want to ensure that your chirp and catalog servers run
+continuously and are automatically restarted after an upgrade, consider using
+<a href="watchdog.html">Watchdog</a>.)</p>
+</div>
+</body>
+</html>

--- a/doc/catalog.html
+++ b/doc/catalog.html
@@ -21,11 +21,11 @@
 
 <p style="text-align: right;"><b>Last edited: 29 April 2016</b></p>
 
-<p>Catalog servers function as connection points for tools that need to interact remotely. Tools can send free-form updates to a catalog server, and can query catalog servers to find other hosts matching some criteria. Catalog updates are sent via UDP, and the catalog server exposes an HTTP interface to view status and make queries.</p>
+<p>Catalog servers function as connection points for tools that need to interact remotely. Tools can send free-form updates to a catalog server, and can query catalog servers to find other hosts matching some criteria. Catalog updates are sent via UDP, and the catalog server exposes a JSON interface to view status and make queries.</p>
 
-<p>To check the status of all of the Chirp servers that are available for use,
-consult the Chirp <a href="http://catalog.cse.nd.edu:9097">storage catalog</a>.
-This web page is a list of all known Chirp servers and their locations.</p>
+<p>To check the status of servers that are available for use,
+consult <a href="http://catalog.cse.nd.edu:9097">Notre Dame's catalog server</a>.
+This web page lists details on all known servers and their locations.</p>
 
 <p>The default view for a catalog server is a human-readable summary. Machine-readable query output is also available at <tt>http://catalog-server/query.json</tt>. Many parts of cctools make use of a catalog server internally. Chirp servers send regular catalog updates indicating the host system's load, available disk space, cctools version, etc. Work Queue masters also advertise their projects through the catalog. When a worker starts, it can query the catalog to automatically discover a master to contact.</p>
 

--- a/doc/catalog.html
+++ b/doc/catalog.html
@@ -19,11 +19,15 @@
 <div id="manual">
 <h1>Catalog Servers</h1>
 
-<p style="text-align: right;"><b>Last edited: 12 April 2016</b></p>
+<p style="text-align: right;"><b>Last edited: 29 April 2016</b></p>
+
+<p>Catalog servers function as connection points for tools that need to interact remotely. Tools can send free-form updates to a catalog server, and can query catalog servers to find other hosts matching some criteria. Catalog updates are sent via UDP, and the catalog server exposes an HTTP interface to view status and make queries.</p>
 
 <p>To check the status of all of the Chirp servers that are available for use,
 consult the Chirp <a href="http://catalog.cse.nd.edu:9097">storage catalog</a>.
 This web page is a list of all known Chirp servers and their locations.</p>
+
+<p>The default view for a catalog server is a human-readable summary. Machine-readable query output is also available at <tt>http://catalog-server/query.json</tt>. Many parts of cctools make use of a catalog server internally. Chirp servers send regular catalog updates indicating the host system's load, available disk space, cctools version, etc. Work Queue masters also advertise their projects through the catalog. When a worker starts, it can query the catalog to automatically discover a master to contact.</p>
 
 <h2 id="specifying">Specifying Catalog Servers<a class="sectionlink" href="#specifying" title="Link to this section.">&#x21d7;</a></h2>
 

--- a/doc/chirp.html
+++ b/doc/chirp.html
@@ -203,39 +203,7 @@ with this option:</p>
 
 <code><span class="prompt">$ </span>chirp_server -u -</code>
 
-<p>Alternatively, you may establish your own catalog server.  This can be
-useful for keeping your systems logically distinct from the main storage pool,
-but can also help performance and availability if your catalog is close to your
-Chirp servers.  The catalog server is installed in the same place as the Chirp
-server.  Simply run it on any machine that you like and then direct your Chirp
-servers to update the new catalog with the -u option.  The catalog will be
-published via HTTP on port 9097 of the catalog machine.</p>
-
-<p>For example, suppose that you wish to run a catalog server on a machine
-named <tt>dopey</tt> and a Chirp server on a machine named <tt>sneezy</tt>:</p>
-
-<code>dopey<span class="prompt">$ </span>catalog_server
-...
-sneezy<span class="prompt">$ </span>chirp_server -u dopey [more options]
-</code>
-
-<p>Finally, point your web browser to: <tt>http://dopey:9097</tt></p>
-
-<p>Or, set an environment variable and use Parrot:</p>
-
-<code><span class="prompt">$ </span>setenv CATALOG_HOST dopey
-<span class="prompt">$ </span>parrot_run tcsh
-<span class="prompt">$ </span>ls /chirp
-</code>
-
-<p>And you will see <a href="http://catalog.cse.nd.edu:9097">something like
-this.</a> You may easily run multiple catalogs for either scalability or fault
-tolerance.  Simply give each Chirp server multiple -u options to name each
-running catalog.</p>
-
-<p>(Hint: If you want to ensure that your chirp and catalog servers run
-continuously and are automatically restarted after an upgrade, consider using
-<a href="watchdog.html">Watchdog</a>.)</p>
+<p>Alternatively, you may establish your own catalog server. See <a href="catalog.html">Catalog Servers</a> for details.</p>
 
 <h2 id="security">Security<a class="sectionlink" href="#security" title="Link to this section.">&#x21d7;</a></h2>
 

--- a/doc/confuga.html
+++ b/doc/confuga.html
@@ -86,7 +86,7 @@
                 heartbeat listener for the Confuga head node. This service is
                 optional because you may use the default catalog server managed
                 by the Cooperative Computing Lab. Or you can start your
-                own.</li>
+                own. See <a href="catalog.html">Catalog Servers</a> for details.</li>
 
             </ul>
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -111,6 +111,7 @@
             <li><a class="man" href="man/chirp_server.html">chirp_server(1)</a></li>
             <li><a class="man" href="man/chirp_server_hdfs.html">chirp_server_hdfs(1)</a></li>
             <li><a href=chirp_protocol.html>The Chirp Protocol</a></li>
+            <li><a href="catalog.html">Catalog Servers</a></li>
         </ul>
         <a href=confuga.html><b>Confuga User's Manual</b></a>
         <ul>

--- a/doc/makeflow.html
+++ b/doc/makeflow.html
@@ -228,14 +228,9 @@ work_queue_worker <b>--password</b> mypwfile ...
 
 <h3 id="workqueue.catalog">Catalog Server<a class="sectionlink" href="#workqueue.catalog" title="Link to this section.">&#x21d7;</a></h3>
 
-<p>Now let's look at how to set up your own catalog server. Say you want to
-run your catalog server on a machine named <tt>catalog.somewhere.edu</tt>.
-The default port that the catalog server will be listening on is 9097, you can
-change it via the '-p' option.</p>
+<p>It is also possible to run your own catalog server. See <a href="catalog.html">Catalog Servers</a> for details.</p>
 
-<code>catalog_server</code>
-
-<p>Now you have a catalog server listening at catalog.somewhere.edu:9097. To
+<p>Suppose you have a catalog server listening at catalog.somewhere.edu:9097. To
 make your masters and workers contact this catalog server, simply add the
 <tt>-C hostname:port</tt> option to both of your master and worker:</p>
 

--- a/doc/workqueue.html
+++ b/doc/workqueue.html
@@ -349,6 +349,7 @@ to the catalog server. Work Queue workers that are provided with the master's
 project name query the catalog server to find the hostname and port of the
 master with the given project name. So, to utilize this feature, the master
 must be specified to run in the <tt>WORK_QUEUE_MASTER_MODE_CATALOG</tt>.
+See <a href="catalog.html">Catalog Servers</a> for details on specifying catalog servers.
 
 <p>For example, to have a Work Queue master advertise its project name as
 <tt>myproject</tt>, add the following code snippet after creating the queue:

--- a/dttools/src/catalog_query.c
+++ b/dttools/src/catalog_query.c
@@ -131,8 +131,12 @@ struct catalog_query *catalog_query_create(const char *hosts, struct jx *filter_
 	struct list *sorted_hosts = catalog_query_sort_hostlist(hosts);
 
 	list_first_item(sorted_hosts);
-	while((h = list_next_item(sorted_hosts))) {
-		struct jx *j = catalog_query_send_query(h->url, stoptime);
+	while(time(NULL) < stoptime) {
+		if(!(h = list_next_item(sorted_hosts))) {
+			list_first_item(sorted_hosts);
+			continue;
+		}
+		struct jx *j = catalog_query_send_query(h->url, time(NULL) + 5);
 
 		if(j) {
 			q = xxmalloc(sizeof(*q));

--- a/dttools/src/catalog_query.c
+++ b/dttools/src/catalog_query.c
@@ -123,6 +123,7 @@ int catalog_query_send_update(const char *hosts, const char *text)
 		}
 
 		if (domain_name_cache_lookup(host, address)) {
+			debug(D_DEBUG, "sending update to %s(%s):%d", host, address, port);
 			datagram_send(d, text, strlen(text), address, port);
 			sent++;
 		} else {

--- a/dttools/src/catalog_query.h
+++ b/dttools/src/catalog_query.h
@@ -50,4 +50,12 @@ struct jx *catalog_query_read(struct catalog_query *q, time_t stoptime);
 */
 void catalog_query_delete(struct catalog_query *q);
 
+/** Send update text to the given hosts
+hosts is a semicolon delimited list of hosts, each of which can be host or host:port
+@param hosts A list of hosts to which to send updates
+@param text String to send
+@return The number of updates successfully sent, 
+*/
+int catalog_query_send_update(const char *hosts, const char *text);
+
 #endif

--- a/dttools/src/catalog_query.h
+++ b/dttools/src/catalog_query.h
@@ -14,7 +14,7 @@ See the file COPYING for details.
 Query the global catalog server for server descriptions.
 */
 
-#define CATALOG_HOST_DEFAULT "catalog.cse.nd.edu"
+#define CATALOG_HOST_DEFAULT "catalog.cse.nd.edu;backup-catalog.cse.nd.edu"
 #define CATALOG_PORT_DEFAULT 9097
 
 #define CATALOG_HOST (getenv("CATALOG_HOST") ? getenv("CATALOG_HOST") : CATALOG_HOST_DEFAULT )

--- a/dttools/src/catalog_query.h
+++ b/dttools/src/catalog_query.h
@@ -25,14 +25,13 @@ Connects to a catalog server, issues a query, and waits for the results.
 The caller may specify a specific catalog host and port.
 If none is given, then the environment variables CATALOG_HOST and CATALOG_PORT will be consulted.
 If neither is set, the system will contact chirp.cse.nd.edu on port 9097.
-@param host The catalog server to query, or null for the default server.
-@param port The port of the server, or 0 for the default port.
+@param hosts A semicolon delimited list of catalog servers to query, or null for the default server.
 @param filter_expr An optional expression to filter the results in JX syntax.
  A null pointer indicates no filter.
 @param stoptime The absolute time at which to abort.
 @return A catalog query object on success, or null on failure.
 */
-struct catalog_query *catalog_query_create(const char *host, int port, struct jx *filter_expr, time_t stoptime);
+struct catalog_query *catalog_query_create(const char *hosts, struct jx *filter_expr, time_t stoptime);
 
 /** Read the next object from a query.
 Returns the next @ref jx expressions from the issued query.

--- a/dttools/src/catalog_server.c
+++ b/dttools/src/catalog_server.c
@@ -191,7 +191,7 @@ static void update_all_catalogs()
 	char *text = jx_print_string(j);
 	jx_delete(j);
 
-	list_iterate(outgoing_host_list, (int (*) (void *, const void *)) catalog_query_send_update, text);
+	list_iterate(outgoing_host_list, (list_op_t) catalog_query_send_update, text);
 	free(text);
 }
 

--- a/dttools/src/catalog_server.c
+++ b/dttools/src/catalog_server.c
@@ -106,7 +106,6 @@ static int outgoing_timeout = 300;
 static struct list *outgoing_host_list;
 
 struct datagram *update_dgram = 0;
-struct datagram *outgoing_dgram = 0;
 
 void shutdown_clean(int sig)
 {
@@ -176,18 +175,7 @@ static void remove_expired_records()
 	last_clean_time = current;
 }
 
-
-static int update_one_catalog( void *outgoing_host, const void *text)
-{
-	char addr[DATAGRAM_ADDRESS_MAX];
-	if(domain_name_cache_lookup(outgoing_host, addr)) {
-		debug(D_DEBUG, "sending update to %s:%d", (char*) outgoing_host, CATALOG_PORT);
-		datagram_send(outgoing_dgram, text, strlen(text), addr, CATALOG_PORT);
-	}
-	return 1;
-}
-
-static void update_all_catalogs(struct datagram *outgoing_dgram)
+static void update_all_catalogs()
 {
 	struct jx *j = jx_object(0);
 	jx_insert_string(j,"type","catalog");
@@ -203,7 +191,7 @@ static void update_all_catalogs(struct datagram *outgoing_dgram)
 	char *text = jx_print_string(j);
 	jx_delete(j);
 
-	list_iterate(outgoing_host_list, update_one_catalog, text);
+	list_iterate(outgoing_host_list, (int (*) (void *, const void *)) catalog_query_send_update, text);
 	free(text);
 }
 
@@ -663,10 +651,6 @@ int main(int argc, char *argv[])
 			fatal("couldn't listen on TCP port %d", port);
 	}
 
-	outgoing_dgram = datagram_create(0);
-	if(!outgoing_dgram)
-		fatal("couldn't create outgoing udp port");
-
 	update_dgram = datagram_create_address(interface, port);
 	if(!update_dgram) {
 		if(interface)
@@ -687,7 +671,7 @@ int main(int argc, char *argv[])
 		remove_expired_records();
 
 		if(time(0) > outgoing_alarm) {
-			update_all_catalogs(outgoing_dgram);
+			update_all_catalogs();
 			outgoing_alarm = time(0) + outgoing_timeout;
 		}
 

--- a/dttools/src/catalog_update.c
+++ b/dttools/src/catalog_update.c
@@ -119,7 +119,7 @@ int main(int argc, char *argv[]) {
 	char *text = jx_print_string(j);
 
 	if(catalog_query_send_update(host, text) < 1) {
-		fatal("Unable to send update");
+		fprintf(stderr, "Unable to send update");
 	}
 
 	jx_delete(j);

--- a/dttools/src/catalog_update.c
+++ b/dttools/src/catalog_update.c
@@ -8,9 +8,7 @@ See the file COPYING for details.
 #include "jx_parse.h"
 
 #include "catalog_query.h"
-#include "datagram.h"
 #include "debug.h"
-#include "domain_name_cache.h"
 #include "int_sizes.h"
 #include "load_average.h"
 #include "host_memory_info.h"
@@ -38,7 +36,6 @@ void show_help(const char *cmd) {
 
 int main(int argc, char *argv[]) {
 	char *host = CATALOG_HOST;
-	int   port = CATALOG_PORT;
 	const char *input_file = 0;
 
 	static const struct option long_options[] = {
@@ -74,12 +71,6 @@ int main(int argc, char *argv[]) {
 				show_help(argv[0]);
 				return EXIT_FAILURE;
 		}
-	}
-
-	struct datagram *d;
-	d = datagram_create(DATAGRAM_PORT_ANY);
-	if (!d) {
-		fatal("could not create datagram port!");
 	}
 
 	struct jx *j;
@@ -127,15 +118,11 @@ int main(int argc, char *argv[]) {
 
 	char *text = jx_print_string(j);
 
-	char address[DATAGRAM_ADDRESS_MAX];
-	if (domain_name_cache_lookup(host, address)) {
-		datagram_send(d, text, strlen(text), address, port);
-	} else {
-		fatal("unable to lookup address of host: %s", host);
+	if(catalog_query_send_update(host, text) < 1) {
+		fatal("Unable to send update");
 	}
 
 	jx_delete(j);
-	datagram_delete(d);
 
 	return EXIT_SUCCESS;
 }

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -962,8 +962,6 @@ int main(int argc, char *argv[])
 	char *change_dir = NULL;
 	char *batchlogfilename = NULL;
 	const char *batch_submit_options = getenv("BATCH_OPTIONS");
-	char *catalog_host;
-	int catalog_port;
 	makeflow_clean_depth clean_mode = MAKEFLOW_CLEAN_NONE;
 	char *email_summary_to = NULL;
 	int explicit_remote_jobs_max = 0;
@@ -1136,15 +1134,7 @@ int main(int argc, char *argv[])
 				}
 				break;
 			case 'C':
-				if(!work_queue_catalog_parse(optarg, &catalog_host, &catalog_port)) {
-					fprintf(stderr, "makeflow: catalog server should be given as HOSTNAME:PORT'.\n");
-					exit(1);
-				}
-				setenv("CATALOG_HOST", catalog_host, 1);
-
-				char *value = string_format("%d", catalog_port);
-				setenv("CATALOG_PORT", value, 1);
-				free(value);
+				setenv("CATALOG_HOST", optarg, 1);
 				break;
 			case 'd':
 				debug_flags_set(optarg);

--- a/sand/src/sand_align_master.c
+++ b/sand/src/sand_align_master.c
@@ -328,9 +328,6 @@ int main(int argc, char *argv[])
 
 	const char *progname = "sand_align_master";
 
-	char *catalog_host = NULL;
-	int catalog_port = 0;
-
 	debug_config(progname);
 
 	// By default, turn on fast abort option since we know each job is of very similar size (in terms of runtime).
@@ -365,17 +362,7 @@ int main(int argc, char *argv[])
 			priority = atoi(optarg);
 			break;
 		case 'C':
-			if(!work_queue_catalog_parse(optarg, &catalog_host, &catalog_port)) {
-				fprintf(stderr, "sand_align: catalog server should be given as HOSTNAME:PORT'.\n");
-				exit(1);
-			}
-
-			setenv("CATALOG_HOST", catalog_host, 1);
-
-			char *value = string_format("%d", catalog_port);
-			setenv("CATALOG_PORT", value, 1);
-			free(value);
-
+			setenv("CATALOG_HOST", optarg, 1);
 			work_queue_master_mode = WORK_QUEUE_MASTER_MODE_CATALOG;
 			break;
 		case 'o':

--- a/sand/src/sand_filter_master.c
+++ b/sand/src/sand_filter_master.c
@@ -488,8 +488,6 @@ static void get_options(int argc, char **argv, const char *progname)
 {
 	signed char c;
 	char tmp[512];
-	char *catalog_host = NULL;
-	int catalog_port = 0;
 
 	while((c = getopt(argc, argv, "p:P:n:d:F:N:C:s:r:R:k:w:c:o:uxvhaZ:")) > -1) {
 		switch (c) {
@@ -531,17 +529,7 @@ static void get_options(int argc, char **argv, const char *progname)
 			priority = atoi(optarg);
 			break;
 		case 'C':
-			if(!work_queue_catalog_parse(optarg, &catalog_host, &catalog_port)) {
-				fprintf(stderr, "sand_filter: catalog server should be given as HOSTNAME:PORT'.\n");
-				exit(1);
-			}
-
-			setenv("CATALOG_HOST", catalog_host, 1);
-
-			char *value = string_format("%d", catalog_port);
-			setenv("CATALOG_PORT", value, 1);
-			free(value);
-
+			setenv("CATALOG_HOST", optarg, 1);
 			work_queue_master_mode = WORK_QUEUE_MASTER_MODE_CATALOG;
 			break;
 		case 'u':

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -683,6 +683,12 @@ void work_queue_specify_num_tasks_left(struct work_queue *q, int ntasks);
 */
 void work_queue_specify_catalog_server(struct work_queue *q, const char *hostname, int port);
 
+/** Specify the catalog server(s) the master should report to.
+@param q A work queue object.
+@param hosts The catalog servers given as a semicolon delimited list of hostnames or hostname:port
+*/
+void work_queue_specify_catalog_servers(struct work_queue *q, const char *hosts);
+
 /** Cancel a submitted task using its task id and remove it from queue.
 @param q A work queue object.
 @param id The taskid returned from @ref work_queue_submit.

--- a/work_queue/src/work_queue_catalog.c
+++ b/work_queue/src/work_queue_catalog.c
@@ -12,6 +12,7 @@ See the file COPYING for details.
 #include "debug.h"
 #include "stringtools.h"
 #include "xxmalloc.h"
+#include "domain_name.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -21,6 +22,7 @@ See the file COPYING for details.
 #include <fcntl.h>
 #include <errno.h>
 
+// Deprecated
 int work_queue_catalog_parse( char *server_string, char **host, int *port )
 {
 	char *colon;
@@ -51,9 +53,16 @@ Return a linked list of jx expressions describing the masters.
 
 struct list * work_queue_catalog_query( const char *catalog_host, int catalog_port, const char *project_regex )
 {
+	char hostport[DOMAIN_NAME_MAX + 8];
 	time_t stoptime = time(0) + 60;
+	struct catalog_query *q;
 
-	struct catalog_query *q = catalog_query_create(catalog_host, catalog_port, 0, stoptime);
+	if(catalog_port > 0) {
+		sprintf(hostport, "%s:%d", catalog_host, catalog_port);
+		q = catalog_query_create(hostport, 0, stoptime);
+	} else {
+		q = catalog_query_create(catalog_host, 0, stoptime);
+	}
 	if(!q) {
 		debug(D_NOTICE,"unable to contact catalog server at %s:%d\n", catalog_host, catalog_port);
 		return 0;

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1843,12 +1843,12 @@ static int serve_master_by_hostport( const char *host, int port, const char *ver
 	return 1;
 }
 
-static int serve_master_by_name( const char *catalog_host, int catalog_port, const char *project_regex )
+static int serve_master_by_name( const char *catalog_hosts, const char *project_regex )
 {
 	static char *last_addr = NULL;
 	static int   last_port = -1;
 
-	struct list *masters_list = work_queue_catalog_query_cached(catalog_host,catalog_port,project_regex);
+	struct list *masters_list = work_queue_catalog_query_cached(catalog_hosts,-1,project_regex);
 
 	debug(D_WQ,"project name %s matches %d masters",project_regex,list_size(masters_list));
 
@@ -2050,8 +2050,7 @@ int main(int argc, char *argv[])
 	int enable_capacity = 1; // enabled by default
 	double fast_abort_multiplier = 0;
 	char *foreman_stats_filename = NULL;
-	char * catalog_host = CATALOG_HOST;
-	int catalog_port = CATALOG_PORT;
+	char * catalog_hosts = CATALOG_HOST;
 
 	worker_start_time = time(0);
 
@@ -2072,10 +2071,7 @@ int main(int argc, char *argv[])
 			//Left here for backwards compatibility
 			break;
 		case 'C':
-			if(!work_queue_catalog_parse(optarg, &catalog_host, &catalog_port)) {
-				fprintf(stderr, "The provided catalog server is invalid. The format of the '-C' option is '-C HOSTNAME:PORT'.\n");
-				exit(1);
-			}
+			catalog_hosts = xxstrdup(optarg);
 			break;
 		case 'd':
 			debug_flags_set(optarg);
@@ -2438,7 +2434,7 @@ int main(int argc, char *argv[])
 		}
 
 		if(project_regex) {
-			result = serve_master_by_name(catalog_host,catalog_port,project_regex);
+			result = serve_master_by_name(catalog_hosts, project_regex);
 		} else {
 			result = serve_master_by_hostport(master_host,master_port,0);
 		}


### PR DESCRIPTION
Here's a first draft of backup catalog server support for #1187. For sending updates or creating queries, everything now takes a string of hosts to try. The default is `catalog.cse.nd.edu;backup-catalog.cse.nd.edu`. Multiple servers are specified in a semicolon delimited list, and each host can optionally have a port specified. For updates, the various places that directly sent datagrams now use a common function that sends to all hosts. Queries are attempted in order, unless a query to a host previously failed, in which that host is tried after other options. I tried to split this PR up into individual commits because changing the catalog interface touches a lot of areas (Makeflow, Work Queue, Chirp, Confuga, etc. ). Also, some catalog stuff is exposed in Work Queue's library interface, so I tried not to break compatibility.