### PR TITLE
JX match functions

### DIFF
--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -57,6 +57,7 @@ SOURCES = \
 	json_aux.c \
 	jx.c \
 	jx_database.c \
+	jx_match.c \
 	jx_parse.c \
 	jx_print.c \
 	jx_pretty_print.c \
@@ -119,6 +120,7 @@ HEADERS_PUBLIC = \
 	http_query.h \
 	int_sizes.h \
 	jx.h \
+	jx_match.h \
 	link.h \
 	md5.h \
 	rmonitor_poll.h \

--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -273,6 +273,18 @@ void jx_array_append( struct jx *array, struct jx *value )
 	*i = jx_item(value,0);
 }
 
+struct jx * jx_array_index( struct jx *j, int nth )
+{
+	if (!jx_istype(j, JX_ARRAY)) return NULL;
+	struct jx_item *item = j->u.items;
+
+	for(int i = 0; i < nth; i++) {
+		if (!item) return NULL;
+		item = item->next;
+	}
+	return item ? item->value : NULL;
+}
+
 void jx_pair_delete( struct jx_pair *pair )
 {
 	if(!pair) return;

--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -490,7 +490,7 @@ struct jx * jx_iterate_array(struct jx *j, void **i) {
 			return NULL;
 		}
 	} else {
-		if (!j) return NULL;
+		if (!jx_istype(j, JX_ARRAY)) return NULL;
 		*i = j->u.items;
 		return *i ? ((struct jx_item *) *i)->value : NULL;
 	}
@@ -507,7 +507,7 @@ struct jx * jx_iterate_keys(struct jx *j, void **i) {
 			return NULL;
 		}
 	} else {
-		if (!j) return NULL;
+		if (!jx_istype(j, JX_OBJECT)) return NULL;
 		*i = j->u.pairs;
 		return *i ? ((struct jx_pair *) *i)->key : NULL;
 	}
@@ -524,7 +524,7 @@ struct jx * jx_iterate_values(struct jx *j, void **i) {
 			return NULL;
 		}
 	} else {
-		if (!j) return NULL;
+		if (!jx_istype(j, JX_OBJECT)) return NULL;
 		*i = j->u.pairs;
 		return *i ? ((struct jx_pair *) *i)->value : NULL;
 	}

--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -466,3 +466,54 @@ void jx_export( struct jx *j )
 		}
 	}
 }
+
+struct jx * jx_iterate_array(struct jx *j, void **i) {
+	if (!i) return NULL;
+	if (*i) {
+		struct jx_item *next = ((struct jx_item *) *i)->next;
+		if (next) {
+			*i = next;
+			return next->value;
+		} else {
+			return NULL;
+		}
+	} else {
+		if (!j) return NULL;
+		*i = j->u.items;
+		return *i ? ((struct jx_item *) *i)->value : NULL;
+	}
+}
+
+struct jx * jx_iterate_keys(struct jx *j, void **i) {
+	if (!i) return NULL;
+	if (*i) {
+		struct jx_pair *next = ((struct jx_pair *) *i)->next;
+		if (next) {
+			*i = next;
+			return next->key;
+		} else {
+			return NULL;
+		}
+	} else {
+		if (!j) return NULL;
+		*i = j->u.pairs;
+		return *i ? ((struct jx_pair *) *i)->key : NULL;
+	}
+}
+
+struct jx * jx_iterate_values(struct jx *j, void **i) {
+	if (!i) return NULL;
+	if (*i) {
+		struct jx_pair *next = ((struct jx_pair *) *i)->next;
+		if (next) {
+			*i = next;
+			return next->value;
+		} else {
+			return NULL;
+		}
+	} else {
+		if (!j) return NULL;
+		*i = j->u.pairs;
+		return *i ? ((struct jx_pair *) *i)->value : NULL;
+	}
+}

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -217,7 +217,7 @@ int jx_is_constant( struct jx *j );
 void jx_export( struct jx *j );
 
 /** Iterate over the values in an array.
- * The iteation state is stored by the caller in an opaque pointer variable. When starting iteration,
+ * The iteration state is stored by the caller in an opaque pointer variable. When starting iteration,
  * the caller MUST pass the address of a pointer initialized to NULL as i. It is undefined behavior
  * to pass a non-NULL iterator variable not set by a previous call. Subsequent calls should
  * use the same variable to continue iteration. After the initial call, the value of j is ignored.
@@ -236,7 +236,7 @@ void jx_export( struct jx *j );
 struct jx * jx_iterate_array(struct jx *j, void **i);
 
 /** Iterate over the values in an object.
- * The iteation state is stored by the caller in an opaque pointer variable. When starting iteration,
+ * The iteration state is stored by the caller in an opaque pointer variable. When starting iteration,
  * the caller MUST pass the address of a pointer initialized to NULL as i. It is undefined behavior
  * to pass a non-NULL iterator variable not set by a previous call. Subsequent calls should
  * use the same variable to continue iteration. After the initial call, the value of j is ignored.
@@ -256,7 +256,7 @@ struct jx * jx_iterate_array(struct jx *j, void **i);
 struct jx * jx_iterate_values(struct jx *j, void **i);
 
 /** Iterate over the keys in an object.
- * The iteation state is stored by the caller in an opaque pointer variable. When starting iteration,
+ * The iteration state is stored by the caller in an opaque pointer variable. When starting iteration,
  * the caller MUST pass the address of a pointer initialized to NULL as i. It is undefined behavior
  * to pass a non-NULL iterator variable not set by a previous call. Subsequent calls should
  * use the same variable to continue iteration. After the initial call, the value of j is ignored.

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -216,4 +216,63 @@ int jx_is_constant( struct jx *j );
 /** Export a jx object as a set of environment variables.  @param j A JX_OBJECT. */
 void jx_export( struct jx *j );
 
