### PR TITLE
print cmd in debug log

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -2829,6 +2829,7 @@ static work_queue_result_code_t start_one_task(struct work_queue *q, struct work
 	long long cmd_len = strlen(command_line);
 	send_worker_msg(q,w, "cmd %lld\n", (long long) cmd_len);
 	link_putlstring(w->link, command_line, cmd_len, /* stoptime */ time(0) + (w->foreman ? q->long_timeout : q->short_timeout));
+	debug(D_WQ, "%s\n", command_line);
 	free(command_line);
 
 	send_worker_msg(q,w, "cores %"PRId64"\n",  limits->cores);


### PR DESCRIPTION
Sending the command line with link_putlstring did not printed in the debug log anymore.