### PR TITLE
Consume multiple / after component.

### DIFF
--- a/chirp/src/chirp_fs_local.c
+++ b/chirp/src/chirp_fs_local.c
@@ -273,7 +273,7 @@ int chirp_fs_local_resolve (const char *path, int *dirfd, char basename[CHIRP_PA
 		char *slash = strchr(working, '/');
 		if (slash) {
 			if (slash == working) {
-				while (*slash == '/') slash++;
+				slash += strspn(slash, "/");
 				memmove(working, slash, strlen(slash)+1);
 				CATCHUNIX(dup2(rootfd, fd));
 				continue;
@@ -281,7 +281,8 @@ int chirp_fs_local_resolve (const char *path, int *dirfd, char basename[CHIRP_PA
 				size_t len = (size_t)(slash-working);
 				memcpy(component, working, len);
 				component[len] = 0;
-				memmove(working, slash+1, strlen(slash+1)+1);
+				slash += strspn(slash, "/");
+				memmove(working, slash, strlen(slash)+1);
 			}
 			debug(D_DEBUG, "path '%s' resolution: component = '%s'", path, component);
 		} else {

--- a/chirp/src/confuga_namespace.c
+++ b/chirp/src/confuga_namespace.c
@@ -130,7 +130,7 @@ static int resolve (confuga *C, const char *path, int *dirfd, char basename[CONF
 		char *slash = strchr(working, '/');
 		if (slash) {
 			if (slash == working) {
-				while (*slash == '/') slash++;
+				slash += strspn(slash, "/");
 				memmove(working, slash, strlen(slash)+1);
 				CATCHUNIX(dup2(C->nsrootfd, fd));
 				continue;
@@ -138,7 +138,8 @@ static int resolve (confuga *C, const char *path, int *dirfd, char basename[CONF
 				size_t len = (size_t)(slash-working);
 				memcpy(component, working, len);
 				component[len] = 0;
-				memmove(working, slash+1, strlen(slash+1)+1);
+				slash += strspn(slash, "/");
+				memmove(working, slash, strlen(slash)+1);
 			}
 			debug(D_DEBUG, "path '%s' resolution: component = '%s'", path, component);
 		} else {


### PR DESCRIPTION
Fixes bug where an extra '/' (e.g. 'foo//bar') would cause resolve to restart
path resolution at root after descending into foo.