+/** Iterate over the values in an array.
+ * The iteation state is stored by the caller in an opaque pointer variable. When starting iteration,
+ * the caller MUST pass the address of a pointer initialized to NULL as i. It is undefined behavior
+ * to pass a non-NULL iterator variable not set by a previous call. Subsequent calls should
+ * use the same variable to continue iteration. After the initial call, the value of j is ignored.
+ *
+ *     struct jx *item;
+ *     for (void *i = NULL; (item = jx_iterate_array(j, &i));) {
+ *         printf("array item: ");
+ *         jx_print_stream(item, stdout);
+ *         printf("\n");
+ *     }
+ *
+ * @param j The JX_ARRAY to iterate over.
+ * @param i A variable to store the iteration state.
+ * @return A pointer to each item in the array, and NULL when iteration is finished.
+ */
+struct jx * jx_iterate_array(struct jx *j, void **i);
+
+/** Iterate over the values in an object.
+ * The iteation state is stored by the caller in an opaque pointer variable. When starting iteration,
+ * the caller MUST pass the address of a pointer initialized to NULL as i. It is undefined behavior
+ * to pass a non-NULL iterator variable not set by a previous call. Subsequent calls should
+ * use the same variable to continue iteration. After the initial call, the value of j is ignored.
+ *
+ *     struct jx *item;
+ *     void *i = NULL;
+ *     while ((item = jx_iterate_values(j, &i))) {
+ *         printf("object value: ");
+ *         jx_print_stream(item, stdout);
+ *         printf("\n");
+ *     }
+ *
+ * @param j The JX_OBJECT to iterate over.
+ * @param i A variable to store the iteration state.
+ * @return A pointer to each value in the object, and NULL when iteration is finished.
+ */
+struct jx * jx_iterate_values(struct jx *j, void **i);
+
+/** Iterate over the keys in an object.
+ * The iteation state is stored by the caller in an opaque pointer variable. When starting iteration,
+ * the caller MUST pass the address of a pointer initialized to NULL as i. It is undefined behavior
+ * to pass a non-NULL iterator variable not set by a previous call. Subsequent calls should
+ * use the same variable to continue iteration. After the initial call, the value of j is ignored.
+ *
+ *     struct jx *item;
+ *     void *i = NULL;
+ *     while ((item = jx_iterate_keys(j, &i))) {
+ *         printf("object key: ");
+ *         jx_print_stream(item, stdout);
+ *         printf("\n");
+ *     }
+ *
+ * @param j The JX_OBJECT to iterate over.
+ * @param i A variable to store the iteration state.
+ * @return A pointer to each key in the object, and NULL when iteration is finished.
+ */
+struct jx * jx_iterate_key(struct jx *j, void **i);
+
 #endif

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -210,6 +210,9 @@ void jx_array_insert( struct jx *array, struct jx *value );
 /** Append an item at the end of an array.  @param array The array to modify.  @param value The value to append. */
 void jx_array_append( struct jx *array, struct jx *value );
 
+/** Get the nth item in an array.  @param array The array to search.  @param nth The index of the desired value. @return The nth element, or NULL if the index is out of bounds. */
+struct jx * jx_array_index( struct jx *j, int nth );
+
 /** Determine if an expression is constant.  Traverses the expression recursively, and returns true if it consists only of constant values, arrays, and objects. @param j The expression to evaluate.  @return True if constant. */
 int jx_is_constant( struct jx *j );
 

