### PR TITLE
Batch job option fix

### DIFF
--- a/batch_job/src/batch_job.c
+++ b/batch_job/src/batch_job.c
@@ -148,13 +148,13 @@ int batch_queue_port(struct batch_queue *q)
 void batch_queue_set_option (struct batch_queue *q, const char *what, const char *value)
 {
 	char *current = hash_table_remove(q->options, what);
-	free(current);
 	if(value) {
 		hash_table_insert(q->options, what, xxstrdup(value));
 		debug(D_BATCH, "set option `%s' to `%s'", what, value);
 	} else {
 		debug(D_BATCH, "cleared option `%s'", what);
 	}
+	free(current);
 	q->module->option_update(q, what, value);
 }
 
@@ -168,6 +168,7 @@ void batch_queue_set_feature (struct batch_queue *q, const char *what, const cha
 	} else {
 		debug(D_BATCH, "cleared feature `%s'", what);
 	}
+	free(current);
 }
 
 void batch_queue_set_int_option(struct batch_queue *q, const char *what, int value) {

--- a/batch_job/src/batch_job.c
+++ b/batch_job/src/batch_job.c
@@ -161,7 +161,6 @@ void batch_queue_set_option (struct batch_queue *q, const char *what, const char
 void batch_queue_set_feature (struct batch_queue *q, const char *what, const char *value)
 {
 	char *current = hash_table_remove(q->features, what);
-	free(current);
 	if(value) {
 		hash_table_insert(q->features, what, xxstrdup(value));
 		debug(D_BATCH, "set feature `%s' to `%s'", what, value);

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -487,7 +487,10 @@ static void makeflow_node_submit(struct dag *d, struct dag_node *n)
 	 * restore it after we submit. */
 	struct dag_variable_lookup_set s = { d, n->category, n, NULL };
 	char *batch_options          = dag_variable_lookup_string("BATCH_OPTIONS", &s);
-	char *previous_batch_options = xxstrdup(batch_queue_get_option(queue, "batch-options"));
+
+	char *previous_batch_options = NULL;
+	if(batch_queue_get_option(queue, "batch-options"))
+		previous_batch_options = xxstrdup(batch_queue_get_option(queue, "batch-options"));
 
 	if(batch_options) {
 		debug(D_MAKEFLOW_RUN, "Batch options: %s\n", batch_options);

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -487,7 +487,7 @@ static void makeflow_node_submit(struct dag *d, struct dag_node *n)
 	 * restore it after we submit. */
 	struct dag_variable_lookup_set s = { d, n->category, n, NULL };
 	char *batch_options          = dag_variable_lookup_string("BATCH_OPTIONS", &s);
-	const char *previous_batch_options = batch_queue_get_option(queue, "batch-options");
+	char *previous_batch_options = xxstrdup(batch_queue_get_option(queue, "batch-options"));
 
 	if(batch_options) {
 		debug(D_MAKEFLOW_RUN, "Batch options: %s\n", batch_options);
@@ -507,6 +507,7 @@ static void makeflow_node_submit(struct dag *d, struct dag_node *n)
 	/* Restore old batch job options. */
 	if(previous_batch_options) {
 		batch_queue_set_option(queue, "batch-options", previous_batch_options);
+		free(previous_batch_options);
 	}
 
 	/* Update all of the necessary data structures. */


### PR DESCRIPTION
This waits to free until after we have made a duplicate of the new value. This prevents an issue if the old value passed back in. e.g. as in Makeflow

previous = batch_queue_get_option (q, "batch-options");
if(new-options)
    batch_queue_set_option(q, "batch-options", new-options);

run task

if(previous)
    batch_queue_set_option(q, "batch-options", previous);

Set option duplicates the passed value, and removes the previous value. When removing the previous value, it also frees that value as batch_job created it in the first place. The issue occurs when you pass back in the original value that you retrieved and it has already been freed. This happens regardless of whether you set new options or not. 

This pull request still frees the internal copy when a new value is set. It also returns a copy on get so we don't have issues if a new value is set while a pointer is held.

Instead of the solution here we could respect const char and not strdup the value, relieving the need to free at all in batch options. 

Before this is merged I need to go through and make sure memory leaks weren't added by strdup on get_option and feature.

Definitely open to a better solution, but this works in SLURM. @btovar @dthain 