### PR TITLE
Add jx_parser_yield to support streaming JSON parsing

### DIFF
--- a/dttools/src/jx_count_obj_test.c
+++ b/dttools/src/jx_count_obj_test.c
@@ -32,7 +32,9 @@ int main(int argc, char **argv) {
 	int count = 0;
 
 	struct jx *j;
-	while((j = jx_parse_stream(stream))) {
+	struct jx_parser *p = jx_parser_create(0);
+	jx_parser_read_stream(p, stream);
+	while((j = jx_parser_yield(p))) {
 		char *str = jx_print_string(j);
 		fprintf(stdout, "%s\n", str);
 
@@ -41,6 +43,7 @@ int main(int argc, char **argv) {
 
 		count++;
 	}
+	jx_parser_delete(p);
 
 	if(count == n) {
 		exit(0);

--- a/dttools/src/jx_parse.c
+++ b/dttools/src/jx_parse.c
@@ -658,6 +658,17 @@ static struct jx * jx_parse_finish( struct jx_parser *p )
 	return j;
 }
 
+struct jx * jx_parser_yield( struct jx_parser *p )
+{
+	struct jx * j = jx_parse(p);
+	if(jx_parser_errors(p)) {
+		jx_parser_delete(p);
+		jx_delete(j);
+		return 0;
+	}
+	return j;
+}
+
 struct jx * jx_parse_string( const char *str )
 {
 	struct jx_parser *p = jx_parser_create(0);

--- a/dttools/src/jx_parse.h
+++ b/dttools/src/jx_parse.h
@@ -48,6 +48,9 @@ void jx_parser_read_string( struct jx_parser *p, const char *str );
 /** Attach parser to a link.  @param p A parser object.  @param l A @ref link object.  @param stoptime The absolute time at which to stop. */
 void jx_parser_read_link( struct jx_parser *p, struct link *l, time_t stoptime );
 
+/** Parse and return a single value. This function is useful for streaming multiple independent values from a single source. @param p A parser object @return A JX expression which must be deleted with @ref jx_delete. If the parse fails or no JSON value is present, null is returned. */
+struct jx * jx_parser_yield( struct jx_parser *p );
+
 /** Parse a JX expression. Note that in the event of a parse error, this function can return a partial result, reflecting the text that was parseable. You must call @ref jx_parser_errors to determine if the parse was successul.  @param p A parser created by @ref jx_parser_create.  @return A JX expression, or null if nothing was parsed. */
 struct jx * jx_parse( struct jx_parser *p );
 


### PR DESCRIPTION
This is in reference to #1231

Since JX expressions allows lookups, the parser has to scan beyond the end of the object/array, and then unscan (if there's no lookup). Since the library JX supports parsing TCP streams directly, seeking back isn't really an option, so to unscan, the parser stores the extra character and uses it on the next scan. Unfortunately for @btovar's use case, `jx_parse_stream` automatically creates and destroys the parser, throwing out the unscanned character and getting the stream out of sync on subsequent calls, hence the garbled test output.

I added a new function, `jx_parser_yield`, that parses a single value and leaves the parser intact for subsequent calls. If someone needs to do streaming JX parsing, I think it's not unreasonable that they dig around in the lower-level functions a bit, so I didn't touch the convenience wrappers (e.g. `jx_parse_stream`). I've updated `jx_count_obj_test.c` to use the new streaming interface, and now the corresponding test passes.