### PR TITLE
Add option to compile with -fsanitize=address and -fsanitize=undefined

### DIFF
--- a/configure
+++ b/configure
@@ -245,6 +245,7 @@ do
 		--debug)
 			optdebug=1
 			optstrict=1
+			optsanitize=1
 			;;
 		--prefix)
 			install_path=$(abspath "${arg}")

--- a/configure
+++ b/configure
@@ -231,7 +231,7 @@ do
 			opt=${opt%%=*}
 			;;
 			# empty arg only for these options
-		--debug|--strict|--without-*|--help)
+		--debug|--strict|--sanitize|--without-*|--help)
 			arg=''
 			;;
 		--*)
@@ -251,6 +251,9 @@ do
 			;;
 		--strict)
 			optstrict=1
+			;;
+		--sanitize)
+			optsanitize=1
 			;;
 		--sge-parameter)
 			if [ -z "$sge_parameters" ]
@@ -378,6 +381,7 @@ Where options are:
   --prefix             <path>
   --debug
   --strict
+  --sanitize
   --sge-parameter      <parameter>
   --globus-flavor      <flavor>
   --xrootd-arch        <arch>
@@ -510,6 +514,12 @@ then
 		ldflags=""
 else
 		ldflags="-static-libgcc"
+fi
+
+if [ "$optsanitize" = 1 ]; then
+	ccflags="${ccflags} -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined"
+	ldflags="-fsanitize=address -lasan -lubsan ${ldflags}"
+	test_ccflags="-lasan -lubsan"
 fi
 
 ##########################################################################
@@ -1443,6 +1453,7 @@ CCTOOLS_FUSE_CCFLAGS=${fuse_ccflags}
 
 CCTOOLS_GLOBUS_LDFLAGS=${globus_ldflags}
 CCTOOLS_GLOBUS_CCFLAGS=${globus_ccflags}
+export CCTOOLS_TEST_CCFLAGS=${test_ccflags}
 EOF
 
 echo ""

