### PR TITLE
bug fix: export correctly CORES, MEMORY, and DISK when task execs

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -2831,8 +2831,7 @@ static work_queue_result_code_t start_one_task(struct work_queue *q, struct work
 {
 	/* wrap command at the last minute, so that we have the updated information
 	 * about resources. */
-	struct rmsummary *limits    = task_worker_box_size(q, w, t);
-	const struct rmsummary *max = task_max_resources(q, t);
+	struct rmsummary *limits = task_worker_box_size(q, w, t);
 
 	char *command_line;
 	if(q->monitor_mode) {
@@ -2862,15 +2861,15 @@ static work_queue_result_code_t start_one_task(struct work_queue *q, struct work
 
 	send_worker_msg(q,w, "category %s\n", t->category);
 
-	send_worker_msg(q,w, "cores %"PRId64"\n",  max->cores);
-	send_worker_msg(q,w, "memory %"PRId64"\n", max->memory);
-	send_worker_msg(q,w, "disk %"PRId64"\n",   max->disk);
-	send_worker_msg(q,w, "gpus %"PRId64"\n",   max->gpus);
+	send_worker_msg(q,w, "cores %"PRId64"\n",  limits->cores);
+	send_worker_msg(q,w, "memory %"PRId64"\n", limits->memory);
+	send_worker_msg(q,w, "disk %"PRId64"\n",   limits->disk);
+	send_worker_msg(q,w, "gpus %"PRId64"\n",   limits->gpus);
 
 	/* Do not specify end, wall_time if running the resource monitor. We let the monitor police these resources. */
 	if(q->monitor_mode == MON_DISABLED) {
-		send_worker_msg(q,w, "end_time %"PRIu64"\n",  max->end);
-		send_worker_msg(q,w, "wall_time %"PRIu64"\n", max->wall_time);
+		send_worker_msg(q,w, "end_time %"PRIu64"\n",  limits->end);
+		send_worker_msg(q,w, "wall_time %"PRIu64"\n", limits->wall_time);
 	}
 
 	itable_insert(w->current_tasks_boxes, t->taskid, limits);

--- a/work_queue/src/work_queue_process.c
+++ b/work_queue/src/work_queue_process.c
@@ -252,10 +252,11 @@ pid_t work_queue_process_execute(struct work_queue_process *p, int container_mod
 		close(p->output_fd);
 
 		clear_environment();
-		export_environment(p);
 
 		/* overwrite CORES, MEMORY, or DISK variables, if the task used specify_* */
 		specify_resources_vars(p);
+
+		export_environment(p);
 
 		va_list arg_lst;
 		if(container_mode == NONE) {


### PR DESCRIPTION
Fixes a bug as reported by @nhazekam 