--- a/dttools/src/jx_match.c
+++ b/dttools/src/jx_match.c
@@ -1,0 +1,198 @@
+/*
+Copyright (C) 2016- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include <stdarg.h>
+#include <string.h>
+
+#include "jx.h"
+#include "jx_match.h"
+
+void *jx_match_null(struct jx *j) {
+	return jx_istype(j, JX_NULL) ? (void *) j : NULL;
+}
+
+int *jx_match_boolean(struct jx *j, int *v) {
+	if (jx_istype(j, JX_BOOLEAN)) {
+		if (v) {
+			*v = !!j->u.boolean_value;
+		}
+		return &j->u.boolean_value;
+	} else {
+		return NULL;
+	}
+}
+
+jx_int_t *jx_match_integer(struct jx *j, jx_int_t *v) {
+	if (jx_istype(j, JX_INTEGER)) {
+		if (v) {
+			*v = j->u.integer_value;
+		}
+		return &j->u.integer_value;
+	} else {
+		return NULL;
+	}
+}
+
+double *jx_match_double(struct jx *j, double *v) {
+	if (jx_istype(j, JX_DOUBLE)) {
+		if (v) {
+			*v = j->u.double_value;
+		}
+		return &j->u.double_value;
+	} else {
+		return NULL;
+	}
+}
+
+char **jx_match_string(struct jx *j, char **v) {
+	if (jx_istype(j, JX_STRING)) {
+		if (v) {
+			*v = strdup(j->u.string_value);
+		}
+		return &j->u.string_value;
+	} else {
+		return NULL;
+	}
+}
+
+char **jx_match_symbol(struct jx *j, char **v) {
+	if (jx_istype(j, JX_SYMBOL)) {
+		if (v) {
+			*v = strdup(j->u.symbol_name);
+		}
+		return &j->u.symbol_name;
+	} else {
+		return NULL;
+	}
+}
+
+struct jx *jx_match_operator(struct jx *j, struct jx **v) {
+	if (jx_istype(j, JX_OPERATOR)) {
+		if (v) {
+			*v = jx_copy(j);
+		}
+		return j;
+	} else {
+		return NULL;
+	}
+}
+
+int jx_match_array(struct jx *j, ...) {
+	va_list ap;
+	int matched = 0;
+	struct jx *item;
+
+	va_start(ap, j);
+	for (void *i = NULL; (item = jx_iterate_array(j, &i));) {
+		void *out = va_arg(ap, void *);
+		if (!out) goto DONE;
+		jx_type_t t = va_arg(ap, jx_type_t);
+
+		if (t == (jx_type_t) JX_ANY) {
+			*((struct jx **) out) = jx_copy(item);
+		} else {
+			switch (t) {
+			case JX_INTEGER:
+				if (!jx_match_integer(item, out)) goto DONE;
+				break;
+			case JX_BOOLEAN:
+				if (!jx_match_boolean(item, out)) goto DONE;
+				break;
+			case JX_DOUBLE:
+				if (!jx_match_double(item, out)) goto DONE;
+				break;
+			case JX_STRING:
+				if (!jx_match_string(item, out)) goto DONE;
+				break;
+			case JX_SYMBOL:
+				if (!jx_match_symbol(item, out)) goto DONE;
+				break;
+			case JX_OBJECT:
+				if (!jx_istype(item, JX_OBJECT)) goto DONE;
+				*((struct jx **) out) = jx_copy(item);
+				break;
+			case JX_ARRAY:
+				if (!jx_istype(item, JX_ARRAY)) goto DONE;
+				*((struct jx **) out) = jx_copy(item);
+				break;
+			case JX_OPERATOR:
+				if (!jx_istype(item, JX_OPERATOR)) goto DONE;
+				*((struct jx **) out) = jx_copy(item);
+				break;
+			case JX_NULL:
+				if (!jx_match_null(item)) goto DONE;
+				*((struct jx **) out) = jx_copy(item);
+				break;
+			default:
+				goto DONE;
+			}
+		}
+		matched++;
+	}
+
+DONE:
+	va_end(ap);
+	return matched;
+}
+
+int jx_match_object(struct jx *j, ...) {
+	va_list ap;
+	int matched = 0;
+	void *out;
+	if (!jx_istype(j, JX_OBJECT)) goto DONE;
+
+	va_start(ap, j);
+	while ((out = va_arg(ap, void *))) {
+		jx_type_t t = va_arg(ap, jx_type_t);
+		struct jx *item = jx_lookup(item, va_arg(ap, const char *));
+		if (!item) goto DONE;
+
+		if (t == (jx_type_t) JX_ANY) {
+			*((struct jx **) out) = jx_copy(item);
+		} else {
+			switch (t) {
+			case JX_INTEGER:
+				if (!jx_match_integer(item, out)) goto DONE;
+				break;
+			case JX_BOOLEAN:
+				if (!jx_match_boolean(item, out)) goto DONE;
+				break;
+			case JX_DOUBLE:
+				if (!jx_match_double(item, out)) goto DONE;
+				break;
+			case JX_STRING:
+				if (!jx_match_string(item, out)) goto DONE;
+				break;
+			case JX_SYMBOL:
+				if (!jx_match_symbol(item, out)) goto DONE;
+				break;
+			case JX_OBJECT:
+				if (!jx_istype(item, JX_OBJECT)) goto DONE;
+				*((struct jx **) out) = jx_copy(item);
+				break;
+			case JX_ARRAY:
+				if (!jx_istype(item, JX_ARRAY)) goto DONE;
+				*((struct jx **) out) = jx_copy(item);
+				break;
+			case JX_OPERATOR:
+				if (!jx_istype(item, JX_OPERATOR)) goto DONE;
+				*((struct jx **) out) = jx_copy(item);
+				break;
+			case JX_NULL:
+				if (!jx_match_null(item)) goto DONE;
+				*((struct jx **) out) = jx_copy(item);
+				break;
+			default:
+				goto DONE;
+			}
+		}
+		matched++;
+	}
+
+DONE:
+	va_end(ap);
+	return matched;
+}

--- a/dttools/src/jx_match.c
+++ b/dttools/src/jx_match.c
@@ -10,58 +10,58 @@ See the file COPYING for details.
 #include "jx.h"
 #include "jx_match.h"
 
-int *jx_match_boolean(struct jx *j, int *v) {
+int jx_match_boolean(struct jx *j, int *v) {
 	if (jx_istype(j, JX_BOOLEAN)) {
 		if (v) {
 			*v = !!j->u.boolean_value;
 		}
-		return &j->u.boolean_value;
+		return 1;
 	} else {
-		return NULL;
+		return 0;
 	}
 }
 
-jx_int_t *jx_match_integer(struct jx *j, jx_int_t *v) {
+int jx_match_integer(struct jx *j, jx_int_t *v) {
 	if (jx_istype(j, JX_INTEGER)) {
 		if (v) {
 			*v = j->u.integer_value;
 		}
-		return &j->u.integer_value;
+		return 1;
 	} else {
-		return NULL;
+		return 0;
 	}
 }
 
-double *jx_match_double(struct jx *j, double *v) {
+int jx_match_double(struct jx *j, double *v) {
 	if (jx_istype(j, JX_DOUBLE)) {
 		if (v) {
 			*v = j->u.double_value;
 		}
-		return &j->u.double_value;
+		return 1;
 	} else {
-		return NULL;
+		return 0;
 	}
 }
 
-char **jx_match_string(struct jx *j, char **v) {
+int jx_match_string(struct jx *j, char **v) {
 	if (jx_istype(j, JX_STRING)) {
 		if (v) {
-			if (!(*v = strdup(j->u.string_value))) return NULL;
+			if (!(*v = strdup(j->u.string_value))) return 0;
 		}
-		return &j->u.string_value;
+		return 1;
 	} else {
-		return NULL;
+		return 0;
 	}
 }
 
-char **jx_match_symbol(struct jx *j, char **v) {
+int jx_match_symbol(struct jx *j, char **v) {
 	if (jx_istype(j, JX_SYMBOL)) {
 		if (v) {
-			if (!(*v = strdup(j->u.symbol_name))) return NULL;
+			if (!(*v = strdup(j->u.symbol_name))) return 0;
 		}
-		return &j->u.symbol_name;
+		return 1;
 	} else {
-		return NULL;
+		return 0;
 	}
 }
 
@@ -108,7 +108,7 @@ int jx_match_array(struct jx *j, ...) {
 				if (!(*((struct jx **) out) = jx_copy(item))) goto DONE;
 				break;
 			case JX_NULL:
-				if (!jx_match_null(item)) goto DONE;
+				if (!jx_istype(item, JX_NULL)) goto DONE;
 				if (!(*((struct jx **) out) = jx_copy(item))) goto DONE;
 				break;
 			default:

--- a/dttools/src/jx_match.c
+++ b/dttools/src/jx_match.c
@@ -147,7 +147,7 @@ int jx_match_object(struct jx *j, ...) {
 	va_start(ap, j);
 	while ((out = va_arg(ap, void *))) {
 		jx_type_t t = va_arg(ap, jx_type_t);
-		struct jx *item = jx_lookup(item, va_arg(ap, const char *));
+		struct jx *item = jx_lookup(j, va_arg(ap, const char *));
 		if (!item) goto DONE;
 
 		if (t == (jx_type_t) JX_ANY) {

--- a/dttools/src/jx_match.c
+++ b/dttools/src/jx_match.c
@@ -68,10 +68,11 @@ int jx_match_symbol(struct jx *j, char **v) {
 int jx_match_array(struct jx *j, ...) {
 	va_list ap;
 	int matched = 0;
-	struct jx *item;
 
 	va_start(ap, j);
-	for (void *i = NULL; (item = jx_iterate_array(j, &i));) {
+	void *i = NULL;
+	struct jx *item;
+	while ((item = jx_iterate_array(j, &i))) {
 		void *out = va_arg(ap, void *);
 		if (!out) goto DONE;
 		jx_type_t t = va_arg(ap, jx_type_t);

--- a/dttools/src/jx_match.c
+++ b/dttools/src/jx_match.c
@@ -50,7 +50,7 @@ double *jx_match_double(struct jx *j, double *v) {
 char **jx_match_string(struct jx *j, char **v) {
 	if (jx_istype(j, JX_STRING)) {
 		if (v) {
-			*v = strdup(j->u.string_value);
+			if (!(*v = strdup(j->u.string_value))) return NULL;
 		}
 		return &j->u.string_value;
 	} else {
@@ -61,7 +61,7 @@ char **jx_match_string(struct jx *j, char **v) {
 char **jx_match_symbol(struct jx *j, char **v) {
 	if (jx_istype(j, JX_SYMBOL)) {
 		if (v) {
-			*v = strdup(j->u.symbol_name);
+			if (!(*v = strdup(j->u.symbol_name))) return NULL;
 		}
 		return &j->u.symbol_name;
 	} else {
@@ -72,7 +72,7 @@ char **jx_match_symbol(struct jx *j, char **v) {
 struct jx *jx_match_operator(struct jx *j, struct jx **v) {
 	if (jx_istype(j, JX_OPERATOR)) {
 		if (v) {
-			*v = jx_copy(j);
+			if (!(*v = jx_copy(j))) return NULL;
 		}
 		return j;
 	} else {
@@ -112,19 +112,19 @@ int jx_match_array(struct jx *j, ...) {
 				break;
 			case JX_OBJECT:
 				if (!jx_istype(item, JX_OBJECT)) goto DONE;
-				*((struct jx **) out) = jx_copy(item);
+				if (!(*((struct jx **) out) = jx_copy(item))) goto DONE;
 				break;
 			case JX_ARRAY:
 				if (!jx_istype(item, JX_ARRAY)) goto DONE;
-				*((struct jx **) out) = jx_copy(item);
+				if (!(*((struct jx **) out) = jx_copy(item))) goto DONE;
 				break;
 			case JX_OPERATOR:
 				if (!jx_istype(item, JX_OPERATOR)) goto DONE;
-				*((struct jx **) out) = jx_copy(item);
+				if (!(*((struct jx **) out) = jx_copy(item))) goto DONE;
 				break;
 			case JX_NULL:
 				if (!jx_match_null(item)) goto DONE;
-				*((struct jx **) out) = jx_copy(item);
+				if (!(*((struct jx **) out) = jx_copy(item))) goto DONE;
 				break;
 			default:
 				goto DONE;
@@ -171,19 +171,19 @@ int jx_match_object(struct jx *j, ...) {
 				break;
 			case JX_OBJECT:
 				if (!jx_istype(item, JX_OBJECT)) goto DONE;
-				*((struct jx **) out) = jx_copy(item);
+				if (!(*((struct jx **) out) = jx_copy(item))) goto DONE;
 				break;
 			case JX_ARRAY:
 				if (!jx_istype(item, JX_ARRAY)) goto DONE;
-				*((struct jx **) out) = jx_copy(item);
+				if (!(*((struct jx **) out) = jx_copy(item))) goto DONE;
 				break;
 			case JX_OPERATOR:
 				if (!jx_istype(item, JX_OPERATOR)) goto DONE;
-				*((struct jx **) out) = jx_copy(item);
+				if (!(*((struct jx **) out) = jx_copy(item))) goto DONE;
 				break;
 			case JX_NULL:
 				if (!jx_match_null(item)) goto DONE;
-				*((struct jx **) out) = jx_copy(item);
+				if (!(*((struct jx **) out) = jx_copy(item))) goto DONE;
 				break;
 			default:
 				goto DONE;

--- a/dttools/src/jx_match.c
+++ b/dttools/src/jx_match.c
@@ -10,10 +10,6 @@ See the file COPYING for details.
 #include "jx.h"
 #include "jx_match.h"
 
-void *jx_match_null(struct jx *j) {
-	return jx_istype(j, JX_NULL) ? (void *) j : NULL;
-}
-
 int *jx_match_boolean(struct jx *j, int *v) {
 	if (jx_istype(j, JX_BOOLEAN)) {
 		if (v) {
@@ -69,17 +65,6 @@ char **jx_match_symbol(struct jx *j, char **v) {
 	}
 }
 
-struct jx *jx_match_operator(struct jx *j, struct jx **v) {
-	if (jx_istype(j, JX_OPERATOR)) {
-		if (v) {
-			if (!(*v = jx_copy(j))) return NULL;
-		}
-		return j;
-	} else {
-		return NULL;
-	}
-}
-
 int jx_match_array(struct jx *j, ...) {
 	va_list ap;
 	int matched = 0;
@@ -90,65 +75,6 @@ int jx_match_array(struct jx *j, ...) {
 		void *out = va_arg(ap, void *);
 		if (!out) goto DONE;
 		jx_type_t t = va_arg(ap, jx_type_t);
-
-		if (t == (jx_type_t) JX_ANY) {
-			*((struct jx **) out) = jx_copy(item);
-		} else {
-			switch (t) {
-			case JX_INTEGER:
-				if (!jx_match_integer(item, out)) goto DONE;
-				break;
-			case JX_BOOLEAN:
-				if (!jx_match_boolean(item, out)) goto DONE;
-				break;
-			case JX_DOUBLE:
-				if (!jx_match_double(item, out)) goto DONE;
-				break;
-			case JX_STRING:
-				if (!jx_match_string(item, out)) goto DONE;
-				break;
-			case JX_SYMBOL:
-				if (!jx_match_symbol(item, out)) goto DONE;
-				break;
-			case JX_OBJECT:
-				if (!jx_istype(item, JX_OBJECT)) goto DONE;
-				if (!(*((struct jx **) out) = jx_copy(item))) goto DONE;
-				break;
-			case JX_ARRAY:
-				if (!jx_istype(item, JX_ARRAY)) goto DONE;
-				if (!(*((struct jx **) out) = jx_copy(item))) goto DONE;
-				break;
-			case JX_OPERATOR:
-				if (!jx_istype(item, JX_OPERATOR)) goto DONE;
-				if (!(*((struct jx **) out) = jx_copy(item))) goto DONE;
-				break;
-			case JX_NULL:
-				if (!jx_match_null(item)) goto DONE;
-				if (!(*((struct jx **) out) = jx_copy(item))) goto DONE;
-				break;
-			default:
-				goto DONE;
-			}
-		}
-		matched++;
-	}
-
-DONE:
-	va_end(ap);
-	return matched;
-}
-
-int jx_match_object(struct jx *j, ...) {
-	va_list ap;
-	int matched = 0;
-	void *out;
-	if (!jx_istype(j, JX_OBJECT)) goto DONE;
-
-	va_start(ap, j);
-	while ((out = va_arg(ap, void *))) {
-		jx_type_t t = va_arg(ap, jx_type_t);
-		struct jx *item = jx_lookup(j, va_arg(ap, const char *));
-		if (!item) goto DONE;
 
 		if (t == (jx_type_t) JX_ANY) {
 			*((struct jx **) out) = jx_copy(item);

--- a/dttools/src/jx_match.h
+++ b/dttools/src/jx_match.h
@@ -142,14 +142,6 @@ See the file COPYING for details.
 #endif
 #endif
 
-/** Unwrap a null value.
- * Since by definition there is no associated data, this function returns
- * an opaque, non-NULL pointer in the case that j is of type JX_NULL.
- * @param j The JX structure to match.
- * @return An opaque, non-NULL pointer if j is a JX_NULL, or NULL otherwise
- */
-void *jx_match_null(struct jx *j) __wur;
-
 /** Unwrap a boolean value.
  * @param j The JX structure to match.
  * @param v An address to copy the boolean value to, or NULL if copying
@@ -214,19 +206,6 @@ char **jx_match_string(struct jx *j, char **v) __wur;
  */
 char **jx_match_symbol(struct jx *j, char **v) __wur;
 
