### PR TITLE
Makeflow Variable are set to most recent Category, not default

### DIFF
--- a/makeflow/src/parser.c
+++ b/makeflow/src/parser.c
@@ -372,7 +372,7 @@ static int dag_parse_variable(struct lexer *bk, struct dag_node *n)
 	}
 	else
 	{
-		current_table = bk->d->default_category->mf_variables;
+		current_table = bk->category->mf_variables;
 		nodeid        = bk->d->nodeid_counter;
 	}
 


### PR DESCRIPTION
Setting to default overwrote the different variable which resulted in every task using the default category values. No values were set in the actual categories. Now every variable is tied to the most recent defined category and not the default, unless that was the most recent.