### PR TITLE
Improve Confuga SN management/membership

### DIFF
--- a/chirp/src/.gitignore
+++ b/chirp/src/.gitignore
@@ -14,4 +14,5 @@ chirp_migrate
 chirp_matrix_roc
 chirp_status
 chirp_partition_stream
+confuga_adm
 libchirp_client.so

--- a/chirp/src/Makefile
+++ b/chirp/src/Makefile
@@ -15,7 +15,9 @@ OBJECTS = chirp_tool.o chirp_fuse.o $(OBJECTS_CONFUGA) $(OBJECTS_LIBRARY) $(OBJE
 OBJECTS_CONFUGA = $(SOURCES_CONFUGA:%.c=%.o)
 OBJECTS_LIBRARY = $(SOURCES_LIBRARY:%.c=%.o)
 OBJECTS_SERVER = $(SOURCES_SERVER:%.c=%.o)
-PROGRAMS = chirp chirp_get chirp_put chirp_server chirp_status chirp_benchmark chirp_stream_files chirp_fuse chirp_distribute
+PROGRAMS = $(PROGRAMS_CHIRP) $(PROGRAMS_CONFUGA)
+PROGRAMS_CHIRP = chirp chirp_get chirp_put chirp_server chirp_status chirp_benchmark chirp_stream_files chirp_fuse chirp_distribute
+PROGRAMS_CONFUGA = confuga_adm
 PUBLIC_HEADERS = chirp_global.h chirp_multi.h chirp_reli.h chirp_client.h chirp_stream.h chirp_protocol.h chirp_matrix.h chirp_types.h chirp_recursive.h confuga.h
 SCRIPTS = chirp_audit_cluster chirp_server_hdfs
 SOURCES_CONFUGA = confuga.c confuga_namespace.c confuga_replica.c confuga_node.c confuga_job.c confuga_file.c confuga_gc.c
@@ -40,13 +42,13 @@ chirp_job.o chirp_fs_local_scheduler.o: chirp_sqlite.h
 libchirp.a: $(OBJECTS_LIBRARY)
 
 confuga.o confuga_job.o confuga_namespace.o confuga_node.o confuga_replica.o confuga_file.o: confuga.h confuga_fs.h chirp_sqlite.h
-libconfuga.a: $(OBJECTS_CONFUGA) $(OBJECTS_LIBRARY)
+libconfuga.a: $(OBJECTS_CONFUGA) $(OBJECTS_LIBRARY) chirp_sqlite.o sqlite3.o
 libconfuga.$(CCTOOLS_DYNAMIC_SUFFIX): $(OBJECTS_CONFUGA) ../../dttools/src/auth_all.o $(EXTERNAL_DEPENDENCIES)
 
 chirp_server: $(OBJECTS_SERVER) libconfuga.a
-$(PROGRAMS): libchirp.a $(EXTERNAL_DEPENDENCIES)
-
-$(PROGRAMS) $(CCTOOLS_SWIG_BINDINGS): libchirp.a $(EXTERNAL_DEPENDENCIES)
+$(PROGRAMS_CONFUGA): libconfuga.a libchirp.a $(EXTERNAL_DEPENDENCIES)
+$(PROGRAMS_CHIRP): libchirp.a $(EXTERNAL_DEPENDENCIES)
+$(CCTOOLS_SWIG_BINDINGS): libchirp.a $(EXTERNAL_DEPENDENCIES)
 
 bindings: $(CCTOOLS_SWIG_BINDINGS)
 $(CCTOOLS_SWIG_BINDINGS): chirp_swig_wrap.o

--- a/chirp/src/confuga.h
+++ b/chirp/src/confuga.h
@@ -54,11 +54,6 @@ typedef uint64_t confuga_off_t; /* maximum file size */
 typedef struct confuga_replica confuga_replica;
 typedef struct confuga_file confuga_file;
 
-struct confuga_host {
-	char hostport[256+8]; /* Maximum length of FQDN is 255 octets per RFC, +8 for port */
-	char root[CONFUGA_PATH_MAX];
-};
-
 struct confuga_stat {
 	/* file content */
 	confuga_fid_t fid;
@@ -114,7 +109,11 @@ CONFUGA_API int confuga_daemon(confuga *C);
 
 CONFUGA_API int confuga_concurrency (confuga *C, uint64_t n);
 
-CONFUGA_API int confuga_nodes (confuga *C, const char *nodes);
+#define CONFUGA_SN_UUID 1
+#define CONFUGA_SN_ADDR 2
+CONFUGA_API int confuga_snadd (confuga *C, const char *id, const char *root, const char *password, int flag);
+CONFUGA_API int confuga_snrm (confuga *C, const char *id, int flag);
+CONFUGA_API int confuga_nodes (confuga *C, const char *nodes); /* deprecated */
 
 #define CONFUGA_SCHEDULER_FIFO 1
 CONFUGA_API int confuga_scheduler_strategy (confuga *C, int strategy, uint64_t n);

--- a/chirp/src/confuga_adm.c
+++ b/chirp/src/confuga_adm.c
@@ -1,0 +1,187 @@
+/*
+Copyright (C) 2016- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include "confuga.h"
+
+#include "catch.h"
+#include "cctools.h"
+#include "debug.h"
+#include "getopt.h"
+#include "random.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <string.h>
+
+static int process (confuga *C, int argc, char *argv[])
+{
+	int rc;
+	int c;
+
+	optind = 0;
+	if (strcmp(argv[0], "sn-add") == 0) {
+		static const struct option long_options[] = {
+			{"help", no_argument, 0, 'h'},
+			{"password", required_argument, 0, 'p'},
+			{"root", required_argument, 0, 'r'},
+			{0, 0, 0, 0}
+		};
+		static const char usage[] = "sn-add [-p password-file] [-r root] <\"uuid\"|\"address\"> <uuid|address>";
+		char password[PATH_MAX] = "";
+		char root[PATH_MAX] = "";
+		int flag = 0;
+
+		while((c = getopt_long(argc, argv, "+hp:r:", long_options, NULL)) > -1) {
+			switch (c) {
+				case 'h':
+					CATCHUNIX(fprintf(stdout, "%s\n", usage));
+					rc = 0;
+					goto out;
+				case 'p':
+					CATCHUNIX(snprintf(password, sizeof password, "%s", optarg));
+					break;
+				case 'r':
+					CATCHUNIX(snprintf(root, sizeof root, "%s", optarg));
+					break;
+				default:
+					CATCHUNIX(fprintf(stderr, "invalid command: %s\n", usage));
+					CATCH(EINVAL);
+					break;
+			}
+		}
+		if (optind != (argc-2) ) {
+			CATCHUNIX(fprintf(stderr, "invalid command: %s\n", usage));
+			CATCH(EINVAL);
+		}
+		if (strcmp(argv[optind], "uuid") == 0)
+			flag |= CONFUGA_SN_UUID;
+		else if (strcmp(argv[optind], "address") == 0)
+			flag |= CONFUGA_SN_ADDR;
+		else CATCH(EINVAL);
+		CATCH(confuga_snadd(C, argv[optind+1], root[0] ? root : NULL, password[0] ? password : NULL, flag));
+	} else if (strcmp(argv[0], "sn-rm") == 0) {
+		static const struct option long_options[] = {
+			{"help", no_argument, 0, 'h'},
+			{0, 0, 0, 0}
+		};
+		static const char usage[] = "sn-rm <\"uuid\"|\"address\"> <uuid|address>";
+		int flag = 0;
+
+		while((c = getopt_long(argc, argv, "+h", long_options, NULL)) > -1) {
+			switch (c) {
+				case 'h':
+					CATCHUNIX(fprintf(stdout, "%s\n", usage));
+					rc = 0;
+					goto out;
+				default:
+					CATCHUNIX(fprintf(stderr, "%s\n", usage));
+					CATCH(EINVAL);
+					break;
+			}
+		}
+		if (optind != (argc-2) ) {
+			CATCHUNIX(fprintf(stderr, "invalid command: %s\n", usage));
+			CATCH(EINVAL);
+		}
+		if (strcmp(argv[optind], "uuid") == 0)
+			flag |= CONFUGA_SN_UUID;
+		else if (strcmp(argv[optind], "address") == 0)
+			flag |= CONFUGA_SN_ADDR;
+		else CATCH(EINVAL);
+		CATCH(confuga_snrm(C, argv[optind+1], flag));
+	} else {
+		CATCHUNIX(fprintf(stderr, "invalid command: %s\n", argv[0]));
+		CATCH(EINVAL);
+	}
+
+	rc = 0;
+	goto out;
+out:
+	return rc;
+}
+
+static void help (const char *argv0)
+{
+	fprintf(stdout, "use: %s [options] <Confuga root> <cmd> [...]\n", argv0);
+	fprintf(stdout, "The most common options are:\n");
+	fprintf(stdout, " %-30s Enable debugging for this subsystem.\n", "-d,--debug=<name>");
+	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)\n", "-o,--debug-file=<file>");
+	fprintf(stdout, " %-30s Show version info.\n", "-v,--version");
+	fprintf(stdout, " %-30s This message.\n", "-h,--help");
+	fprintf(stdout, "\n");
+	fprintf(stdout, "Where debug flags are: ");
+	debug_flags_print(stdout);
+	fprintf(stdout, "\n\n");
+}
+
+int main (int argc, char *argv[])
+{
+	int rc;
+	int c;
+	confuga *C = NULL;
+	const char *root = NULL;
+
+	random_init();
+	debug_config(argv[0]);
+
+	static const struct option long_options[] = {
+		{"debug", required_argument, 0, 'd'},
+		{"debug-file", required_argument, 0, 'o'},
+		{"help", no_argument, 0, 'h'},
+		{"version", no_argument, 0, 'v'},
+		{0, 0, 0, 0}
+	};
+
+	while((c = getopt_long(argc, argv, "+d:ho:v", long_options, NULL)) > -1) {
+		switch (c) {
+			case 'd':
+				debug_flags_set(optarg);
+				break;
+			case 'h':
+				help(argv[0]);
+				exit(EXIT_SUCCESS);
+				break;
+			case 'o':
+				debug_config_file(optarg);
+				break;
+			case 'v':
+				cctools_version_print(stdout, argv[0]);
+				exit(EXIT_SUCCESS);
+				break;
+			default:
+				help(argv[0]);
+				exit(EXIT_FAILURE);
+		}
+	}
+
+	cctools_version_debug(D_DEBUG, argv[0]);
+
+	if (optind >= argc) {
+		help(argv[0]);
+		exit(EXIT_FAILURE);
+	}
+
+	root = argv[optind];
+	rc = confuga_connect(&C, root, NULL);
+	if (rc) {
+		fprintf(stderr, "could not connect to %s: %s\n", root, strerror(rc));
+		exit(EXIT_FAILURE);
+	}
+	optind++;
+
+	if (optind < argc) {
+		process(C, argc-optind, &argv[optind]);
+	}
+
+	rc = confuga_disconnect(C);
+	if (rc) {
+		fprintf(stderr, "warning: could not disconnect from %s: %s\n", argv[optind], strerror(rc));
+	}
+
+	return 0;
+}
+
+/* vim: set noexpandtab tabstop=4: */

--- a/chirp/src/confuga_fs.h
+++ b/chirp/src/confuga_fs.h
@@ -39,6 +39,13 @@ struct confuga {
 	uint64_t operations;
 };
 
+struct confuga_host {
+	char hostport[256+8]; /* Maximum length of FQDN is 255 octets per RFC, +8 for port */
+	char root[CONFUGA_PATH_MAX];
+};
+
+#define CONFUGA_SN_ROOT_DEFAULT "/.confuga"
+
 #define CONFUGA_TICKET_BITS 1024
 #define _stringify(D) #D
 #define stringify(D) _stringify(D)
@@ -70,12 +77,12 @@ CONFUGA_IAPI int confugaR_manager (confuga *C);
 
 CONFUGA_IAPI int confugaS_catalog (confuga *C, const char *catalog);
 CONFUGA_IAPI int confugaS_catalog_sync (confuga *C);
-CONFUGA_IAPI int confugaS_setup (confuga *C);
+CONFUGA_IAPI int confugaS_manager (confuga *C);
 CONFUGA_IAPI int confugaS_node_insert (confuga *C, const char *hostport, const char *root);
 
 CONFUGA_IAPI int confugaJ_schedule (confuga *C);
 
-#define CONFUGA_DB_VERSION  1
+#define CONFUGA_DB_VERSION  2
 
 #define str(s) #s
 #define xstr(s) str(s)

--- a/chirp/src/confuga_job.c
+++ b/chirp/src/confuga_job.c
@@ -1189,7 +1189,7 @@ static int job_create (confuga *C)
 	static const char SQL[] =
 		"SELECT ConfugaJob.id, ConfugaJob.tag, StorageNode.hostport"
 		"	FROM ConfugaJob INNER JOIN Confuga.StorageNode ON ConfugaJob.sid = StorageNode.id"
-		"	WHERE state = 'REPLICATED'"
+		"	WHERE ConfugaJob.state = 'REPLICATED'"
 		"	ORDER BY RANDOM()" /* to ensure no starvation, create may result in a ROLLBACK that aborts this SELECT */
 		"	LIMIT (CASE WHEN ?1 == 0 THEN -1 ELSE MAX(0, (?1 - (SELECT COUNT(*) FROM ConfugaJobExecuting))) END);";
 
@@ -1253,7 +1253,7 @@ static int job_commit (confuga *C)
 	static const char SQL[] =
 		"SELECT ConfugaJob.id, ConfugaJob.tag, StorageNode.hostport, ConfugaJob.cid"
 		"	FROM ConfugaJob INNER JOIN Confuga.StorageNode ON ConfugaJob.sid = StorageNode.id"
-		"	WHERE state = 'CREATED';";
+		"	WHERE ConfugaJob.state = 'CREATED';";
 
 	int rc;
 	sqlite3 *db = C->db;
@@ -1485,7 +1485,7 @@ static int job_reap (confuga *C)
 	static const char SQL[] =
 		"SELECT ConfugaJob.id, ConfugaJob.tag, StorageNode.hostport, ConfugaJob.cid"
 		"	FROM ConfugaJob INNER JOIN Confuga.StorageNode ON ConfugaJob.sid = StorageNode.id"
-		"	WHERE state = 'WAITED';";
+		"	WHERE ConfugaJob.state = 'WAITED';";
 
 	int rc;
 	sqlite3 *db = C->db;

--- a/chirp/src/confuga_node.c
+++ b/chirp/src/confuga_node.c
@@ -12,8 +12,11 @@ See the file COPYING for details.
 
 #include "catalog_query.h"
 #include "catch.h"
+#include "copy_stream.h"
 #include "debug.h"
 #include "jx.h"
+#include "pattern.h"
+#include "random.h"
 #include "sha1.h"
 
 #include <sys/stat.h>
@@ -47,10 +50,12 @@ out:
 CONFUGA_IAPI int confugaS_catalog_sync (confuga *C)
 {
 	static const char SQL[] =
-		"SELECT COUNT(*) FROM Confuga.StorageNode WHERE strftime('%s', 'now', '-2 minutes') <= lastheardfrom;"
 		"BEGIN IMMEDIATE TRANSACTION;"
 		"UPDATE Confuga.StorageNode"
 		"    SET"
+				/* Confuga */
+		"		hostport = ?,"
+				/* Catalog */
 		"		address = ?,"
 		"		avail = ?,"
 		"		backend = ?,"
@@ -74,10 +79,13 @@ CONFUGA_IAPI int confugaS_catalog_sync (confuga *C)
 		"		total = ?,"
 		"		total_ops = ?,"
 		"		url = ?,"
+		"		uuid = ?,"
 		"		version = ?"
-		"    WHERE hostport = ? || ':' || ? OR"
-		"          hostport = ? || ':' || ? OR"
-		"          'chirp://' || hostport = ?;"
+		"    WHERE"
+		"		uuid = ?"
+				/* backwards compatibility... */
+		"		OR uuid IS NULL AND (hostport = ? || ':' || ? OR hostport = ? || ':' || ? OR 'chirp://' || hostport = ?)"
+		";"
 		"END TRANSACTION;";
 
 	int rc;
@@ -87,14 +95,8 @@ CONFUGA_IAPI int confugaS_catalog_sync (confuga *C)
 	time_t stoptime = time(NULL)+15;
 	struct catalog_query *Q = NULL;
 	struct jx *j = NULL;
-
-	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
-	sqlcatchcode(sqlite3_step(stmt), SQLITE_ROW);
-	if (sqlite3_column_int(stmt, 0) > 0) {
-		rc = 0;
-		goto out;
-	}
-	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
+	char *host = NULL;
+	char *port = NULL;
 
 	debug(D_DEBUG|D_CONFUGA, "syncing with catalog");
 
@@ -111,9 +113,30 @@ CONFUGA_IAPI int confugaS_catalog_sync (confuga *C)
 	while ((j = catalog_query_read(Q, stoptime))) {
 		const char *type = jx_lookup_string(j, "type");
 		if (type && strcmp(type, "chirp") == 0) {
+			char hostport[256+8] = "";
 			int n = 1;
+			const char *jaddr = jx_lookup_string(j, "address");
+			const char *jname = jx_lookup_string(j, "name");
+			int jport = jx_lookup_integer(j, "port");
+			const char *jurl = jx_lookup_string(j, "url");
+			const char *juuid = jx_lookup_string(j, "uuid");
+
 			/* UPDATE */
-			sqlcatch(sqlite3_bind_text(stmt, n++, jx_lookup_string(j, "address"), -1, SQLITE_TRANSIENT));
+
+			/* Confuga fields */
+			if (jurl && pattern_match(jurl, "^chirp://([^:]+)%:(%d+)", &host, &port) >= 0) {
+				CATCHUNIX(snprintf(hostport, sizeof hostport, "%s:%s", host, port));
+				host = realloc(host, 0);
+				port = realloc(port, 0);
+			} else if (jname && jport) {
+				CATCHUNIX(snprintf(hostport, sizeof hostport, "%s:%d", jname, jport));
+			} else if (jaddr && jport) {
+				CATCHUNIX(snprintf(hostport, sizeof hostport, "%s:%d", jaddr, jport));
+			} else strcpy(hostport, "");
+			sqlcatch(sqlite3_bind_text(stmt, n++, hostport, -1, SQLITE_TRANSIENT));
+
+			/* Catalog fields */
+			sqlcatch(sqlite3_bind_text(stmt, n++, jaddr, -1, SQLITE_TRANSIENT));
 			sqlcatch(sqlite3_bind_int64(stmt, n++, jx_lookup_integer(j, "avail")));
 			sqlcatch(sqlite3_bind_text(stmt, n++, jx_lookup_string(j, "backend"), -1, SQLITE_TRANSIENT));
 			sqlcatch(sqlite3_bind_int64(stmt, n++, jx_lookup_integer(j, "bytes_read")));
@@ -127,23 +150,28 @@ CONFUGA_IAPI int confugaS_catalog_sync (confuga *C)
 			sqlcatch(sqlite3_bind_int64(stmt, n++, jx_lookup_integer(j, "memory_avail")));
 			sqlcatch(sqlite3_bind_int64(stmt, n++, jx_lookup_integer(j, "memory_total")));
 			sqlcatch(sqlite3_bind_int64(stmt, n++, jx_lookup_integer(j, "minfree")));
-			sqlcatch(sqlite3_bind_text(stmt, n++, jx_lookup_string(j, "name"), -1, SQLITE_TRANSIENT));
+			sqlcatch(sqlite3_bind_text(stmt, n++, jname, -1, SQLITE_TRANSIENT));
 			sqlcatch(sqlite3_bind_text(stmt, n++, jx_lookup_string(j, "opsys"), -1, SQLITE_TRANSIENT));
 			sqlcatch(sqlite3_bind_text(stmt, n++, jx_lookup_string(j, "opsysversion"), -1, SQLITE_TRANSIENT));
 			sqlcatch(sqlite3_bind_text(stmt, n++, jx_lookup_string(j, "owner"), -1, SQLITE_TRANSIENT));
-			sqlcatch(sqlite3_bind_int64(stmt, n++, jx_lookup_integer(j, "port")));
+			sqlcatch(sqlite3_bind_int64(stmt, n++, jport));
 			sqlcatch(sqlite3_bind_int64(stmt, n++, jx_lookup_integer(j, "starttime")));
 			sqlcatch(sqlite3_bind_int64(stmt, n++, jx_lookup_integer(j, "total")));
 			sqlcatch(sqlite3_bind_int64(stmt, n++, jx_lookup_integer(j, "total_ops")));
-			sqlcatch(sqlite3_bind_text(stmt, n++, jx_lookup_string(j, "url"), -1, SQLITE_TRANSIENT));
+			sqlcatch(sqlite3_bind_text(stmt, n++, jurl, -1, SQLITE_TRANSIENT));
+			sqlcatch(sqlite3_bind_text(stmt, n++, juuid, -1, SQLITE_TRANSIENT));
 			sqlcatch(sqlite3_bind_text(stmt, n++, jx_lookup_string(j, "version"), -1, SQLITE_TRANSIENT));
+
 			/* WHERE hostport = ? */
-			sqlcatch(sqlite3_bind_text(stmt, n++, jx_lookup_string(j, "name"), -1, SQLITE_TRANSIENT));
-			sqlcatch(sqlite3_bind_int64(stmt, n++, jx_lookup_integer(j, "port")));
-			sqlcatch(sqlite3_bind_text(stmt, n++, jx_lookup_string(j, "address"), -1, SQLITE_TRANSIENT));
-			sqlcatch(sqlite3_bind_int64(stmt, n++, jx_lookup_integer(j, "port")));
-			sqlcatch(sqlite3_bind_text(stmt, n++, jx_lookup_string(j, "url"), -1, SQLITE_TRANSIENT));
+			sqlcatch(sqlite3_bind_text(stmt, n++, juuid, -1, SQLITE_TRANSIENT));
+			sqlcatch(sqlite3_bind_text(stmt, n++, jname, -1, SQLITE_TRANSIENT));
+			sqlcatch(sqlite3_bind_int64(stmt, n++, jport));
+			sqlcatch(sqlite3_bind_text(stmt, n++, jaddr, -1, SQLITE_TRANSIENT));
+			sqlcatch(sqlite3_bind_int64(stmt, n++, jport));
+			sqlcatch(sqlite3_bind_text(stmt, n++, jurl, -1, SQLITE_TRANSIENT));
+
 			sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
+			C->operations++;
 			sqlcatch(sqlite3_reset(stmt));
 			sqlcatch(sqlite3_clear_bindings(stmt));
 		}
@@ -161,50 +189,79 @@ out:
 		catalog_query_delete(Q);
 	sqlite3_finalize(stmt);
 	sqlend(db);
+	free(host);
+	free(port);
 	return rc;
 }
 
-static int sn_ticket (confuga *C, const struct confuga_host *host)
+static int sn_ticket (confuga *C)
 {
 	static const char SQL[] =
+		"SELECT id, hostport, root"
+		"	FROM Confuga.StorageNodeActive"
+		"	WHERE hostport IS NOT NULL AND (ticket IS NULL OR ticket != ? OR time_ticket < strftime('%s', 'now', '-8 hours'))"
+		"	ORDER BY RANDOM()"
+		"	LIMIT 1"
+		";"
 		"UPDATE Confuga.StorageNode"
-		"	SET ticket = ?2"
-		"	WHERE hostport = ?1;"
+		"	SET"
+		"		ticket = ?2,"
+		"		time_ticket = (strftime('%s', 'now'))"
+		"	WHERE id = ?1"
+		";"
 		;
 
 	int rc;
 	sqlite3 *db = C->db;
 	sqlite3_stmt *stmt = NULL;
+	sqlite3_stmt *select = NULL;
+	sqlite3_stmt *update = NULL;
 	const char *current = SQL;
-	time_t stoptime = STOPTIME_SHORT;
-
-	char ticket[PATH_MAX];
-	char path[CHIRP_PATH_MAX];
-	struct stat info;
 	FILE *stream = NULL;
 
-	CATCHUNIX(snprintf(ticket, sizeof(ticket), "%s/ticket", C->root));
-	CATCHUNIX(chirp_reli_ticket_register(host->hostport, ticket, "self", TICKET_DURATION, stoptime));
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &select, &current));
+	sqlcatch(sqlite3_bind_blob(select, 1, C->ticket, sizeof(C->ticket), SQLITE_STATIC));
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &update, &current));
+	sqlcatch(sqlite3_bind_blob(update, 2, C->ticket, sizeof(C->ticket), SQLITE_STATIC));
 
