### PR TITLE
Added function to escape Condor, called in batch_job_condor

### DIFF
--- a/batch_job/src/batch_job_condor.c
+++ b/batch_job/src/batch_job_condor.c
@@ -115,7 +115,9 @@ static batch_job_id_t batch_job_condor_submit (struct batch_queue *q, const char
 
 	fprintf(file, "universe = vanilla\n");
 	fprintf(file, "executable = condor.sh\n");
-	fprintf(file, "arguments = %s\n",cmd);
+	char *escaped = string_escape_condor(cmd);
+	fprintf(file, "arguments = %s\n", escaped);
+	free(escaped);
 	if(extra_input_files)
 		fprintf(file, "transfer_input_files = %s\n", extra_input_files);
 	// Note that we do not use transfer_output_files, because that causes the job

--- a/dttools/src/stringtools.h
+++ b/dttools/src/stringtools.h
@@ -23,6 +23,14 @@ typedef char *(*string_subst_lookup_t) (const char *name, void *arg);
   @return String with special characters escaped.
   */
 char *string_escape_shell (const char *str);
+
+/** Takes a command string, escapes double quotes with another double 
+  quote, and escapes single quotes with two additional single quotes.
+  This is a utilized when putting wrapped and nested commands in Condor.
+  @param str Command string presented to be escaped.
+  @return String with special characters escaped.
+  */
+char *string_escape_condor( const char *str);
 void string_from_ip_address(const unsigned char *ip_addr_bytes, char *str);
 int string_to_ip_address(const char *str, unsigned char *ip_addr_bytes);
 int string_ip_subnet(const char *addr, char *subnet);

--- a/dttools/test/TR_stringtools.sh
+++ b/dttools/test/TR_stringtools.sh
@@ -69,12 +69,29 @@ void t_string_time_parse (void)
 	a_int64eql(string_time_parse("1023 d"), 1023LL*60*60*24);
 }
 
+void t_string_escape_shell (void)
+{
+	a_streql(string_escape_shell("$ test var"), "\\"\\\\$ test var\\"");
+	a_streql(string_escape_shell("\`test var\`"), "\\"\\\\\`test var\\\\\`\\"");
+	a_streql(string_escape_shell("\\\\test var"), "\\"\\\\\\\\test var\\"");
+	a_streql(string_escape_shell("\"test var\""), "\\"\\\\\\"test var\\\\\\"\\"");
+}
+
+void t_string_escape_condor (void)
+{
+	a_streql(string_escape_condor("test var"), "\\"test var \\"");
+	a_streql(string_escape_condor("test \\"var\\""), "\\"test \\"\\"var\\"\\" \\"");
+	a_streql(string_escape_condor("test 'var'"), "\\"test '''var''' \\"");
+	a_streql(string_escape_condor("\\"test 'var'\\""), "\\"\\"\\"test '''var'''\\"\\" \\"");
+}
 
 int main (int argc, char *argv[])
 {
 	t_string_metric();
 	t_string_parse();
 	t_string_time_parse();
+	t_string_escape_shell();
+	t_string_escape_condor();
 
 	return 0;
 }


### PR DESCRIPTION
Added function that escapes quotes which is required in a condor submit file. Needed as quotes are used in wrapping of commands with wrappers and resource monitor.