### PR TITLE
Fix signedness when printing resources to the wq log.

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -393,9 +393,9 @@ static void log_worker_stats(struct work_queue *q)
 	fprintf(q->logfile, "%" PRIu64 " ", timestamp_get());
 	fprintf(q->logfile, "%d %d %d %d %d %d ", s.total_workers_connected, s.workers_init, s.workers_idle, s.workers_busy, s.total_workers_joined, s.total_workers_removed);
 	fprintf(q->logfile, "%d %d %d %d %d %d ", s.tasks_waiting, s.tasks_running, s.tasks_complete, s.total_tasks_dispatched, s.total_tasks_complete, s.total_tasks_cancelled);
-	fprintf(q->logfile, "%" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %f %f %d ", s.start_time, s.total_send_time, s.total_receive_time, s.total_bytes_sent, s.total_bytes_received, s.efficiency, s.idle_percentage, s.capacity);
-	fprintf(q->logfile, "%f %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " ", s.bandwidth, s.total_cores, s.total_memory, s.total_disk, s.total_gpus);
-	fprintf(q->logfile, "%" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " ", s.min_cores, s.max_cores, s.min_memory, s.max_memory, s.min_disk, s.max_disk, s.min_gpus, s.max_gpus);
+	fprintf(q->logfile, "%" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRId64 " %" PRId64 " %f %f %d ", s.start_time, s.total_send_time, s.total_receive_time, s.total_bytes_sent, s.total_bytes_received, s.efficiency, s.idle_percentage, s.capacity);
+	fprintf(q->logfile, "%f %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " ", s.bandwidth, s.total_cores, s.total_memory, s.total_disk, s.total_gpus);
+	fprintf(q->logfile, "%" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " ", s.min_cores, s.max_cores, s.min_memory, s.max_memory, s.min_disk, s.max_disk, s.min_gpus, s.max_gpus);
 	fprintf(q->logfile, "%" PRIu64 " %" PRIu64 " ", s.total_execute_time, s.total_good_execute_time);
 	fprintf(q->logfile, "\n");
 }
@@ -869,14 +869,7 @@ static void add_worker(struct work_queue *q)
 
 	w->last_update_msg_time = w->start_time;
 
-	struct work_queue_resources *r = work_queue_resources_create();
-
-	r->cores.smallest = r->cores.largest = r->cores.total = -1;//default_resource_value;
-	r->memory.smallest = r->memory.largest = r->memory.total = -1;//default_resource_value;
-	r->disk.smallest = r->disk.largest = r->disk.total = -1;//default_resource_value;
-	r->gpus.smallest = r->gpus.largest = r->gpus.total = -1;//default_resource_value;
-
-	w->resources = r;
+	w->resources = work_queue_resources_create();
 
 	w->workerid = NULL;
 
@@ -5833,7 +5826,10 @@ void aggregate_workers_resources( struct work_queue *q, struct work_queue_resour
 
 	hash_table_firstkey(q->worker_table);
 	while(hash_table_nextkey(q->worker_table,&key,(void**)&w)) {
-			work_queue_resources_add(total,w->resources);
+		if(w->resources->tag < 0)
+			continue;
+
+		work_queue_resources_add(total,w->resources);
 	}
 }
 

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -243,14 +243,14 @@ int64_t measure_worker_disk() {
 
 	path_disk_size_info_get_r("./cache", max_time_on_measurement, &state);
 
-	int64_t disk_measured = -1;
+	int64_t disk_measured = 0;
 	if(state->last_byte_size_complete >= 0) {
 		disk_measured = (int64_t) ceil(state->last_byte_size_complete/(1.0*MEGA));
 	}
 
 	files_counted = state->last_file_count_complete;
 
-	if(state->complete_measurement && disk_measured > -1) {
+	if(state->complete_measurement) {
 		/* if a complete measurement has been done, then update
 		 * for the found value, and add the known values of the processes. */
 
@@ -2454,6 +2454,10 @@ int main(int argc, char *argv[])
 	local_resources = work_queue_resources_create();
 	total_resources = work_queue_resources_create();
 	total_resources_last = work_queue_resources_create();
+
+	if(manual_cores_option == 0) {
+		manual_cores_option = load_average_get_cpus();
+	}
 
 	int backoff_interval = init_backoff_interval;
 	connect_stoptime = time(0) + connect_timeout;


### PR DESCRIPTION
As reported by @yannakopoulos. Two issues:

Noise from new workers was causing resource totals in the log to be negative.
Signed numbers were being printed as signed.