-	/* The list permission is necessary because chirp_fs_local_scheduler.c:geturl does a stat. */
-	CATCHUNIX(snprintf(path, sizeof(path), "%s/file", host->root));
-	CATCHUNIX(chirp_reli_ticket_modify(host->hostport, ticket, path, "lr", stoptime));
+	while ((rc = sqlite3_step(select)) == SQLITE_ROW) {
+		confuga_sid_t sid = sqlite3_column_int64(select, 0);
+		const char *hostport = (const char *)sqlite3_column_text(select, 1);
+		const char *root = (const char *)sqlite3_column_text(select, 2);
+		time_t stoptime = STOPTIME_SHORT;
+		char ticket[PATH_MAX];
+		char path[CHIRP_PATH_MAX];
+		struct stat info;
 
-	/* Add write permission because a putfile may need retried. */
-	CATCHUNIX(snprintf(path, sizeof(path), "%s/open", host->root));
-	CATCHUNIX(chirp_reli_ticket_modify(host->hostport, ticket, path, "pw", stoptime));
+		CATCHUNIX(snprintf(ticket, sizeof(ticket), "%s/ticket", C->root));
+		CATCHUNIX(chirp_reli_ticket_register(hostport, ticket, "self", TICKET_DURATION, stoptime));
 
-	CATCHUNIX(snprintf(path, sizeof(path), "%s/ticket", host->root));
-	stream = fopen(ticket, "r");
-	CATCHUNIX(stream ? 0 : -1);
-	CATCHUNIX(fstat(fileno(stream), &info));
-	CATCHUNIX(chirp_reli_putfile(host->hostport, path, stream, S_IRUSR, info.st_size, stoptime));
+		/* The list permission is necessary because chirp_fs_local_scheduler.c:geturl does a stat. */
+		CATCHUNIX(snprintf(path, sizeof(path), "%s/file", root));
+		CATCHUNIX(chirp_reli_ticket_modify(hostport, ticket, path, "lr", stoptime));
 
-	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
-	sqlcatch(sqlite3_bind_text(stmt, 1, host->hostport, -1, SQLITE_STATIC));
-	sqlcatch(sqlite3_bind_blob(stmt, 2, C->ticket, sizeof(C->ticket), SQLITE_STATIC));
-	sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
-	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
+		/* Add write permission because a putfile may need retried. */
+		CATCHUNIX(snprintf(path, sizeof(path), "%s/open", root));
+		CATCHUNIX(chirp_reli_ticket_modify(hostport, ticket, path, "pw", stoptime));
+
+		CATCHUNIX(snprintf(path, sizeof(path), "%s/ticket", root));
+		stream = fopen(ticket, "r");
+		CATCHUNIX(stream ? 0 : -1);
+		CATCHUNIX(fstat(fileno(stream), &info));
+		CATCHUNIX(chirp_reli_putfile(hostport, path, stream, S_IRUSR, info.st_size, stoptime));
+		CATCHUNIX(fclose(stream));
+		stream = NULL;
+
+		sqlcatch(sqlite3_bind_int64(update, 1, sid));
+		sqlcatchcode(sqlite3_step(update), SQLITE_DONE);
+		debug(D_CONFUGA, "Storage Node " CONFUGA_SID_DEBFMT " (%s/%s) ticket registered", sid, hostport, root);
+		C->operations += 1;
+		sqlcatch(sqlite3_reset(update));
+		sqlcatch(sqlite3_reset(select));
+	}
+	sqlcatchcode(rc, SQLITE_DONE);
+	sqlcatch(sqlite3_finalize(select); select = NULL);
+	sqlcatch(sqlite3_finalize(update); update = NULL);
 
 	rc = 0;
 	goto out;
