### PR TITLE
Add jx_count_obj_test and libforce_halt_enospc.so to .gitignore

### DIFF
--- a/dttools/src/.gitignore
+++ b/dttools/src/.gitignore
@@ -22,3 +22,5 @@ work_queue_worker
 work_queue_workload_simulator
 worker
 worker_condor_submit
+libforce_halt_enospc.so
+jx_count_obj_test


### PR DESCRIPTION
These binaries keep showing up in my `git status`