-/** Unwrap an operator.
- * Operators don't have a natural C representation, but a match function
- * is still included for completeness. This function simply returns the
- * address of the operator passed in, and optionally gives back a
- * copy as well.
- * @param j The JX structure to match.
- * @param v The address of a (struct jx *) to store the newly copied
- * operator. The caller is responsible for deleting the copy.
- * @return The address of the passed in operator, or NULL if j
- * is not a JX_OPERATOR.
- */
-struct jx *jx_match_operator(struct jx *j, struct jx **v) __wur;
-
 /** Destructure an array.
  * This function accepts an arbitrary number of positional specifications
  * to attempt to match. Each specification is of the form
@@ -243,23 +222,5 @@ struct jx *jx_match_operator(struct jx *j, struct jx **v) __wur;
  * @return The number of elements successfully matched.
  */
 int jx_match_array(struct jx *j, ...) __wur __sentinel;
-
-/** Destructure an object.
- * This function accepts an arbitrary number of keyword specifications
- * to attempt to match. Each specification is of the form
- *
- *     <address>, <jx type>, <key>
- *
- * where <jx type> is JX_INTEGER, JX_ANY, etc., <key> is a string key in
- * the object j, and <address> is the address
- * to store the matched value. The last argument must be NULL to mark the
- * end of the specifications. The specifications will be matched
- * in the order given, and matching ends on the first failure. If the JX
- * value passed in was not an object, this is considered a failure before
- * any matches succeed, so 0 is returned.
- * @param j The JX structure to match.
- * @return The number of elements successfully matched.
- */
-int jx_match_object(struct jx *j, ...) __wur __sentinel;
 
 #endif