@@ -212,137 +269,548 @@ out:
 	if (stream)
 		fclose(stream);
 	sqlite3_finalize(stmt);
+	sqlite3_finalize(select);
+	sqlite3_finalize(update);
 	return rc;
 }
 
-static int sn_init (confuga *C, confuga_sid_t sid, const struct confuga_host *host)
+static int sn_build (confuga *C)
 {
 	static const confuga_fid_t empty = {CONFUGA_FID_EMPTY};
 	static const char SQL[] =
+		"SELECT id, hostport, root"
+		"	FROM Confuga.StorageNodeAuthenticated"
+		"	WHERE hostport IS NOT NULL AND state = 'BUILDING'"
+		"	ORDER BY RANDOM()"
+		"	LIMIT 1"
+		";"
 		"UPDATE Confuga.StorageNode"
-		"	SET initialized = 1"
-		"	WHERE hostport = ?1;";
+		"	SET state = 'ONLINE'"
+		"	WHERE id = ?1"
+		";"
+		;
 
 	int rc;
 	sqlite3 *db = C->db;
 	sqlite3_stmt *stmt = NULL;
+	sqlite3_stmt *select = NULL;
+	sqlite3_stmt *update = NULL;
 	const char *current = SQL;
 
-	char template[CHIRP_PATH_MAX];
-	time_t stoptime = STOPTIME_SHORT;
-	char whoami[128];
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &select, &current));
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &update, &current));
 
