### PR TITLE
Handle symbolic links within Chirp root.

### DIFF
--- a/chirp/src/chirp_fs_local.c
+++ b/chirp/src/chirp_fs_local.c
@@ -21,19 +21,19 @@ See the file COPYING for details.
 #include <utime.h>
 
 #if defined(HAS_ATTR_XATTR_H)
-#include <attr/xattr.h>
+#	include <attr/xattr.h>
 #elif defined(HAS_SYS_XATTR_H)
-#include <sys/xattr.h>
+#	include <sys/xattr.h>
 #endif
 
 #include <sys/mount.h>
 #include <sys/param.h>
 #include <sys/stat.h>
 #ifdef HAS_SYS_STATFS_H
-#include <sys/statfs.h>
+#	include <sys/statfs.h>
 #endif
 #ifdef HAS_SYS_STATVFS_H
-#include <sys/statvfs.h>
+#	include <sys/statvfs.h>
 #endif
 
 #include <assert.h>

--- a/chirp/src/chirp_fs_local.h
+++ b/chirp/src/chirp_fs_local.h
@@ -11,7 +11,7 @@ See the file COPYING for details.
 
 extern struct chirp_filesystem chirp_fs_local;
 
-int chirp_fs_local_resolve (const char *path, char resolved[CHIRP_PATH_MAX]);
+int chirp_fs_local_resolve (const char *path, int *dirfd, char basename[CHIRP_PATH_MAX], int follow);
 
 #endif
 

--- a/chirp/src/chirp_fs_local_scheduler.c
+++ b/chirp/src/chirp_fs_local_scheduler.c
@@ -13,6 +13,8 @@
  * o binding of symlink outputs does not follow transaction semantics (also use intermediate file with rename?)
  */
 
+#include "compat-at.h"
+
 #include "catch.h"
 #include "chirp_acl.h"
 #include "chirp_client.h"
