### PR TITLE
Wq status fixes

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -846,6 +846,8 @@ static void add_worker(struct work_queue *q)
 	w->finished_tasks = 0;
 	w->start_time = timestamp_get();
 
+	w->last_update_msg_time = w->start_time;
+
 	struct work_queue_resources *r = work_queue_resources_create();
 
 	r->cores.smallest = r->cores.largest = r->cores.total = -1;//default_resource_value;
@@ -3279,11 +3281,23 @@ static void ask_for_workers_updates(struct work_queue *q) {
 	hash_table_firstkey(q->worker_table);
 	while(hash_table_nextkey(q->worker_table, &key, (void **) &w)) {
 		if(q->keepalive_interval > 0) {
-			if(!strcmp(w->hostname, "unknown")){
-				last_recv_elapsed_time = (int64_t)(current_time - w->start_time)/1000000;
-			} else {
-				last_recv_elapsed_time = (int64_t)(current_time - w->last_update_msg_time)/1000000;
+
+			/* do no send message to work_queue_status. */
+			if(!strcmp(w->hostname, "QUEUE_STATUS")) {
+				continue;
 			}
+
+			/* we have not received workqueue message from worker yet, so we
+			 * simply check agains its start_time. */
+			if(!strcmp(w->hostname, "unknown")){
+				if ((int)((current_time - w->start_time)/1000000) >= q->keepalive_timeout) {
+					debug(D_WQ, "Removing worker %s (%s): hasn't sent its initialization in more than %d s", w->hostname, w->addrport, q->keepalive_timeout);
+					handle_worker_failure(q, w);
+				}
+				continue;
+			}
+
+			last_recv_elapsed_time = (int64_t)(current_time - w->last_update_msg_time)/1000000;
 
 			// send new keepalive check only (1) if we received a response since last keepalive check AND
 			// (2) we are past keepalive interval

--- a/work_queue/src/work_queue_status.c
+++ b/work_queue/src/work_queue_status.c
@@ -406,9 +406,14 @@ int do_direct_query( const char *master_host, int master_port, time_t stoptime )
 		return 1;
 	}
 
-	struct jx * jarray = jx_parse_link(l,stoptime);
-
 	link_putfstring(l,"%s_status\n",stoptime,query_string);
+
+	struct jx *jarray = jx_parse_link(l,stoptime);
+
+	if(!jarray || jarray->type != JX_ARRAY) {
+		fprintf(stderr,"couldn't read from %s port %d: %s",master_host,master_port,strerror(errno));
+		return 1;
+	}
 
 	if(format_mode==FORMAT_TABLE) {
 		jx_table_print_header(query_header,stdout);


### PR DESCRIPTION
Fixes two bugs:

- We were asking keepalive checks from status workers.
- The master was not sending arrays to work_queue_status, which either timedout or segfaulted.

Fixes #1253 