### PR TITLE
do not retry tasks that already went over maximum

### DIFF
--- a/dttools/src/category.h
+++ b/dttools/src/category.h
@@ -71,7 +71,8 @@ void category_delete(struct hash_table *categories, const char *name);
 void category_accumulate_summary(struct hash_table *categories, const char *category, struct rmsummary *rs);
 void category_update_first_allocation(struct hash_table *categories, const char *category);
 void categories_initialize(struct hash_table *categories, struct rmsummary *top, const char *summaries_file);
-category_allocation_t category_next_label(struct hash_table *categories, const char *category, category_allocation_t current_label, int resource_overflow);
 
-const struct rmsummary *category_task_dynamic_label(category_allocation_t request, struct rmsummary *max, struct rmsummary *first, struct rmsummary *user);
+category_allocation_t category_next_label(struct hash_table *categories, const char *category, category_allocation_t current_label, int resource_overflow, struct rmsummary *user, struct rmsummary *measured);
+
+const struct rmsummary *category_task_dynamic_label(struct rmsummary *max, struct rmsummary *first, struct rmsummary *user, category_allocation_t requested);
 #endif

--- a/makeflow/src/dag_node.c
+++ b/makeflow/src/dag_node.c
@@ -323,7 +323,7 @@ struct jx * dag_node_env_create( struct dag *d, struct dag_node *n )
 const struct rmsummary *dag_node_dynamic_label(struct dag_node *n) {
 	struct category *c = n->category;
 
-	return category_task_dynamic_label(n->resource_request, c->max_allocation, c->first_allocation, n->resources_requested);
+	return category_task_dynamic_label(c->max_allocation, c->first_allocation, n->resources_requested, n->resource_request);
 }
 
 /* vim: set noexpandtab tabstop=4: */

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -685,7 +685,7 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 				fprintf(stderr, "\n");
 			}
 
-			category_allocation_t next = category_next_label(d->categories, n->category->name, n->resource_request, /* resource overflow */ 1);
+			category_allocation_t next = category_next_label(d->categories, n->category->name, n->resource_request, /* resource overflow */ 1, n->resources_requested, n->resources_measured);
 
 			if(next == CATEGORY_ALLOCATION_AUTO_MAX) {
 				debug(D_MAKEFLOW_RUN, "Rule %d resubmitted using new resource allocation.\n", n->nodeid);


### PR DESCRIPTION
When tasks were first ran and exhausted resources, they were always retried regardless if they exhausted their maximum limit or a worker limit. Now they are only retried for worker limits.