### PR TITLE
Wq alloc by max seen

### DIFF
--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -32,6 +32,8 @@ static uint64_t time_bucket_size      = 60000000;  /* 1 minute */
 static uint64_t bytes_bucket_size     = MEGABYTE;  /* 1 M */
 static uint64_t bandwidth_bucket_size = 1000000;   /* 1 Mbit/s */
 
+static uint64_t first_allocation_every_n_tasks = 50; /* tasks */
+
 struct category *category_lookup_or_create(struct hash_table *categories, const char *name) {
 	struct category *c;
 

--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -661,7 +661,7 @@ const struct rmsummary *category_dynamic_task_max_resources(struct category *c, 
 	struct rmsummary *first = c->first_allocation;
 	struct rmsummary *seen  = c->max_resources_seen;
 
-	if(c->completions_since_last_reset >= first_allocation_every_n_tasks) {
+	if(category_in_steady_state(c)) {
 		internal->cores  = seen->cores;
 		internal->memory = seen->memory;
 		internal->disk   = seen->disk;
@@ -705,6 +705,10 @@ const struct rmsummary *category_dynamic_task_min_resources(struct category *c, 
 	rmsummary_merge_override(internal, max);
 
 	return internal;
+}
+
+int category_in_steady_state(struct category *c) {
+	return (c->completions_since_last_reset >= first_allocation_every_n_tasks);
 }
 
 void category_tune_bucket_size(const char *resource, uint64_t size) {

--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -322,6 +322,15 @@ int64_t category_first_allocation_min_waste(struct itable *histogram, int assume
 		int64_t a  = keys[i];
 		double  Ea;
 
+		if(a < 1) {
+			continue;
+		}
+
+		if(a > top_resource) {
+			a_1 = top_resource;
+			break;
+		}
+
 		double Pa = 1 - ((double) counts_accum[i])/counts_accum[n-1];
 
 		if(assume_independence) {
@@ -382,6 +391,11 @@ int64_t category_first_allocation_max_throughput(struct itable *histogram, int64
 			continue;
 		}
 
+		if(a > top_resource) {
+			a_1 = top_resource;
+			break;
+		}
+
 		double Pbef = ((double) counts_accum[i])/counts_accum[n-1];
 		double Paft = 1 - Pbef;
 
@@ -410,18 +424,24 @@ int64_t category_first_allocation_max_throughput(struct itable *histogram, int64
 }
 
 int64_t category_first_allocation(struct itable *histogram, int assume_independence, category_mode_t mode,  int64_t top_resource) {
+
+	int64_t alloc;
+
 	switch(mode) {
 		case CATEGORY_ALLOCATION_MODE_MIN_WASTE:
-			return category_first_allocation_min_waste(histogram, assume_independence, top_resource);
+			alloc = category_first_allocation_min_waste(histogram, assume_independence, top_resource);
 			break;
 		case CATEGORY_ALLOCATION_MODE_MAX_THROUGHPUT:
-			return category_first_allocation_max_throughput(histogram, top_resource);
+			alloc = category_first_allocation_max_throughput(histogram, top_resource);
 			break;
+		case CATEGORY_ALLOCATION_MODE_FIXED:
 		case CATEGORY_ALLOCATION_MODE_MAX:
 		default:
-			return top_resource;
+			alloc = top_resource;
 			break;
 	}
+
+	return alloc;
 }
 
 #define update_first_allocation_field(c, top, independence, field)\

--- a/dttools/src/category.h
+++ b/dttools/src/category.h
@@ -82,6 +82,9 @@ struct category {
 	/* assume that peak usage is independent of wall time */
 	int time_peak_independece;
 
+	/* last time, in seconds, that the first allocation was computed. */
+	time_t first_allocation_time;
+
 	/* stats for wq */
 	uint64_t average_task_time;
 	struct work_queue_stats *wq_stats;

--- a/dttools/src/category.h
+++ b/dttools/src/category.h
@@ -107,6 +107,8 @@ void categories_initialize(struct hash_table *categories, struct rmsummary *top,
 int category_accumulate_summary(struct category *c, const struct rmsummary *rs, const struct rmsummary *max_worker);
 int category_update_first_allocation(struct category *c, const struct rmsummary *max_worker);
 
+int category_in_steady_state(struct category *c);
+
 category_allocation_t category_next_label(struct category *c, category_allocation_t current_label, int resource_overflow, struct rmsummary *user, struct rmsummary *measured);
 
 const struct rmsummary *category_dynamic_task_max_resources(struct category *c, struct rmsummary *user, category_allocation_t request);

--- a/dttools/src/category.h
+++ b/dttools/src/category.h
@@ -52,9 +52,7 @@ struct category {
 
 	struct rmsummary *first_allocation;
 	struct rmsummary *max_allocation;
-
 	struct rmsummary *max_resources_seen;
-	struct rmsummary *max_resources_completed;
 
 	/* if 1, use first allocations. 0, use max fixed (if given) */
 	struct rmsummary *autolabel_resource;
@@ -82,8 +80,8 @@ struct category {
 	/* assume that peak usage is independent of wall time */
 	int time_peak_independece;
 
-	/* last time, in seconds, that the first allocation was computed. */
-	time_t first_allocation_time;
+	/* completions since last time first-allocation was updated. */
+	uint64_t completions_since_last_reset;
 
 	/* stats for wq */
 	uint64_t average_task_time;
@@ -104,10 +102,10 @@ void category_specify_first_allocation_guess(struct category *c, const struct rm
 
 struct category *category_lookup_or_create(struct hash_table *categories, const char *name);
 void category_delete(struct hash_table *categories, const char *name);
-void category_accumulate_summary(struct hash_table *categories, const char *category, struct rmsummary *rs);
-void category_update_first_allocation(struct hash_table *categories, const char *category);
 void categories_initialize(struct hash_table *categories, struct rmsummary *top, const char *summaries_file);
 
+int category_accumulate_summary(struct category *c, const struct rmsummary *rs, const struct rmsummary *max_worker);
+int category_update_first_allocation(struct category *c, const struct rmsummary *max_worker);
 
 category_allocation_t category_next_label(struct category *c, category_allocation_t current_label, int resource_overflow, struct rmsummary *user, struct rmsummary *measured);
 

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -639,7 +639,7 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 			rmsummary_delete(n->resources_measured);
 		n->resources_measured = rmsummary_parse_file_single(summary_name);
 
-		category_accumulate_summary(d->categories, n->category->name, n->resources_measured);
+		category_accumulate_summary(n->category, n->resources_measured, NULL);
 
 		free(nodeid);
 		free(log_name_prefix);

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -1008,7 +1008,7 @@ void set_fa_min_waste_time_dependence(struct rmDsummary_set *s, struct hash_tabl
 	c->time_peak_independece = 0;
 	c->allocation_mode       = CATEGORY_ALLOCATION_MODE_MIN_WASTE;
 
-	category_update_first_allocation(categories, s->category);
+	category_update_first_allocation(c, NULL);
 
 	if(!c->first_allocation)
 		return;
@@ -1038,7 +1038,7 @@ void set_fa_min_waste_time_independence(struct rmDsummary_set *s, struct hash_ta
 	c->time_peak_independece = 1;
 	c->allocation_mode       = CATEGORY_ALLOCATION_MODE_MIN_WASTE;
 
-	category_update_first_allocation(categories, s->category);
+	category_update_first_allocation(c, NULL);
 
 	if(!c->first_allocation)
 		return;
@@ -1068,7 +1068,7 @@ void set_fa_max_throughput(struct rmDsummary_set *s, struct hash_table *categori
 	c->time_peak_independece = 0;
 	c->allocation_mode       = CATEGORY_ALLOCATION_MODE_MAX_THROUGHPUT;
 
-	category_update_first_allocation(categories, s->category);
+	category_update_first_allocation(c, NULL);
 
 	if(!c->first_allocation)
 		return;

--- a/resource_monitor/src/rmon_tools.c
+++ b/resource_monitor/src/rmon_tools.c
@@ -323,9 +323,11 @@ struct rmDsummary *parse_summary(FILE *stream, char *filename, struct hash_table
 		return NULL;
 
 	if(categories) {
-		category_accumulate_summary(categories, ALL_SUMMARIES_CATEGORY, so);
+		struct category *c = category_lookup_or_create(categories, ALL_SUMMARIES_CATEGORY);
+		category_accumulate_summary(c, so, NULL);
 		if(so->category) {
-			category_accumulate_summary(categories, so->category, so);
+			c = category_lookup_or_create(categories, so->category);
+			category_accumulate_summary(c, so, NULL);
 		}
 	}
 

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1296,8 +1296,6 @@ void resource_monitor_append_report(struct work_queue *q, struct work_queue_task
 
 		if(!t->resources_measured)
 		{
-			/* mark all resources with -1, to signal that no information is available. */
-			t->resources_measured = rmsummary_create(-1);
 			fprintf(q->monitor_file, "# Summary for task %d was not available.\n", t->taskid);
 		}
 
@@ -1382,8 +1380,6 @@ static void fetch_output_from_worker(struct work_queue *q, struct work_queue_wor
 	 * queue summary, update t->resources_used, and delete the task summary. */
 	if(q->monitor_mode) {
 		read_measured_resources(q, t);
-
-		resource_monitor_append_report(q, t);
 
 		/* Further, if we got debug and series files, gzip them. */
 		if(q->monitor_mode == MON_FULL)
@@ -2934,6 +2930,8 @@ static void add_task_report( struct work_queue *q, struct work_queue_task *t )
 	  tr = list_pop_head(q->task_reports);
 		free(tr);
 	}
+
+	resource_monitor_append_report(q, t);
 }
 
 /*
@@ -5810,8 +5808,6 @@ void work_queue_category_accumulate_task(struct work_queue *q, struct work_queue
 	s->total_receive_time   += (t->time_receive_output_finish - t->time_receive_output_start);
 
 	s->bandwidth = (1.0*MEGABYTE*(s->total_bytes_sent + s->total_bytes_received))/(s->total_send_time + s->total_receive_time + 1);
-
-	rmsummary_merge_max(c->max_resources_seen, t->resources_measured);
 
 	if(t->result == WORK_QUEUE_RESULT_SUCCESS)
 	{

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -119,7 +119,6 @@ double wq_option_send_receive_ratio    = 0.5;
 int wq_option_scheduler = WORK_QUEUE_SCHEDULE_TIME;
 
 int first_allocation_every_n_tasks   = 25;
-int first_allocation_every_n_seconds = 300;
 
 /* default timeout for slow workers to come back to the pool */
 double wq_option_blacklist_slow_workers_timeout = 900;
@@ -1961,7 +1960,7 @@ sent to the catalog.
 			char *max_str = string_format("%" PRId64, largest->field);\
 			jx_insert_string(j, "max_" #field, max_str);\
 			free(max_str);\
-		} else if(c->max_resources_seen->limits_exceeded && c->max_resources_seen->limits_exceeded->field > -1) {\
+		} else if(!category_in_steady_state(c) && c->max_resources_seen->limits_exceeded && c->max_resources_seen->limits_exceeded->field > -1) {\
 			char *max_str = string_format(">%" PRId64, c->max_resources_seen->field - 1);\
 			jx_insert_string(j, "max_" #field, max_str);\
 			free(max_str);\

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -144,7 +144,7 @@ struct work_queue_task {
 
 	int max_retries;                                       /**< Number of times the task is retried on worker errors until success. If less than one, the task is retried indefinitely. */
 
-	struct rmsummary *resources_measured;                  /**< When monitoring is enabled, it points to the measured resources used by the task. */
+	struct rmsummary *resources_measured;                  /**< When monitoring is enabled, it points to the measured resources used by the task in its latest attempt. */
 	struct rmsummary *resources_requested;                 /**< Number of cores, disk, memory, time, etc. the task requires. */
 
 	category_allocation_t resource_request;                /**< See @ref category_allocation_t */

--- a/work_queue/src/work_queue.i
+++ b/work_queue/src/work_queue.i
@@ -27,3 +27,4 @@
 %include "timestamp.h"
 %include "work_queue.h"
 %include "rmsummary.h"
+%include "category.h"


### PR DESCRIPTION
Part 2 of #1269.

update first allocation using max worker/max seen per category.

First commit is: 
 	Compute allocation every n tasks. 			d3b2be5