-	debug(D_CONFUGA, "initializing %s/%s", host->hostport, host->root);
+	while ((rc = sqlite3_step(select)) == SQLITE_ROW) {
+		confuga_sid_t sid = sqlite3_column_int64(select, 0);
+		const char *hostport = (const char *)sqlite3_column_text(select, 1);
+		const char *root = (const char *)sqlite3_column_text(select, 2);
+		char template[CHIRP_PATH_MAX];
+		time_t stoptime = STOPTIME_SHORT;
+		char whoami[128];
 
-	CATCHUNIX(chirp_reli_whoami(host->hostport, whoami, sizeof(whoami), stoptime));
+		debug(D_CONFUGA, "building %s/%s", hostport, root);
 
-	CATCHUNIXIGNORE(chirp_reli_mkdir_recursive(host->hostport, host->root, S_IRWXU, stoptime), EEXIST);
+		CATCHUNIX(chirp_reli_whoami(hostport, whoami, sizeof(whoami), stoptime));
 
-	CATCHUNIX(snprintf(template, sizeof(template), "%s/file", host->root));
-	CATCHUNIXIGNORE(chirp_reli_mkdir(host->hostport, template, S_IRWXU, stoptime), EEXIST);
-	CATCHUNIX(chirp_reli_setacl(host->hostport, template, whoami, "rwldpa", stoptime));
+		CATCHUNIXIGNORE(chirp_reli_mkdir_recursive(hostport, root, S_IRWXU, stoptime), EEXIST);
 
-	CATCHUNIX(snprintf(template, sizeof(template), "%s/file/" CONFUGA_FID_PRIFMT, host->root, CONFUGA_FID_PRIARGS(empty)));
-	CATCHUNIXIGNORE(chirp_reli_putfile_buffer(host->hostport, template, "", S_IRUSR, 0, stoptime), EEXIST);
-	CATCH(confugaR_register(C, empty, 0, sid));
+		CATCHUNIX(snprintf(template, sizeof(template), "%s/file", root));
+		CATCHUNIXIGNORE(chirp_reli_mkdir(hostport, template, S_IRWXU, stoptime), EEXIST);
+		CATCHUNIX(chirp_reli_setacl(hostport, template, whoami, "rwldpa", stoptime));
 
-	CATCHUNIX(snprintf(template, sizeof(template), "%s/open", host->root));
-	CATCHUNIXIGNORE(chirp_reli_mkdir(host->hostport, template, S_IRWXU, stoptime), EEXIST);
-	CATCHUNIX(chirp_reli_setacl(host->hostport, template, whoami, "rwldpa", stoptime));
+		CATCHUNIX(snprintf(template, sizeof(template), "%s/file/" CONFUGA_FID_PRIFMT, root, CONFUGA_FID_PRIARGS(empty)));
+		CATCHUNIXIGNORE(chirp_reli_putfile_buffer(hostport, template, "", S_IRUSR, 0, stoptime), EEXIST);
+		CATCH(confugaR_register(C, empty, 0, sid));
 
-	CATCHUNIX(snprintf(template, sizeof(template), "%s/tickets", host->root));
-	CATCHUNIXIGNORE(chirp_reli_mkdir(host->hostport, template, S_IRWXU, stoptime), EEXIST);
-	CATCHUNIX(chirp_reli_setacl(host->hostport, template, whoami, "rwldpa", stoptime));
+		CATCHUNIX(snprintf(template, sizeof(template), "%s/open", root));
+		CATCHUNIXIGNORE(chirp_reli_mkdir(hostport, template, S_IRWXU, stoptime), EEXIST);
+		CATCHUNIX(chirp_reli_setacl(hostport, template, whoami, "rwldpa", stoptime));
 
-	debug(D_DEBUG, "setting `%s' to initialized", host->hostport);
-	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
-	sqlcatch(sqlite3_bind_text(stmt, 1, host->hostport, -1, SQLITE_STATIC));
-	sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
-	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
-	debug(D_CONFUGA, "%s/%s initialized", host->hostport, host->root);
+		CATCHUNIX(snprintf(template, sizeof(template), "%s/tickets", root));
+		CATCHUNIXIGNORE(chirp_reli_mkdir(hostport, template, S_IRWXU, stoptime), EEXIST);
+		CATCHUNIX(chirp_reli_setacl(hostport, template, whoami, "rwldpa", stoptime));
+
+		sqlcatch(sqlite3_bind_int64(update, 1, sid));
+		sqlcatchcode(sqlite3_step(update), SQLITE_DONE);
+		debug(D_CONFUGA, "Storage Node " CONFUGA_SID_DEBFMT " (%s/%s) ONLINE", sid, hostport, root);
+		C->operations += 1;
+		sqlcatch(sqlite3_reset(update));
+		sqlcatch(sqlite3_reset(select));
+	}
+	sqlcatchcode(rc, SQLITE_DONE);
+	sqlcatch(sqlite3_finalize(select); select = NULL);
+	sqlcatch(sqlite3_finalize(update); update = NULL);
 
 	rc = 0;
 	goto out;
 out:
 	sqlite3_finalize(stmt);
+	sqlite3_finalize(select);
+	sqlite3_finalize(update);
 	return rc;
 }
 
-CONFUGA_IAPI int confugaS_node_insert (confuga *C, const char *hostport, const char *root)
+static int sn_set_password (confuga *C)
 {
 	static const char SQL[] =
-		"INSERT OR IGNORE INTO Confuga.StorageNode (hostport, root)"
-		"	VALUES (?1, ?2);";
+		"SELECT id, hostport, root"
+		"	FROM Confuga.StorageNodeAlive"
+		"	WHERE password IS NULL"
+		"	ORDER BY RANDOM()"
+		"	LIMIT 1"
+		";"
+		"UPDATE Confuga.StorageNode"
+		"	SET password = ?2"
+		"	WHERE id = ?1"
+		";"
+		;
 
 	int rc;
 	sqlite3 *db = C->db;
 	sqlite3_stmt *stmt = NULL;
+	sqlite3_stmt *select = NULL;
+	sqlite3_stmt *update = NULL;
 	const char *current = SQL;
 
-	if (strlen(root) == 0)
-		root = "/";
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &select, &current));
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &update, &current));
 
