### PR TITLE
Worker broken promises

### DIFF
--- a/doc/man/work_queue_worker.m4
+++ b/doc/man/work_queue_worker.m4
@@ -47,6 +47,7 @@ OPTION_TRIPLET(-w, tcp-window-size, size)Set TCP window size.
 OPTION_TRIPLET(-i, min-backoff, time)Set initial value for backoff interval when worker fails to connect to a master. (default=1s)
 OPTION_TRIPLET(-b, max-backoff, time)Set maxmimum value for backoff interval when worker fails to connect to a master. (default=60s)
 OPTION_TRIPLET(-z, disk-threshold, size)Set available disk space threshold (in MB). When exceeded worker will clean up and reconnect. (default=100MB)
+OPTION_PAIR(--memory-threshold, size)Set available memory threshold (in MB). When exceeded worker will clean up and reconnect. (default=100MB)
 OPTION_TRIPLET(-A, arch, arch)Set the architecture string the worker reports to its supervisor. (default=the value reported by uname)
 OPTION_TRIPLET(-O, os, os)Set the operating system string the worker reports to its supervisor. (default=the value reported by uname)
 OPTION_TRIPLET(-s, workdir, path)Set the location where the worker should create its working directory. (default=/tmp)

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -2394,6 +2394,12 @@ int main(int argc, char *argv[])
 	while(1) {
 		int result;
 
+		measure_worker_resources();
+		if(!enforce_worker_limits(NULL)) {
+			abort_flag = 1;
+			break;
+		}
+
 		if(project_regex) {
 			result = serve_master_by_name(catalog_host,catalog_port,project_regex);
 		} else {
@@ -2420,11 +2426,6 @@ int main(int argc, char *argv[])
 			}
 		} else {
 			backoff_interval = MIN(backoff_interval*2,max_backoff_interval);
-		}
-
-		measure_worker_resources();
-		if(!enforce_worker_limits(NULL)) {
-			abort_flag = 1;
 		}
 
 		if(abort_flag) {

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1425,7 +1425,7 @@ static int enforce_worker_limits(struct link *master) {
 		return 0;
 	}
 
-	if( manual_disk_option > 0 && local_resources->disk.inuse > (manual_disk_option - disk_avail_threshold) ) {
+	if( manual_disk_option > 0 && local_resources->disk.inuse > (manual_disk_option - disk_avail_threshold/2) ) {
 		fprintf(stderr,"work_queue_worker: %s used more than declared disk space (--disk - --disk-threshold < disk used) %"PRIu64" - %"PRIu64 " < %"PRIu64" MB\n", workspace, manual_disk_option, disk_avail_threshold, local_resources->disk.inuse);
 
 		if(master) {
@@ -1435,7 +1435,7 @@ static int enforce_worker_limits(struct link *master) {
 		return 0;
 	}
 
-	if( manual_memory_option > 0 && local_resources->memory.inuse > (manual_memory_option - memory_avail_threshold) ) {
+	if( manual_memory_option > 0 && local_resources->memory.inuse > (manual_memory_option - memory_avail_threshold/2) ) {
 		fprintf(stderr,"work_queue_worker: used more than declared memory (--memory - --memory-threshold < memory used) %"PRIu64" - %"PRIu64 " < %"PRIu64" MB\n", manual_memory_option, memory_avail_threshold, local_resources->memory.inuse);
 
 		if(master) {

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -114,9 +114,9 @@ static int abort_flag = 0;
 // Flag used to indicate a child must be waited for.
 static int sigchld_received_flag = 0;
 
-// Threshold for available memory, and disk space (MB) beyond which clean up and restart.
+// Threshold for available memory, and disk space (MB) beyond which clean up and quit.
 static int64_t disk_avail_threshold = 100;
-//static int64_t memory_avail_threshold = 100;
+static int64_t memory_avail_threshold = 100;
 
 // Password shared between master and worker.
 char *password = 0;
@@ -333,7 +333,8 @@ static void send_resource_update(struct link *master)
 		total_resources->disk.inuse = local_resources->disk.inuse;
 	}
 
-	total_resources->disk.total = local_resources->disk.total   - disk_avail_threshold;
+	total_resources->disk.total   = local_resources->disk.total   - disk_avail_threshold;
+	total_resources->memory.total = local_resources->memory.total - memory_avail_threshold;
 
 	work_queue_resources_send(master,total_resources,stoptime);
 	send_master_message(master, "info end_of_resource_update %d\n", 0);
@@ -1434,6 +1435,16 @@ static int enforce_worker_limits(struct link *master) {
 		return 0;
 	}
 
+	if( manual_memory_option > 0 && local_resources->memory.inuse > (manual_memory_option - memory_avail_threshold) ) {
+		fprintf(stderr,"work_queue_worker: has less than the promised memory (--memory - --memory-threshold < memory used) %"PRIu64" - %"PRIu64 " < %"PRIu64" MB\n", manual_memory_option, memory_avail_threshold, local_resources->memory.inuse);
+
+		if(master) {
+			send_master_message(master, "info memory_space_exhausted %lld\n", (long long) local_resources->memory.inuse);
+		}
+
+		return 0;
+	}
+
 
 	return 1;
 }
@@ -1894,6 +1905,8 @@ static void show_help(const char *cmd)
 	printf( " %-30s to a master. (default=%ds)\n", "", max_backoff_interval);
 	printf( " %-30s Set available disk space threshold (in MB). When exceeded worker will\n", "-z,--disk-threshold=<size>");
 	printf( " %-30s clean up and reconnect. (default=%" PRIu64 "MB)\n", "", disk_avail_threshold);
+	printf( " %-30s Set available memory size threshold (in MB). When exceeded worker will\n", "--memory-threshold=<size>");
+	printf( " %-30s clean up and reconnect. (default=%" PRIu64 "MB)\n", "", memory_avail_threshold);
 	printf( " %-30s Set architecture string for the worker to report to master instead\n", "-A,--arch=<arch>");
 	printf( " %-30s of the value in uname (%s).\n", "", arch_name);
 	printf( " %-30s Set operating system string for the worker to report to master instead\n", "-O,--os=<os>");
@@ -1921,7 +1934,8 @@ enum {LONG_OPT_DEBUG_FILESIZE = 256, LONG_OPT_VOLATILITY, LONG_OPT_BANDWIDTH,
 	  LONG_OPT_DEBUG_RELEASE, LONG_OPT_SPECIFY_LOG, LONG_OPT_CORES, LONG_OPT_MEMORY,
 	  LONG_OPT_DISK, LONG_OPT_GPUS, LONG_OPT_FOREMAN, LONG_OPT_FOREMAN_PORT, LONG_OPT_DISABLE_SYMLINKS,
 	  LONG_OPT_IDLE_TIMEOUT, LONG_OPT_CONNECT_TIMEOUT, LONG_OPT_RUN_DOCKER, LONG_OPT_RUN_DOCKER_PRESERVE,
-	  LONG_OPT_BUILD_FROM_TAR, LONG_OPT_SINGLE_SHOT, LONG_OPT_WALL_TIME, LONG_OPT_DISK_ALLOCATION};
+	  LONG_OPT_BUILD_FROM_TAR, LONG_OPT_SINGLE_SHOT, LONG_OPT_WALL_TIME, LONG_OPT_DISK_ALLOCATION,
+	  LONG_OPT_MEMORY_THRESHOLD};
 
 static const struct option long_options[] = {
 	{"advertise",           no_argument,        0,  'a'},
@@ -1948,6 +1962,7 @@ static const struct option long_options[] = {
 	{"single-shot",		    no_argument,        0,  LONG_OPT_SINGLE_SHOT },
 	{"disable-symlinks",    no_argument,        0,  LONG_OPT_DISABLE_SYMLINKS},
 	{"disk-threshold",      required_argument,  0,  'z'},
+	{"memory-threshold",    required_argument,  0,  LONG_OPT_MEMORY_THRESHOLD},
 	{"arch",                required_argument,  0,  'A'},
 	{"os",                  required_argument,  0,  'O'},
 	{"workdir",             required_argument,  0,  's'},
@@ -2081,6 +2096,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'z':
 			disk_avail_threshold = atoll(optarg) * MEGA;
+			break;
+		case LONG_OPT_MEMORY_THRESHOLD:
+			memory_avail_threshold = atoll(optarg);
 			break;
 		case 'A':
 			free(arch_name); //free the arch string obtained from uname
@@ -2221,6 +2239,11 @@ int main(int argc, char *argv[])
 	//checks disk options make sense
 	if(manual_disk_option > 0 &&  manual_disk_option <= disk_avail_threshold) {
 		fatal("Disk space specified (%" PRId64 " MB) is less than minimum threshold (%"PRId64 " MB).\n See --disk and --disk-threshold options.", manual_disk_option, disk_avail_threshold);
+	}
+
+	//checks memory options make sense
+	if(manual_memory_option > 0 &&  manual_memory_option <= memory_avail_threshold) {
+		fatal("Memory specified (%" PRId64 " MB) is less than minimum threshold (%"PRId64 " MB).\n See --memory and --memory-threshold options.", manual_memory_option, memory_avail_threshold);
 	}
 
 	if(!project_regex) {

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1424,7 +1424,7 @@ static int enforce_worker_limits(struct link *master) {
 	}
 
 	if( manual_disk_option > 0 && disk_measured > (manual_disk_option - disk_avail_threshold) ) {
-		fprintf(stderr,"work_queue_worker: %s has less than the promised disk space %"PRIu64" < %"PRIu64" MB\n", workspace, manual_disk_option, disk_measured);
+		fprintf(stderr,"work_queue_worker: %s has less than the promised disk space (--disk - --disk-threshold < disk used) %"PRIu64" - %"PRIu64 " < %"PRIu64" MB\n", workspace, manual_disk_option, disk_avail_threshold, disk_measured);
 
 		if(master) {
 			send_master_message(master, "info disk_space_exhausted %lld\n", (long long) disk_measured);

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -114,8 +114,9 @@ static int abort_flag = 0;
 // Flag used to indicate a child must be waited for.
 static int sigchld_received_flag = 0;
 
-// Threshold for available disk space (MB) beyond which clean up and restart.
+// Threshold for available memory, and disk space (MB) beyond which clean up and restart.
 static int64_t disk_avail_threshold = 100;
+//static int64_t memory_avail_threshold = 100;
 
 // Password shared between master and worker.
 char *password = 0;
@@ -333,6 +334,8 @@ static void send_resource_update(struct link *master)
 		total_resources->disk.total = local_resources->disk.total;
 		total_resources->disk.inuse = local_resources->disk.inuse;
 	}
+
+	total_resources->disk.total = local_resources->disk.total - disk_avail_threshold;
 
 	work_queue_resources_send(master,total_resources,stoptime);
 	send_master_message(master, "info end_of_resource_update %d\n", 0);

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1426,20 +1426,40 @@ static int enforce_worker_limits(struct link *master) {
 	}
 
 	if( manual_disk_option > 0 && local_resources->disk.inuse > (manual_disk_option - disk_avail_threshold) ) {
-		fprintf(stderr,"work_queue_worker: %s has less than the promised disk space (--disk - --disk-threshold < disk used) %"PRIu64" - %"PRIu64 " < %"PRIu64" MB\n", workspace, manual_disk_option, disk_avail_threshold, local_resources->disk.inuse);
+		fprintf(stderr,"work_queue_worker: %s used more than declared disk space (--disk - --disk-threshold < disk used) %"PRIu64" - %"PRIu64 " < %"PRIu64" MB\n", workspace, manual_disk_option, disk_avail_threshold, local_resources->disk.inuse);
 
 		if(master) {
-			send_master_message(master, "info disk_space_exhausted %lld\n", (long long) local_resources->disk.inuse);
+			send_master_message(master, "info disk_exhausted %lld\n", (long long) local_resources->disk.inuse);
 		}
 
 		return 0;
 	}
 
 	if( manual_memory_option > 0 && local_resources->memory.inuse > (manual_memory_option - memory_avail_threshold) ) {
-		fprintf(stderr,"work_queue_worker: has less than the promised memory (--memory - --memory-threshold < memory used) %"PRIu64" - %"PRIu64 " < %"PRIu64" MB\n", manual_memory_option, memory_avail_threshold, local_resources->memory.inuse);
+		fprintf(stderr,"work_queue_worker: used more than declared memory (--memory - --memory-threshold < memory used) %"PRIu64" - %"PRIu64 " < %"PRIu64" MB\n", manual_memory_option, memory_avail_threshold, local_resources->memory.inuse);
 
 		if(master) {
-			send_master_message(master, "info memory_space_exhausted %lld\n", (long long) local_resources->memory.inuse);
+			send_master_message(master, "info memory_exhausted %lld\n", (long long) local_resources->memory.inuse);
+		}
+
+		return 0;
+	}
+
+	if( manual_disk_option > 0 && local_resources->disk.total < manual_disk_option) {
+		fprintf(stderr,"work_queue_worker: has less than the promised disk space (--disk > disk total) %"PRIu64" < %"PRIu64" MB\n", manual_disk_option, local_resources->disk.total);
+
+		if(master) {
+			send_master_message(master, "info disk_error %lld\n", (long long) local_resources->disk.total);
+		}
+
+		return 0;
+	}
+
+	if( manual_memory_option > 0 && local_resources->memory.total < manual_memory_option) {
+		fprintf(stderr,"work_queue_worker: has less than the promised memory (--memory > memory total) %"PRIu64" < %"PRIu64" MB\n", manual_memory_option, local_resources->memory.total);
+
+		if(master) {
+			send_master_message(master, "info memory_error %lld\n", (long long) local_resources->memory.total);
 		}
 
 		return 0;


### PR DESCRIPTION
Add memory-threshold, that works as disk-threshold.
Check also against resource.total, rather than only resource.inuse.

Also, give some breathing room to the resource monitor. For example, for disk, the worker reports to the master:  disk.total - disk_threshold as the disk size. Then we check in the worker with disk.inuse > disk.manual - disk_threshold/2. Same for memory.