### PR TITLE
Monitor fetch

### DIFF
--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -619,6 +619,19 @@ class Task(_object):
 
         return self._task.resources_measured
 
+    ##
+    # Get the resources the task exceeded. For valid field see @resources_measured.
+    #
+    @property
+    def limits_exceeded(self):
+        if not self._task.resources_measured:
+            return None
+
+        if not self._task.resources_measured.limits_exceeded:
+            return None
+
+        return self._task.resources_measured.limits_exceeded
+
 
     ##
     # Get the resources the task requested to run. For valid fields see @resources_measured.

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -241,6 +241,7 @@ static void add_task_report(struct work_queue *q, struct work_queue_task *t );
 
 static void commit_task_to_worker(struct work_queue *q, struct work_queue_worker *w, struct work_queue_task *t);
 static void reap_task_from_worker(struct work_queue *q, struct work_queue_worker *w, struct work_queue_task *t, work_queue_task_state_t new_state);
+static int cancel_task_on_worker(struct work_queue *q, struct work_queue_task *t, work_queue_task_state_t new_state);
 static void count_worker_resources(struct work_queue *q, struct work_queue_worker *w);
 
 static void push_task_to_ready_list( struct work_queue *q, struct work_queue_task *t );
@@ -1412,7 +1413,6 @@ static void fetch_output_from_worker(struct work_queue *q, struct work_queue_wor
 		q->stats->total_good_transfer_time += t->total_transfer_time;
 	}
 