-	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
-	sqlcatch(sqlite3_bind_text(stmt, 1, hostport, -1, SQLITE_STATIC));
-	sqlcatch(sqlite3_bind_text(stmt, 2, root, -1, SQLITE_STATIC));
-	sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
-	if (sqlite3_changes(db) == 1)
-		debug(D_CONFUGA, "Storage Node " CONFUGA_SID_DEBFMT " (chirp://%s/%s) online", (confuga_sid_t)sqlite3_last_insert_rowid(db), hostport, root);
-	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
+	while ((rc = sqlite3_step(select)) == SQLITE_ROW) {
+		confuga_sid_t sid = sqlite3_column_int64(select, 0);
+		const char *hostport = (const char *)sqlite3_column_text(select, 1);
+		const char *root = (const char *)sqlite3_column_text(select, 2);
+		time_t stoptime = STOPTIME_SHORT;
+		char path[CHIRP_PATH_MAX];
+		unsigned char password[20];
+		unsigned char digest[SHA1_DIGEST_LENGTH];
 
-	rc = 0;
-	goto out;
-out:
-	sqlite3_finalize(stmt);
-	return rc;
-}
+		random_array(password, sizeof password);
+		sha1_buffer(password, sizeof password, digest);
 
-CONFUGA_IAPI int confugaS_setup (confuga *C)
-{
-	static const char SQL[] =
-		"DROP TABLE IF EXISTS ConfugaResults;"
-		"CREATE TEMPORARY TABLE ConfugaResults AS" /* so we don't hold read locks */
-		"	SELECT id, hostport, root, initialized, ticket"
-		"		FROM Confuga.StorageNodeAlive;"
-		"SELECT * FROM ConfugaResults;";
-
-	int rc;
-	sqlite3 *db = C->db;
-	sqlite3_stmt *stmt = NULL;
-	const char *current = SQL;
-
-	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
-	sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
-	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
-
-	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
-	sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
-	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
-
-	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
-	while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
-		confuga_sid_t sid;
-		struct confuga_host host;
-		sid = sqlite3_column_int64(stmt, 0);
-		CATCHUNIX(snprintf(host.hostport, sizeof(host.hostport), "%s", (const char *) sqlite3_column_text(stmt, 1)));
-		CATCHUNIX(snprintf(host.root, sizeof(host.root), "%s", (const char *) sqlite3_column_text(stmt, 2)));
-		if (!sqlite3_column_int(stmt, 3)) {
-			sn_init(C, sid, &host);
+		CATCHUNIXIGNORE(chirp_reli_mkdir_recursive(hostport, root, S_IRWXU, stoptime), EEXIST);
+		CATCHUNIX(snprintf(path, sizeof(path), "%s/password", root));
+		rc = UNIXRC(chirp_reli_putfile_buffer(hostport, path, password, S_IRUSR, sizeof password, stoptime));
+		if (rc == 0) {
+		} else {
+			CATCH(rc);
 		}
-		const unsigned char *ticket = sqlite3_column_blob(stmt, 4);
-		assert(sqlite3_column_bytes(stmt, 4) == 0 || sqlite3_column_bytes(stmt, 4) == sizeof(C->ticket));
-		if (ticket == NULL || !(memcmp(ticket, C->ticket, sizeof(C->ticket)) == 0)) {
-			sn_ticket(C, &host);
+
+		sqlcatch(sqlite3_bind_int64(update, 1, sid));
+		sqlcatch(sqlite3_bind_blob(update, 2, digest, sizeof digest, SQLITE_STATIC));
+		sqlcatchcode(sqlite3_step(update), SQLITE_DONE);
+		debug(D_CONFUGA, "Storage Node " CONFUGA_SID_DEBFMT " (%s/%s) password set", sid, hostport, root);
+		C->operations += 1;
+		sqlcatch(sqlite3_reset(update));
+		sqlcatch(sqlite3_reset(select));
+	}
+	sqlcatchcode(rc, SQLITE_DONE);
+	sqlcatch(sqlite3_finalize(select); select = NULL);
+	sqlcatch(sqlite3_finalize(update); update = NULL);
+
+	rc = 0;
+	goto out;
+out:
+	sqlite3_finalize(stmt);
+	sqlite3_finalize(select);
+	sqlite3_finalize(update);
+	return rc;
+}
+
+/* Ideally this would be done anytime the Confuga HN (re)connects to a storage node. */
+static int sn_authenticate (confuga *C)
+{
+	static const char SQL[] =
+		"SELECT id, hostport, root, password"
+		"	FROM Confuga.StorageNodeAlive"
+		"	WHERE password IS NOT NULL AND (NOT authenticated OR time_authenticated < strftime('%s', 'now', '-15 minutes'))"
+		"	ORDER BY RANDOM()"
+		";"
+		"UPDATE Confuga.StorageNode"
+		"	SET"
+		"		authenticated = 1,"
+		"		time_authenticated = (strftime('%s', 'now'))"
+		"	WHERE id = ?1"
+		";"
+		;
+
+	int rc;
+	sqlite3 *db = C->db;
+	sqlite3_stmt *stmt = NULL;
+	sqlite3_stmt *select = NULL;
+	sqlite3_stmt *update = NULL;
+	const char *current = SQL;
+
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &select, &current));
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &update, &current));
+
+	while ((rc = sqlite3_step(select)) == SQLITE_ROW) {
+		confuga_sid_t sid = sqlite3_column_int64(select, 0);
+		const char *hostport = (const char *)sqlite3_column_text(select, 1);
+		const char *root = (const char *)sqlite3_column_text(select, 2);
+		const void *password = sqlite3_column_blob(select, 3);
+		time_t stoptime = STOPTIME_SHORT;
+		char path[CHIRP_PATH_MAX];
+		unsigned char digest[SHA1_DIGEST_LENGTH];
+
+		assert(sqlite3_column_bytes(select, 3) == SHA1_DIGEST_LENGTH);
+		CATCHUNIX(snprintf(path, sizeof(path), "%s/password", root));
+		rc = chirp_reli_hash(hostport, path, "sha1", digest, stoptime);
+		if (rc >= 0) {
+			if (memcmp(password, digest, SHA1_DIGEST_LENGTH) == 0) {
+				sqlcatch(sqlite3_bind_int64(update, 1, sid));
+				sqlcatchcode(sqlite3_step(update), SQLITE_DONE);
+				sqlcatch(sqlite3_reset(update));
+				debug(D_CONFUGA, "Storage Node " CONFUGA_SID_DEBFMT " (%s/%s) password correct", sid, hostport, root);
+				C->operations += 1;
+			} else {
+				debug(D_CONFUGA, "Storage Node " CONFUGA_SID_DEBFMT " (%s/%s) password failure", sid, hostport, root);
+				/* FIXME what to do? */
+			}
+		} else {
+			CATCH(errno);
+			/* FIXME what to do? */
 		}
 	}
 	sqlcatchcode(rc, SQLITE_DONE);