--- a/dttools/src/jx_match.h
+++ b/dttools/src/jx_match.h
@@ -64,7 +64,7 @@ See the file COPYING for details.
  * @code
  *     jx_int_t a;
  *     double b;
- *     switch (jx_match_positional(j, &a, JX_INTEGER, &b, JX_DOUBLE)) {
+ *     switch (jx_match_array(j, &a, JX_INTEGER, &b, JX_DOUBLE)) {
  *     case 1:
  *         printf("got int %d\n", a);
  *     case 2:
@@ -84,7 +84,7 @@ See the file COPYING for details.
  * @code
  *     struct jx *a;
  *     struct jx *b;
- *     if (jx_match_keyword(j, &a, JX_ARRAY, "array key", &b, JX_ANY, "???") == 2) {
+ *     if (jx_match_object(j, &a, JX_ARRAY, "array key", &b, JX_ANY, "???") == 2) {
  *         printf("got JX_ARRAY at %p\n", a);
  *         if (jx_istype(b, JX_STRING)) {
  *             printf("no longer supported\n");

--- a/dttools/src/jx_match.h
+++ b/dttools/src/jx_match.h
@@ -1,0 +1,261 @@
+/*
+Copyright (C) 2016- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+/** @file jx_match.h Unwrap JX types
+ *
+ * The functions in this header are intended to make JX types more usable
+ * from C code. All unwrap JX values in some manner, allowing access to
+ * native C types. For the collection types, the match functions can be
+ * used to destructure their arguments, extracting and type-checking
+ * components in a single call.
+ * The match functions for single values return a pointer to a primitive
+ * type, e.g. (int *), that references the value inside the given JX struct.
+ * On match failure, NULL is returned. This allows arbitrary data
+ * manipulation, but also requires care in how the matched values are used.
+ * DO NOT attempt to free() the returned values.
+ * The match functions can also give the caller a copy of
+ * the matched value. For heap-allocated types, the caller is responsible
+ * for free()ing/jx_delete()ing the copied values.
+ *
+ * The common use case is that programs will have some stack allocated
+ * variables for local use, and would like to read the value in a JX struct.
+ *
+ * @code
+ *     double val;
+ *     if (jx_match_double(j, &val)) {
+ *         printf("got value %f\n", val);
+ *     } else {
+ *         printf("not a valid double\n");
+ *     }
+ * @endcode
+ *
+ * Here, the return value is used to check that the given JX struct was
+ * in fact a double, and to copy the value onto the local function's
+ * stack. If a function needs to modify the JX structure, it should
+ * capture the returned pointer.
+ *
+ * @code
+ *     double *ptr = jx_match_double(j, NULL);
+ *     if (ptr) {
+ *         *ptr /= 2;
+ *         printf("now halved: %f\n", *ptr)
+ *     } else {
+ *         printf("bad value\n");
+ *     }
+ * @endcode
+ *
+ * There are also matching functions to extract multiple positional or
+ * keyword values from an array/object and validate types in a single call.
+ * These functions have a scanf()-like interface.
+ * The collection matching functions take a JX struct
+ * and a sequence of item specifications. Each item
+ * spec includes a JX type, the location of a pointer that will reference
+ * the extracted value, and for objects, a key name. The match functions
+ * process each specification in turn, stopping on an invalid spec,
+ * or NULL, and returning the number of items succesfully matched.
+ *
+ * @code
+ *     jx_int_t a;
+ *     double b;
+ *     switch (jx_match_positional(j, &a, JX_INTEGER, &b, JX_DOUBLE)) {
+ *     case 1:
+ *         printf("got int %d\n", a);
+ *     case 2:
+ *         printf("got %d and %f\n", a, b)
+ *     default:
+ *         printf("bad match\n");
+ *     }
+ * @endcode
+ *
+ * It's also possible to match on a position/key without looking at the
+ * type of the matched value. The pseudo-type JX_ANY is provided
+ * for this purpose. Since the type of the value matched by JX_ANY is
+ * unknown, the caller might want to use the other match functions to
+ * handle whatever cases they're interested in. The following example
+ * uses most of the matching functionality.
+ *
+ * @code
+ *     struct jx *a;
+ *     struct jx *b;
+ *     if (jx_match_keyword(j, &a, JX_ARRAY, "array key", &b, JX_ANY, "???") == 2) {
+ *         printf("got JX_ARRAY at %p\n", a);
+ *         if (jx_istype(b, JX_STRING)) {
+ *             printf("no longer supported\n");
+ *             return 0;
+ *         }
+ *         jx_int_t val;
+ *         if (jx_match_integer(b, &val)) {
+ *             return val % 8;
+ *         }
+ *     }
+ * @endcode
+ */
+
+#ifndef JX_MATCH_H
+#define JX_MATCH_H
+
+#ifndef JX_ANY
+#define JX_ANY -1
+#endif
+
+/*
+ * Macro to test if we're using a GNU C compiler of a specific vintage
+ * or later, for e.g. features that appeared in a particular version
+ * of GNU C.  Usage:
+ *
+ * #if __GNUC_PREREQ__(major, minor)
+ * ...cool feature...
+ * #else
+ * ...delete feature...
+ * #endif
+ */
+#ifndef __GNUC_PREREQ__
+#ifdef __GNUC__
+#define __GNUC_PREREQ__(x, y) \
+	((__GNUC__ == (x) && __GNUC_MINOR__ >= (y)) || \
+	 (__GNUC__ > (x)))
+#else
+#define __GNUC_PREREQ__(x, y) 0
+#endif
+#endif
+
+#ifndef __wur
+#if __GNUC_PREREQ__(3, 4)
+#define __wur __attribute__((warn_unused_result))
+#else
+#define __wur
+#endif
+#endif
+
+#ifndef __sentinel
+#if __GNUC_PREREQ__(4, 0)
+#define __sentinel __attribute__((sentinel))
+#else
+#define __sentinel
+#endif
+#endif
+
+/** Unwrap a null value.
+ * Since by definition there is no associated data, this function returns
+ * an opaque, non-NULL pointer in the case that j is of type JX_NULL.
+ * @param j The JX structure to match.
+ * @return An opaque, non-NULL pointer if j is a JX_NULL, or NULL otherwise
+ */
+void *jx_match_null(struct jx *j) __wur;
+
+/** Unwrap a boolean value.
+ * @param j The JX structure to match.
+ * @param v An address to copy the boolean value to, or NULL if copying
+ * the value is unnecessary.
+ * @return A pointer to the boolean value within j if j is a JX_BOOLEAN,
+ * or NULL otherwise.
+ */
+int *jx_match_boolean(struct jx *j, int *v) __wur;
+
+/** Unwrap an integer value.
+ * @param j The JX structure to match.
+ * @param v An address to copy the integer value to, or NULL if copying
+ * the value is unnecessary.
+ * @return A pointer to the integer value within j if j is a JX_INTEGER,
+ * or NULL otherwise.
+ */
+jx_int_t *jx_match_integer(struct jx *j, jx_int_t *v) __wur;
+
+/** Unwrap a double value.
+ * @param j The JX structure to match.
+ * @param v An address to copy the double value to, or NULL if copying
+ * the value is unnecessary.
+ * @return A pointer to the double value within j if j is a JX_DOUBLE,
+ * or NULL otherwise.
+ */
+double *jx_match_double(struct jx *j, double *v) __wur;
+
+/** Unwrap a string value.
+ * Since C strings are just pointers to char arrays, the interface
+ * here is a little awkward. If the caller has a stack-allocated
+ * (char *), this function can allocate a copy of the string value
+ * and store the address in the caller's pointer variable, e.g.
+ *
+ * @code
+ *     char *val;
+ *     if (jx_match_string(j, &val)) {
+ *         printf("got value %s\n", val);
+ *     }
+ * @endcode
+ *
+ * The return value is the address of the (char *) within the JX struct.
+ * This way, it's possible to change which string the struct is using.
+ *
+ * @param j The JX structure to match.
+ * @param v The address of a (char *) in which to store the address of
+ * the newly malloc()ed string, or NULL if copying the value is unnecessary.
+ * @return A pointer to the (char *) within j if j is a JX_STRING,
+ * or NULL otherwise.
+ */
+char **jx_match_string(struct jx *j, char **v) __wur;
+
+/** Unwrap a symbol value.
+ * This function accesses the symbol name as a string.
+ * See @ref jx_match_string for details.
+ *
+ * @param j The JX structure to match.
+ * @param v The address of a (char *) in which to store the address of
+ * the newly malloc()ed symbol name, or NULL
+ * if copying the value is unnecessary.
+ * @return A pointer to the (char *) within j if j is a JX_SYMBOL,
+ * or NULL otherwise.
+ */
+char **jx_match_symbol(struct jx *j, char **v) __wur;
+
+/** Unwrap an operator.
+ * Operators don't have a natural C representation, but a match function
+ * is still included for completeness. This function simply returns the
+ * address of the operator passed in, and optionally gives back a
+ * copy as well.
+ * @param j The JX structure to match.
+ * @param v The address of a (struct jx *) to store the newly copied
+ * operator. The caller is responsible for deleting the copy.
+ * @return The address of the passed in operator, or NULL if j
+ * is not a JX_OPERATOR.
+ */
+struct jx *jx_match_operator(struct jx *j, struct jx **v) __wur;
+
+/** Destructure an array.
+ * This function accepts an arbitrary number of positional specifications
+ * to attempt to match. Each specification is of the form
+ *
+ *     <address>, <jx type>
+ *
+ * where <jx type> is JX_INTEGER, JX_ANY, etc. and <address> is the address
+ * to store the matched value. The last argument must be NULL to mark the
+ * end of the specifications. The specifications will be matched
+ * in the order given, and matching ends on the first failure. If the JX
+ * value passed in was not an array, this is considered a failure before
+ * any matches succeed, so 0 is returned.
+ * @param j The JX structure to match.
+ * @return The number of elements successfully matched.
+ */
+int jx_match_array(struct jx *j, ...) __wur __sentinel;
+
+/** Destructure an object.
+ * This function accepts an arbitrary number of keyword specifications
+ * to attempt to match. Each specification is of the form
+ *
+ *     <address>, <jx type>, <key>
+ *
+ * where <jx type> is JX_INTEGER, JX_ANY, etc., <key> is a string key in
+ * the object j, and <address> is the address
+ * to store the matched value. The last argument must be NULL to mark the
+ * end of the specifications. The specifications will be matched
+ * in the order given, and matching ends on the first failure. If the JX
+ * value passed in was not an object, this is considered a failure before
+ * any matches succeed, so 0 is returned.
+ * @param j The JX structure to match.
+ * @return The number of elements successfully matched.
+ */
+int jx_match_object(struct jx *j, ...) __wur __sentinel;
+
+#endif

--- a/dttools/src/jx_match.h
+++ b/dttools/src/jx_match.h
@@ -18,7 +18,11 @@ See the file COPYING for details.
  * DO NOT attempt to free() the returned values.
  * The match functions can also give the caller a copy of
  * the matched value. For heap-allocated types, the caller is responsible
- * for free()ing/jx_delete()ing the copied values.
+ * for free()ing/jx_delete()ing the copied values. In the case that the
+ * caller requested a heap-allocated copy but malloc() fails, the match
+ * as a whole will fail. This ensures that it is always safe to dereference
+ * the copy given back, but might falsely indicate an incorrect type. Code
+ * that needs to run in out of memory conditions must not request copies.
  *
  * The common use case is that programs will have some stack allocated
  * variables for local use, and would like to read the value in a JX struct.

--- a/dttools/test/TR_jx_match.sh
+++ b/dttools/test/TR_jx_match.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+. ../../dttools/test/test_runner_common.sh
+
+exe="match.test"
+
+prepare()
+{
+	gcc -g -o "$exe" -I ../src/ -x c - -x none ../src/libdttools.a -lm <<EOF
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jx.h"
+#include "jx_match.h"
+
+
+int main(int argc, char **argv)
+{
+	char *ee;
+
+	struct jx *a = jx_boolean(10);
+	int aa = 42;
+	assert(jx_match_boolean(a, &aa));
+	assert(!jx_match_symbol(a, &ee));
+	assert(aa == 1);
+	jx_delete(a);
+
+	struct jx *b = jx_double(2.71);
+	double bb = 100.0;
+	assert(jx_match_double(b, &bb));
+	assert(!jx_match_boolean(b, &aa));
+	assert(bb == 2.71);
+	jx_delete(b);
+
+	struct jx *c = jx_integer(17);
+	jx_int_t cc = -10;
+	assert(jx_match_integer(c, &cc));
+	assert(!jx_match_double(c, &bb));
+	assert(cc == 17);
+	jx_delete(c);
+
+	struct jx *d = jx_string("d");
+	char *dd = NULL;
+	assert(jx_match_string(d, &dd));
+	assert(!jx_match_integer(d, &cc));
+	jx_delete(d);
+	assert(strlen(dd) == 1);
+	free(dd);
+
+	struct jx *e = jx_symbol("e");
+	assert(jx_match_symbol(e, &ee));
+	assert(!jx_match_string(e, &ee));
+	jx_delete(e);
+	assert(strlen(ee) == 1);
+	free(ee);
+
+	int f1;
+	char *f2;
+	double f3;
+	struct jx *f4 = jx_null();
+	struct jx *f = jx_array(NULL);
+	jx_array_insert(f, jx_double(3.14));
+	jx_array_insert(f, jx_string("pi"));
+	jx_array_insert(f, jx_boolean(0));
+	assert(!jx_match_boolean(f, &f1));
+	assert(!jx_match_array(f, NULL));
+	assert(!jx_match_array(f4, &f1, JX_BOOLEAN, NULL));
+	jx_delete(f4);
+	assert(jx_match_array(f, &f1, JX_BOOLEAN, &f3, JX_DOUBLE, NULL) == 1);
+	assert(jx_match_array(f, &f1, JX_BOOLEAN, &f2, JX_STRING, &f3, JX_DOUBLE, NULL) == 3);
+	assert(f1 == 0);
+	assert(strlen(f2) == 2);
+	assert(f3 == 3.14);
+	free(f2);
+	assert(jx_match_array(f, &f4, JX_ANY, NULL) == 1);
+	assert(jx_match_boolean(f4, &f1));
+	assert(f1 == 0);
+
+	return 0;
+}
+EOF
+	return $?
+}
+
+run()
+{
+	./"$exe"
+	return $?
+}
+
+clean()
+{
+	rm -f "$exe"
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:


### PR DESCRIPTION
I wrote up some access functions for unwrapping JX structs. The common case I had in mind (and encountered a lot with JX functions and Makeflow import) is reading a value of a specific type into a local variable. There are specialized functions for lookups in objects, so these do something similar for `struct jx`s in general. In addition to the extra opportunities for the compiler to check things, these functions are more readable in code than digging around in struct fields and enum variants.

The `jx_match_*` functions follow a common interface. Each type has a specialized match function. If the struct is the requested type, a pointer to the raw field inside the `struct jx` is returned, or `NULL` otherwise. This can be used to directly modify the `struct jx`, or more commonly, can be used as a truth value to make sure that the type was correct.  Each function also accepts an optional pointer to a local variable. The unwrapped value is written by value (or copied for a heap allocated type).

The [header documentation](https://github.com/trshaffer/cctools/blob/6981308b799434d97f22bc2e93aadfd8f330bfdb/dttools/src/jx_match.h) is pretty comprehensive, so that's a good place to look for details and examples of use.