### PR TITLE
Do readlink on final exe path component.

### DIFF
--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -25,6 +25,7 @@ extern "C" {
 #include "int_sizes.h"
 #include "macros.h"
 #include "memfdexe.h"
+#include "path.h"
 #include "pattern.h"
 #include "stringtools.h"
 #include "tracer.h"
@@ -936,6 +937,22 @@ static void decode_execve( struct pfs_process *p, int entering, INT64_T syscall,
 		p->set_gid = p->egid;
 
 		tracer_copy_in_string(p->tracer,logical_name,POINTER(args[0]),sizeof(logical_name),0);
+
+		{
+			char buf[PATH_MAX] = "";
+			if(pfs_readlink(logical_name, buf, sizeof buf - 1) > 0) {
+				if (buf[0] == '/') {
+					snprintf(logical_name, sizeof logical_name, "%s", buf);
+				} else {
+					char *sep = strrchr(logical_name, '/');
+					if (!sep) {
+						sep = logical_name;
+					}
+					snprintf(sep, sizeof logical_name - (size_t)(sep-logical_name), "/%s", buf);
+				}
+			}
+		}
+
 		strncpy(p->new_logical_name, logical_name, sizeof(p->new_logical_name)-1);
 		p->exefd = -1;
 
@@ -997,7 +1014,9 @@ done:
 
 		p->completing_execve = 0;
 		if (actual == 0) {
-			p->table->complete_at_path(AT_FDCWD, p->new_logical_name, p->name);
+			char path[PATH_MAX];
+			p->table->complete_at_path(AT_FDCWD, p->new_logical_name, path);
+			path_collapse(path, p->name, 1);
 			debug(D_PROCESS, "execve: %s (%s) succeeded in 32-bit mode", p->new_logical_name, p->name);
 			/* Undo "syscall_args_changed = 1" because execve returns multiple results in syscall argument registers. */
 			p->syscall_args_changed = 0;

--- a/parrot/test/TR_parrot_procexe.sh
+++ b/parrot/test/TR_parrot_procexe.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -ex
+
+. ../../dttools/test/test_runner_common.sh
+. ./parrot-test.sh
+
+prepare()
+{
+	cp "$(which find)" find || return 1
+	ln -sf ./find lfind || return 1
+}
+
+run()
+{
+	[ "$(parrot ./lfind /proc/self/exe -printf %l)" = "$(./lfind /proc/self/exe -printf %l)" ] || return 1
+}
+
+clean()
+{
+	rm -f find lfind
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:


### PR DESCRIPTION
    This is necessary for the Linux loader which relies on /proc/self/exe being the
    canonical path to the executable.
    
    Note that this commit doesn't stricly make /proc/self/exe the canonical path.
    We only resolve the final component as that should catch all instances of this
    bug. [If there is a link in the middle of the path, it will be resolved
    normally in any case.]
    
    Fixes #930.