+	sqlcatch(sqlite3_finalize(select); select = NULL);
+	sqlcatch(sqlite3_finalize(update); update = NULL);
+
+	rc = 0;
+	goto out;
+out:
+	sqlite3_finalize(stmt);
+	sqlite3_finalize(update);
+	sqlite3_finalize(select);
+	return rc;
+}
+
+static int sn_removing (confuga *C)
+{
+	static const char SQL[] =
+		"WITH"
+		"	DepartingStorageNode AS ("
+		"		SELECT Confuga.StorageNodeAuthenticated.id"
+		"			FROM"
+		"				Confuga.StorageNodeAuthenticated"
+		"				LEFT OUTER JOIN Confuga.ActiveTransfers AS fat ON StorageNodeAuthenticated.id = fat.fsid"
+		"				LEFT OUTER JOIN Confuga.ActiveTransfers AS tat ON StorageNodeAuthenticated.id = tat.tsid"
+		"				LEFT OUTER JOIN ConfugaJobAllocated ON StorageNodeAuthenticated.id = ConfugaJobAllocated.sid"
+		"			WHERE StorageNodeAuthenticated.state = 'REMOVING' AND fat.fsid IS NULL AND tat.tsid IS NULL AND ConfugaJobAllocated.sid IS NULL"
+		"	),"
+		"	DegradedFile AS ("
+		"		SELECT File.id"
+		"			FROM"
+		"				Confuga.File"
+		"				LEFT OUTER JOIN (Confuga.Replica JOIN Confuga.StorageNodeActive ON Replica.sid = StorageNodeActive.id) ON File.id = Replica.fid"
+		"			GROUP BY File.id"
+		"			HAVING COUNT(Replica.sid) < MIN(3, File.minimum_replicas)"
+		"	)"
+		"SELECT DepartingStorageNode.id, Replica.fid"
+		"	FROM"
+		"		DepartingStorageNode JOIN Confuga.Replica ON DepartingStorageNode.id = Replica.sid"
+		"	WHERE Replica.fid NOT IN (SELECT DegradedFile.id FROM DegradedFile)"
+		"	ORDER BY RANDOM()"
+		";"
+		;
+
+	int rc;
+	sqlite3 *db = C->db;
+	sqlite3_stmt *stmt = NULL;
+	const char *current = SQL;
+
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
+	while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+		confuga_sid_t id = sqlite3_column_int64(stmt, 0);
+		confuga_fid_t fid;
+		CATCH(confugaF_set(C, &fid, sqlite3_column_blob(stmt, 1)));
+		CATCH(confugaR_delete(C, id, fid));
+		C->operations++;
+	}
+	sqlcatchcode(rc, SQLITE_DONE);
+
+	rc = 0;
+	goto out;
+out:
+	sqlite3_finalize(stmt);
+	return rc;
+}
+
+static int sn_remove (confuga *C)
+{
+	static const char SQL[] =
+		"BEGIN TRANSACTION;"
+		"SELECT StorageNode.id, StorageNode.hostport, StorageNode.root"
+		"	FROM"
+		"		Confuga.StorageNode"
+		"		LEFT OUTER JOIN Confuga.Replica ON StorageNode.id = Replica.sid"
+		"		LEFT OUTER JOIN Confuga.DeadReplica ON StorageNode.id = DeadReplica.sid"
+		"		LEFT OUTER JOIN Confuga.ActiveTransfers AS fat ON StorageNode.id = fat.fsid"
+		"		LEFT OUTER JOIN Confuga.ActiveTransfers AS tat ON StorageNode.id = tat.tsid"
+		"		LEFT OUTER JOIN ConfugaJobAllocated ON StorageNode.id = ConfugaJobAllocated.sid"
+		"	WHERE StorageNode.state = 'REMOVING' AND Replica.sid IS NULL AND DeadReplica.sid IS NULL AND fat.fsid IS NULL AND tat.tsid IS NULL AND ConfugaJobAllocated.sid IS NULL"
+		"	ORDER BY RANDOM()"
+		";"
+		"DELETE FROM Confuga.TransferJob"
+		"	WHERE (fsid = ?1 OR tsid = ?1) AND NOT EXISTS (SELECT id FROM Confuga.ActiveTransfers WHERE fsid = ?1 OR tsid = ?1);"
+		"DELETE FROM Confuga.StorageNode"
+		"	WHERE id = ?;"
+		"END TRANSACTION;"
+		;
+
+	int rc;
+	sqlite3 *db = C->db;
+	sqlite3_stmt *stmt = NULL;
+	sqlite3_stmt *select = NULL;
+	sqlite3_stmt *delete1 = NULL;
+	sqlite3_stmt *delete2 = NULL;
+	const char *current = SQL;
+
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
+	sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
+	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
+
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &select, &current));
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &delete1, &current));
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &delete2, &current));
+
+	while ((rc = sqlite3_step(select)) == SQLITE_ROW) {
+		confuga_sid_t id = sqlite3_column_int64(select, 0);
+		const char *hostport = (const char *)sqlite3_column_text(select, 1);
+		const char *root = (const char *)sqlite3_column_text(select, 2);
+		sqlcatch(sqlite3_bind_int64(delete1, 1, id));
+		sqlcatchcode(sqlite3_step(delete1), SQLITE_DONE);
+		sqlcatch(sqlite3_bind_int64(delete2, 1, id));
+		sqlcatchcode(sqlite3_step(delete2), SQLITE_DONE);
+		debug(D_CONFUGA, "Storage Node " CONFUGA_SID_DEBFMT " (%s/%s) removed from cluster", id, hostport, root);
+		C->operations++;
+	}
+	sqlcatchcode(rc, SQLITE_DONE);
+
+	sqlcatch(sqlite3_finalize(delete1); delete1 = NULL);
+	sqlcatch(sqlite3_finalize(delete2); delete2 = NULL);
+	sqlcatch(sqlite3_finalize(select); select = NULL);
+
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
+	sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
 	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
 
 	rc = 0;
 	goto out;
 out:
 	sqlite3_finalize(stmt);
-	sqlite3_exec(db, "DROP TABLE IF EXISTS ConfugaResults;", NULL, NULL, NULL);
+	sqlite3_finalize(delete2);
+	sqlite3_finalize(delete1);
+	sqlite3_finalize(select);
+	sqlend(db);
+	return rc;
+}
+
+CONFUGA_IAPI int confugaS_manager (confuga *C)
+{
+	sn_build(C);
+	sn_ticket(C);
+	sn_set_password(C);
+	sn_authenticate(C);
+	sn_removing(C);
+	sn_remove(C);
+	return 0;
+}
+
+static int addbyaddr (confuga *C, const char *address, const char *root, const char *password)
+{
+	static const char SQL[] =
+		"INSERT INTO Confuga.StorageNode (hostport, root, password, state)"
+		"	SELECT ?1, ?2, ?3, 'BUILDING'"
+		"		WHERE NOT EXISTS (SELECT id FROM Confuga.StorageNode WHERE hostport = ?1)"
+		";"
+		;
+
+	int rc;
+	sqlite3 *db = C->db;
+	sqlite3_stmt *stmt = NULL;
+	const char *current = SQL;
+	root = !root || strlen(root) == 0 ? CONFUGA_SN_ROOT_DEFAULT : root;
+
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
+	sqlcatch(sqlite3_bind_text(stmt, 1, address, -1, SQLITE_STATIC));
+	sqlcatch(sqlite3_bind_text(stmt, 2, root, -1, SQLITE_STATIC));
+	if (password) {
+		unsigned char digest[SHA1_DIGEST_LENGTH];
+		sha1_buffer(password, strlen(password), digest);
+		sqlcatch(sqlite3_bind_blob(stmt, 3, digest, sizeof digest, SQLITE_TRANSIENT));
+	}
+	sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
+	if (sqlite3_changes(db) == 1) {
+		debug(D_CONFUGA, "Storage Node " CONFUGA_SID_DEBFMT " (%s/%s) added to cluster", (confuga_sid_t)sqlite3_last_insert_rowid(db), address, root);
+		C->operations += 1;
+	}
+	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
+
+	rc = 0;
+	goto out;
+out:
+	sqlite3_finalize(stmt);
+	return rc;
+}
+
+static int addbyuuid (confuga *C, const char *uuid, const char *root, const char *password)
+{
+	static const char SQL[] =
+		"INSERT INTO Confuga.StorageNode (uuid, root, password)"
+		"	VALUES (?, ?, ?)"
+		";"
+		;
+
+	int rc;
+	sqlite3 *db = C->db;
+	sqlite3_stmt *stmt = NULL;
+	const char *current = SQL;
+	root = !root || strlen(root) == 0 ? CONFUGA_SN_ROOT_DEFAULT : root;
+
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
+	sqlcatch(sqlite3_bind_text(stmt, 1, uuid, -1, SQLITE_STATIC));
+	sqlcatch(sqlite3_bind_text(stmt, 2, root, -1, SQLITE_STATIC));
+	if (password) {
+		unsigned char digest[SHA1_DIGEST_LENGTH];
+		sha1_buffer(password, strlen(password), digest);
+		sqlcatch(sqlite3_bind_blob(stmt, 3, digest, sizeof digest, SQLITE_TRANSIENT));
+	}
+	sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
+	if (sqlite3_changes(db) == 1) {
+		debug(D_CONFUGA, "Storage Node " CONFUGA_SID_DEBFMT " (%s) added to cluster", (confuga_sid_t)sqlite3_last_insert_rowid(db), uuid);
+		C->operations++;
+	}
+	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
+
+	rc = 0;
+	goto out;
+out:
+	sqlite3_finalize(stmt);
+	return rc;
+}
+
+CONFUGA_API int confuga_nodes (confuga *C, const char *nodes)
+{
+	int rc;
+	FILE *file = NULL;
+	char *node = NULL;
+	const char *rest;
+	char *hostport = NULL;
+	char *root = NULL;
+	size_t n;
+
+	if (pattern_match(nodes, "^node:(.*)", &node) >= 0) {
+		/* do nothing */
+	} else if (pattern_match(nodes, "^file:(.*)", &node) >= 0) {
+		file = fopen(node, "r");
+		CATCHUNIX(file ? 0 : -1);
+		CATCHUNIX(copy_stream_to_buffer(file, &node, NULL));
+	} else CATCH(EINVAL);
+
+	rest = node;
+	while (pattern_match(rest, "^[%s,]*chirp://([^/,%s]+)([^,%s]*)()", &hostport, &root, &n) >= 0) {
+		addbyaddr(C, hostport, root, NULL);
+		rest += n;
+		hostport = realloc(hostport, 0);
+		root = realloc(root, 0);
+		C->operations++;
+	}
+
+	rc = 0;
+	goto out;
+out:
+	if (file)
+		fclose(file);
+	free(node);
+	free(hostport);
+	free(root);
+	return rc;
+}
+
+CONFUGA_API int confuga_snadd (confuga *C, const char *id, const char *root, const char *password, int flag)
+{
+	int rc;
+	int opmask = CONFUGA_SN_UUID | CONFUGA_SN_ADDR;
+
+	if ((flag & opmask) == opmask || (flag & opmask) == 0)
+		CATCH(EINVAL);
+
+	if (flag & CONFUGA_SN_UUID) {
+		CATCH(addbyuuid(C, id, root, password));
+	} else if (flag & CONFUGA_SN_ADDR) {
+		CATCH(addbyaddr(C, id, root, password));
+	} else assert(0);
+
+	rc = 0;
+	goto out;
+out:
+	return rc;
+}
+
+CONFUGA_API int confuga_snrm (confuga *C, const char *id, int flag)
+{
+	static const char SQL[] =
+		"BEGIN TRANSACTION;"
+		"SELECT id, hostport, root"
+		"	FROM Confuga.StorageNode"
+		"	WHERE uuid = ? OR hostport = ?"
+		";"
+		"UPDATE Confuga.StorageNode"
+		"	SET state = 'REMOVING'"
+		"	WHERE id = ?"
+		";"
+		"END TRANSACTION;"
+		;
+
+	int rc;
+	sqlite3 *db = C->db;
+	sqlite3_stmt *stmt = NULL;
+	sqlite3_stmt *select = NULL;
+	sqlite3_stmt *update = NULL;
+	const char *current = SQL;
+
+	int opmask = CONFUGA_SN_UUID | CONFUGA_SN_ADDR;
+
+	if ((flag & opmask) == opmask || (flag & opmask) == 0)
+		CATCH(EINVAL);
+
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
+	sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
+	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
+
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &select, &current));
+	if (flag & CONFUGA_SN_UUID)
+		sqlcatch(sqlite3_bind_text(select, 1, id, -1, SQLITE_STATIC));
+	else if (flag & CONFUGA_SN_ADDR)
+		sqlcatch(sqlite3_bind_text(select, 2, id, -1, SQLITE_STATIC));
+	else assert(0);
+	sqlcatchcode(sqlite3_step(select), SQLITE_ROW);
+	confuga_sid_t sid = sqlite3_column_int64(select, 0);
+	const char *hostport = (const char *)sqlite3_column_text(select, 1);
+	const char *root = (const char *)sqlite3_column_text(select, 2);
+
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &update, &current));
+	sqlcatch(sqlite3_bind_int64(update, 1, sid));
+	sqlcatchcode(sqlite3_step(update), SQLITE_DONE);
+	if (sqlite3_changes(db) == 1) {
+		debug(D_CONFUGA, "Storage Node " CONFUGA_SID_DEBFMT " (%s/%s) to be removed from cluster", sid, hostport, root);
+		C->operations++;
+	}
+
+	sqlcatch(sqlite3_finalize(update); update = NULL);
+	sqlcatch(sqlite3_finalize(select); select = NULL);
+
+	sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
+	sqlcatchcode(sqlite3_step(stmt), SQLITE_DONE);
+	sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
+
+	rc = 0;
+	goto out;
+out:
+	sqlite3_finalize(stmt);
+	sqlite3_finalize(select);
+	sqlite3_finalize(update);
+	sqlend(db);
 	return rc;
 }
 

