### PR TITLE
Condor submit fix

### DIFF
--- a/work_queue/src/condor_submit_workers
+++ b/work_queue/src/condor_submit_workers
@@ -98,10 +98,10 @@ EOF
 	#Disk in kilobytes
 	echo "request_disk = ${disk}" >> condor_submit_file
 
-	echo "queue $count" >> condor_submit_file.$$
 
-	condor_submit condor_submit_file.$$
-	rm condor_submit_file.$$
+	echo "queue $count" >> condor_submit_file
+
+	condor_submit condor_submit_file
 }
 
 submit_workers "$@"

--- a/work_queue/src/condor_submit_workers
+++ b/work_queue/src/condor_submit_workers
@@ -79,7 +79,6 @@ when_to_transfer_output = on_exit
 output = worker.\$(PROCESS).output
 error = worker.\$(PROCESS).error
 log = workers.log
-requirements = $requirements
 
 # Some programs assume some variables are set, like HOME, so we export the
 # environment variables with the job.  Comment the next line if you do not want
@@ -87,8 +86,8 @@ requirements = $requirements
 getenv = true
 EOF
 
-	if [ ! -z "$cores" ]; then
-		echo "request_cpus = ${cores}" >> condor_submit_file.$$
+	if [ ! -z "$requirements" ]; then
+		echo "requirements = ${requirements}" >> condor_submit_file
 	fi
 
 	echo "request_cpus = ${cores}" >> condor_submit_file

--- a/work_queue/src/condor_submit_workers
+++ b/work_queue/src/condor_submit_workers
@@ -25,6 +25,11 @@ transfer_input_files="work_queue_worker, cctools_gpu_autodetect"
 
 parse_arguments()
 {
+	# set default values:
+	cores=${cores:-1}
+	memory=${memory:-1024}   # MB, e.g. 1 GB
+	disk=${disk:-1024}      # MB, e.g. 1 GB
+
 	while [ $# -gt 0 ]
 	do
 		case $1 in

--- a/work_queue/src/condor_submit_workers
+++ b/work_queue/src/condor_submit_workers
@@ -30,6 +30,9 @@ parse_arguments()
 	memory=${memory:-1024}   # MB, e.g. 1 GB
 	disk=${disk:-1024}      # MB, e.g. 1 GB
 
+	# convert disk to kB to make what follows easier, as condor want disk in kB
+	disk=$((disk*1024))
+
 	while [ $# -gt 0 ]
 	do
 		case $1 in
@@ -39,25 +42,9 @@ parse_arguments()
 			;;
 
 			--autosize)
-			arguments="$arguments --cores \$\$(TotalSlotCpus) --memory \$\$(TotalSlotMemory) --disk \$\$(TotalSlotDisk)"
-
-			if [ -z "$cores" ]; then
-				cores="TotalSlotCpus"
-			else
 				cores="ifThenElse($cores > TotalSlotCpus, $cores, TotalSlotCpus)"
-			fi
-
-			if [ -z "$memory" ]; then
-				memory="TotalSlotMemory"
-			else
 				memory="ifThenElse($memory > TotalSlotMemory, $memory, TotalSlotMemory)"
-			fi
-
-			if [ -z "$disk" ]; then
-				disk="TotalSlotDisk"
-			else
 				disk="ifThenElse($disk > TotalSlotDisk, $disk, TotalSlotDisk)"
-			fi
 			;;
 
 			*)
@@ -78,7 +65,11 @@ set_up_password_file()
 
 submit_workers_command()
 {
-	cat > condor_submit_file.$$ <<EOF
+	# rewrite cores, memory, disk with size of given slot. (sometimes the slot
+	# given is larger than the minimum requested).
+	arguments="$arguments --cores \$\$([TARGET.Cpus]) --memory \$\$([TARGET.Memory]) --disk \$\$([TARGET.Disk/1024])"
+
+	cat > condor_submit_file <<EOF
 universe = vanilla
 executable = work_queue_worker
 arguments = $arguments $host $port
@@ -100,15 +91,13 @@ EOF
 		echo "request_cpus = ${cores}" >> condor_submit_file.$$
 	fi
 
-	if [ ! -z "$memory" ]; then
-		#Memory in megabytes
-		echo "request_memory = ${memory}" >> condor_submit_file.$$
-	fi
+	echo "request_cpus = ${cores}" >> condor_submit_file
 
-	if [ ! -z "$disk" ]; then
-		#Disk in kilobytes
-		echo "$disk" | awk '{ printf "request_disk =  %d\n", $1 * 1024 }' >> condor_submit_file.$$
-	fi
+	#Memory in megabytes
+	echo "request_memory = ${memory}" >> condor_submit_file
+
+	#Disk in kilobytes
+	echo "request_disk = ${disk}" >> condor_submit_file
 
 	echo "queue $count" >> condor_submit_file.$$
 


### PR DESCRIPTION
Fix request of disk, and simplify --autosize option handling.

Always set the size of the worker to size of TARGET, as TARGET may be larger.

Also, request by default a minimum of 1 core, 1 GB of RAM and 1 GB of disk.