### PR TITLE
Give attached fd its real name.

### DIFF
--- a/parrot/src/pfs_process.cc
+++ b/parrot/src/pfs_process.cc
@@ -126,7 +126,7 @@ static void initfd( pfs_process *p, int fd )
 				/* The fd was closed and opened as a "Parrot fd" by the root tracee, find its inode: */
 				if (pfs_process_stat(p->pid, fd, &buf) == -1)
 					fatal("could not stat root tracee: %s", strerror(errno));
-				p->table->attach(fd, nfd, fdflags, S_IRUSR|S_IWUSR, "fd", &buf);
+				p->table->attach(fd, nfd, fdflags, S_IRUSR|S_IWUSR, NULL, &buf);
 			}
 		}
 	}

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -228,7 +228,16 @@ to this physical file descriptor in the tracing process.
 
 void pfs_table::attach( int logical, int physical, int flags, mode_t mode, const char *name, struct stat *buf )
 {
+	char selfname[PATH_MAX] = "";
 	assert(VALID_FD(logical) && pointers[logical] == NULL);
+	if (!name) {
+		char path[PATH_MAX];
+		snprintf(path, PATH_MAX, "/proc/self/fd/%d", physical);
+		if (::readlink(path, selfname, sizeof selfname - 1) == -1) {
+			fatal("could not get name for fd %d: %s", physical, strerror(errno));
+		}
+		name = selfname;
+	}
 	pointers[logical] = new pfs_pointer(pfs_file_bootstrap(physical,name),flags,mode);
 	fd_flags[logical] = 0;
 	setparrot(logical, logical, buf);


### PR DESCRIPTION
This resolves a problem with /proc/pid/fd/n giving "fd" instead of the real
path to the bootstrapped file.