--- a/doc/confuga.html
+++ b/doc/confuga.html
@@ -93,21 +93,10 @@
             <h3 id="starting.cluster">Running a Test Cluster<a class="sectionlink" href="#starting.cluster" title="Link to this section.">&#x21d7;</a></h3>
 
                 <p>Let's get started quickly by setting up a 2 storage node
-                test cluster on your local workstation. Because we are running
-                these storage nodes on <tt>localhost</tt>, we use a self-hosted
-                catalog. Otherwise, the head node will not be able to match
-                storage nodes (localhost is ambiguous in a global list of
-                servers).</p>
+                test cluster on your local workstation.</p>
 
-                <p><b>The Catalog:</b>
-                <code><span class="prompt">$ </span>catalog_server --history=catalog.history \
-    --update-log=catalog.update \
-    --interface=127.0.0.1 \
-    &amp;</code>
-
-                <p><b>Storage Node 1:</b>
+                <p><b>Start Storage Node 1:</b>
                 <code><span class="prompt">$ </span>chirp_server \
-    --advertise=localhost \
     --catalog-name=localhost \
     --catalog-update=10s \
     --interface=127.0.0.1 \
@@ -120,9 +109,8 @@
     &amp;</code>
                 </p>
 
-                <p><b>Storage Node 2:</b>
+                <p><b>Start Storage Node 2:</b>
                 <code><span class="prompt">$ </span>chirp_server \
-    --advertise=localhost \
     --catalog-name=localhost \
     --catalog-update=10s \
     --interface=127.0.0.1 \
@@ -135,16 +123,19 @@
     &amp;</code>
                 </p>
 
-                <p><b>The Head Node:</b>
+                <p><b>Add the Storage Nodes to Confuga:</b>
+                <code><span class="prompt">$ </span>confuga_adm confuga:///$(pwd)/confuga.root/ sn-add address localhost:9001
+<span class="prompt">$ </span>confuga_adm confuga:///$(pwd)/confuga.root/ sn-add address localhost:9002</code>
+
+                <p><b>Start the Head Node:</b>
                 <code><span class="prompt">$ </span>chirp_server \
-    --advertise=localhost \
     --catalog-name=localhost \
     --catalog-update=30s \
     --debug=confuga \
     --jobs \
     --port=9000 \
     --project-name=`whoami`-test \
-    --root='confuga://./confuga.root/?auth=unix&amp;nodes=node:chirp://localhost:9001/,chirp://localhost:9002/'</code>
+    --root="confuga://$(pwd)/confuga.root/?auth=unix"</code>
                 </p>
 
                 <p>Confuga will output debug information to your terminal, so
@@ -152,11 +143,11 @@
                 <tt>chirp_status</tt> to query the catalog allowing you to see
                 the status of the cluster:</p>
 
-                <code><span class="prompt">$ </span>chirp_status --catalog=localhost --server-project=`whoami`-test
+                <code><span class="prompt">$ </span>chirp_status --server-project=`whoami`-test
 TYPE     NAME                      PORT  OWNER      VERSION     TOTAL    AVAIL
-chirp    localhost.localdomain     9002  batrick    4.4.0     81.6 GB  17.0 GB
-chirp    localhost.localdomain     9001  batrick    4.4.0     81.6 GB  17.0 GB
-chirp    localhost.localdomain     9094  batrick    4.4.0    163.1 GB  34.0 GB</code>
+chirp    *.*.*.*                   9002  batrick    6.0.0     81.6 GB  56.2 GB
+chirp    *.*.*.*                   9001  batrick    6.0.0     81.6 GB  56.2 GB
+chirp    *.*.*.*                   9000  batrick    6.0.0    163.1 GB 112.4 GB</code>
 
                 <p>This example cluster also appears at the end of the Confuga manpage <a class="man" href="man/confuga.html">confuga(1)</a>.</p>
 
@@ -202,8 +193,9 @@ nothing left to do.</code>
             <h3 id="confuga.nodes">Running Storage Nodes<a class="sectionlink" href="#starting.nodes" title="Link to this section.">&#x21d7;</a></h3>
 
                 <p>Confuga uses regular Chirp servers as storage nodes. Each
-                storage node is specified using the <tt>nodes</tt> Confuga
-                option.  All storage node Chirp servers must be run with:</p>
+                storage node is added to the cluster using the <a class="man"
+                href="man/confuga_adm.html">confuga_adm(1)</a>. command.  All
+                storage node Chirp servers must be run with:</p>
 
                 <ul>
                     <li>Ticket authentication enabled (<tt>--auth=ticket</tt>). Remember by default all authentication mechanisms are enabled.)</li>
@@ -236,20 +228,13 @@ nothing left to do.</code>
 
                 <p>The workspace path is the location Confuga maintains metadata
                 and databases for the head node. Confuga specific options are
-                also passed through the URI. The two primary options are
-                documented below.</p>
+                also passed through the URI. The primary option is documented below.</p>
 
                 <ul>
 
                     <li><tt style="font-weight: bold;">auth=method</tt> Enable this method for Head Node to
                     Storage Node authentication. The default is to enable all
                     available authentication mechanisms.</li>
-
-                    <li><tt style="font-weight: bold;">nodes=node-list</tt> Sets the whitespace or comma
-                    delimited list of storage nodes to use for the cluster. May
-                    be specified directly as a list
-                    <tt>node:&lt;node1,node2,...&gt;</tt> or as a file
-                    <tt>file:&lt;node file&gt;</tt>.
 
                 </ul>
 
@@ -362,13 +347,6 @@ nothing left to do.</code>
                 <tt>LINK</tt> file binding. For this reason, it cannot use
                 Chirp servers running with <tt>--root</tt> on AFS.</p>
 
-        <h2 id="missing">Missing Features<a class="sectionlink" href="#missing" title="Link to this section.">&#x21d7;</a></h2>
-
-            <p>Confuga is a beta quality software and is presently missing a few features that will be addressed in future releases:</p>
-
-            <ul>
-                <li><b>Organize storage nodes by project name.</b> Attaching a project name to storage nodes would allow Confuga to dynamically pick up new storage nodes. It also greatly simplifies specifying storage nodes. Please see issue <a href="https://github.com/cooperative-computing-lab/cctools/issues/828">#828</a> for updates.</li>
-            </ul>
     </div>
 </body>
 