-	int rschedule = 0;
 	if(t->result == WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION) {
 		q->stats->total_exhausted_execute_time += t->cmd_execution_time;
 		q->stats->total_exhausted_attempts++;
@@ -1422,26 +1422,7 @@ static void fetch_output_from_worker(struct work_queue *q, struct work_queue_wor
 
 		category_allocation_t next = category_next_label(q->categories, t->category, t->resource_request, /* resource overflow */ 1);
 
-		if(next == CATEGORY_ALLOCATION_AUTO_MAX) {
-			debug(D_WQ, "Task %d resubmitted using new resource allocation.\n", t->taskid);
-			t->resource_request = next;
-			change_task_state(q, t, WORK_QUEUE_TASK_WAITING_RESUBMISSION);
-			rschedule = 1;
-		} else {
-			debug(D_WQ, "Task %d failed given max resource exhaustion.\n", t->taskid);
-		}
-	}
-
-	if(rschedule == 0) {
-		add_task_report(q, t);
-		debug(D_WQ, "%s (%s) done in %.02lfs total tasks %lld average %.02lfs",
-				w->hostname,
-				w->addrport,
-				(t->time_receive_output_finish - t->time_send_input_start) / 1000000.0,
-				(long long) w->total_tasks_complete,
-				w->total_task_time / w->total_tasks_complete / 1000000.0);
-	} else if(t->resources_measured && t->resources_measured->limits_exceeded) {
-		struct jx *j = rmsummary_to_json(t->resources_requested->limits_exceeded, 1);
+		struct jx *j = rmsummary_to_json(t->resources_measured->limits_exceeded, 1);
 		if(j) {
 			char *str = jx_print_string(j);
 			debug(D_WQ, "Task %d exhausted resources on %s (%s): %s\n",
@@ -1452,7 +1433,24 @@ static void fetch_output_from_worker(struct work_queue *q, struct work_queue_wor
 			free(str);
 			jx_delete(j);
 		}
+
+		if(next == CATEGORY_ALLOCATION_AUTO_MAX) {
+			debug(D_WQ, "Task %d resubmitted using new resource allocation.\n", t->taskid);
+			t->resource_request = next;
+			change_task_state(q, t, WORK_QUEUE_TASK_READY);
+			return;
+		} else {
+			debug(D_WQ, "Task %d failed given max resource exhaustion.\n", t->taskid);
+		}
 	}
+
+	add_task_report(q, t);
+	debug(D_WQ, "%s (%s) done in %.02lfs total tasks %lld average %.02lfs",
+			w->hostname,
+			w->addrport,
+			(t->time_receive_output_finish - t->time_send_input_start) / 1000000.0,
+			(long long) w->total_tasks_complete,
+			w->total_task_time / w->total_tasks_complete / 1000000.0);
 
 	return;
 }
@@ -3589,9 +3587,10 @@ static int cancel_task_on_worker(struct work_queue *q, struct work_queue_task *t
 		reap_task_from_worker(q, w, t, new_state);
 
 		return 1;
+	} else {
+		change_task_state(q, t, new_state);
+		return 0;
 	}
-
-	return 0;
 }
 
 static struct work_queue_task *find_task_by_tag(struct work_queue *q, const char *tasktag) {
@@ -3675,7 +3674,10 @@ struct work_queue_task *work_queue_task_create(const char *command_line)
 	t->env_list = list_create();
 	t->return_status = -1;
 
+	t->result = WORK_QUEUE_RESULT_UNKNOWN;
+
 	t->resource_request   = CATEGORY_ALLOCATION_UNLABELED;
+
 
 	/* In the absence of additional information, a task consumes an entire worker. */
 	t->resources_requested = rmsummary_create(-1);
@@ -5378,7 +5380,7 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 
 		//Re-enqueue the tasks that workers labeled for resubmission.
 		while((t = task_state_any(q, WORK_QUEUE_TASK_WAITING_RESUBMISSION))) {
-			cancel_task_on_worker(q, t, WORK_QUEUE_TASK_READY);
+			change_task_state(q, t, WORK_QUEUE_TASK_READY);
 		}
 
 		//We have the resources we have been waiting for; start task transfers

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1403,7 +1403,10 @@ static void fetch_output_from_worker(struct work_queue *q, struct work_queue_wor
 	int rschedule = 0;
 	if(t->result == WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION) {
 		q->stats->total_exhausted_execute_time += t->cmd_execution_time;
-		q->stats->total_exhausted_retries ++;
+		q->stats->total_exhausted_attempts++;
+
+		t->total_cmd_exhausted_execute_time += t->cmd_execution_time;
+		t->exhausted_attempts++;
 
 		category_allocation_t next = category_next_label(q->categories, t->category, t->resource_request, /* resource overflow */ 1);
 
@@ -2040,7 +2043,7 @@ static struct jx * queue_to_jx( struct work_queue *q, struct link *foreman_uplin
 	jx_insert_integer(j,"total_execute_time",info.total_execute_time);
 	jx_insert_integer(j,"total_good_execute_time",info.total_good_execute_time);
 	jx_insert_integer(j,"total_exhausted_execute_time",info.total_exhausted_execute_time);
-	jx_insert_integer(j,"total_exhausted_retries",info.total_exhausted_retries);
+	jx_insert_integer(j,"total_exhausted_retries",info.total_exhausted_attempts);
 	jx_insert_string(j,"master_preferred_connection",q->master_preferred_connection);
 
 	// Add the blacklisted workers
@@ -5678,7 +5681,7 @@ void work_queue_get_stats(struct work_queue *q, struct work_queue_stats *s)
 	s->total_bytes_received = qs->total_bytes_received;
 	s->total_execute_time = qs->total_execute_time;
 	s->total_good_execute_time = qs->total_good_execute_time;
-	s->total_exhausted_retries = qs->total_exhausted_retries;
+	s->total_exhausted_attempts = qs->total_exhausted_attempts;
 	s->total_exhausted_execute_time = qs->total_exhausted_execute_time;
 
 	timestamp_t wall_clock_time = timestamp_get() - qs->start_time;

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -135,6 +135,8 @@ struct work_queue_task {
 	timestamp_t total_cmd_execution_time;                  /**< Accumulated time spent in microseconds for executing the command on any worker, regardless of whether the task finished (i.e., this includes time running on workers that disconnected). */
 	timestamp_t total_cmd_exhausted_execute_time;          /**< Accumulated time spent in microseconds spent in attempts that executed resources. */
 
+	timestamp_t total_time_until_worker_failure;           /**< Accumulated time for runs that terminated in worker failure/disconnection. */
+
 	int exhausted_attempts;                                /**< Number of times the task failed given exhausted resources. */
 
 	double priority;                                       /**< The priority of this task relative to others in the queue: higher number run earlier. */

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -133,6 +133,9 @@ struct work_queue_task {
 	timestamp_t cmd_execution_time;                        /**< Time spent in microseconds for executing the command until completion on a single worker. */
 	int total_submissions;                                 /**< The number of times the task has been submitted. */
 	timestamp_t total_cmd_execution_time;                  /**< Accumulated time spent in microseconds for executing the command on any worker, regardless of whether the task finished (i.e., this includes time running on workers that disconnected). */
+	timestamp_t total_cmd_exhausted_execute_time;          /**< Accumulated time spent in microseconds spent in attempts that executed resources. */
+
+	int exhausted_attempts;                                /**< Number of times the task failed given exhausted resources. */
 
 	double priority;                                       /**< The priority of this task relative to others in the queue: higher number run earlier. */
 
@@ -174,7 +177,7 @@ struct work_queue_stats {
 	int total_tasks_complete;       /**< Total number of tasks completed and returned to user. */
 	int total_tasks_failed;         /**< Total number of tasks completed and returned to user with result other than WQ_RESULT_SUCCESS. */
 	int total_tasks_cancelled;      /**< Total number of tasks cancelled. */
-	int total_exhausted_retries;    /**< Total number of retries given resource exhaustion. */
+	int total_exhausted_attempts;   /**< Total number of task executions that failed given resource exhaustion. */
 
 	timestamp_t start_time;         /**< Absolute time at which the master started. */
 	timestamp_t total_send_time;    /**< Total time in microseconds spent in sending data to workers. */
@@ -184,7 +187,6 @@ struct work_queue_stats {
 	timestamp_t total_execute_time;      /**< Total time in microseconds workers spent executing completed tasks. */
 	timestamp_t total_good_execute_time; /**< Total time in microseconds workers spent executing successful tasks. */
 	timestamp_t total_exhausted_execute_time; /**< Total time in microseconds workers spent on tasks that exhausted resources. */
-
 
 	int64_t total_bytes_sent;       /**< Total number of file bytes (not including protocol control msg bytes) sent out to the workers by the master. */
 	int64_t total_bytes_received;   /**< Total number of file bytes (not including protocol control msg bytes) received from the workers by the master. */

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -174,6 +174,7 @@ struct work_queue_stats {
 	int total_tasks_complete;       /**< Total number of tasks completed and returned to user. */
 	int total_tasks_failed;         /**< Total number of tasks completed and returned to user with result other than WQ_RESULT_SUCCESS. */
 	int total_tasks_cancelled;      /**< Total number of tasks cancelled. */
+	int total_exhausted_retries;    /**< Total number of retries given resource exhaustion. */
 
 	timestamp_t start_time;         /**< Absolute time at which the master started. */
 	timestamp_t total_send_time;    /**< Total time in microseconds spent in sending data to workers. */
@@ -182,6 +183,7 @@ struct work_queue_stats {
 
 	timestamp_t total_execute_time;      /**< Total time in microseconds workers spent executing completed tasks. */
 	timestamp_t total_good_execute_time; /**< Total time in microseconds workers spent executing successful tasks. */
+	timestamp_t total_exhausted_execute_time; /**< Total time in microseconds workers spent on tasks that exhausted resources. */
 
 
 	int64_t total_bytes_sent;       /**< Total number of file bytes (not including protocol control msg bytes) sent out to the workers by the master. */


### PR DESCRIPTION
On resource exhaustion, we just retrieve the summary for the task (retrieving all output files does not make sense, as the task was killed by the monitor.)

Also, we add to the stats the retries and time spent given resource exhaustion.