--- a/dttools/test/TR_b64.sh
+++ b/dttools/test/TR_b64.sh
@@ -6,7 +6,7 @@ exe="b64.test"
 
 prepare()
 {
-	gcc -I../src/ -g -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
+	gcc -I../src/ -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
 #include "b64.h"
 #include "buffer.h"
 #include "debug.h"

--- a/dttools/test/TR_buffer.sh
+++ b/dttools/test/TR_buffer.sh
@@ -6,7 +6,7 @@ exe="buffer.test"
 
 prepare()
 {
-	gcc -I../src/ -g -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
+	gcc -I../src/ -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
 #include "buffer.h"
 #include "debug.h"
 

--- a/dttools/test/TR_chunk_test.sh
+++ b/dttools/test/TR_chunk_test.sh
@@ -7,7 +7,7 @@ output="chunk.output"
 
 prepare()
 {
-	gcc -g -o "$exe" -I ../src/ -x c - -x none ../src/libdttools.a -lm <<EOF
+	gcc -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -I ../src/ -x c - -x none ../src/libdttools.a -lm <<EOF
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/dttools/test/TR_data_struct_set.sh
+++ b/dttools/test/TR_data_struct_set.sh
@@ -6,7 +6,7 @@ exe="data_struct_set.test"
 
 prepare()
 {
-	gcc -g -o "$exe" -I ../src/ -x c - -x none ../src/libdttools.a -lm <<EOF
+	gcc -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -I ../src/ -x c - -x none ../src/libdttools.a -lm <<EOF
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/dttools/test/TR_hmac_test.sh
+++ b/dttools/test/TR_hmac_test.sh
@@ -6,7 +6,7 @@ exe="hmac_test.test"
 
 prepare()
 {
-	gcc -g -o "$exe" -I ../src/ -x c - -x none ../src/libdttools.a -lm <<EOF
+	gcc -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -I ../src/ -x c - -x none ../src/libdttools.a -lm <<EOF
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/dttools/test/TR_path_basename.sh
+++ b/dttools/test/TR_path_basename.sh
@@ -6,7 +6,7 @@ exe="path_basename.test"
 
 prepare()
 {
-	gcc -g -o "$exe" -x c - -x none -I ../src ../src/libdttools.a -lm <<EOF
+	gcc -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none -I ../src ../src/libdttools.a -lm <<EOF
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/dttools/test/TR_path_collapse.sh
+++ b/dttools/test/TR_path_collapse.sh
@@ -6,7 +6,7 @@ exe="path_collapse.test"
 
 prepare()
 {
-	gcc -g -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
+	gcc -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/dttools/test/TR_path_dirname.sh
+++ b/dttools/test/TR_path_dirname.sh
@@ -6,7 +6,7 @@ exe="path_dirname.test"
 
 prepare()
 {
-	gcc -g -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
+	gcc -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/dttools/test/TR_path_extension.sh
+++ b/dttools/test/TR_path_extension.sh
@@ -6,7 +6,7 @@ exe="path_extension.test"
 
 prepare()
 {
-	gcc -g -o "$exe" -x c - -x none -I ../src ../src/libdttools.a -lm <<EOF
+	gcc -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none -I ../src ../src/libdttools.a -lm <<EOF
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/dttools/test/TR_path_remove_trailing_slashes.sh
+++ b/dttools/test/TR_path_remove_trailing_slashes.sh
@@ -6,7 +6,7 @@ exe="path_remove_trailing_slashes.test"
 
 prepare()
 {
-	gcc -g -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
+	gcc -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/dttools/test/TR_pattern.sh
+++ b/dttools/test/TR_pattern.sh
@@ -6,7 +6,7 @@ exe="pattern.test"
 
 prepare()
 {
-	gcc -I../src/ -g -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
+	gcc -I../src/ -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
 #include "pattern.h"
 #include "debug.h"
 

--- a/dttools/test/TR_stringtools.sh
+++ b/dttools/test/TR_stringtools.sh
@@ -6,7 +6,7 @@ exe="stringtools.test"
 
 prepare()
 {
-	gcc -g -o "$exe" -x c - -x none -I ../src ../src/libdttools.a -lm <<EOF
+	gcc -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none -I ../src ../src/libdttools.a -lm <<EOF
 #include "stringtools.h"
 
 #include <inttypes.h>

--- a/dttools/test/TR_umr.sh
+++ b/dttools/test/TR_umr.sh
@@ -6,7 +6,7 @@ exe="$0.test"
 
 prepare()
 {
-	gcc -I../src/ -g -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
+	gcc -I../src/ -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none ../src/libdttools.a -lm <<EOF
 #include "create_dir.h"
 #include "debug.h"
 #include "unlink_recursive.h"

--- a/parrot/test/TR_parrot_bind.sh
+++ b/parrot/test/TR_parrot_bind.sh
@@ -7,7 +7,7 @@ exe="socket.test"
 
 prepare()
 {
-	gcc -I../src/ -g -o "$exe" -x c - -x none -lm <<EOF
+	gcc -I../src/ -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none -lm <<EOF
 #include <unistd.h>
 #include <fcntl.h>
 

--- a/parrot/test/TR_parrot_cloexec.sh
+++ b/parrot/test/TR_parrot_cloexec.sh
@@ -7,7 +7,7 @@ exe="$0.test"
 
 prepare()
 {
-	gcc -I../src/ -g -o "$exe" -x c - -x none -lpthread -lm <<EOF
+	gcc -I../src/ -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none -lpthread -lm <<EOF
 #include <fcntl.h>
 #include <unistd.h>
 

--- a/parrot/test/TR_parrot_clone.sh
+++ b/parrot/test/TR_parrot_clone.sh
@@ -7,7 +7,7 @@ exe="${0}.test"
 
 prepare()
 {
-	gcc -I../src/ -g -o "$exe" -x c - -x none -lpthread -lm <<EOF
+	gcc -I../src/ -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none -lpthread -lm <<EOF
 #define _GNU_SOURCE
 
 #include <pthread.h>

--- a/parrot/test/TR_parrot_clone_untraced.sh
+++ b/parrot/test/TR_parrot_clone_untraced.sh
@@ -7,7 +7,7 @@ exe="${0}.test"
 
 prepare()
 {
-	gcc -I../src/ -g -o "$exe" -x c - -x none -lm <<EOF
+	gcc -I../src/ -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none -lm <<EOF
 #define _GNU_SOURCE
 
 #include <fcntl.h>

--- a/parrot/test/TR_parrot_dir.sh
+++ b/parrot/test/TR_parrot_dir.sh
@@ -7,7 +7,7 @@ exe="dir.test"
 
 prepare()
 {
-	gcc -I../src/ -g -o "$exe" -x c - -x none -lm <<EOF
+	gcc -I../src/ -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none -lm <<EOF
 /* Required for O_DIRECTORY on old glibcs */
 #define _GNU_SOURCE
 

--- a/parrot/test/TR_parrot_execve.sh
+++ b/parrot/test/TR_parrot_execve.sh
@@ -20,7 +20,7 @@ prepare()
 
 	set +e
 	# -static requires "libc-devel" which is missing on some platforms
-	gcc -static -I../src/ -g -o "$exe" -x c - -x none <<EOF
+	gcc -static -I../src/ -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none <<EOF
 #include <stdio.h>
 int main (int argc, char *argv[])
 {

--- a/parrot/test/TR_parrot_fake_setuid.sh
+++ b/parrot/test/TR_parrot_fake_setuid.sh
@@ -7,7 +7,7 @@ exe=$PWD/parrot_fake_setuid.$PPID
 
 prepare()
 {
-	gcc -g -o "$exe" -x c - -x none <<EOF
+	gcc -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none <<EOF
 #define _GNU_SOURCE
 #include <unistd.h>
 #include <sys/fsuid.h>

--- a/parrot/test/TR_parrot_mmap.sh
+++ b/parrot/test/TR_parrot_mmap.sh
@@ -7,7 +7,7 @@ exe="mmap.test"
 
 prepare()
 {
-	gcc -I../src/ -g -o "$exe" -x c - -x none -lm <<EOF
+	gcc -I../src/ -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none -lm <<EOF
 #include <unistd.h>
 #include <fcntl.h>
 

--- a/parrot/test/TR_parrot_msg_fd.sh
+++ b/parrot/test/TR_parrot_msg_fd.sh
@@ -7,7 +7,7 @@ exe="socket.test"
 
 prepare()
 {
-	gcc -I../src/ -g -o "$exe" -x c - -x none -lm <<EOF
+	gcc -I../src/ -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none -lm <<EOF
 #include <unistd.h>
 #include <fcntl.h>
 

--- a/parrot/test/TR_parrot_personality.sh
+++ b/parrot/test/TR_parrot_personality.sh
@@ -8,7 +8,7 @@ exe="$name.test"
 
 prepare()
 {
-	gcc -g -o "$exe" -x c - -x none -lm <<EOF
+	gcc -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none -lm <<EOF
 #include <unistd.h>
 
 #ifdef __linux__

--- a/parrot/test/TR_parrot_thread_fd.sh
+++ b/parrot/test/TR_parrot_thread_fd.sh
@@ -7,7 +7,7 @@ exe="$0.test"
 
 prepare()
 {
-	gcc -I../src/ -g -o "$exe" -x c - -x none -lpthread -lm <<EOF
+	gcc -I../src/ -g $CCTOOLS_TEST_CCFLAGS -o "$exe" -x c - -x none -lpthread -lm <<EOF
 #include <fcntl.h>
 #include <pthread.h>
 #include <sched.h>

--- a/resource_monitor/src/piggybacker.c
+++ b/resource_monitor/src/piggybacker.c
@@ -45,7 +45,6 @@ uint64_t write_h_file(char *path_h, char *str_var, char *path_lib)
 	}
 	else
 	{
-		lib_data = calloc(n, sizeof(char));
 		copy_stream_to_buffer(fl, (char **) &lib_data, NULL);
 
 		fprintf(fh, "static char lib_helper_data[%" PRIu64 "] = {\n", (uint64_t) n);


### PR DESCRIPTION
This is for #1286.

I added a new option to the `configure` script to compile with these options. N.B. that GCC>=4.8 is required. If configured as

    ./configure --sanitize

all programs will exit with non-zero status and print details in the case of leaks. The numerous changed files are due to test scripts that compile their own code. Extra linker flags are required for those tests, so I passed them through an environment variable. I'm not sure if this is the most correct way to do it, though