### PR TITLE
Avoid free()ing constant string

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -653,7 +653,7 @@ void update_catalog(struct work_queue *q, struct link *foreman_uplink, int force
 		return;
 
 	// If host and port are not set, pick defaults.
-	if(!q->catalog_hosts) q->catalog_hosts = CATALOG_HOST;
+	if(!q->catalog_hosts) q->catalog_hosts = xxstrdup(CATALOG_HOST);
 
 	// Generate the master status in an jx, and print it to a buffer.
 	struct jx *j = queue_to_jx(q,foreman_uplink);


### PR DESCRIPTION
For #1312

Need to make a copy in case of a string constant