### PR TITLE
Makeflow JSON import

### DIFF
--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -442,6 +442,20 @@ struct jx  *jx_copy( struct jx *j )
 	return 0;
 }
 
+struct jx *jx_merge(struct jx *j, ...) {
+	va_list ap;
+	va_start (ap, j);
+	struct jx *result = jx_object(NULL);
+	for (struct jx *next = j; jx_istype(next, JX_OBJECT); next = va_arg(ap, struct jx *)) {
+		for (struct jx_pair *p = next->u.pairs; p; p = p->next) {
+			jx_delete(jx_remove(result, p->key));
+			jx_insert(result, jx_copy(p->key), jx_copy(p->value));
+		}
+	}
+	va_end(ap);
+	return result;
+}
+
 int jx_pair_is_constant( struct jx_pair *p )
 {
 	return jx_is_constant(p->key)

--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -183,6 +183,16 @@ jx_int_t jx_lookup_integer( struct jx *object, const char *key )
 	}
 }
 
+int jx_lookup_boolean( struct jx *object, const char *key )
+{
+	struct jx *j = jx_lookup(object,key);
+	if(j && jx_istype(j,JX_BOOLEAN)) {
+		return !!j->u.boolean_value;
+	} else {
+		return 0;
+	}
+}
+
 double jx_lookup_double( struct jx *object, const char *key )
 {
 	struct jx *j = jx_lookup(object,key);

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -279,7 +279,7 @@ struct jx * jx_iterate_values(struct jx *j, void **i);
  * @param i A variable to store the iteration state.
  * @return A pointer to each key in the object, and NULL when iteration is finished.
  */
-struct jx * jx_iterate_key(struct jx *j, void **i);
+struct jx * jx_iterate_keys(struct jx *j, void **i);
 
 /** Merge an arbitrary number of JX_OBJECTs into a single new one. The constituent objects are not consumed. Objects are merged in the order given, i.e. a key can replace an identical key in a preceding object. The last argument must be NULL to mark the end of the list. @return A merged JX_OBJECT that must be deleted with jx_delete. */
 struct jx *jx_merge(struct jx *j, ...);

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -201,6 +201,9 @@ const char * jx_lookup_string( struct jx *object, const char *key );
 /** Search for an integer item in an object.  The key is an ordinary string value.  @param object The object in which to search.  @param key The string key to match.  @return The integer value of the matching object, or zero if it is not found, or is not an integer. */
 jx_int_t jx_lookup_integer( struct jx *object, const char *key );
 
+/** Search for a boolean item in an object.  The key is an ordinary string value.  @param object The object in which to search.  @param key The string key to match.  @return One if the value of the matching object is true, or zero if it is false, not found, or not a boolean. */
+int jx_lookup_boolean( struct jx *object, const char *key );
+
 /** Search for a double item in an object.  The key is an ordinary string value.  @param object The object in which to search.  @param key The string key to match.  @return The double value of the matching object, or null if it is not found, or is not a double. */
 double jx_lookup_double( struct jx *object, const char *key );
 

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -281,4 +281,7 @@ struct jx * jx_iterate_values(struct jx *j, void **i);
  */
 struct jx * jx_iterate_key(struct jx *j, void **i);
 
+/** Merge an arbitrary number of JX_OBJECTs into a single new one. The constituent objects are not consumed. Objects are merged in the order given, i.e. a key can replace an identical key in a preceding object. The last argument must be NULL to mark the end of the list. @return A merged JX_OBJECT that must be deleted with jx_delete. */
+struct jx *jx_merge(struct jx *j, ...);
+
 #endif

--- a/makeflow/example/example.json
+++ b/makeflow/example/example.json
@@ -1,5 +1,5 @@
 {
-  "#":[
+  "comment":[
     "This is a sample Makeflow script that retrieves an image from the web",
     "creates four variations of it, and then combines them into an animation"
   ],
@@ -72,7 +72,7 @@
       "environment":{
         "URL":"http://ccl.cse.nd.edu/images/capitol.jpg"
       },
-      "#":"If a rule is specified with local_job, it executes at the local site",
+      "comment":"If a rule is specified with local_job, it executes at the local site",
       "local_job":true
     }
   ]

--- a/makeflow/example/example.json
+++ b/makeflow/example/example.json
@@ -3,13 +3,9 @@
     "This is a sample Makeflow script that retrieves an image from the web",
     "creates four variations of it, and then combines them into an animation"
   ],