@@ -207,7 +209,7 @@ static int interpolate (chirp_jobid_t id, int sandboxfd, const char *task_path, 
 	int fd = -1;
 	char *mark;
 
-	CATCHUNIX(fd = openat(sandboxfd, task_path, O_RDONLY|O_CLOEXEC|O_NOFOLLOW|O_NOCTTY));
+	CATCHUNIX(fd = openat(sandboxfd, task_path, O_RDONLY|O_CLOEXEC|O_NOFOLLOW|O_NOCTTY, 0));
 
 	for (mark = serv_path; (mark = strchr(mark, '%')); ) {
 		switch (mark[1]) {
@@ -336,7 +338,7 @@ static int bindfile (sqlite3 *db, chirp_jobid_t id, const char *subject, const c
 				CATCHUNIX(linkat(serv_path_dirfd, serv_path_basename, sandboxfd, task_path, 0));
 				CATCHUNIX(fchmodat(sandboxfd, task_path, S_IRWXU, 0));
 			} else if (strcmp(binding, "COPY") == 0) {
-				int fdin = openat(serv_path_dirfd, serv_path_basename, O_RDONLY);
+				int fdin = openat(serv_path_dirfd, serv_path_basename, O_RDONLY, 0);
 				CATCHUNIX(fdin);
 				int fdout = openat(sandboxfd, task_path, O_WRONLY|O_CREAT|O_TRUNC, S_IRWXU);
 				CATCHUNIX(fdout);
@@ -356,7 +358,7 @@ static int bindfile (sqlite3 *db, chirp_jobid_t id, const char *subject, const c
 				CATCHUNIX(linkat(sandboxfd, task_path, serv_path_dirfd, serv_path_basename, 0));
 			} else if (strcmp(binding, "COPY") == 0) {
 				int fdin, fdout;
-				CATCHUNIX(fdin = openat(sandboxfd, task_path, O_RDONLY));
+				CATCHUNIX(fdin = openat(sandboxfd, task_path, O_RDONLY, 0));
 				CATCHUNIX(fdout = openat(serv_path_dirfd, serv_path_basename, O_CREAT|O_TRUNC|O_WRONLY|O_NOFOLLOW, S_IRWXU));
 				CATCHUNIX(fchmod(fdout, S_IRWXU));
 				CATCHUNIX(copy_fd_to_fd(fdin, fdout));

--- a/chirp/src/chirp_fs_local_scheduler.c
+++ b/chirp/src/chirp_fs_local_scheduler.c
@@ -30,11 +30,13 @@
 #include "domain_name.h"
 #include "fd.h"
 #include "md5.h"
+#include "mkdir_recursive.h"
 #include "path.h"
 #include "pattern.h"
+#include "random.h"
 #include "sha1.h"
-#include "string_array.h"
 #include "sigdef.h"
+#include "string_array.h"
 #include "unlink_recursive.h"
 
 #include <unistd.h>
@@ -52,9 +54,12 @@
 #include <stdint.h>
 #include <string.h>
 
-
-extern char chirp_hostname[DOMAIN_NAME_MAX];
-extern int chirp_port;
+#ifndef O_CLOEXEC
+#	define O_CLOEXEC 0
+#endif
+#ifndef O_NOFOLLOW
+#	define O_NOFOLLOW 0
+#endif
 
 struct url_binding {
 	char path[PATH_MAX]; /* task_path */
@@ -151,38 +156,58 @@ out:
 static int sandbox_create (char sandbox[PATH_MAX], chirp_jobid_t id)
 {
 	int rc;
-	char path[PATH_MAX] = "";
+	int i;
+	int serv_path_dirfd = -1;
 
-	CATCHUNIX(snprintf(path, PATH_MAX, "/.__job.%" PRICHIRP_JOBID_T ".XXXXXX", id));
-	if (rc >= PATH_MAX)
-		CATCH(ENAMETOOLONG);
-	CATCHUNIX(chirp_fs_local_resolve(path, sandbox));
-	CATCHUNIX(mkdtemp(sandbox) ? 0 : -1);
+	{
+		char _basename[PATH_MAX];
+		CATCHUNIX(chirp_fs_local_resolve("/", &serv_path_dirfd, _basename, 0));
+	}
+
+	for (i = 0; i < 10; i++) {
+		char guid[10 + 1] = "";
+		random_hex(guid, sizeof(guid));
+		CATCHUNIX(snprintf(sandbox, PATH_MAX, ".__job.%" PRICHIRP_JOBID_T ".%s", id, guid));
+		if (rc >= PATH_MAX)
+			CATCH(ENAMETOOLONG);
+		rc = mkdirat(serv_path_dirfd, sandbox, S_IRWXU);
+		if (rc == 0)
+			break;
+	}
+
 	debug(D_DEBUG, "created new sandbox `%s'", sandbox);
 
 	rc = 0;
 	goto out;
 out:
+	close(serv_path_dirfd);
 	return rc;
 }
 
 static int sandbox_delete (const char *sandbox)
 {
 	int rc;
+	int serv_path_dirfd = -1;
+	char serv_path_basename[PATH_MAX];
 
-	CATCHUNIX(unlink_recursive(sandbox));
+	CATCHUNIX(chirp_fs_local_resolve(sandbox, &serv_path_dirfd, serv_path_basename, 0));
+	CATCHUNIX(unlinkat_recursive(serv_path_dirfd, serv_path_basename));
 
 	rc = 0;
 	goto out;
 out:
+	close(serv_path_dirfd);
 	return rc;
 }
 
 #define MAX_SIZE_HASH  (1<<24)
-static int interpolate (chirp_jobid_t id, char task_path[CHIRP_PATH_MAX], char serv_path[CHIRP_PATH_MAX])
+static int interpolate (chirp_jobid_t id, int sandboxfd, const char *task_path, char serv_path[CHIRP_PATH_MAX])
 {
 	int rc;
+	int fd = -1;
 	char *mark;
+
+	CATCHUNIX(fd = openat(sandboxfd, task_path, O_RDONLY|O_CLOEXEC|O_NOFOLLOW|O_NOCTTY));
 
 	for (mark = serv_path; (mark = strchr(mark, '%')); ) {
 		switch (mark[1]) {
@@ -193,14 +218,14 @@ static int interpolate (chirp_jobid_t id, char task_path[CHIRP_PATH_MAX], char s
 				/* replace with hash of task_path */
 				unsigned char digest[SHA1_DIGEST_LENGTH];
 				if (mark[1] == 'h')
-					CATCHUNIX(sha1_file(task_path, digest) ? 0 : -1);
+					CATCHUNIX(sha1_fd(fd, digest) ? 0 : -1);
 				else if (mark[1] == 'g')
 					sqlite3_randomness(SHA1_DIGEST_LENGTH, digest);
 				else if (mark[1] == 's') {
 					struct stat64 buf;
-					CATCHUNIX(stat64(task_path, &buf));
+					CATCHUNIX(fstat64(fd, &buf));
 					if (buf.st_size <= MAX_SIZE_HASH) {
-						CATCHUNIX(sha1_file(task_path, digest) ? 0 : -1);
+						CATCHUNIX(sha1_fd(fd, digest) ? 0 : -1);
 					} else {
 						sqlite3_randomness(SHA1_DIGEST_LENGTH, digest);
 					}
@@ -245,6 +270,7 @@ static int interpolate (chirp_jobid_t id, char task_path[CHIRP_PATH_MAX], char s
 	rc = 0;
 	goto out;
 out:
+	close(fd);
 	return rc;
 }
 
@@ -259,23 +285,27 @@ static int bindfile (sqlite3 *db, chirp_jobid_t id, const char *subject, const c
 	int rc;
 	sqlite3_stmt *stmt = NULL;
 	const char *current = SQL;
-
-	char task_path_resolved[CHIRP_PATH_MAX] = "";
+	char task_path_dir[PATH_MAX] = ""; /* directory containing task_path_resolved */
+	int sandboxfd = -1;
+	int  serv_path_dirfd = -1;
+	char serv_path_basename[CHIRP_PATH_MAX];;
 	char serv_path_interpolated[CHIRP_PATH_MAX] = "";
-	char serv_path_resolved[CHIRP_PATH_MAX] = "";
-	char task_path_dir[CHIRP_PATH_MAX] = ""; /* directory containing task_path_resolved */
 
-	CATCHUNIX(snprintf(task_path_resolved, sizeof(task_path_resolved), "%s/%s", sandbox, task_path));
-	if ((size_t)rc >= sizeof(task_path_resolved))
-		CATCH(ENAMETOOLONG);
-	path_dirname(task_path_resolved, task_path_dir);
+	{
+		char _sandbox[PATH_MAX];
+		char _basename[PATH_MAX];
+		CATCHUNIX(snprintf(_sandbox, PATH_MAX, "%s/.", sandbox));
+		CATCHUNIX(chirp_fs_local_resolve(_sandbox, &sandboxfd, _basename, 0));
+	}
+
+	path_dirname(task_path, task_path_dir);
 
 	if (strcmp(binding, "URL") == 0) {
 		if (strcmp(type, "INPUT") != 0)
 			CATCH(EINVAL);
 		if (mode == BOOTSTRAP) {
 			debug(D_DEBUG, "binding `%s' for future URL fetch `%s'", task_path, serv_path);
-			CATCHUNIX(create_dir(task_path_dir, S_IRWXU) ? 0 : -1);
+			CATCHUNIX(mkdirat_recursive(sandboxfd, task_path_dir, S_IRWXU));
 			struct url_binding *url = malloc(sizeof(struct url_binding));
 			CATCHUNIX(url ? 0 : -1);
 			memset(url, 0, sizeof(struct url_binding));
@@ -292,22 +322,29 @@ static int bindfile (sqlite3 *db, chirp_jobid_t id, const char *subject, const c
 
 	strncpy(serv_path_interpolated, serv_path, sizeof(serv_path_interpolated)-1);
 	if (mode == STRAPBOOT && strcmp(type, "OUTPUT") == 0)
-		CATCH(interpolate(id, task_path_resolved, serv_path_interpolated));
+		CATCH(interpolate(id, sandboxfd, task_path, serv_path_interpolated));
 	serv_path = serv_path_interpolated;
-	CATCH(chirp_fs_local_resolve(serv_path, serv_path_resolved));
+	CATCHUNIX(chirp_fs_local_resolve(serv_path, &serv_path_dirfd, serv_path_basename, 1));
 
 	if (mode == BOOTSTRAP) {
 		debug(D_DEBUG, "binding `%s' as `%s'", task_path, serv_path);
 
-		CATCHUNIX(create_dir(task_path_dir, S_IRWXU) ? 0 : -1);
+		CATCHUNIX(mkdirat_recursive(sandboxfd, task_path_dir, S_IRWXU));
 
 		if (strcmp(type, "INPUT") == 0) {
 			if (strcmp(binding, "LINK") == 0) {
-				CATCHUNIX(link(serv_path_resolved, task_path_resolved));
+				CATCHUNIX(linkat(serv_path_dirfd, serv_path_basename, sandboxfd, task_path, 0));
+				CATCHUNIX(fchmodat(sandboxfd, task_path, S_IRWXU, 0));
 			} else if (strcmp(binding, "COPY") == 0) {
-				CATCHUNIX(copy_file_to_file(serv_path_resolved, task_path_resolved));
+				int fdin = openat(serv_path_dirfd, serv_path_basename, O_RDONLY);
+				CATCHUNIX(fdin);
+				int fdout = openat(sandboxfd, task_path, O_WRONLY|O_CREAT|O_TRUNC, S_IRWXU);
+				CATCHUNIX(fdout);
+				CATCHUNIX(copy_fd_to_fd(fdin, fdout));
+				CATCHUNIX(fchmod(fdout, S_IRWXU));
+				CATCHUNIX(close(fdin));
+				CATCHUNIX(close(fdout));
 			} else assert(0);
-			CATCHUNIX(chmod(serv_path_resolved, S_IRWXU));
 		}
 	} else if (mode == STRAPBOOT) {
 		if (strcmp(type, "OUTPUT") == 0) {
@@ -315,14 +352,19 @@ static int bindfile (sqlite3 *db, chirp_jobid_t id, const char *subject, const c
 
 			debug(D_DEBUG, "binding output file `%s' as `%s'", task_path, serv_path);
 			if (strcmp(binding, "LINK") == 0) {
-				CATCHUNIXIGNORE(unlink(serv_path_resolved), ENOENT); /* ignore error/success */
-				CATCHUNIX(link(task_path_resolved, serv_path_resolved));
+				CATCHUNIXIGNORE(unlinkat(serv_path_dirfd, serv_path_basename, 0), ENOENT); /* ignore error/success */
+				CATCHUNIX(linkat(sandboxfd, task_path, serv_path_dirfd, serv_path_basename, 0));
 			} else if (strcmp(binding, "COPY") == 0) {
-				CATCHUNIXIGNORE(unlink(serv_path_resolved), ENOENT);
-				CATCHUNIX(copy_file_to_file(task_path_resolved, serv_path_resolved));
+				int fdin, fdout;
+				CATCHUNIX(fdin = openat(sandboxfd, task_path, O_RDONLY));
+				CATCHUNIX(fdout = openat(serv_path_dirfd, serv_path_basename, O_CREAT|O_TRUNC|O_WRONLY|O_NOFOLLOW, S_IRWXU));
+				CATCHUNIX(fchmod(fdout, S_IRWXU));
+				CATCHUNIX(copy_fd_to_fd(fdin, fdout));
+				CATCHUNIX(close(fdin));
+				CATCHUNIX(close(fdout));
 			}
 
-			if (stat(serv_path_resolved, &info) == 0) {
+			if (fstatat(serv_path_dirfd, serv_path_basename, &info, AT_SYMLINK_NOFOLLOW) == 0) {
 				sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
 				sqlcatch(sqlite3_bind_text(stmt, 1, serv_path, -1, SQLITE_STATIC));
 				sqlcatch(sqlite3_bind_int64(stmt, 2, info.st_size));
@@ -338,6 +380,8 @@ static int bindfile (sqlite3 *db, chirp_jobid_t id, const char *subject, const c
 	goto out;
 out:
 	sqlite3_finalize(stmt);
+	close(sandboxfd);
+	close(serv_path_dirfd);
 	return rc;
 }
 
@@ -419,59 +463,6 @@ out:
 	return rc;
 }
 
-static const char *readenv (char *const *env, const char *name)
-{
-	for (; *env; env++)
-		if (strncmp(*env, name, strlen(name)) == 0 && (*env)[strlen(name)] == '=')
-			return &(*env)[strlen(name)+1];
-	return NULL;
-}
-
-static int envinsert (char ***env, const char *name, const char *fmt, ...)
-{
-	int rc;
-	buffer_t B[1];
-	buffer_init(B);
-
-	if (!readenv(*env, name)) {
-		va_list ap;
-
-		CATCHUNIX(buffer_putfstring(B, "%s=", name));
-
-		va_start(ap, fmt);
-		rc = buffer_putvfstring(B, fmt, ap);
-		va_end(ap);
-		CATCHUNIX(rc);
-		*env = string_array_append(*env, buffer_tostring(B));
-	}
-
-	rc = 0;
-	goto out;
-out:
-	buffer_free(B);
-	return rc;
-}
-
-static int envdefaults (char ***env, chirp_jobid_t id, const char *subject, const char *sandbox)
-{
-	int rc;
-
-	CATCH(envinsert(env, "CHIRP_SUBJECT", "%s", subject));
-	CATCH(envinsert(env, "CHIRP_HOST", "%s:%d", chirp_hostname, chirp_port));
-	CATCH(envinsert(env, "HOME", "%s", sandbox));
-	CATCH(envinsert(env, "LANG", "C"));
-	CATCH(envinsert(env, "LC_ALL", "C"));
-	CATCH(envinsert(env, "PATH", "/bin:/usr/bin:/usr/local/bin"));
-	CATCH(envinsert(env, "PWD", "%s", sandbox));
-	CATCH(envinsert(env, "TMPDIR", "%s", sandbox));
-	CATCH(envinsert(env, "USER", "chirp"));
-
-	rc = 0;
-	goto out;
-out:
-	return rc;
-}
-
 static int jgetenv (sqlite3 *db, chirp_jobid_t id, const char *subject, const char *sandbox, char ***env)
 {
 	static const char SQL[] =
@@ -503,7 +494,6 @@ static int jgetenv (sqlite3 *db, chirp_jobid_t id, const char *subject, const ch
 	}
 	sqlcatchcode(rc, SQLITE_DONE);
 	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
-	CATCH(envdefaults(env, id, subject, sandbox)); /* ideally these would be set at the start and then replaced but it's awkward to replace entries in the char *[] */
 
 	rc = 0;
 	goto out;
@@ -612,20 +602,105 @@ out:
 	return rc;
 }
 
-static void run (const char *sandbox, const char *path, char *const argv[], char *const envp[], const struct url_binding *urls)
+static const char *readenv (char *const *env, const char *name)
+{
+	for (; *env; env++)
+		if (strncmp(*env, name, strlen(name)) == 0 && (*env)[strlen(name)] == '=')
+			return &(*env)[strlen(name)+1];
+	return NULL;
+}
+
+static int envdefaults (char ***env, chirp_jobid_t id, const char *subject)
+{
+	extern char chirp_hostname[DOMAIN_NAME_MAX];
+	extern int chirp_port;
+
+	int rc;
+	char cwd[PATH_MAX] = "";
+	buffer_t B[1];
+
+	buffer_init(B);
+	CATCHUNIX(getcwd(cwd, sizeof(cwd)) == NULL ? -1 : 0);
+
+	if (!readenv(*env, "CHIRP_HOST")) {
+		buffer_rewind(B, 0);
+		CATCHUNIX(buffer_putfstring(B, "CHIRP_HOST=%s:%d", chirp_hostname, chirp_port));
+		*env = string_array_append(*env, buffer_tostring(B));
+	}
+	if (!readenv(*env, "CHIRP_SUBJECT")) {
+		buffer_rewind(B, 0);
+		CATCHUNIX(buffer_putfstring(B, "CHIRP_SUBJECT=%s", subject));
+		*env = string_array_append(*env, buffer_tostring(B));
+	}
+	if (!readenv(*env, "HOME")) {
+		buffer_rewind(B, 0);
+		CATCHUNIX(buffer_putfstring(B, "HOME=%s", cwd));
+		*env = string_array_append(*env, buffer_tostring(B));
+	}
+	if (!readenv(*env, "LANG")) {
+		buffer_rewind(B, 0);
+		CATCHUNIX(buffer_putliteral(B, "LANG=C"));
+		*env = string_array_append(*env, buffer_tostring(B));
+	}
+	if (!readenv(*env, "LC_ALL")) {
+		buffer_rewind(B, 0);
+		CATCHUNIX(buffer_putliteral(B, "LC_ALL=C"));
+		*env = string_array_append(*env, buffer_tostring(B));
+	}
+	if (!readenv(*env, "PATH")) {
+		buffer_rewind(B, 0);
+		CATCHUNIX(buffer_putliteral(B, "PATH=/bin:/usr/bin:/usr/local/bin"));
+		*env = string_array_append(*env, buffer_tostring(B));
+	}
+	if (!readenv(*env, "PWD")) {
+		buffer_rewind(B, 0);
+		CATCHUNIX(buffer_putfstring(B, "PWD=%s", cwd));
+		*env = string_array_append(*env, buffer_tostring(B));
+	}
+	if (!readenv(*env, "TMPDIR")) {
+		buffer_rewind(B, 0);
+		CATCHUNIX(buffer_putfstring(B, "TMPDIR=%s", cwd));
+		*env = string_array_append(*env, buffer_tostring(B));
+	}
+	if (!readenv(*env, "USER")) {
+		buffer_rewind(B, 0);
+		CATCHUNIX(buffer_putliteral(B, "USER=chirp"));
+		*env = string_array_append(*env, buffer_tostring(B));
+	}
+
+	rc = 0;
+	goto out;
+out:
+	buffer_free(B);
+	return rc;
+}
+
+static void run (chirp_jobid_t id, const char *sandbox, const char *subject, const char *path, char *const argv[], char ***env, const struct url_binding *urls)
 {
 	int rc;
-	/* TODO don't propagate CHIRP_CLIENT_TICKETS across execve. */
+	int sandboxfd = -1;
 
 	signal(SIGUSR1, SIG_DFL);
+
+	/* create new process group */
+	CATCHUNIX(setpgid(0, 0));
+
+	/* change to sandbox directory */
+	{
+		char _sandbox[PATH_MAX];
+		char _basename[PATH_MAX];
+		CATCHUNIX(snprintf(_sandbox, PATH_MAX, "%s/.", sandbox));
+		CATCHUNIX(chirp_fs_local_resolve(_sandbox, &sandboxfd, _basename, 0));
+		CATCHUNIX(fchdir(sandboxfd));
+		CATCHUNIX(close(sandboxfd));
+		sandboxfd = -1;
+	}
 
 	/* reassign std files and close everything else */
 	CATCH(fd_nonstd_close());
 	CATCH(fd_null(STDIN_FILENO, O_RDONLY));
 	CATCH(fd_null(STDOUT_FILENO, O_WRONLY));
 	CATCH(fd_null(STDERR_FILENO, O_WRONLY));
-	CATCHUNIX(chdir(sandbox));
-	CATCHUNIX(setpgid(0, 0)); /* create new process group */
 
 	/* write debug information to `debug': can be examined by the user by adding an OUTPUT file */
 	debug_config("chirp@job");
@@ -633,6 +708,8 @@ static void run (const char *sandbox, const char *path, char *const argv[], char
 	debug_flags_set("all");
 	debug_config_file(".chirp.debug");
 	cctools_version_debug(D_DEBUG, "chirp@job");
+
+	envdefaults(env, id, subject);
 
 #if defined(__linux__) && defined(SYS_ioprio_get)
 	/* Reduce the iopriority of jobs below the scheduler. */
@@ -649,7 +726,7 @@ static void run (const char *sandbox, const char *path, char *const argv[], char
 	/* order matters! */
 	auth_clear();
 	auth_ticket_register();
-	auth_ticket_load(readenv(envp, CHIRP_CLIENT_TICKETS));
+	auth_ticket_load(readenv(*env, CHIRP_CLIENT_TICKETS));
 	auth_hostname_register();
 	auth_address_register();
 
@@ -662,9 +739,9 @@ static void run (const char *sandbox, const char *path, char *const argv[], char
 	}
 
 	if (strcmp(path, "@put") == 0) {
-		do_put(argv, envp);
+		do_put(argv, *env);
 	} else if (strcmp(path, "@hash") == 0) {
-		do_hash(argv, envp);
+		do_hash(argv, *env);
 	} else {
 		buffer_t B[1];
 		buffer_init(B);
@@ -677,23 +754,25 @@ static void run (const char *sandbox, const char *path, char *const argv[], char
 		}
 		debug(D_CHIRP, "execve('%s', [%s], [...])", path, buffer_tostring(B));
 		buffer_free(B);
-		CATCHUNIX(execve(path, argv, envp));
+		/* TODO don't propagate CHIRP_CLIENT_TICKETS across execve. */
+		CATCHUNIX(execve(path, argv, *env));
 	}
 
 	rc = 0;
 	goto out;
 out:
 	debug(D_FATAL, "execution failed: %s", strerror(rc));
+	close(sandboxfd);
 	raise(SIGUSR1); /* signal abnormal termination before program starts */
 	abort();
 }
 
-static int jexecute (pid_t *pid, chirp_jobid_t id, const char *sandbox, const char *path, char *const argv[], char *const envp[], const struct url_binding *urls)
+static int jexecute (pid_t *pid, chirp_jobid_t id, const char *subject, const char *sandbox, const char *path, char *const argv[], char ***env, const struct url_binding *urls)
 {
 	int rc = 0;
 	*pid = fork();
 	if (*pid == 0) { /* child */
-		run(sandbox, path, argv, envp, urls);
+		run(id, sandbox, subject, path, argv, env, urls);
 	} else if (*pid > 0) { /* parent */
 		setpgid(*pid, 0); /* handle race condition */
 		debug(D_CHIRP, "job %" PRICHIRP_JOBID_T " started as pid %d", id, (int)*pid);
@@ -738,7 +817,7 @@ static int jstart (sqlite3 *db, chirp_jobid_t id, const char *executable, const 
 	CATCH(jgetargs(db, id, &arguments));
 	CATCH(jgetenv(db, id, subject, sandbox, &environment));
 	CATCH(jbindfiles(db, id, subject, sandbox, &urls, BOOTSTRAP));
-	CATCH(jexecute(&pid, id, sandbox, executable, arguments, environment, urls));
+	CATCH(jexecute(&pid, id, subject, sandbox, executable, arguments, &environment, urls));
 
 	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
 	sqlcatch(sqlite3_bind_int64(stmt, 1, (sqlite3_int64)id));

--- a/chirp/test/TR_chirp_symlinks.sh
+++ b/chirp/test/TR_chirp_symlinks.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+set -e
+
+. ../../dttools/test/test_runner_common.sh
+. ./chirp-common.sh
+
+c="./hostport.$PPID"
+
+prepare()
+{
+	chirp_start local
+	echo "$hostport" > "$c"
+	return 0
+}
+
+run()
+{
+	if ! [ -s "$c" ]; then
+		return 0
+	fi
+	hostport=$(cat "$c")
+
+	chirp "$hostport" <<EOF
+mkdir foo
+mkdir foo/bar
+ln -s ../foo foo/baz
+ln -s ../../ /baz
+stat baz
+stat /
+stat /baz/foo
+stat /baz/foo/bar
+stat /baz/foo/baz
+EOF
+	return 0
+}
+
+clean()
+{
+	chirp_clean
+	rm -f "$c"
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/configure
+++ b/configure
@@ -1218,6 +1218,7 @@ optional_function fdatasync /usr/include/unistd.h HAVE_FDATASYNC
 optional_function isnan /usr/include/math.h HAS_ISNAN HAVE_ISNAN SQLITE_HAVE_ISNAN
 optional_function localtime_r /usr/include/time.h HAVE_LOCALTIME_R
 optional_function localtime_s /usr/include/time.h HAVE_LOCALTIME_S
+optional_function openat /usr/include/fcntl.h HAS_OPENAT
 optional_function pread /usr/include/unistd.h HAS_PREAD USE_PREAD
 optional_function pread64 /usr/include/unistd.h USE_PREAD64
 optional_function pwrite /usr/include/unistd.h HAS_PWRITE USE_PWRITE

--- a/configure
+++ b/configure
@@ -1226,6 +1226,7 @@ optional_function strchrnul /usr/include/string.h HAVE_STRCHRNUL
 optional_function strsignal /usr/include/string.h HAS_STRSIGNAL
 optional_function usleep /usr/include/unistd.h HAS_USLEEP HAVE_USLEEP
 optional_function utime /usr/include/utime.h HAS_UTIME HAVE_UTIME
+optional_function utimensat /usr/include/sys/stat.h HAS_UTIMENSAT
 
 # sqlite3 uses define "HAVE_*"
 optional_include attr/xattr.h HAS_ATTR_XATTR_H

--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -19,6 +19,7 @@ SOURCES = \
 	change_process_title.c \
 	chunk.c \
 	clean_dir.c \
+	compat-at.c \
 	console_login.c \
 	copy_stream.c \
 	create_dir.c \

--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -69,6 +69,7 @@ SOURCES = \
 	md5.c \
 	memfdexe.c \
 	mergesort.c \
+	mkdir_recursive.c \
 	mt19937-64.c \
 	nvpair.c \
 	nvpair_jx.c \

--- a/dttools/src/catch.h
+++ b/dttools/src/catch.h
@@ -7,6 +7,8 @@
 #ifndef CATCH_H
 #define CATCH_H
 
+#include "debug.h"
+
 #include <errno.h>
 #include <string.h>
 

--- a/dttools/src/catch.h
+++ b/dttools/src/catch.h
@@ -22,7 +22,7 @@
 	do {\
 		rc = (expr);\
 		if (rc) {\
-			debug(D_DEBUG, "%s: %s:%d[%s] error: %d `%s'", __func__, __FILE__, __LINE__, CCTOOLS_SOURCE, rc, strerror(rc));\
+			debug(D_DEBUG, "%s: %s:%d[%s] error: %d `%s'", __func__, __FILE__, __LINE__, CCTOOLS_SOURCE, (int)rc, strerror((int)rc));\
 			goto out;\
 		}\
 	} while (0)
@@ -32,7 +32,7 @@
 		rc = (expr);\
 		if (rc == -1) {\
 			rc = errno;\
-			debug(D_DEBUG, "%s: %s:%d[%s] unix error: -1 (errno = %d) `%s'", __func__, __FILE__, __LINE__, CCTOOLS_SOURCE, rc, strerror(rc));\
+			debug(D_DEBUG, "%s: %s:%d[%s] unix error: -1 (errno = %d) `%s'", __func__, __FILE__, __LINE__, CCTOOLS_SOURCE, (int)rc, strerror((int)rc));\
 			goto out;\
 		}\
 	} while (0)
@@ -42,12 +42,12 @@
 		rc = (expr);\
 		if (rc == -1 && errno != err) {\
 			rc = errno;\
-			debug(D_DEBUG, "%s: %s:%d[%s] unix error: -1 (errno = %d) `%s'", __func__, __FILE__, __LINE__, CCTOOLS_SOURCE, rc, strerror(rc));\
+			debug(D_DEBUG, "%s: %s:%d[%s] unix error: -1 (errno = %d) `%s'", __func__, __FILE__, __LINE__, CCTOOLS_SOURCE, (int)rc, strerror((int)rc));\
 			goto out;\
 		}\
 	} while (0)
 
-#define RCUNIX(rc) (rc == 0 ? 0 : (errno = rc, -1))
+#define RCUNIX(rc) (rc == 0 ? 0 : (errno = (int)rc, -1))
 
 #endif
 

--- a/dttools/src/compat-at.c
+++ b/dttools/src/compat-at.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2016- The University of Notre Dame
+ * This software is distributed under the GNU General Public License.
+ * See the file COPYING for details.
+*/
+
+#if !defined(HAS_OPENAT) || !defined(HAS_UTIMENSAT)
+
+#include "compat-at.h"
+
+#include "debug.h"
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static int getfullpath (int dirfd, const char *path, char fullpath[PATH_MAX])
+{
+	char dirpath[PATH_MAX] = ".";
+	if (path[0] == '/') {
+		dirpath[0] = 0;
+	} else if (dirfd != AT_FDCWD) {
+#if defined(CCTOOLS_OPSYS_DARWIN)
+		if (fcntl(dirfd, F_GETPATH, dirpath) == -1)
+			return -1;
+#elif defined(CCTOOLS_OPSYS_LINUX)
+		char dirpath[PATH_MAX];
+		char procpath[PATH_MAX];
+		snprintf(procpath, PATH_MAX, "/proc/self/fd/%d", dirfd);
+		if (readlink(procpath, dirpath, PATH_MAX) == -1)
+			return -1;
+#else
+#	error "Cannot proceed without support for *at system calls."
+#endif
+	}
+	int rc = snprintf(fullpath, PATH_MAX, "%s/%s", dirpath, path);
+	if (rc == -1)
+		abort();
+	else if (rc >= PATH_MAX)
+		return (errno = ENAMETOOLONG, -1);
+	debug(D_DEBUG, "full path %s", fullpath);
+	return 0;
+}
+
+#ifndef HAS_OPENAT
+int cctools_faccessat (int dirfd, const char *path, int amode, int flag)
+{
+	char fullpath[PATH_MAX];
+	if (getfullpath(dirfd, path, fullpath) == -1)
+		return -1;
+	(void)flag;
+	return access(fullpath, amode);
+}
+
+int cctools_fchmodat (int dirfd, const char *path, mode_t mode, int flag)
+{
+	char fullpath[PATH_MAX];
+	if (getfullpath(dirfd, path, fullpath) == -1)
+		return -1;
+	(void)flag;
+	return chmod(fullpath, mode);
+}
+
+DIR *cctools_fdopendir (int dirfd)
+{
+	char fullpath[PATH_MAX];
+	if (getfullpath(dirfd, ".", fullpath) == -1)
+		return NULL;
+	return opendir(fullpath);
+}
+
+int cctools_fstatat (int dirfd, const char *path, struct stat *buf, int flag)
+{
+	char fullpath[PATH_MAX];
+	if (getfullpath(dirfd, path, fullpath) == -1)
+		return -1;
+	if (flag & AT_SYMLINK_NOFOLLOW) {
+		return lstat(fullpath, buf);
+	} else {
+		return stat(fullpath, buf);
+	}
+}
+
+int cctools_linkat (int dirfd, const char *path, int newdirfd, const char *newpath, int flag)
+{
+	char fullpath[PATH_MAX];
+	if (getfullpath(dirfd, path, fullpath) == -1)
+		return -1;
+	char newfullpath[PATH_MAX];
+	if (getfullpath(newdirfd, newpath, newfullpath) == -1)
+		return -1;
+	(void)flag;
+	return link(fullpath, newfullpath);
+}
+
+int cctools_openat (int dirfd, const char *path, int oflag, mode_t cmode)
+{
+	char fullpath[PATH_MAX];
+	if (getfullpath(dirfd, path, fullpath) == -1)
+		return -1;
+	return open(fullpath, oflag, cmode);
+}
+
+int cctools_mkdirat (int dirfd, const char *path, mode_t mode)
+{
+	char fullpath[PATH_MAX];
+	if (getfullpath(dirfd, path, fullpath) == -1)
+		return -1;
+	return mkdir(fullpath, mode);
+}
+
+int cctools_readlinkat (int dirfd, const char *path, char *buf, size_t bufsize)
+{
+	char fullpath[PATH_MAX];
+	if (getfullpath(dirfd, path, fullpath) == -1)
+		return -1;
+	return readlink(fullpath, buf, bufsize);
+}
+
+int cctools_renameat (int dirfd, const char *path, int newdirfd, const char *newpath)
+{
+	char fullpath[PATH_MAX];
+	if (getfullpath(dirfd, path, fullpath) == -1)
+		return -1;
+	char newfullpath[PATH_MAX];
+	if (getfullpath(newdirfd, newpath, newfullpath) == -1)
+		return -1;
+	return rename(fullpath, newfullpath);
+}
+
+int cctools_symlinkat (const char *target, int dirfd, const char *path)
+{
+	char fullpath[PATH_MAX];
+	if (getfullpath(dirfd, path, fullpath) == -1)
+		return -1;
+	return symlink(target, fullpath);
+}
+
+int cctools_unlinkat (int dirfd, const char *path, int flag)
+{
+	char fullpath[PATH_MAX];
+	if (getfullpath(dirfd, path, fullpath) == -1)
+		return -1;
+	if (flag == AT_REMOVEDIR) {
+		return rmdir(fullpath);
+	} else {
+		return unlink(fullpath);
+	}
+}
+#endif /* HAS_OPENAT */
+
+#ifndef HAS_UTIMENSAT
+int cctools_utimensat (int dirfd, const char *path, const struct timespec times[2], int flag)
+{
+	struct timeval tv[2] = {{.tv_sec = times[0].tv_sec}, {.tv_sec = times[1].tv_sec}};
+	char fullpath[PATH_MAX];
+	if (getfullpath(dirfd, path, fullpath) == -1)
+		return -1;
+	(void)flag;
+	return utimes(fullpath, tv);
+}
+#endif /* HAS_UTIMENSAT */
+
+#endif /* !defined(HAS_OPENAT) || !defined(HAS_UTIMENSAT) */
+
+/* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/compat-at.h
+++ b/dttools/src/compat-at.h
@@ -1,0 +1,64 @@
+/*
+Copyright (C) 2016- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#ifndef COMPAT_AT_H
+#define COMPAT_AT_H
+
+/** @file compat-at.h at syscall compatibility layer.
+*/
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <limits.h>
+
+#ifndef AT_FDCWD
+#	define AT_FDCWD -100
+#endif
+#ifndef AT_SYMLINK_NOFOLLOW
+#	define AT_SYMLINK_NOFOLLOW 1
+#endif
+#ifndef AT_REMOVEDIR
+#	define AT_REMOVEDIR 2
+#endif
+
+#ifndef HAS_OPENAT
+	int cctools_faccessat (int dirfd, const char *path, int amode, int flag);
+	int cctools_fchmodat (int dirfd, const char *path, mode_t mode, int flag);
+	DIR *cctools_fdopendir (int dirfd);
+	int cctools_fstatat (int dirfd, const char *path, struct stat *buf, int flag);
+	int cctools_linkat (int dirfd, const char *path, int newdirfd, const char *newpath, int flag);
+	int cctools_mkdirat (int dirfd, const char *path, mode_t mode);
+	int cctools_openat (int dirfd, const char *path, int oflag, mode_t cmode);
+	int cctools_readlinkat (int dirfd, const char *path, char *buf, size_t bufsize);
+	int cctools_renameat (int dirfd, const char *path, int newdirfd, const char *newpath);
+	int cctools_symlinkat (const char *target, int dirfd, const char *path);
+	int cctools_unlinkat (int dirfd, const char *path, int flag);
+#	define faccessat  cctools_faccessat
+#	define fchmodat   cctools_fchmodat
+#	define fdopendir  cctools_fdopendir
+#	define fstatat    cctools_fstatat
+#	define linkat     cctools_linkat
+#	define mkdirat    cctools_mkdirat
+#	define openat     cctools_openat
+#	define readlinkat cctools_readlinkat
+#	define renameat   cctools_renameat
+#	define symlinkat  cctools_symlinkat
+#	define unlinkat   cctools_unlinkat
+#endif /* HAS_OPENAT */
+
+/* utimensat added in Linux 2.6.22 */
+#ifndef HAS_UTIMENSAT
+	int cctools_utimensat (int dirfd, const char *path, const struct timespec times[2], int flag);
+#	define utimensat  cctools_utimensat
+#endif
+
+#endif /* COMPAT_AT_H */
+
+/* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/create_dir.c
+++ b/dttools/src/create_dir.c
@@ -1,80 +1,21 @@
 /*
-Copyright (C) 2003-2004 Douglas Thain and the University of Wisconsin
-Copyright (C) 2005- The University of Notre Dame
+Copyright (C) 2016- The University of Notre Dame
 This software is distributed under the GNU General Public License.
 See the file COPYING for details.
 */
 
-#include <unistd.h>
-#include <string.h>
-#include <errno.h>
-#include <stdlib.h>
-#include <sys/stat.h>
-#include <sys/types.h>
+#include "create_dir.h"
 
-int create_dir(const char *path, int mode)
+#include "mkdir_recursive.h"
+
+int create_dir (const char *path, mode_t mode)
 {
-	char *temp;
-	char *current;
-
-	current = temp = malloc(strlen(path) + 2);
-	strcpy(temp, path);
-	strcat(temp, "/");
-
-	while((current = strchr(current, '/'))) {
-		struct stat buf;
-		char oldchar = *current;
-		if (current == temp) {
-		  current += 1;
-		  continue;
-		}
-		*current = 0;
-		if (stat(temp, &buf) == 0) {
-			if (S_ISDIR(buf.st_mode)) {
-				/* continue */
-			} else {
-				free(temp);
-				errno = ENOTDIR;
-				return 0;
-			}
-		} else if (errno == ENOENT) {
-			if(mkdir(temp, mode)==0 || errno==EEXIST) {
-				/* continue */
-			} else {
-				free(temp);
-				// use errno from mkdir
-				return 0;
-			}
-		} else {
-			free(temp);
-			return 0;
-		}
-
-		*current = oldchar;
-		current += 1;
-	}
-
-	free(temp);
-	return 1;
+	return mkdir_recursive(path, mode) == 0 ? 1 : 0;
 }
 
-int create_dir_parents(const char *path, int mode)
+int create_dir_parents (const char *path, mode_t mode)
 {
-	int result = 0;
-
-	char *tmp = strdup(path);
-	char *slash = strrchr(tmp,'/');
-
-	if(slash && slash>tmp ) {
-		*slash = 0;
-		result = create_dir(tmp,mode);
-	} else {
-		result = 1;
-	}
-
-	free(tmp);
-	return result;
-
+	return mkdir_recursive_parents(path, mode) == 0 ? 1 : 0;
 }
 
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/create_dir.h
+++ b/dttools/src/create_dir.h
@@ -10,13 +10,15 @@ See the file COPYING for details.
 
 /** @file create_dir.h Create a new directory recursively. */
 
+#include <sys/stat.h>
+
 /** Create a new directory recursively.
 @param path The full path of a directory.  It is not necessary for all components of the path to exist.
 @param mode The desired unix mode bits of the directory and parents.
 @return One on success, zero on failure.
 */
 
-int create_dir(const char *path, int mode);
+int create_dir (const char *path, mode_t mode);
 
 /** Create needed parent directories of a file or directory.
 @param path The full path of a file or directory.
@@ -24,6 +26,8 @@ int create_dir(const char *path, int mode);
 @return One on success, zero on failure.
 */
 
-int create_dir_parents(const char *path, int mode);
+int create_dir_parents (const char *path, mode_t mode);
 
 #endif
+
+/* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/mkdir_recursive.c
+++ b/dttools/src/mkdir_recursive.c
@@ -1,0 +1,91 @@
+/*
+Copyright (C) 2003-2004 Douglas Thain and the University of Wisconsin
+Copyright (C) 2005- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include "mkdir_recursive.h"
+
+#include "catch.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+int mkdirat_recursive (int fd, const char *path, mode_t mode)
+{
+	int rc;
+	size_t i;
+
+	if (strlen(path) >= PATH_MAX)
+		CATCH(ENAMETOOLONG);
+
+	for (i = strspn(path, "/"); path[i]; i += strspn(path+i, "/")) {
+		char subpath[PATH_MAX] = "";
+		size_t nextdelim = strcspn(path+i, "/");
+
+		assert(i+nextdelim < PATH_MAX);
+		memcpy(subpath, path, i+nextdelim);
+
+		rc = mkdirat(fd, subpath, mode);
+		if (rc == -1) {
+			if (errno == EEXIST) {
+				struct stat info;
+				CATCHUNIX(fstatat(fd, subpath, &info, 0));
+				if (!S_ISDIR(info.st_mode))
+					CATCH(ENOTDIR);
+			} else {
+				CATCH(errno);
+			}
+		}
+
+		i += nextdelim;
+	}
+
+	rc = 0;
+	goto out;
+out:
+	return RCUNIX(rc);
+}
+
+int mkdir_recursive (const char *path, mode_t mode)
+{
+	return mkdirat_recursive(AT_FDCWD, path, mode);
+}
+
+int mkdirat_recursive_parents (int fd, const char *path, mode_t mode)
+{
+	int rc;
+	char parent[PATH_MAX] = "";
+	char *slash;
+
+	if (strlen(path) >= PATH_MAX)
+		CATCH(ENAMETOOLONG);
+
+	strcpy(parent, path);
+	slash = strrchr(parent+1, '/');
+	if (slash) {
+		*slash = 0;
+		CATCHUNIX(mkdirat_recursive(fd, parent, mode));
+	}
+
+	rc = 0;
+	goto out;
+out:
+	return RCUNIX(rc);
+}
+
+int mkdir_recursive_parents (const char *path, mode_t mode)
+{
+	return mkdirat_recursive_parents(AT_FDCWD, path, mode);
+}
+
+/* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/mkdir_recursive.h
+++ b/dttools/src/mkdir_recursive.h
@@ -7,6 +7,8 @@ See the file COPYING for details.
 #ifndef MKDIR_RECURSIVE_H
 #define MKDIR_RECURSIVE_H
 
+#include "compat-at.h"
+
 #include <fcntl.h>
 #include <sys/stat.h>
 

--- a/dttools/src/mkdir_recursive.h
+++ b/dttools/src/mkdir_recursive.h
@@ -1,0 +1,50 @@
+/*
+Copyright (C) 2015- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#ifndef MKDIR_RECURSIVE_H
+#define MKDIR_RECURSIVE_H
+
+#include <fcntl.h>
+#include <sys/stat.h>
+
+/** @file mkdir_recursive.h Create a new directory recursively. */
+
+/** Create a new directory recursively.
+@param fd The directory path is relative to.
+@param path The full path of a directory.  It is not necessary for all components of the path to exist.
+@param mode The desired unix mode bits of the directory and parents.
+@return -1 on failure, 0 on success.
+*/
+
+int mkdirat_recursive(int fd, const char *path, mode_t mode);
+
+/** Create a new directory recursively.
+@param path The full path of a directory.  It is not necessary for all components of the path to exist.
+@param mode The desired unix mode bits of the directory and parents.
+@return -1 on failure, 0 on success.
+*/
+
+int mkdir_recursive(const char *path, mode_t mode);
+
+
+/** Create needed parent directories of a file or directory.
+@param fd The directory path is relative to.
+@param path The full path of a file or directory.
+@param mode The desired unix mode bits of the parent directories.
+@return -1 on failure, 0 on success.
+*/
+
+int mkdirat_recursive_parents(int fd, const char *path, mode_t mode);
+
+/** Create needed parent directories of a file or directory.
+@param path The full path of a file or directory.
+@param mode The desired unix mode bits of the parent directories.
+@return -1 on failure, 0 on success.
+*/
+
+int mkdir_recursive_parents(const char *path, mode_t mode);
+
+#endif

--- a/dttools/src/sha1.h
+++ b/dttools/src/sha1.h
@@ -50,12 +50,14 @@ void sha1_buffer(const void *buffer, size_t length, unsigned char digest[SHA1_DI
 /** Checksum a local file.
 Note that this function produces a digest in binary form
 which  must be converted to a human readable form with @ref sha1_string.
-@param filename Path to the file to checksum.
+@param path Path to the file to checksum.
 @param digest Pointer to a buffer to store the digest.
 @return One on success, zero on failure.
 */
 
-int sha1_file(const char *filename, unsigned char digest[SHA1_DIGEST_LENGTH]);
+int sha1_file(const char *path, unsigned char digest[SHA1_DIGEST_LENGTH]);
+
+int sha1_fd(int fd, unsigned char digest[SHA1_DIGEST_LENGTH]);
 
 /** Convert an SHA1 digest into a printable string.
 @param digest A binary digest returned from @ref sha1_file.

--- a/dttools/src/unlink_recursive.c
+++ b/dttools/src/unlink_recursive.c
@@ -32,7 +32,7 @@ int unlinkat_recursive (int dirfd, const char *path)
 {
 	int rc = unlinkat(dirfd, path, 0);
 	if(rc == -1 && (errno == EISDIR || errno == EPERM || errno == ENOTEMPTY)) {
-		int subdirfd = openat(dirfd, path, O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW);
+		int subdirfd = openat(dirfd, path, O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW, 0);
 		if (subdirfd >= 0) {
 			DIR *dir = fdopendir(subdirfd);
 			if (dir) {
@@ -66,7 +66,7 @@ int unlink_recursive (const char *path)
 int unlink_dir_contents (const char *path)
 {
 	int rc;
-	int dirfd = openat(AT_FDCWD, path, O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOCTTY);
+	int dirfd = openat(AT_FDCWD, path, O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOCTTY, 0);
 	if (dirfd >= 0) {
 		DIR *dir = fdopendir(dirfd);
 		if (dir) {

--- a/dttools/src/unlink_recursive.h
+++ b/dttools/src/unlink_recursive.h
@@ -7,6 +7,10 @@ See the file COPYING for details.
 #ifndef UNLINK_RECURSIVE_H
 #define UNLINK_RECURSIVE_H
 
+#include "compat-at.h"
+
+#include <fcntl.h>
+
 /** @file unlink_recursive.h Unlink recursively. */
 
 /** Delete a path recursively.

--- a/dttools/src/unlink_recursive.h
+++ b/dttools/src/unlink_recursive.h
@@ -10,15 +10,22 @@ See the file COPYING for details.
 /** @file unlink_recursive.h Unlink recursively. */
 
 /** Delete a path recursively.
+@param fd Open directory.
+@param path The path relative to the open directory fd to unlink recursively.
+@return 0 on success, -1 on failure.
+*/
+int unlinkat_recursive (int fd, const char *path);
+
+/** Delete a path recursively.
 @param path The path to unlink recursively.
 @return 0 on success, -1 on failure.
 */
 int unlink_recursive (const char *path);
 
 /** Unlink only the contents of the directory recursively.
-@param dirname The path of the directory.
+@param path The path of the directory.
 @return 0 on success, -1 on failure.
 */
-int unlink_dir_contents (const char *dirname);
+int unlink_dir_contents (const char *path);
 
 #endif

--- a/dttools/test/TR_umr.sh
+++ b/dttools/test/TR_umr.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+. ../../dttools/test/test_runner_common.sh
+
+exe="$0.test"
+
+prepare()
+{
+	gcc -I../src/ -g -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
+#include "create_dir.h"
+#include "debug.h"
+#include "unlink_recursive.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define check(cmp,expr) \
+	do {\
+		int rc = (expr);\
+		if (!(cmp rc))\
+			fatal("[%s:%d]: unexpected failure: %s -> %d '%s'", __FILE__, __LINE__, #cmp " " #expr, rc, strerror(errno));\
+	} while (0)
+
+int main (int argc, char *argv[])
+{
+	debug_config(argv[0]);
+	debug_flags_set("all");
+	check(0 ==, mkdir("foo", S_IRWXU));
+	check(0 ==, mkdir("foo/bar", S_IRWXU));
+	check(0 ==, symlink("../", "foo/baz"));
+	check(0 ==, unlink_recursive("foo"));
+
+	check(1 ==, create_dir("foo/bar", 0777));
+	check(0 ==, access("foo/bar", F_OK));
+	check(0 ==, unlink_recursive("foo"));
+
+	return 0;
+}
+EOF
+	return $?
+}
+
+run()
+{
+	./"$exe"
+	return $?
+}
+
+clean()
+{
+	rm -f "$exe"
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:


### PR DESCRIPTION
This is solution 1b of issue #380.

Each operation involving a path is decomposed into components which are traversed. All symlinks are handled by Chirp without the kernel's help.

Fixes #380.
