### PR TITLE
Remove unused is_seekable logic.

### DIFF
--- a/parrot/src/pfs_service.cc
+++ b/parrot/src/pfs_service.cc
@@ -26,14 +26,6 @@ extern "C" {
 #include <string.h>
 #include <stdlib.h>
 
-pfs_service::pfs_service()
-{
-}
-
-pfs_service::~pfs_service()
-{
-}
-
 void * pfs_service::connect( pfs_name *name )
 {
 	errno = ENOSYS;
@@ -50,11 +42,6 @@ int pfs_service::get_default_port()
 }
 
 int pfs_service::tilde_is_special()
-{
-	return 0;
-}
-
-int pfs_service::is_seekable()
 {
 	return 0;
 }

--- a/parrot/src/pfs_service.h
+++ b/parrot/src/pfs_service.h
@@ -16,15 +16,14 @@ See the file COPYING for details.
 
 class pfs_service {
 public:
-	pfs_service();
-	virtual ~pfs_service();
+	virtual ~pfs_service() {};
 
 	virtual void * connect( pfs_name *name );
 	virtual void disconnect( pfs_name *name, void *cxn );
 	virtual int get_default_port();
 	virtual int get_block_size();
 	virtual int tilde_is_special();
-	virtual int is_seekable();
+	virtual int is_seekable() = 0;
 	virtual int is_local();
 
 	virtual pfs_file * open( pfs_name *name, int flags, mode_t mode );

--- a/parrot/src/pfs_service_ftp.cc
+++ b/parrot/src/pfs_service_ftp.cc
@@ -314,6 +314,10 @@ public:
 		}
 		return result;
 	}
+
+	virtual int is_seekable (void) {
+		return 0;
+	}
 };
 
 static pfs_service_ftp pfs_service_ftp_instance(USERPASS);

--- a/parrot/src/pfs_service_grow.cc
+++ b/parrot/src/pfs_service_grow.cc
@@ -846,6 +846,10 @@ public:
 		errno = EROFS;
 		return -1;
 	}
+
+	virtual int is_seekable (void) {
+		return 0;
+	}
 };
 
 static pfs_service_grow pfs_service_grow_instance;

--- a/parrot/src/pfs_service_http.cc
+++ b/parrot/src/pfs_service_http.cc
@@ -121,6 +121,10 @@ public:
 	virtual int lstat( pfs_name *name, struct pfs_stat *buf ) {
 		return this->stat(name,buf);
 	}
+
+	virtual int is_seekable (void) {
+		return 0;
+	}
 };
 
 static pfs_service_http pfs_service_http_instance;


### PR DESCRIPTION
All services report files as seekable. The local service no longer opens
unseekable files since the introduction of native file descriptors.

This resolves an issue privately reported by Benjamin Wynne. In his case, an
attached fd during the bootstrap phase was wrongly marked as unseekable. The
fix for that is obviated by this commit which simply removes all the unused
seekable logic.