### PR TITLE
Do not pprint summaries at scale.

### DIFF
--- a/dttools/src/jx_pretty_print.h
+++ b/dttools/src/jx_pretty_print.h
@@ -4,8 +4,8 @@ This software is distributed under the GNU General Public License.
 See the file COPYING for details.
 */
 
-#ifndef JX_PRINT_H
-#define JX_PRINT_H
+#ifndef JX_PPRINT_H
+#define JX_PPRINT_H
 
 /** @file jx_print.h Print JX expressions to strings, files, and buffers. */
 

--- a/dttools/src/rmonitor.c
+++ b/dttools/src/rmonitor.c
@@ -100,15 +100,13 @@ char *resource_monitor_locate(const char *path_from_cmdline)
 //to change it.
 char *resource_monitor_write_command(const char *monitor_path, const char *template_filename, const struct rmsummary *limits, const char *extra_monitor_options, int debug_output, int time_series, int inotify_stats)
 {
-
-
 	buffer_t cmd_builder;
 	buffer_init(&cmd_builder);
 
 	if(!monitor_path)
 		fatal("Monitor path should be specified.");
 
-	buffer_printf(&cmd_builder, "%s", monitor_path);
+	buffer_printf(&cmd_builder, "%s --no-pprint", monitor_path);
 	buffer_printf(&cmd_builder, " --with-output-files=%s", template_filename);
 
 	if(debug_output)

--- a/dttools/src/rmsummary.c
+++ b/dttools/src/rmsummary.c
@@ -27,6 +27,7 @@
 #include "jx.h"
 #include "jx_parse.h"
 #include "jx_pretty_print.h"
+#include "jx_print.h"
 #include "list.h"
 #include "macros.h"
 #include "rmsummary.h"
@@ -670,7 +671,7 @@ struct rmsummary *rmsummary_parse_next(FILE *stream)
 	return s;
 }
 
-void rmsummary_print(FILE *stream, struct rmsummary *s, struct jx *verbatim_fields)
+void rmsummary_print(FILE *stream, struct rmsummary *s, int pprint, struct jx *verbatim_fields)
 {
 	struct jx *jsum = rmsummary_to_json(s, 0);
 
@@ -686,7 +687,12 @@ void rmsummary_print(FILE *stream, struct rmsummary *s, struct jx *verbatim_fiel
 		}
 	}
 
-	jx_pretty_print_stream(jsum, stream);
+	if(pprint) {
+		jx_pretty_print_stream(jsum, stream);
+	} else {
+		jx_print_stream(jsum, stream);
+	}
+
 	jx_delete(jsum);
 }
 

--- a/dttools/src/rmsummary.h
+++ b/dttools/src/rmsummary.h
@@ -76,7 +76,7 @@ struct rmsummary_field
 	}       value;
 };
 
-void rmsummary_print(FILE *stream, struct rmsummary *s, struct jx *verbatim_fields);
+void rmsummary_print(FILE *stream, struct rmsummary *s, int pprint, struct jx *verbatim_fields);
 
 int rmsummary_assign_int_field(struct rmsummary *s, const char *key, int64_t value);
 int rmsummary_assign_char_field(struct rmsummary *s, const char *key, char *value);

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -686,7 +686,7 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 			fprintf(stderr, "\nrule %d failed because it exceeded the resources limits.\n", n->nodeid);
 			if(n->resources_measured)
 			{
-				rmsummary_print(stderr, n->resources_measured, NULL);
+				rmsummary_print(stderr, n->resources_measured, /* pprint */ 0, /* extra fields */ NULL);
 				fprintf(stderr, "\n");
 			}
 

--- a/resource_monitor/src/rmon_tools.c
+++ b/resource_monitor/src/rmon_tools.c
@@ -486,7 +486,7 @@ void rmDsummary_print(FILE *output, struct rmDsummary *so) {
 	to_internal(so, s, total_files, "files");
 	to_internal(so, s, disk, "MB");
 
-	rmsummary_print(output, s, 0);
+	rmsummary_print(output, s, /* pprint */ 1, /* extra fields */ 0);
 	rmsummary_delete(s);
 
 	return;

--- a/resource_monitor/src/rmonitor_poll_example.c
+++ b/resource_monitor/src/rmonitor_poll_example.c
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
 			resources->cores);
 
 	fprintf(stdout, "\n\njson output:\n");
-	rmsummary_print(stdout, resources, 0);
+	rmsummary_print(stdout, resources, /* pprint */ 1, /* extra fields */ 0);
 
 	rmsummary_delete(resources);
 

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4694,7 +4694,7 @@ void work_queue_disable_monitoring(struct work_queue *q) {
 			jx_insert_string(extra, "master_name", q->name);
 		}
 
-		rmsummary_print(final, q->measured_local_resources, extra);
+		rmsummary_print(final, q->measured_local_resources, /* pprint */ 0, extra);
 
 		copy_fd_to_stream(summs_fd, final);
 


### PR DESCRIPTION
The spaces and newlines accumulated fast when accounting the size of
files.