### PR TITLE
Report unmatched tasks

### DIFF
--- a/doc/man/work_queue_status.m4
+++ b/doc/man/work_queue_status.m4
@@ -30,8 +30,9 @@ OPTION_ITEM(`-Q, --statistics')Show summary information about queues. (default)
 OPTION_ITEM(`-M, --project-name=<name>')Filter results of -Q for masters matching <name>.
 OPTION_ITEM(`-W, --workers')Show details of all workers connected to the master.
 OPTION_ITEM(`-T, --tasks')Show details of all tasks in the queue.
-OPTION_ITEM(`-l, --verbose')Long output.
+OPTION_ITEM(`-A, --able-workers')List categories of the given master, size of largest task, and workers that can run it.
 OPTION_ITEM(`-R, --resources')Show available resources for each master.
+OPTION_ITEM(`-l, --verbose')Long output.
 OPTION_TRIPLET(-C, catalog, catalog)Set catalog server to <catalog>. Format: HOSTNAME:PORT
 OPTION_TRIPLET(-d, debug, flag)Enable debugging for the given subsystem. Try -d all as a start.
 OPTION_TRIPLET(-t, timeout, time)RPC timeout (default=300s).

--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -493,7 +493,7 @@ category_allocation_t category_next_label(struct hash_table *categories, const c
 
 	struct category *c = category_lookup_or_create(categories, category);
 	/* If category is not labeling, and user is not labeling, return unlabeled. */
-	if(!c->max_allocation) {
+	if(c && !c->max_allocation) {
 		return CATEGORY_ALLOCATION_UNLABELED;
 	}
 
@@ -502,7 +502,7 @@ category_allocation_t category_next_label(struct hash_table *categories, const c
 		return CATEGORY_ALLOCATION_AUTO_MAX;
 	}
 
-	if(c->first_allocation) {
+	if(c && c->first_allocation) {
 		/* Use first allocation when it is available. */
 		return CATEGORY_ALLOCATION_AUTO_FIRST;
 	} else {

--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -136,21 +136,31 @@ struct jx * jx_arrayv( struct jx *value, ... )
 	return array;
 }
 
-struct jx * jx_lookup( struct jx *j, const char *key )
+struct jx * jx_lookup_guard( struct jx *j, const char *key, int *found )
 {
 	struct jx_pair *p;
+
+	if(found)
+		*found = 0;
 
 	if(!j || j->type!=JX_OBJECT) return 0;
 
 	for(p=j->u.pairs;p;p=p->next) {
 		if(p && p->key && p->key->type==JX_STRING) {
 			if(!strcmp(p->key->u.string_value,key)) {
+				if(found)
+					*found = 1;
 				return p->value;
 			}
 		}
 	}
 
 	return 0;
+}
+
+struct jx * jx_lookup( struct jx *j, const char *key )
+{
+	return jx_lookup_guard(j, key, NULL);
 }
 
 const char * jx_lookup_string( struct jx *object, const char *key )

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -192,6 +192,9 @@ void jx_insert_string( struct jx *object, const char *key, const char *value );
 /** Search for a arbitrary item in an object.  The key is an ordinary string value.  @param object The object in which to search.  @param key The string key to match.  @return The value of the matching pair, or null if none is found. */
 struct jx * jx_lookup( struct jx *object, const char *key );
 
+/* Like @ref jx_lookup, but found is set to 1 when the key is found. Useful for when value is false. */
+struct jx * jx_lookup_guard( struct jx *j, const char *key, int *found );
+
 /** Search for a string item in an object.  The key is an ordinary string value.  @param object The object in which to search.  @param key The string key to match.  @return The C string value of the matching object, or null if it is not found, or is not a string. */
 const char * jx_lookup_string( struct jx *object, const char *key );
 

--- a/dttools/src/jx_table.c
+++ b/dttools/src/jx_table.c
@@ -56,8 +56,9 @@ void jx_table_print( struct jx_table *t, struct jx *j, FILE * f )
 			string_metric(jx_lookup_integer(j,t->name), -1, line);
 			strcat(line, "B");
 		} else {
-			struct jx *v = jx_lookup(j,t->name);
-			if(!v) {
+			int found;
+			struct jx *v = jx_lookup_guard(j,t->name,&found);
+			if(!found) {
 				line = strdup("???");
 			} else if(v->type==JX_STRING) {
 				// special case b/c we want to see

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -526,7 +526,7 @@ static work_queue_msg_code_t recv_worker_msg(struct work_queue *q, struct work_q
 		result = MSG_PROCESSED;
 	} else if(string_prefix_is(line, "workqueue")) {
 		result = process_workqueue(q, w, line);
-	} else if (string_prefix_is(line,"queue_status") || string_prefix_is(line, "worker_status") || string_prefix_is(line, "task_status")) {
+	} else if (string_prefix_is(line,"queue_status") || string_prefix_is(line, "worker_status") || string_prefix_is(line, "task_status") || string_prefix_is(line, "wable_status")) {
 		result = process_queue_status(q, w, line, stoptime);
 	} else if (string_prefix_is(line, "available_results")) {
 		hash_table_insert(q->workers_with_available_results, w->hashkey, w);

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1812,10 +1812,12 @@ static struct rmsummary *largest_waiting_task(struct work_queue *q) {
 
 	list_first_item(q->ready_list);
 	while((t = list_next_item(q->ready_list))) {
-		if(!t->resources_requested || t->resource_request != CATEGORY_ALLOCATION_USER) {
+		if(t->resource_request != CATEGORY_ALLOCATION_USER) {
 			continue;
 		}
-		rmsummary_merge_max(max_resources_waiting, t->resources_requested);
+
+		const struct rmsummary *r = task_dynamic_label(q, t);
+		rmsummary_merge_max(max_resources_waiting, r);
 	}
 
 	return max_resources_waiting;

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -335,7 +335,7 @@ static int available_workers(struct work_queue *q) {
 
 	hash_table_firstkey(q->worker_table);
 	while(hash_table_nextkey(q->worker_table, &id, (void**)&w)) {
-		if(strcmp(w->hostname, "unknown")){
+		if(strcmp(w->hostname, "unknown") != 0 && strcmp(w->hostname, "QUEUE_STATUS") != 0){
 			if(w->resources->unlabeled.inuse > 0)
 			{
 				if(overcommitted_resource_total(q, w->resources->workers.total, 1) > w->resources->unlabeled.inuse) {

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -207,8 +207,11 @@ struct work_queue_stats {
 	int64_t max_disk;               /**< The largest disk space in MB observed among the connected workers. */
 	int64_t min_gpus;               /**< The lowest number of GPUs observed among the connected workers. */
 	int64_t max_gpus;               /**< The highest number of GPUs observed among the connected workers. */
-	int port;
-	int priority;
+
+	int workers_able;               /**< Number of workers on which the largest task can run. */
+
+	int port;                       /**< @deprecated Use ref work_queue_port Port of the queue. */
+	int priority;                   /**< @deprecated Not used. */
 	int workers_ready;              /**< @deprecated Use @ref workers_idle instead. */
 	int workers_full;               /**< @deprecated Use @ref workers_busy insead. */
 	int total_worker_slots;         /**< @deprecated Use @ref tasks_running instead. */

--- a/work_queue/src/work_queue_status.c
+++ b/work_queue/src/work_queue_status.c
@@ -104,8 +104,9 @@ static void show_help(const char *progname)
 	fprintf(stdout, " %-30s Filter results of -Q for masters matching <name>\n", "-M,--project-name<name>");
 	fprintf(stdout, " %-30s List workers connected to the given master.\n", "-W,--workers");
 	fprintf(stdout, " %-30s List tasks of the given master.\n", "-T,--tasks");
-	fprintf(stdout, " %-30s Long text output.\n", "-l,--verbose");
+	fprintf(stdout, " %-30s List categories of the given master, size of largest task, and workers that can run it.\n", "-A,--able-workers");
 	fprintf(stdout, " %-30s Shows aggregated resources of all masters.\n", "-R,--resources");
+	fprintf(stdout, " %-30s Long text output.\n", "-l,--verbose");
 	fprintf(stdout, " %-30s Set catalog server to <catalog>. Format: HOSTNAME:PORT\n", "-C,--catalog=<catalog>");
 	fprintf(stdout, " %-30s Enable debugging for this subsystem.\n", "-d,--debug <flag>");
 	fprintf(stdout, " %-30s Filter results by this expression.\n","   --where=<expr>\n");


### PR DESCRIPTION
Adds -A to work_queue_status, so that the number of workers that can run tasks, per category, are reported. E.g.:

work_queue_status -A localhost 9001
````
CATEGORY          WAITING  FIT-WORKERS    MAX-CORES   MAX-MEMORY     MAX-DISK

my_category             1            0            4          ???          ???

default                 0            0          ???          ???          ???

manual-label            1            0            5          ???          ???
````

@klannon, is this what you were thinking about?

Also available with the API, the value of FIT-WORKERS is stats.workers_able, as whole and per category.
