### PR TITLE
Wq long wait status fix

### DIFF
--- a/dttools/src/buffer.c
+++ b/dttools/src/buffer.c
@@ -29,6 +29,7 @@
 
 void buffer_init(buffer_t * b)
 {
+	bzero(b->initial, sizeof(b->initial));
 	b->buf = b->end = b->initial;
 	b->len = sizeof(b->initial);
 	b->ubuf.buf = NULL;

--- a/dttools/src/jx_print.c
+++ b/dttools/src/jx_print.c
@@ -173,7 +173,11 @@ void jx_print_link( struct jx *j, struct link *l, time_t stoptime )
 	buffer_t buffer;
 	buffer_init(&buffer);
 	jx_print_buffer(j,&buffer);
-	link_write(l,buffer.buf,buffer.len,stoptime);
+
+	size_t len;
+	const char *str = buffer_tolstring(&buffer, &len);
+
+	link_write(l,str,len,stoptime);
 	buffer_free(&buffer);
 }
 

--- a/work_queue/src/work_queue_status.c
+++ b/work_queue/src/work_queue_status.c
@@ -41,7 +41,7 @@ typedef enum {
 
 static format_t format_mode = FORMAT_TABLE;
 static query_t query_mode = NO_QUERY;
-static int work_queue_status_timeout = 300;
+static int work_queue_status_timeout = 30;
 static char *catalog_host = NULL;
 static int catalog_port = 0;
 int catalog_size = CATALOG_SIZE;


### PR DESCRIPTION
wq_status would wait for jx_parse to receive an EOF from the master's jx_print_link. However, once the master sent a status message, it would not send anything else. This commit makes it so that the status worker is removed immediately after the status message is sent (wq_status is used in a one-shot manner anyway).

Along the way, a valgrind warning about an initialized buffer was silenced.