### PR TITLE
jx yield fix

### DIFF
--- a/dttools/src/jx_count_obj_test.c
+++ b/dttools/src/jx_count_obj_test.c
@@ -43,6 +43,11 @@ int main(int argc, char **argv) {
 
 		count++;
 	}
+
+	if(jx_parser_errors(p)) {
+		fprintf(stderr, "%s error: %s\n", argv[0], jx_parser_error_string(p));
+	}
+
 	jx_parser_delete(p);
 
 	if(count == n) {

--- a/dttools/src/jx_parse.c
+++ b/dttools/src/jx_parse.c
@@ -662,7 +662,6 @@ struct jx * jx_parser_yield( struct jx_parser *p )
 {
 	struct jx * j = jx_parse(p);
 	if(jx_parser_errors(p)) {
-		jx_parser_delete(p);
 		jx_delete(j);
 		return 0;
 	}


### PR DESCRIPTION
 Do not delete parser on error for yield, let caller see errors. If yield calls delete, the outside call has no way of knowing delete should not be called again.