### PR TITLE
Update docs to reflect catalog host delimiter

### DIFF
--- a/doc/catalog.html
+++ b/doc/catalog.html
@@ -4,7 +4,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>Chirp Protocol Version 2</title>
+<title>Catalog Servers</title>
 <style type="text/css">
 .command {
     margin: 10px;
@@ -19,7 +19,7 @@
 <div id="manual">
 <h1>Catalog Servers</h1>
 
-<p style="text-align: right;"><b>Last edited: 29 April 2016</b></p>
+<p style="text-align: right;"><b>Last edited: 4 May 2016</b></p>
 
 <p>Catalog servers function as connection points for tools that need to interact remotely. Tools can send free-form updates to a catalog server, and can query catalog servers to find other hosts matching some criteria. Catalog updates are sent via UDP, and the catalog server exposes a JSON interface to view status and make queries.</p>
 
@@ -31,10 +31,10 @@ This web page lists details on all known servers and their locations.</p>
 
 <h2 id="specifying">Specifying Catalog Servers<a class="sectionlink" href="#specifying" title="Link to this section.">&#x21d7;</a></h2>
 
-<p>Many of the tools accept command line arguments or environment variables to specify the catalog server(s) to use. The catalog host is specified as a semicolon delimited list of servers to use. Each may optionally include a port number. If no port is specified, the value of the environment variable <tt>CATALOG_PORT</tt> is used, or the default of port 9097. If no catalog server is given on the command line, the <tt>CATALOG_HOST</tt> environment variable is used. If that is unset, the default of
-<code>catalog.cse.nd.edu;backup-catalog.cse.nd.edu</code>
+<p>Many of the tools accept command line arguments or environment variables to specify the catalog server(s) to use. The catalog host is specified as a comma delimited list of servers to use. Each may optionally include a port number. If no port is specified, the value of the environment variable <tt>CATALOG_PORT</tt> is used, or the default of port 9097. If no catalog server is given on the command line, the <tt>CATALOG_HOST</tt> environment variable is used. If that is unset, the default of
+<code>catalog.cse.nd.edu,backup-catalog.cse.nd.edu</code>
 This could be written more verbosely as
-<code>catalog.cse.nd.edu:9097;backup-catalog.cse.nd.edu:9097</code>
+<code>catalog.cse.nd.edu:9097,backup-catalog.cse.nd.edu:9097</code>
 assuming the catalog port was not set in the environment.</p>
 
 <h2 id="updates">Updates<a class="sectionlink" href="#updates" title="Link to this section.">&#x21d7;</a></h2>
@@ -74,8 +74,8 @@ sneezy<span class="prompt">$ </span>chirp_server -u dopey [more options]
 <p>And you will see <a href="http://catalog.cse.nd.edu:9097">something like
 this.</a> You may easily run multiple catalogs for either scalability or fault
 tolerance.  Simply give each Chirp server the name of each
-running catalog separated by semicolons, e.g.
-<code><span class="prompt">$ </span>chirp_server -u 'dopey;happy:9000;grumpy'</code>
+running catalog separated by commas, e.g.
+<code><span class="prompt">$ </span>chirp_server -u 'dopey,happy:9000,grumpy'</code>
 </p>
 
 <p>(Hint: If you want to ensure that your chirp and catalog servers run

--- a/doc/index.html
+++ b/doc/index.html
@@ -68,6 +68,7 @@
 
 	<b>Catalog Server Manuals</b>
 	<ul>
+            <li><a href="catalog.html">Catalog Servers</a></li>
             <li><a class="man" href="man/catalog_server.html">catalog_server(1)</a></li>
             <li><a class="man" href="man/catalog_update.html">catalog_update(1)</a></li>
             <li><a class="man" href="man/deltadb_query.html">deltadb_query(1)</a></li>
@@ -111,7 +112,6 @@
             <li><a class="man" href="man/chirp_server.html">chirp_server(1)</a></li>
             <li><a class="man" href="man/chirp_server_hdfs.html">chirp_server_hdfs(1)</a></li>
             <li><a href=chirp_protocol.html>The Chirp Protocol</a></li>
-            <li><a href="catalog.html">Catalog Servers</a></li>
         </ul>
         <a href=confuga.html><b>Confuga User's Manual</b></a>
         <ul>

--- a/dttools/src/catalog_query.c
+++ b/dttools/src/catalog_query.c
@@ -34,7 +34,7 @@ struct catalog_host {
 
 static struct set *down_hosts = NULL;
 
-/* Given a semicolon delimited list of host:port or host, set the values pointed
+/* Given a comma delimited list of host:port or host, set the values pointed
    to by host and port, using the default port if not provided. Return the address
    of the next hostport in the string, or NULL if there are no more
 */

--- a/dttools/src/catalog_query.h
+++ b/dttools/src/catalog_query.h
@@ -25,7 +25,7 @@ Connects to a catalog server, issues a query, and waits for the results.
 The caller may specify a specific catalog host and port.
 If none is given, then the environment variables CATALOG_HOST and CATALOG_PORT will be consulted.
 If neither is set, the system will contact chirp.cse.nd.edu on port 9097.
-@param hosts A semicolon delimited list of catalog servers to query, or null for the default server.
+@param hosts A comma delimited list of catalog servers to query, or null for the default server.
 @param filter_expr An optional expression to filter the results in JX syntax.
  A null pointer indicates no filter.
 @param stoptime The absolute time at which to abort.
@@ -50,7 +50,7 @@ struct jx *catalog_query_read(struct catalog_query *q, time_t stoptime);
 void catalog_query_delete(struct catalog_query *q);
 
 /** Send update text to the given hosts
-hosts is a semicolon delimited list of hosts, each of which can be host or host:port
+hosts is a comma delimited list of hosts, each of which can be host or host:port
 @param hosts A list of hosts to which to send updates
 @param text String to send
 @return The number of updates successfully sent, 

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -685,7 +685,7 @@ void work_queue_specify_catalog_server(struct work_queue *q, const char *hostnam
 
 /** Specify the catalog server(s) the master should report to.
 @param q A work queue object.
-@param hosts The catalog servers given as a semicolon delimited list of hostnames or hostname:port
+@param hosts The catalog servers given as a comma delimited list of hostnames or hostname:port
 */
 void work_queue_specify_catalog_servers(struct work_queue *q, const char *hosts);
 


### PR DESCRIPTION
Forgot to clean up the documentation on this, thanks @dthain 