-  "categories":{
-    "default":{
-      "environment":{
-        "CONVERT":"/usr/bin/convert",
-        "CURL":"/usr/bin/curl"
-      }
-    }
+  "environment":{
+    "CONVERT":"/usr/bin/convert",
+    "CURL":"/usr/bin/curl"
   },
   "rules":[
     {

--- a/makeflow/example/example.json
+++ b/makeflow/example/example.json
@@ -1,0 +1,80 @@
+{
+  "#":[
+    "This is a sample Makeflow script that retrieves an image from the web",
+    "creates four variations of it, and then combines them into an animation"
+  ],
+  "categories":{
+    "default":{
+      "environment":{
+        "CONVERT":"/usr/bin/convert",
+        "CURL":"/usr/bin/curl"
+      }
+    }
+  },
+  "rules":[
+    {
+      "command":"$CONVERT -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.montage.gif",
+      "outputs":[
+        "capitol.montage.gif"
+      ],
+      "inputs":[
+        "capitol.jpg",
+        "capitol.90.jpg",
+        "capitol.180.jpg",
+        "capitol.270.jpg",
+        "capitol.360.jpg"
+      ]
+    },
+    {
+      "command":"$CONVERT -swirl 90 capitol.jpg capitol.90.jpg",
+      "outputs":[
+        "capitol.90.jpg"
+      ],
+      "inputs":[
+        "capitol.jpg"
+      ]
+    },
+    {
+      "command":"$CONVERT -swirl 180 capitol.jpg capitol.180.jpg",
+      "outputs":[
+        "capitol.180.jpg"
+      ],
+      "inputs":[
+        "capitol.jpg"
+      ]
+    },
+    {
+      "command":"$CONVERT -swirl 270 capitol.jpg capitol.270.jpg",
+      "outputs":[
+        "capitol.270.jpg"
+      ],
+      "inputs":[
+        "capitol.jpg"
+      ]
+    },
+    {
+      "command":"$CONVERT -swirl 360 capitol.jpg capitol.360.jpg",
+      "outputs":[
+        "capitol.360.jpg"
+      ],
+      "inputs":[
+        "capitol.jpg"
+      ]
+    },
+    {
+      "command":"$CURL -o capitol.jpg \"$URL\"",
+      "outputs":[
+        "capitol.jpg"
+      ],
+      "inputs":[
+
+      ],
+      "environment":{
+        "URL":"http://ccl.cse.nd.edu/images/capitol.jpg"
+      },
+      "#":"If a rule is specified with local_job, it executes at the local site",
+      "local_job":true
+    }
+  ]
+}
+

--- a/makeflow/example/example.jx
+++ b/makeflow/example/example.jx
@@ -12,61 +12,32 @@
   "rules":[
     {
       "command":"$CONVERT -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.montage.gif",
-      "outputs":[
-        "capitol.montage.gif"
-      ],
-      "inputs":[
-        "capitol.jpg",
-        "capitol.90.jpg",
-        "capitol.180.jpg",
-        "capitol.270.jpg",
-        "capitol.360.jpg"
-      ]
+      "outputs":["capitol.montage.gif"],
+      "inputs":["capitol.jpg", "capitol.90.jpg", "capitol.180.jpg", "capitol.270.jpg", "capitol.360.jpg"]
     },
     {
       "command":"$CONVERT -swirl 90 capitol.jpg capitol.90.jpg",
-      "outputs":[
-        "capitol.90.jpg"
-      ],
-      "inputs":[
-        "capitol.jpg"
-      ]
+      "outputs":["capitol.90.jpg"],
+      "inputs":["capitol.jpg"]
     },
     {
       "command":"$CONVERT -swirl 180 capitol.jpg capitol.180.jpg",
-      "outputs":[
-        "capitol.180.jpg"
-      ],
-      "inputs":[
-        "capitol.jpg"
-      ]
+      "outputs":["capitol.180.jpg"],
+      "inputs":["capitol.jpg"]
     },
     {
       "command":"$CONVERT -swirl 270 capitol.jpg capitol.270.jpg",
-      "outputs":[
-        "capitol.270.jpg"
-      ],
-      "inputs":[
-        "capitol.jpg"
-      ]
+      "outputs":["capitol.270.jpg"],
+      "inputs":["capitol.jpg"]
     },
     {
       "command":"$CONVERT -swirl 360 capitol.jpg capitol.360.jpg",
-      "outputs":[
-        "capitol.360.jpg"
-      ],
-      "inputs":[
-        "capitol.jpg"
-      ]
+      "outputs":["capitol.360.jpg"],
+      "inputs":["capitol.jpg"]
     },
     {
       "command":CURL + " -o capitol.jpg " + URL,
-      "outputs":[
-        "capitol.jpg"
-      ],
-      "inputs":[
-
-      ],
+      "outputs":["capitol.jpg"],
       "variables":{
         "URL":"http://ccl.cse.nd.edu/images/capitol.jpg"
       },

--- a/makeflow/example/example.jx
+++ b/makeflow/example/example.jx
@@ -3,9 +3,11 @@
     "This is a sample Makeflow script that retrieves an image from the web",
     "creates four variations of it, and then combines them into an animation"
   ],
-  "environment":{
-    "CONVERT":"/usr/bin/convert",
+  "variables":{
     "CURL":"/usr/bin/curl"
+  },
+  "environment":{
+    "CONVERT":"/usr/bin/convert"
   },
   "rules":[
     {
@@ -58,14 +60,14 @@
       ]
     },
     {
-      "command":"$CURL -o capitol.jpg \"$URL\"",
+      "command":CURL + " -o capitol.jpg " + URL,
       "outputs":[
         "capitol.jpg"
       ],
       "inputs":[
 
       ],
-      "environment":{
+      "variables":{
         "URL":"http://ccl.cse.nd.edu/images/capitol.jpg"
       },
       "comment":"If a rule is specified with local_job, it executes at the local site",

--- a/makeflow/src/Makefile
+++ b/makeflow/src/Makefile
@@ -6,7 +6,7 @@ include ../../rules.mk
 LOCAL_LINKAGE=$(CCTOOLS_GLOBUS_LDFLAGS)
 
 EXTERNAL_DEPENDENCIES = ../../batch_job/src/libbatch_job.a ../../work_queue/src/libwork_queue.a ../../chirp/src/libchirp.a ../../dttools/src/libdttools.a
-OBJECTS = dag.o dag_node.o dag_file.o dag_variable.o dag_visitors.o dag_resources.o lexer.o parser.o
+OBJECTS = dag.o dag_node.o dag_file.o dag_variable.o dag_visitors.o dag_resources.o lexer.o parser.o parser_jx.o
 PROGRAMS = makeflow makeflow_viz makeflow_analyze makeflow_linker
 SCRIPTS = condor_submit_makeflow makeflow_graph_log makeflow_monitor starch makeflow_linker_perl_driver makeflow_linker_python_driver
 TARGETS = $(PROGRAMS)

--- a/makeflow/src/dag_node.c
+++ b/makeflow/src/dag_node.c
@@ -187,7 +187,7 @@ static const char *dag_node_add_remote_name(struct dag_node *n, const char *file
 /* Adds the local name to the list of source files of the node,
  * and adds the node as a dependant of the file. If remotename is
  * not NULL, it is added to the namespace of the node. */
-void dag_node_add_source_file(struct dag_node *n, const char *filename, char *remotename)
+void dag_node_add_source_file(struct dag_node *n, const char *filename, const char *remotename)
 {
 	struct dag_file *source = dag_file_lookup_or_create(n->d, filename);
 
@@ -206,7 +206,7 @@ void dag_node_add_source_file(struct dag_node *n, const char *filename, char *re
 /* Adds the local name as a target of the node, and register the
  * node as the producer of the file. If remotename is not NULL,
  * it is added to the namespace of the node. */
-void dag_node_add_target_file(struct dag_node *n, const char *filename, char *remotename)
+void dag_node_add_target_file(struct dag_node *n, const char *filename, const char *remotename)
 {
 	struct dag_file *target = dag_file_lookup_or_create(n->d, filename);
 

--- a/makeflow/src/dag_node.h
+++ b/makeflow/src/dag_node.h
@@ -80,8 +80,8 @@ struct dag_node {
 
 struct dag_node *dag_node_create(struct dag *d, int linenum);
 
-void dag_node_add_source_file(struct dag_node *n, const char *filename, char *remotename);
-void dag_node_add_target_file(struct dag_node *n, const char *filename, char *remotename);
+void dag_node_add_source_file(struct dag_node *n, const char *filename, const char *remotename);
+void dag_node_add_target_file(struct dag_node *n, const char *filename, const char *remotename);
 
 const char *dag_node_get_remote_name(struct dag_node *n, const char *filename );
 const char *dag_node_get_local_name(struct dag_node *n, const char *filename );

--- a/makeflow/src/dag_visitors.c
+++ b/makeflow/src/dag_visitors.c
@@ -1180,19 +1180,7 @@ struct jx *resources_to_json(struct rmsummary *r) {
 
 struct jx *category_to_json(struct category *c) {
 	struct jx *result = resources_to_json(c->max_allocation);
-	jx_insert_unless_empty(result, jx_string("variables"), variables_to_json(c->mf_variables));
-	return result;
-}
-
-struct jx *env_to_json(struct dag *d) {
-	char *name;
-	struct jx *result = jx_object(NULL);
-
-	set_first_element(d->export_vars);
-	while((name = set_next_element(d->export_vars))) {
-		jx_insert(result, jx_string(name), jx_null());
-	}
-
+	jx_insert_unless_empty(result, jx_string("environment"), variables_to_json(c->mf_variables));
 	return result;
 }
 
@@ -1234,8 +1222,8 @@ struct jx *dag_nodes_to_json(struct dag_node *node) {
 		rule = jx_object(NULL);
 		jx_insert(rule, jx_string("local_job"), jx_boolean(n->local_job));
 		jx_insert(rule, jx_string("category"), jx_string(n->category->name));
-		jx_insert_unless_empty(rule, jx_string("variables"), variables_to_json(n->variables));
-		jx_insert_unless_empty(rule, jx_string("resources_requested"), resources_to_json(n->resources_requested));
+		jx_insert_unless_empty(rule, jx_string("environment"), variables_to_json(n->variables));
+		jx_insert_unless_empty(rule, jx_string("resources"), resources_to_json(n->resources_requested));
 		jx_insert(rule, jx_string("inputs"), files_to_json(n->source_files));
 		jx_insert(rule, jx_string("outputs"), files_to_json(n->target_files));
 		jx_insert_unless_empty(rule, jx_string("remote_names"), remote_names_to_json(n->remote_names));
@@ -1262,7 +1250,6 @@ struct jx *dag_to_json(struct dag *d) {
 	void *value;
 	struct jx *result = jx_object(NULL);
 	struct jx *categories = jx_object(NULL);
-	jx_insert_unless_empty(result, jx_string("environment"), env_to_json(d));
 	jx_insert(result, jx_string("rules"), dag_nodes_to_json(d->nodes));
 	hash_table_firstkey(d->categories);
 	while(hash_table_nextkey(d->categories, &key,& value)) {

--- a/makeflow/src/parser.h
+++ b/makeflow/src/parser.h
@@ -8,5 +8,7 @@ See the file COPYING for details.
 #define PARSER_H
 
 struct dag *dag_from_file(const char *filename);
+void dag_close_over_categories(struct dag *d);
+void dag_close_over_environment(struct dag *d);
 
 #endif

--- a/makeflow/src/parser_jx.c
+++ b/makeflow/src/parser_jx.c
@@ -1,0 +1,278 @@
+/*
+Copyright (C) 2016- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include "dag.h"
+#include "dag_node.h"
+#include "dag_variable.h"
+#include "dag_resources.h"
+#include "parser_jx.h"
+#include "xxmalloc.h"
+#include "set.h"
+#include "itable.h"
+#include "stringtools.h"
+#include "path.h"
+#include "hash_table.h"
+#include "debug.h"
+#include "parser.h"
+
+static int environment_from_jx(struct dag *d, struct dag_node *n, struct hash_table *h, struct jx *env) {
+	debug(D_MAKEFLOW_PARSER, "Parsing environment");
+	int nodeid;
+	if (n) {
+		nodeid = n->nodeid;
+	} else {
+		nodeid = 0;
+	}
+
+	if (jx_istype(env, JX_OBJECT)) {
+		for (struct jx_pair *p = env->u.pairs; p; p = p->next) {
+			if (jx_istype(p->key, JX_STRING)) {
+				debug(D_MAKEFLOW_PARSER, "export %s", p->key->u.string_value);
+				set_insert(d->export_vars, xxstrdup(p->key->u.string_value));
+				if (jx_istype(p->value, JX_STRING)) {
+					debug(D_MAKEFLOW_PARSER, "env %s=%s", p->key->u.string_value, p->value->u.string_value);
+					dag_variable_add_value(p->key->u.string_value, h, nodeid, p->value->u.string_value);
+				}
+			} else {
+				debug(D_MAKEFLOW_PARSER, "Environment key/value must be strings");
+				return 0;
+			}
+		}
+	} else {
+		debug(D_MAKEFLOW_PARSER, "Expected environment to be an object");
+		return 0;
+	}
+	return 1;
+}
+
+static int resources_from_jx(struct hash_table *h, struct jx *j) {
+	debug(D_MAKEFLOW_PARSER, "Parsing resources");
+	int cores = jx_lookup_integer(j, "cores");
+	if (cores) {
+		debug(D_MAKEFLOW_PARSER, "%d core(s)", cores);
+		dag_variable_add_value(RESOURCES_CORES, h, 0, string_format("%d", cores));
+	} else {
+		debug(D_MAKEFLOW_PARSER, "cores malformed or missing");
+	}
+
+	int disk = jx_lookup_integer(j, "disk");
+	if (disk) {
+		debug(D_MAKEFLOW_PARSER, "%d disk(s)", disk);
+		dag_variable_add_value(RESOURCES_DISK, h, 0, string_format("%d", disk));
+	} else {
+		debug(D_MAKEFLOW_PARSER, "disks malformed or missing");
+	}
+
+	int memory = jx_lookup_integer(j, "memory");
+	if (memory) {
+		debug(D_MAKEFLOW_PARSER, "%d memory", memory);
+		dag_variable_add_value(RESOURCES_MEMORY, h, 0, string_format("%d", memory));
+	} else {
+		debug(D_MAKEFLOW_PARSER, "memory malformed or missing");
+	}
+
+	int gpus = jx_lookup_integer(j, "gpus");
+	if (gpus) {
+		debug(D_MAKEFLOW_PARSER, "%d gpus", gpus);
+		dag_variable_add_value(RESOURCES_GPUS, h, 0, string_format("%d", gpus));
+	} else {
+		debug(D_MAKEFLOW_PARSER, "gpus malformed or missing");
+	}
+
+	return 1;
+}
+
+static int rule_from_jx(struct dag *d, struct jx *j) {
+	debug(D_MAKEFLOW_PARSER, "Parsing rule");
+	struct dag_node *n;
+
+	struct jx *makeflow = jx_lookup(j, "makeflow");
+	struct jx *command = jx_lookup(j, "command");
+
+	if (makeflow && command) {
+		debug(D_MAKEFLOW_PARSER, "Rule must not have both command and submakeflow");
+		return 0;
+	}
+
+	if (jx_istype(command, JX_STRING)) {
+		n = dag_node_create(d, 0);
+		n->command = xxstrdup(command->u.string_value);
+		debug(D_MAKEFLOW_PARSER, "command: %s", command->u.string_value);
+	} else if (jx_istype(makeflow, JX_OBJECT)) {
+		const char *path = jx_lookup_string(makeflow, "path");
+		if (path) {
+			debug(D_MAKEFLOW_PARSER, "Submakeflow at %s", path);
+			n = dag_node_create(d, 0);
+			n->nested_job = 1;
+			n->makeflow_dag = xxstrdup(path);
+			const char *cwd = jx_lookup_string(makeflow, "cwd");
+			if (cwd) {
+				debug(D_MAKEFLOW_PARSER, "working directory %s", cwd);
+				n->makeflow_cwd = xxstrdup(cwd);
+			} else {
+				debug(D_MAKEFLOW_PARSER, "cwd malformed or missing, using process cwd");
+				n->makeflow_cwd = path_getcwd();
+			}
+		} else {
+			debug(D_MAKEFLOW_PARSER, "Submakeflow must specify a path");
+			return 0;
+		}
+	} else {
+		debug(D_MAKEFLOW_PARSER, "Rule must have a command or submakeflow");
+		return 0;
+	}
+	n->next = d->nodes;
+	d->nodes = n;
+	itable_insert(d->node_table, n->nodeid, n);
+
+	// If we got this far, the rule specification is valid and the dag_node exists
+
+	int local_job = jx_lookup_boolean(j, "local_job");
+	if (local_job) {
+		debug(D_MAKEFLOW_PARSER, "Local job");
+		n->local_job = 1;
+	}
+
+	const char *category = jx_lookup_string(j, "category");
+	if (category) {
+		debug(D_MAKEFLOW_PARSER, "Category %s", category);
+		n->category = makeflow_category_lookup_or_create(d, category);
+	} else {
+		debug(D_MAKEFLOW_PARSER, "category malformed or missing, using default");
+		n->category = makeflow_category_lookup_or_create(d, "default");
+	}
+
+	if (!resources_from_jx(n->variables, jx_lookup(j, "resources"))) {
+		debug(D_MAKEFLOW_PARSER, "Failure parsing resources");
+		return 0;
+	}
+
+	struct jx *remotes = jx_lookup(j, "remote_names");
+	struct jx *inputs = jx_lookup(j, "inputs");
+	if (jx_istype(inputs, JX_ARRAY)) {
+		for (struct jx_item *i = inputs->u.items; i; i = i->next) {
+			if (jx_istype(i->value, JX_STRING)) {
+				debug(D_MAKEFLOW_PARSER, "Input %s", i->value->u.string_value);
+				const char *r = jx_lookup_string(remotes, i->value->u.string_value);
+				if (r) {
+					debug(D_MAKEFLOW_PARSER, "Remote name %s", r);
+				} else {
+					debug(D_MAKEFLOW_PARSER, "Remote name malformed or missing");
+				}
+				dag_node_add_source_file(n, i->value->u.string_value, r);
+			} else {
+				debug(D_MAKEFLOW_PARSER, "Input must be a string");
+				return 0;
+			}
+		}
+	} else {
+		debug(D_MAKEFLOW_PARSER, "inputs malformed or missing");
+	}
+
+	struct jx *outputs = jx_lookup(j, "outputs");
+	if (jx_istype(outputs, JX_ARRAY)) {
+		for (struct jx_item *i = outputs->u.items; i; i = i->next) {
+			if (jx_istype(i->value, JX_STRING)) {
+				debug(D_MAKEFLOW_PARSER, "Output %s", i->value->u.string_value);
+				const char *r = jx_lookup_string(remotes, i->value->u.string_value);
+				if (r) {
+					debug(D_MAKEFLOW_PARSER, "Remote name %s", r);
+				}
+				dag_node_add_target_file(n, i->value->u.string_value, r);
+			} else {
+				debug(D_MAKEFLOW_PARSER, "Output must be a string");
+				return 0;
+			}
+		}
+	} else {
+		debug(D_MAKEFLOW_PARSER, "Outputs malformed or missing");
+	}
+
+	const char *allocation = jx_lookup_string(j, "allocation");
+	if (allocation) {
+		if (!strcmp(allocation, "first")) {
+			debug(D_MAKEFLOW_PARSER, "first allocation");
+			n->resource_request = CATEGORY_ALLOCATION_FIRST;
+		} else if (!strcmp(allocation, "max")) {
+			debug(D_MAKEFLOW_PARSER, "max allocation");
+			n->resource_request = CATEGORY_ALLOCATION_MAX;
+		} else if (!strcmp(allocation, "error")) {
+			debug(D_MAKEFLOW_PARSER, "error allocation");
+			n->resource_request = CATEGORY_ALLOCATION_ERROR;
+		} else {
+			debug(D_MAKEFLOW_PARSER, "Unknown allocation");
+			return 0;
+		}
+	} else {
+		debug(D_MAKEFLOW_PARSER, "Allocation malformed or missing");
+	}
+
+	struct jx *environment = jx_lookup(j, "environment");
+	if (environment) {
+		environment_from_jx(d, n, n->variables, environment);
+	} else {
+		debug(D_MAKEFLOW_PARSER, "environment malformed or missing");
+	}
+
+	return 1;
+}
+
+// This leaks memory on failure, but it's assumed that if the DAG can't be
+// parsed, the program will be exiting soon anyway
+struct dag *dag_from_jx(struct jx *j) {
+	if (!j) {
+		return NULL;
+	}
+
+	struct dag *d = dag_create();
+
+	debug(D_MAKEFLOW_PARSER, "Parsing categories");
+	struct jx *categories = jx_lookup(j, "categories");
+	if (jx_istype(categories, JX_OBJECT)) {
+		for (struct jx_pair *p = categories->u.pairs; p; p = p->next) {
+			if (jx_istype(p->key, JX_STRING)) {
+				struct category *c = makeflow_category_lookup_or_create(d, p->key->u.string_value);
+				if (!resources_from_jx(c->mf_variables, p->value)) {
+					debug(D_MAKEFLOW_PARSER, "Failure parsing resources");
+					return NULL;
+				}
+				struct jx *environment = jx_lookup(p->value, "environment");
+				if (environment) {
+					environment_from_jx(d, NULL, c->mf_variables, environment);
+				}
+			} else {
+				debug(D_MAKEFLOW_PARSER, "Category names must be strings");
+				return NULL;
+			}
+		}
+	} else {
+		debug(D_MAKEFLOW_PARSER, "categories malformed or missing");
+	}
+
+	const char *default_category = jx_lookup_string(j, "default_category");
+	if (default_category) {
+		debug(D_MAKEFLOW_PARSER, "Default category %s", default_category);
+	} else {
+		debug(D_MAKEFLOW_PARSER, "default_category malformed or missing, using default");
+		default_category = "default";
+	}
+	d->default_category = makeflow_category_lookup_or_create(d, default_category);
+
+	struct jx *rules = jx_lookup(j, "rules");
+	if (jx_istype(rules, JX_ARRAY)) {
+		for (struct jx_item *i = rules->u.items; i; i = i->next) {
+			if (!rule_from_jx(d, i->value)) {
+				debug(D_MAKEFLOW_PARSER, "Failure parsing rule");
+				return NULL;
+			}
+		}
+	}
+
+	dag_close_over_environment(d);
+	dag_close_over_categories(d);
+	return d;
+}
+

--- a/makeflow/src/parser_jx.c
+++ b/makeflow/src/parser_jx.c
@@ -306,7 +306,7 @@ struct dag *dag_from_jx(struct jx *j) {
 	struct jx *rules = jx_lookup(j, "rules");
 	if (jx_istype(rules, JX_ARRAY)) {
 		for (struct jx_item *i = rules->u.items; i; i = i->next) {
-			struct jx *rule_context = jx_merge(variables ? variables : dummy_context, jx_lookup(i->value, "variables"));
+			struct jx *rule_context = jx_merge(variables ? variables : dummy_context, jx_lookup(i->value, "variables"), NULL);
 			if (!rule_from_jx(d, rule_context, i->value)) {
 				debug(D_MAKEFLOW_PARSER, "Failure parsing rule");
 				return NULL;

--- a/makeflow/src/parser_jx.h
+++ b/makeflow/src/parser_jx.h
@@ -1,0 +1,15 @@
+/*
+Copyright (C) 2016- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#ifndef PARSER_JX
+#define PARSER_JX
+
+#include "dag.h"
+
+struct dag *dag_from_jx(struct jx *);
+
+#endif
+


### PR DESCRIPTION
Here's a first pass at a parser for the Makeflow JSON format (#1178). I added the `--json` flag to Makeflow to switch to the JSON format. I made some adjustments to the output format as well. If I dump JSON from `example.makeflow`, I get

    {
      "default_category":"default",
      "categories":
        {
          "default":
            {
              "environment":
                {
                  "CONVERT":"/usr/bin/convert",
                  "CURL":"/usr/bin/curl",
                  "URL":"http://ccl.cse.nd.edu/images/capitol.jpg",
                  "MAKEFLOW_INPUTS":"",
                  "MAKEFLOW_OUTPUTS":"capitol.montage.gif"
                }
            }
        },
      "rules":
        [
          
          {
            "command":"/usr/bin/convert -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.montage.gif",
            "allocation":"first",
            "outputs":
              [
                "capitol.montage.gif"
              ],
            "inputs":
              [
                "capitol.jpg",
                "capitol.90.jpg",
                "capitol.180.jpg",
                "capitol.270.jpg",
                "capitol.360.jpg"
              ],
            "category":"default",
            "local_job":false
          },
          
          {
            "command":"/usr/bin/convert -swirl 90 capitol.jpg capitol.90.jpg",
            "allocation":"first",
            "outputs":
              [
                "capitol.90.jpg"
              ],
            "inputs":
              [
                "capitol.jpg"
              ],
            "category":"default",
            "local_job":false
          },
          
          {
            "command":"/usr/bin/convert -swirl 180 capitol.jpg capitol.180.jpg",
            "allocation":"first",
            "outputs":
              [
                "capitol.180.jpg"
              ],
            "inputs":
              [
                "capitol.jpg"
              ],
            "category":"default",
            "local_job":false
          },
          
          {
            "command":"/usr/bin/convert -swirl 270 capitol.jpg capitol.270.jpg",
            "allocation":"first",
            "outputs":
              [
                "capitol.270.jpg"
              ],
            "inputs":
              [
                "capitol.jpg"
              ],
            "category":"default",
            "local_job":false
          },
          
          {
            "command":"/usr/bin/convert -swirl 360 capitol.jpg capitol.360.jpg",
            "allocation":"first",
            "outputs":
              [
                "capitol.360.jpg"
              ],
            "inputs":
              [
                "capitol.jpg"
              ],
            "category":"default",
            "local_job":false
          },
          
          {
            "command":"/usr/bin/curl -o capitol.jpg http://ccl.cse.nd.edu/images/capitol.jpg",
            "allocation":"first",
            "outputs":
              [
                "capitol.jpg"
              ],
            "inputs":
              [
              ],
            "category":"default",
            "local_job":true
          }
        ]
    }

Although this runs, it's picked up a some cruft on its way through Makeflow. I put a [cleaner example JSON file](https://github.com/trshaffer/cctools/blob/5adf4c6fea99d727dbbd72b9879637ac62925517/makeflow/example/example.json) in the PR. In particular, per-category and per-rule environment variables seem to be working. Some outstanding things:

- We might want to special case the `"environment"` key on the DAG object. As in the example, global variables have to be somewhat awkwardly specified on a category. If we add top-level `"environment"` to the default category, it's possible to specify rules and environment variables without (visibly) using categories at all.
- I didn't include `MAKEFLOW_INPUTS` and `MAKEFLOW_OUTPUTS`. They don't really fit as variables, but Make syntax doesn't have a lot of options. In JSON, should we put `"inputs"` and `"outputs"` keys on the top-level object? This is consistent with the convention used within the rules, reflects their use as inputs/outputs of the DAG as a whole, and lends itself to better structure than string variables.
- JX expressions are not yet implemented. I've been keeping the `"variables"` key to use as context for that.