--- a/doc/man/confuga.m4
+++ b/doc/man/confuga.m4
@@ -35,7 +35,6 @@ the end of this manual.
 OPTIONS_BEGIN
 OPTION_PAIR(auth,method)Enable this method for Head Node to Storage Node authentication. The default is to enable all available authentication mechanisms.
 OPTION_PAIR(concurrency,limit)Limits the number of concurrent jobs executed by the cluster. The default is 0 for limitless.
-OPTION_PAIR(nodes,node-list)Sets the whitespace or comma delimited list of storage nodes to use for the cluster. May be specified directly as a list BOLD(`node:<node1,node2,...>') or as a file BOLD(`file:<node file>').
 OPTION_PAIR(pull-threshold,bytes)Sets the threshold for pull transfers. The default is 128MB.
 OPTION_PAIR(replication,type)Sets the replication mode for satisfying job dependencies. BOLD(type) may be BOLD(push-sync) or BOLD(push-async-N). The default is BOLD(push-async-1).
 OPTION_PAIR(scheduler,type)Sets the scheduler used to assign jobs to storage nodes. The default is BOLD(fifo-0).
@@ -46,8 +45,8 @@ SECTION(STORAGE NODES)
 
 PARA
 Confuga uses regular Chirp servers as storage nodes. Each storage node is
-specified using the BOLD(nodes) Confuga option. All storage node Chirp servers
-must be run with:
+added to the cluster using the MANPAGE(confuga_adm,1) command.  All storage
+node Chirp servers must be run with:
 
 LIST_BEGIN
 LIST_ITEM(Ticket authentication enabled (BOLD(--auth=ticket)). Remember by default all authentication mechanisms are enabled.)
@@ -68,6 +67,12 @@ You must also ensure that the storage nodes and the Confuga head node are using
 the same MANPAGE(catalog_server,1). By default, this should be the case. The
 BOLD(EXAMPLES) section below includes an example cluster using a manually
 hosted catalog server.
+
+SUBSECTION(ADDING STORAGE NODES)
+
+PARA
+To add storage nodes to the Confuga cluster, use the MANPAGE(confuga_adm,1)
+administrative tool.
 
 SECTION(EXECUTING WORKFLOWS)
 
@@ -124,17 +129,19 @@ LONGCODE_END
 SECTION(EXAMPLES)
 
 PARA
-Launch a head node with workspace BOLD(./confuga.root), replication mode of BOLD(push-async-1), and a storage node list in file BOLD(nodes.lst):
+Launch a head node with Confuga state stored in BOLD(./confuga.root):
 
 LONGCODE_BEGIN
-chirp_server --jobs --root='confuga://./confuga.root/?replication=push-async-1&nodes=file:nodes.lst'
+chirp_server --jobs --root="confuga://$(pwd)/confuga.root/"
 LONGCODE_END
 
 PARA
-Launch a head node with workspace BOLD(/tmp/confuga.root) using storage nodes BOLD(chirp://localhost:10001/) and BOLD(chirp://localhost:10002/):
+Launch a head node with workspace BOLD(/tmp/confuga.root) using storage nodes BOLD(chirp://localhost:10001) and BOLD(chirp://localhost:10002/u/joe/confuga):
 
 LONGCODE_BEGIN
-chirp_server --jobs --root='confuga:///tmp/confuga.root/?nodes=node:chirp://localhost:10001/,chirp://localhost:10002/'
+chirp_server --jobs --root='confuga:///tmp/confuga.root/'
+confuga_adm confuga:///tmp/confuga.root/ sn-add address localhost:10001
+confuga_adm confuga:///tmp/confuga.root/ sn-add -r /u/joe/confuga address localhost:10001
 LONGCODE_END
 
 PARA
@@ -174,13 +181,15 @@ chirp_server --advertise=localhost \\
              &
 # sleep for a time so catalog can receive storage node status
 sleep 5
+confuga_adm confuga:///$(pwd)/confuga.root/ sn-add address localhost:9001
+confuga_adm confuga:///$(pwd)/confuga.root/ sn-add address localhost:9002
 # start the Confuga head node
 chirp_server --advertise=localhost \\
              --catalog-name=localhost \\
              --catalog-update=30s \\
              --debug=confuga \\
              --jobs \\
-             --root='confuga://./confuga.root/?auth=unix&nodes=node:chirp://localhost:9001/,chirp://localhost:9002/' \\
+             --root="confuga://$(pwd)/confuga.root/?auth=unix" \\
              --port=9000
 LONGCODE_END
 
@@ -188,6 +197,6 @@ SECTION(COPYRIGHT)
 COPYRIGHT_BOILERPLATE
 
 SECTION(SEE ALSO)
-SEE_ALSO_CHIRP
+MANPAGE(confuga_adm,1) SEE_ALSO_CHIRP
 
 FOOTER

--- a/doc/man/confuga_adm.m4
+++ b/doc/man/confuga_adm.m4
@@ -1,0 +1,56 @@
+include(manual.h)dnl
+HEADER(confuga_adm)
+
+SECTION(NAME)
+BOLD(Confuga Administration) - Administrating the Confuga cluster.
+
+SECTION(SYNOPSIS)
+CODE(BOLD(confuga_adm [options] <Confuga URI> <command> [command options] ...))
+
+SECTION(DESCRIPTION)
+
+PARA
+Performs administrative commands on the Confuga cluster.
+
+PARA
+For complete details with examples, see the LINK(Confuga User's Manual,http://ccl.cse.nd.edu/software/manuals/confuga.html).
+
+SECTION(OPTIONS)
+
+OPTIONS_BEGIN
+OPTION_TRIPLET(-d, debug, flag)Enable debugging for this sybsystem
+OPTION_ITEM(`-h, --help')Give help information.
+OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+OPTION_ITEM(`-v, --version')Show version info.
+OPTIONS_END
+
+SECTION(COMMANDS)
+
+LIST_BEGIN
+LIST_ITEM(BOLD(sn-add [-r <root>] [-p <password file>] <"uuid"|"address"> <uuid|address>)) Add a storage node to the cluster. Using the UUID of the Chirp server is recommended.
+LIST_ITEM(BOLD(sn-rm [options] <"uuid"|"address"> <uuid|address>)) Remove a storage from the cluster. Using the UUID of the Chirp server is recommended. The storage node is removed when Confuga no longer relies on it to maintain minimum replication for files and when the storage node completes all running jobs.
+LIST_END
+
+SECTION(EXAMPLES)
+
+PARA
+Add a storage node with Confuga state stored in BOLD(/u/joe/confuga):
+
+LONGCODE_BEGIN
+confuga_adm sn-add -r /u/joe/confuga address 10.0.1.125:9090
+LONGCODE_END
+
+PARA
+Remove a storage node:
+
+LONGCODE_BEGIN
+confuga_adm sn-rm address 10.0.1.125:9090
+LONGCODE_END
+
+SECTION(COPYRIGHT)
+COPYRIGHT_BOILERPLATE
+
+SECTION(SEE ALSO)
+MANPAGE(confuga,1)
+
+FOOTER


### PR DESCRIPTION
    This commit adds a new CLI tool (with accompanying C API) for adding and removing SN in Confuga.
    
        $ confuga_adm confuga://... sn-add [-p <password file>] [-r <root>] <"uuid"|"address"> <uuid|address>
    
        and
    
        $ confuga_adm confuga://... sn-rm <"uuid"|"address"> <uuid|address>
    
    The root directory of the storage node set via the "-r" switch is the location
    the HN will use to store SN state. The default root directory is "/.confuga".
    
    The password file passed via "-p" is expected to hold the same contents as a
    file on the storage node located at '/password' under the storage node's root
    directory set via the '-r' switch. Usually the user doesn't want to explicitly
    set this up so the HN will automatically create this password file if the '-p'
    option is not used.
    
    Examples:
    
        $ confuga_adm confuga:///path/to/confuga/ sn-add uuid 46BE3610-42F5-4B7C-B9D1-2B3421C4F172
        OR
        $ confuga_adm confuga:///path/to/confuga/ sn-add address localhost:1024
    
        $ confuga_adm confuga:///path/to/confuga/ sn-rm uuid 46BE3610-42F5-4B7C-B9D1-2B3421C4F172
        OR
        $ confuga_adm confuga:///path/to/confuga/ sn-rm address localhost:1024
    
    The HN will authenticate a SN by using the SHA1 hash RPC to check the password
    file at "/<root>/password" is correct. The HN does not reauthenticate every new
    session as sessions are handled at the Chirp reli layer. Instead, the HN
    reauthenticates a storage node every 15 minutes.
    
    Storage nodes are now remembered by the HN using UUIDs broadcast as part of
    normal Catalog updates. This allows the HN to distinguish between storage nodes
    operating with the same address and port (localhost/LAN).
    
    The HN is now also capable of removing storage nodes. This is done by marking a
    storage node to be removed which prevents it from being used for future jobs
    and new replicas. The HN will remove its replicas so long as sufficient
    replicas exist in the cluster. The HN will replicate as necessary so that the
    SN can eventually be removed. Once all replicas have been removed and jobs have
    completed, the SN will be removed.

    Fixes #1324.
    Fixes #1325.
    Fixes #1326.