### PR TITLE
wq stats cleanup

### DIFF
--- a/batch_job/src/batch_job_work_queue.c
+++ b/batch_job/src/batch_job_work_queue.c
@@ -118,9 +118,9 @@ static batch_job_id_t batch_job_wq_wait (struct batch_queue * q, struct batch_jo
 
 	struct work_queue_task *t = work_queue_wait(q->data, timeout);
 	if(t) {
-		info->submitted = t->time_task_submit / 1000000;
-		info->started = t->time_send_input_start / 1000000;
-		info->finished = t->time_receive_output_finish / 1000000;
+		info->submitted = t->time_when_submitted / 1000000;
+		info->started   = t->time_when_commit_end / 1000000;
+		info->finished  = t->time_when_done / 1000000;
 		info->exited_normally = 1;
 		info->exit_code = t->return_status;
 		info->exit_signal = 0;

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -108,7 +108,7 @@ static int count_workers_needed( struct list *masters_list, int only_waiting )
 		const char *host =   jx_lookup_string(j,"name");
 		const int  port =    jx_lookup_integer(j,"port");
 		const char *owner =  jx_lookup_string(j,"owner");
-		const int tr =       jx_lookup_integer(j,"tasks_running");
+		const int tr =       jx_lookup_integer(j,"tasks_on_workers");
 		const int tw =       jx_lookup_integer(j,"tasks_waiting");
 		const int tl =       jx_lookup_integer(j,"tasks_left");
 		const int capacity = jx_lookup_integer(j,"capacity");
@@ -274,13 +274,13 @@ void remove_all_workers( struct batch_queue *queue, struct itable *job_table )
 }
 
 static struct jx_table queue_headers[] = {
-{"project",       "PROJECT", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, -18},
-{"name",          "HOST",    JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, -21},
-{"port",          "PORT",    JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 5},
-{"tasks_waiting", "WAITING", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 7},
-{"tasks_running", "RUNNING", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 7},
-{"tasks_complete","COMPLETE",JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 8},
-{"workers",       "WORKERS", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 7},
+{"project",           "PROJECT", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, -18},
+{"name",              "HOST",    JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, -21},
+{"port",              "PORT",    JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 5},
+{"tasks_waiting",     "WAITING", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 7},
+{"tasks_running",     "RUNNING", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 7},
+{"tasks_done",        "COMPLETE",JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 8},
+{"workers_connected", "WORKERS", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 7},
 {NULL,NULL,0,0,0}
 };
 

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -5538,9 +5538,16 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 			continue;
 		}
 
-		if( q->process_pending_check && process_pending() ) {
-			events++;
-			break;
+		if(q->process_pending_check) {
+
+			BEGIN_ACCUM_TIME(q, time_internal);
+			int pending = process_pending();
+			END_ACCUM_TIME(q, time_internal);
+
+			if(pending) {
+				events++;
+				break;
+			}
 		}
 
 		// return if queue is empty.
@@ -5557,11 +5564,12 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 		}
 	}
 
+	BEGIN_ACCUM_TIME(q, time_internal);
 	if(events > 0) {
 		log_queue_stats(q);
 	}
-
 	q->last_outside_waiting = timestamp_get();
+	END_ACCUM_TIME(q, time_internal);
 
 	return t;
 }

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -5034,7 +5034,7 @@ static void fill_deprecated_tasks_stats(struct work_queue_task *t) {
 	t->time_execute_cmd_start  = t->time_when_commit_start;
 	t->time_execute_cmd_finish = t->time_when_retrieval;
 
-	t->total_transfer_time = (t->time_when_commit_end - t->time_when_commit_start) - (t->time_when_done - t->time_when_retrieval);
+	t->total_transfer_time = (t->time_when_commit_end - t->time_when_commit_start) + (t->time_when_done - t->time_when_retrieval);
 
 	t->cmd_execution_time = t->time_workers_execute_last;
 	t->total_cmd_execution_time = t->time_workers_execute_all;

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -143,6 +143,7 @@ struct work_queue {
 	struct hash_table *workers_with_available_results;
 
 	struct work_queue_stats *stats;
+	struct work_queue_stats *stats_measure;
 	struct work_queue_stats *stats_disconnected_workers;
 
 	int worker_selection_algorithm;
@@ -235,6 +236,7 @@ struct blacklist_host_info {
 
 static void handle_worker_failure(struct work_queue *q, struct work_queue_worker *w);
 static void handle_app_failure(struct work_queue *q, struct work_queue_worker *w, struct work_queue_task *t);
+static void remove_worker(struct work_queue *q, struct work_queue_worker *w);
 
 static void add_task_report(struct work_queue *q, struct work_queue_task *t );
 
@@ -277,7 +279,7 @@ char *work_queue_monitor_wrap(struct work_queue *q, struct work_queue_worker *w,
 const struct rmsummary *task_max_resources(struct work_queue *q, struct work_queue_task *t);
 const struct rmsummary *task_min_resources(struct work_queue *q, struct work_queue_task *t);
 
-void work_queue_category_accumulate_task(struct work_queue *q, struct work_queue_task *t);
+void work_queue_accumulate_task(struct work_queue *q, struct work_queue_task *t);
 struct category *work_queue_category_lookup_or_create(struct work_queue *q, const char *name);
 
 static void write_transaction(struct work_queue *q, const char *str);
@@ -373,28 +375,101 @@ static int workers_with_tasks(struct work_queue *q) {
 	return workers_with_tasks;
 }
 
-static void log_worker_stats(struct work_queue *q)
+static void log_queue_stats(struct work_queue *q)
 {
 	struct work_queue_stats s;
 
-	debug(D_WQ, "workers status -- total: %d, active: %d, available: %d.",
-		hash_table_size(q->worker_table),
-		known_workers(q),
-		available_workers(q));
-
-	if(!q->logfile) return;
-
 	work_queue_get_stats(q, &s);
 
-	//print in the order described by the headers in specify_log().
-	fprintf(q->logfile, "%" PRIu64 " ", timestamp_get());
-	fprintf(q->logfile, "%d %d %d %d %d %d ", s.total_workers_connected, s.workers_init, s.workers_idle, s.workers_busy, s.total_workers_joined, s.total_workers_removed);
-	fprintf(q->logfile, "%d %d %d %d %d %d ", s.tasks_waiting, s.tasks_running, s.tasks_complete, s.total_tasks_dispatched, s.total_tasks_complete, s.total_tasks_cancelled);
-	fprintf(q->logfile, "%" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRId64 " %" PRId64 " %f %f %d ", s.start_time, s.total_send_time, s.total_receive_time, s.total_bytes_sent, s.total_bytes_received, s.efficiency, s.idle_percentage, s.capacity);
-	fprintf(q->logfile, "%f %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " ", s.bandwidth, s.total_cores, s.total_memory, s.total_disk, s.total_gpus);
-	fprintf(q->logfile, "%" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " ", s.min_cores, s.max_cores, s.min_memory, s.max_memory, s.min_disk, s.max_disk, s.min_gpus, s.max_gpus);
-	fprintf(q->logfile, "%" PRIu64 " %" PRIu64 " ", s.total_execute_time, s.total_good_execute_time);
-	fprintf(q->logfile, "\n");
+	debug(D_WQ, "workers status -- total: %d, active: %d, available: %d.",
+			s.workers_connected,
+			s.workers_connected - s.workers_init,
+			available_workers(q));
+
+	if(!q->logfile)
+		return;
+
+	buffer_t B;
+	buffer_init(&B);
+
+	buffer_printf(&B, "%" PRIu64, timestamp_get());
+
+	/* Stats for the current state of workers: */
+	buffer_printf(&B, " %d", s.workers_connected);
+	buffer_printf(&B, " %d", s.workers_init);
+	buffer_printf(&B, " %d", s.workers_idle);
+	buffer_printf(&B, " %d", s.workers_busy);
+	buffer_printf(&B, " %d", s.workers_able);
+
+	/* Cummulative stats for workers: */
+	buffer_printf(&B, " %d", s.workers_joined);
+	buffer_printf(&B, " %d", s.workers_removed);
+	buffer_printf(&B, " %d", s.workers_released);
+	buffer_printf(&B, " %d", s.workers_idled_out);
+	buffer_printf(&B, " %d", s.workers_fast_aborted);
+	buffer_printf(&B, " %d", s.workers_blacklisted);
+	buffer_printf(&B, " %d", s.workers_lost);
+
+	/* Stats for the current state of tasks: */
+	buffer_printf(&B, " %d", s.tasks_waiting);
+	buffer_printf(&B, " %d", s.tasks_on_workers);
+	buffer_printf(&B, " %d", s.tasks_running);
+	buffer_printf(&B, " %d", s.tasks_with_results);
+
+	/* Cummulative stats for tasks: */
+	buffer_printf(&B, " %d", s.tasks_submitted);
+	buffer_printf(&B, " %d", s.tasks_dispatched);
+	buffer_printf(&B, " %d", s.tasks_done);
+	buffer_printf(&B, " %d", s.tasks_failed);
+	buffer_printf(&B, " %d", s.tasks_cancelled);
+	buffer_printf(&B, " %d", s.tasks_exhausted_attempts);
+
+	/* Master time statistics: */
+	buffer_printf(&B, " %" PRId64, s.time_when_started);
+	buffer_printf(&B, " %" PRId64, s.time_send);
+	buffer_printf(&B, " %" PRId64, s.time_receive);
+	buffer_printf(&B, " %" PRId64, s.time_send_good);
+	buffer_printf(&B, " %" PRId64, s.time_receive_good);
+	buffer_printf(&B, " %" PRId64, s.time_status_msgs);
+	buffer_printf(&B, " %" PRId64, s.time_internal);
+	buffer_printf(&B, " %" PRId64, s.time_polling);
+	buffer_printf(&B, " %" PRId64, s.time_application);
+
+	/* Workers time statistics: */
+	buffer_printf(&B, " %" PRId64, s.time_workers_execute);
+	buffer_printf(&B, " %" PRId64, s.time_workers_execute_good);
+	buffer_printf(&B, " %" PRId64, s.time_workers_execute_exhaustion);
+
+	/* BW statistics */
+	buffer_printf(&B, " %" PRId64, s.bytes_sent);
+	buffer_printf(&B, " %" PRId64, s.bytes_received);
+	buffer_printf(&B, " %f", s.bandwidth);
+
+	/* resources statistics */
+	buffer_printf(&B, " %d", s.capacity_tasks);
+	buffer_printf(&B, " %d", s.capacity_cores);
+	buffer_printf(&B, " %d", s.capacity_memory);
+	buffer_printf(&B, " %d", s.capacity_disk);
+
+	buffer_printf(&B, " %" PRId64, s.total_cores);
+	buffer_printf(&B, " %" PRId64, s.total_memory);
+	buffer_printf(&B, " %" PRId64, s.total_disk);
+
+	buffer_printf(&B, " %" PRId64, s.committed_cores);
+	buffer_printf(&B, " %" PRId64, s.committed_memory);
+	buffer_printf(&B, " %" PRId64, s.committed_disk);
+
+	buffer_printf(&B, " %" PRId64, s.max_cores);
+	buffer_printf(&B, " %" PRId64, s.max_memory);
+	buffer_printf(&B, " %" PRId64, s.max_disk);
+
+	buffer_printf(&B, " %" PRId64, s.min_cores);
+	buffer_printf(&B, " %" PRId64, s.min_memory);
+	buffer_printf(&B, " %" PRId64, s.min_disk);
+
+	fprintf(q->logfile, "%s\n", buffer_tostring(&B));
+
+	buffer_free(&B);
 }
 
 static void link_to_hash_key(struct link *link, char *key)
@@ -468,26 +543,27 @@ work_queue_msg_code_t process_info(struct work_queue *q, struct work_queue_worke
 	if(n != 2)
 		return MSG_FAILURE;
 
-	if(string_prefix_is(field, "total_workers_joined")) {
-		w->stats->total_workers_joined = atoll(value);
-	} else if(string_prefix_is(field, "total_workers_removed")) {
-		w->stats->total_workers_removed = atoll(value);
-	} else if(string_prefix_is(field, "total_send_time")) {
-		w->stats->total_send_time = atoll(value);
-	} else if(string_prefix_is(field, "total_receive_time")) {
-		w->stats->total_receive_time = atoll(value);
-	} else if(string_prefix_is(field, "total_execute_time")) {
-		w->stats->total_execute_time = atoll(value);
-	} else if(string_prefix_is(field, "total_bytes_sent")) {
-		w->stats->total_bytes_sent = atoll(value);
-	} else if(string_prefix_is(field, "total_bytes_received")) {
-		w->stats->total_bytes_received = atoll(value);
+	if(string_prefix_is(field, "workers_joined")) {
+		w->stats->workers_joined = atoll(value);
+	} else if(string_prefix_is(field, "workers_removed")) {
+		w->stats->workers_removed = atoll(value);
+	} else if(string_prefix_is(field, "time_send")) {
+		w->stats->time_send = atoll(value);
+	} else if(string_prefix_is(field, "time_receive")) {
+		w->stats->time_receive = atoll(value);
+	} else if(string_prefix_is(field, "time_execute")) {
+		w->stats->time_workers_execute = atoll(value);
+	} else if(string_prefix_is(field, "bytes_sent")) {
+		w->stats->bytes_sent = atoll(value);
+	} else if(string_prefix_is(field, "bytes_received")) {
+		w->stats->bytes_received = atoll(value);
 	} else if(string_prefix_is(field, "tasks_waiting")) {
 		w->stats->tasks_waiting = atoll(value);
 	} else if(string_prefix_is(field, "tasks_running")) {
 		w->stats->tasks_running = atoll(value);
 	} else if(string_prefix_is(field, "idle-disconnecting")) {
-		q->stats->total_workers_idled_out++;
+		remove_worker(q, w);
+		q->stats->workers_idled_out++;
 	} else if(string_prefix_is(field, "end_of_resource_update")) {
 		count_worker_resources(q, w);
 	} else if(string_prefix_is(field, "worker-id")) {
@@ -575,8 +651,8 @@ work_queue_msg_code_t recv_worker_msg_retry( struct work_queue *q, struct work_q
 static double get_queue_transfer_rate(struct work_queue *q, char **data_source)
 {
 	double queue_transfer_rate; // bytes per second
-	int64_t     q_total_bytes_transferred = q->stats->total_bytes_sent + q->stats->total_bytes_received;
-	timestamp_t q_total_transfer_time     = q->stats->total_send_time  + q->stats->total_receive_time;
+	int64_t     q_total_bytes_transferred = q->stats->bytes_sent + q->stats->bytes_received;
+	timestamp_t q_total_transfer_time     = q->stats->time_send  + q->stats->time_receive;
 
 	// Note q_total_transfer_time is timestamp_t with units of milliseconds.
 	if(q_total_transfer_time>1000000) {
@@ -671,13 +747,15 @@ void update_catalog(struct work_queue *q, struct link *foreman_uplink, int force
 
 static void clean_task_state(struct work_queue_task *t) {
 
-		t->total_bytes_transferred = 0;
-		t->total_bytes_received = 0;
-		t->total_bytes_sent = 0;
-		t->total_transfer_time = 0;
-		t->cmd_execution_time = 0;
+		t->time_when_commit_start = 0;
+		t->time_when_commit_end   = 0;
+		t->time_when_retrieval    = 0;
 
-		t->time_execute_cmd_start = 0;
+		t->time_workers_execute_last = 0;
+
+		t->bytes_sent = 0;
+		t->bytes_received = 0;
+		t->bytes_transferred = 0;
 
 		if(t->output) {
 			free(t->output);
@@ -715,15 +793,14 @@ static void cleanup_worker(struct work_queue *q, struct work_queue_worker *w)
 
 	itable_firstkey(w->current_tasks);
 	while(itable_nextkey(w->current_tasks, &taskid, (void **)&t)) {
-
-		if (t->time_execute_cmd_start >= t->time_committed) {
-			timestamp_t delta_time = timestamp_get() - t->time_execute_cmd_start;
-			t->total_time_until_worker_failure += delta_time;
-			t->total_cmd_execution_time += delta_time;
+		if (t->time_when_commit_end >= t->time_when_commit_start) {
+			timestamp_t delta_time = timestamp_get() - t->time_when_commit_end;
+			t->time_workers_execute_failure += delta_time;
+			t->time_workers_execute_all     += delta_time;
 		}
 
 		clean_task_state(t);
-		if(t->max_retries > 0 && (t->total_submissions >= t->max_retries)) {
+		if(t->max_retries > 0 && (t->try_count >= t->max_retries)) {
 			update_task_result(t, WORK_QUEUE_RESULT_MAX_RETRIES);
 			reap_task_from_worker(q, w, t, WORK_QUEUE_TASK_RETRIEVED);
 		} else {
@@ -751,18 +828,23 @@ static void record_removed_worker_stats(struct work_queue *q, struct work_queue_
 	struct work_queue_stats *qs = q->stats_disconnected_workers;
 	struct work_queue_stats *ws = w->stats;
 
-	accumulate_stat(qs, ws, total_workers_joined);
-	accumulate_stat(qs, ws, total_workers_idled_out);
-	accumulate_stat(qs, ws, total_workers_lost);
-	accumulate_stat(qs, ws, total_workers_fast_aborted);
-	accumulate_stat(qs, ws, total_send_time);
-	accumulate_stat(qs, ws, total_receive_time);
-	accumulate_stat(qs, ws, total_execute_time);
-	accumulate_stat(qs, ws, total_bytes_sent);
-	accumulate_stat(qs, ws, total_bytes_received);
+	accumulate_stat(qs, ws, workers_joined);
+	accumulate_stat(qs, ws, workers_removed);
+	accumulate_stat(qs, ws, workers_released);
+	accumulate_stat(qs, ws, workers_idled_out);
+	accumulate_stat(qs, ws, workers_fast_aborted);
+	accumulate_stat(qs, ws, workers_blacklisted);
+	accumulate_stat(qs, ws, workers_lost);
+
+	accumulate_stat(qs, ws, time_send);
+	accumulate_stat(qs, ws, time_receive);
+	accumulate_stat(qs, ws, time_workers_execute);
+
+	accumulate_stat(qs, ws, bytes_sent);
+	accumulate_stat(qs, ws, bytes_received);
 
 	//Count all the workers joined as removed.
-	qs->total_workers_removed = ws->total_workers_joined;
+	qs->workers_removed = ws->workers_joined;
 }
 
 static void remove_worker(struct work_queue *q, struct work_queue_worker *w)
@@ -771,7 +853,7 @@ static void remove_worker(struct work_queue *q, struct work_queue_worker *w)
 
 	debug(D_WQ, "worker %s (%s) removed", w->hostname, w->addrport);
 
-	q->stats->total_workers_removed++;
+	q->stats->workers_removed++;
 
 	write_transaction_worker(q, w, 1);
 
@@ -781,7 +863,6 @@ static void remove_worker(struct work_queue *q, struct work_queue_worker *w)
 	hash_table_remove(q->workers_with_available_results, w->hashkey);
 
 	record_removed_worker_stats(q, w);
-	log_worker_stats(q);
 
 	if(w->link)
 		link_close(w->link);
@@ -808,8 +889,11 @@ static void remove_worker(struct work_queue *q, struct work_queue_worker *w)
 static int release_worker(struct work_queue *q, struct work_queue_worker *w)
 {
 	if(!w) return 0;
+
 	send_worker_msg(q,w,"release\n");
 	remove_worker(q, w);
+	q->stats->workers_released++;
+
 	return 1;
 }
 
@@ -872,8 +956,7 @@ static void add_worker(struct work_queue *q)
 	link_to_hash_key(link, w->hashkey);
 	sprintf(w->addrport, "%s:%d", addr, port);
 	hash_table_insert(q->worker_table, w->hashkey, w);
-	log_worker_stats(q);
-	q->stats->total_workers_joined++;
+	q->stats->workers_joined++;
 
 	debug(D_WQ, "%d workers are connected in total now", hash_table_size(q->worker_table));
 
@@ -1135,13 +1218,14 @@ static work_queue_result_code_t get_output_file( struct work_queue *q, struct wo
 	timestamp_t sum_time = close_time - open_time;
 
 	if(total_bytes>0) {
-		q->stats->total_bytes_received += total_bytes;
-		q->stats->total_receive_time += sum_time;
-		t->total_bytes_received += total_bytes;
-		t->total_bytes_transferred += total_bytes;
-		t->total_transfer_time += sum_time;
+		q->stats->bytes_received += total_bytes;
+
+		t->bytes_received    += total_bytes;
+		t->bytes_transferred += total_bytes;
+
 		w->total_bytes_transferred += total_bytes;
 		w->total_transfer_time += sum_time;
+
 		debug(D_WQ, "%s (%s) sent %.2lf MB in %.02lfs (%.02lfs MB/s) average %.02lfs MB/s", w->hostname, w->addrport, total_bytes / 1000000.0, sum_time / 1000000.0, (double) total_bytes / sum_time, (double) w->total_bytes_transferred / w->total_transfer_time);
 	}
 
@@ -1351,8 +1435,8 @@ static void fetch_output_from_worker(struct work_queue *q, struct work_queue_wor
 		return;
 	}
 
-	// Receiving output ...
-	t->time_receive_output_start = timestamp_get();
+	// Start receiving output...
+	t->time_when_retrieval = timestamp_get();
 
 	if(t->result == WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION) {
 		result = get_monitor_output_file(q,w,t);
@@ -1365,10 +1449,12 @@ static void fetch_output_from_worker(struct work_queue *q, struct work_queue_wor
 		handle_failure(q, w, t, result);
 	}
 
-	if(result == WORKER_FAILURE)
-		return;
+	if(result == WORKER_FAILURE) {
+		// Finish receiving output:
+		t->time_when_done = timestamp_get();
 
-	t->time_receive_output_finish = timestamp_get();
+		return;
+	}
 
 	delete_uncacheable_files(q,w,t);
 
@@ -1382,33 +1468,18 @@ static void fetch_output_from_worker(struct work_queue *q, struct work_queue_wor
 			resource_monitor_compress_logs(q, t);
 	}
 
-	work_queue_category_accumulate_task(q, t);
+	// Finish receiving output.
+	t->time_when_done = timestamp_get();
+
+	work_queue_accumulate_task(q, t);
 
 	// At this point, a task is completed.
 	reap_task_from_worker(q, w, t, WORK_QUEUE_TASK_RETRIEVED);
 
 	w->finished_tasks--;
-	t->time_task_finish = timestamp_get();
-
-	// Update completed tasks and the total task execution time.
-	q->stats->total_tasks_complete++;
 	w->total_tasks_complete++;
 
-	w->total_task_time += t->cmd_execution_time;
-
-	if(t->result == WORK_QUEUE_RESULT_SUCCESS)
-	{
-		q->stats->total_good_execute_time  += t->cmd_execution_time;
-		q->stats->total_good_transfer_time += t->total_transfer_time;
-	}
-
 	if(t->result == WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION) {
-		q->stats->total_exhausted_execute_time += t->cmd_execution_time;
-		q->stats->total_exhausted_attempts++;
-
-		t->total_cmd_exhausted_execute_time += t->cmd_execution_time;
-		t->exhausted_attempts++;
-
 		if(t->resources_measured && t->resources_measured->limits_exceeded) {
 			struct jx *j = rmsummary_to_json(t->resources_measured->limits_exceeded, 1);
 			if(j) {
@@ -1446,7 +1517,7 @@ static void fetch_output_from_worker(struct work_queue *q, struct work_queue_wor
 	debug(D_WQ, "%s (%s) done in %.02lfs total tasks %lld average %.02lfs",
 			w->hostname,
 			w->addrport,
-			(t->time_receive_output_finish - t->time_send_input_start) / 1000000.0,
+			(t->time_when_done - t->time_when_commit_start) / 1000000.0,
 			(long long) w->total_tasks_complete,
 			w->total_task_time / w->total_tasks_complete / 1000000.0);
 
@@ -1511,7 +1582,7 @@ static void handle_app_failure(struct work_queue *q, struct work_queue_worker *w
 	application may resubmit the task and the resubmitted task may produce
 	different outputs. */
 	if(t) {
-		if(t->time_execute_cmd_start > 0) {
+		if(t->time_when_commit_end > 0) {
 			delete_task_output_files(q,w,t);
 		}
 	}
@@ -1566,7 +1637,6 @@ static work_queue_msg_code_t process_workqueue(struct work_queue *q, struct work
 		w->foreman = 1;
 	}
 
-	log_worker_stats(q);
 	debug(D_WQ, "%s (%s) running CCTools version %s on %s (operating system) with architecture %s is ready", w->hostname, w->addrport, w->version, w->os, w->arch);
 
 	if(cctools_version_cmp(CCTOOLS_VERSION, w->version) != 0) {
@@ -1689,13 +1759,12 @@ static work_queue_result_code_t get_result(struct work_queue *q, struct work_que
 		return SUCCESS;
 	}
 
-	t->time_receive_result_start = timestamp_get();
-	observed_execution_time = timestamp_get() - t->time_execute_cmd_start;
+	observed_execution_time = timestamp_get() - t->time_when_commit_end;
 
 	execution_time = atoll(items[3]);
-	t->cmd_execution_time = observed_execution_time > execution_time ? execution_time : observed_execution_time;
+	t->time_workers_execute_last = observed_execution_time > execution_time ? execution_time : observed_execution_time;
 
-	t->total_cmd_execution_time += t->cmd_execution_time;
+	t->time_workers_execute_all += t->time_workers_execute_last;
 
 	if(task_status == WORK_QUEUE_RESULT_DISK_ALLOC_FULL) {
 		t->disk_allocation_exhausted = 1;
@@ -1762,13 +1831,10 @@ static work_queue_result_code_t get_result(struct work_queue *q, struct work_que
 	if(t->output)
 		t->output[actual] = 0;
 
-	t->time_receive_result_finish = timestamp_get();
-
 	t->result        = task_status;
 	t->return_status = exit_status;
 
-	t->time_execute_cmd_finish = t->time_execute_cmd_start + t->cmd_execution_time;
-	q->stats->total_execute_time += t->cmd_execution_time;
+	q->stats->time_workers_execute += t->time_workers_execute_last;
 
 	w->finished_tasks++;
 
@@ -1987,20 +2053,20 @@ static struct jx * category_to_jx(struct work_queue *q, const char *category) {
 	struct work_queue_stats s;
 	work_queue_get_stats_category(q, category, &s);
 
-	if(s.tasks_waiting + s.tasks_running + s.tasks_complete < 1)
+	if(s.tasks_waiting + s.tasks_running + s.tasks_done < 1)
 		return 0;
 
 	struct jx *j = jx_object(0);
 	if(!j) return 0;
 
-	jx_insert_string(j, "category", category);
-	jx_insert_integer(j, "tasks_waiting", s.tasks_waiting);
-	jx_insert_integer(j, "tasks_running", s.tasks_running + s.tasks_complete);
-	jx_insert_integer(j, "total_tasks_dispatched", s.total_tasks_dispatched);
-	jx_insert_integer(j, "total_tasks_complete", s.total_tasks_complete);
-	jx_insert_integer(j, "total_tasks_failed", s.total_tasks_failed);
-	jx_insert_integer(j, "total_tasks_cancelled", s.total_tasks_cancelled);
-	jx_insert_integer(j, "workers_able", s.workers_able);
+	jx_insert_string(j,  "category",         category);
+	jx_insert_integer(j, "tasks_waiting",    s.tasks_waiting);
+	jx_insert_integer(j, "tasks_running",    s.tasks_running);
+	jx_insert_integer(j, "tasks_dispatched", s.tasks_dispatched);
+	jx_insert_integer(j, "tasks_done",       s.tasks_done);
+	jx_insert_integer(j, "tasks_failed",     s.tasks_failed);
+	jx_insert_integer(j, "tasks_cancelled",  s.tasks_cancelled);
+	jx_insert_integer(j, "workers_able",     s.workers_able);
 
 	category_jx_insert_max(j, c, cores);
 	category_jx_insert_max(j, c, memory);
@@ -2050,47 +2116,65 @@ static struct jx * queue_to_jx( struct work_queue *q, struct link *foreman_uplin
 	struct work_queue_stats info;
 	work_queue_get_stats(q,&info);
 
-	jx_insert_integer(j,"port",info.port);
+	jx_insert_integer(j,"port",work_queue_port(q));
 	jx_insert_integer(j,"priority",info.priority);
 	jx_insert_integer(j,"tasks_left",q->num_tasks_left);
 
 	//send info on workers
-	jx_insert_integer(j,"workers",info.total_workers_connected);
+	jx_insert_integer(j,"workers",info.workers_connected);
+	jx_insert_integer(j,"workers_connected",info.workers_connected);
 	jx_insert_integer(j,"workers_init",info.workers_init);
 	jx_insert_integer(j,"workers_idle",info.workers_idle);
 	jx_insert_integer(j,"workers_busy",info.workers_busy);
 	jx_insert_integer(j,"workers_able",info.workers_able);
-	jx_insert_integer(j,"workers_ready",info.workers_ready); //workers_ready is deprecated
-	jx_insert_integer(j,"total_workers_connected",info.total_workers_connected);
-	jx_insert_integer(j,"total_workers_joined",info.total_workers_joined);
-	jx_insert_integer(j,"total_workers_removed",info.total_workers_removed);
-	jx_insert_integer(j,"total_workers_idled_out",info.total_workers_idled_out);
-	jx_insert_integer(j,"total_workers_lost",info.total_workers_lost);
-	jx_insert_integer(j,"total_workers_fast_aborted",info.total_workers_fast_aborted);
+
+	jx_insert_integer(j,"workers_joined",info.workers_joined);
+	jx_insert_integer(j,"workers_removed",info.workers_removed);
+	jx_insert_integer(j,"workers_released",info.workers_released);
+	jx_insert_integer(j,"workers_idled_out",info.workers_idled_out);
+	jx_insert_integer(j,"workers_fast_aborted",info.workers_fast_aborted);
+	jx_insert_integer(j,"workers_blacklisted",info.workers_blacklisted);
+	jx_insert_integer(j,"workers_lost",info.workers_lost);
 
 	//send info on tasks
 	jx_insert_integer(j,"tasks_waiting",info.tasks_waiting);
+	jx_insert_integer(j,"tasks_on_workers",info.tasks_on_workers);
 	jx_insert_integer(j,"tasks_running",info.tasks_running);
-	// KNOWN HACK: The following line is inconsistent but kept for compatibility reasons.
-	// Everyone wants to know total_tasks_complete, but few are interested in tasks_complete.
-	jx_insert_integer(j,"tasks_complete",info.total_tasks_complete);
-	jx_insert_integer(j,"total_tasks_complete",info.total_tasks_complete);
-	jx_insert_integer(j,"total_tasks_dispatched",info.total_tasks_dispatched);
-	jx_insert_integer(j,"total_tasks_cancelled",info.total_tasks_cancelled);
+	jx_insert_integer(j,"tasks_with_results",info.tasks_with_results);
+
+	jx_insert_integer(j,"tasks_submitted",info.tasks_submitted);
+	jx_insert_integer(j,"tasks_dispatched",info.tasks_dispatched);
+	jx_insert_integer(j,"tasks_done",info.tasks_done);
+	jx_insert_integer(j,"tasks_failed",info.tasks_failed);
+	jx_insert_integer(j,"tasks_cancelled",info.tasks_cancelled);
+	jx_insert_integer(j,"tasks_exhausted_attempts",info.tasks_exhausted_attempts);
+
+	// tasks_complete is deprecated, but the old work_queue_status expects it.
+	jx_insert_integer(j,"tasks_complete",info.tasks_done);
 
 	//send info on queue
-	jx_insert_integer(j,"start_time",info.start_time);
-	jx_insert_integer(j,"total_send_time",info.total_send_time);
-	jx_insert_integer(j,"total_receive_time",info.total_receive_time);
-	jx_insert_integer(j,"total_bytes_sent",info.total_bytes_sent);
-	jx_insert_integer(j,"total_bytes_received",info.total_bytes_received);
-	jx_insert_double(j,"efficiency",info.efficiency);
-	jx_insert_double(j,"idle_percentage",info.idle_percentage);
-	jx_insert_integer(j,"capacity",info.capacity);
-	jx_insert_integer(j,"total_execute_time",info.total_execute_time);
-	jx_insert_integer(j,"total_good_execute_time",info.total_good_execute_time);
-	jx_insert_integer(j,"total_exhausted_execute_time",info.total_exhausted_execute_time);
-	jx_insert_integer(j,"total_exhausted_retries",info.total_exhausted_attempts);
+	jx_insert_integer(j,"time_when_started",info.time_when_started);
+	jx_insert_integer(j,"time_send",info.time_send);
+	jx_insert_integer(j,"time_receive",info.time_receive);
+	jx_insert_integer(j,"time_send_good",info.time_send_good);
+	jx_insert_integer(j,"time_receive_good",info.time_receive_good);
+	jx_insert_integer(j,"time_status_msgs",info.time_status_msgs);
+	jx_insert_integer(j,"time_internal",info.time_internal);
+	jx_insert_integer(j,"time_polling",info.time_polling);
+	jx_insert_integer(j,"time_application",info.time_application);
+
+	jx_insert_integer(j,"time_workers_execute",info.time_workers_execute);
+	jx_insert_integer(j,"time_workers_execute_good",info.time_workers_execute_good);
+	jx_insert_integer(j,"time_workers_execute_exhaustion",info.time_workers_execute_exhaustion);
+
+	jx_insert_integer(j,"bytes_sent",info.bytes_sent);
+	jx_insert_integer(j,"bytes_received",info.bytes_received);
+
+	jx_insert_integer(j,"capacity_tasks",info.capacity_tasks);
+	jx_insert_integer(j,"capacity_cores",info.capacity_cores);
+	jx_insert_integer(j,"capacity_memory",info.capacity_memory);
+	jx_insert_integer(j,"capacity_disk",info.capacity_disk);
+
 	jx_insert_string(j,"master_preferred_connection",q->master_preferred_connection);
 
 	// Add the blacklisted workers
@@ -2111,7 +2195,7 @@ static struct jx * queue_to_jx( struct work_queue *q, struct link *foreman_uplin
 	// Add special properties expected by the catalog server
 	jx_insert_string(j,"type","wq_master");
 	if(q->name) jx_insert_string(j,"project",q->name);
-	jx_insert_integer(j,"starttime",(q->stats->start_time/1000000)); // catalog expects time_t not timestamp_t
+	jx_insert_integer(j,"starttime",(q->stats->time_when_started/1000000)); // catalog expects time_t not timestamp_t
 	jx_insert_string(j,"working_dir",q->workingdir);
 	jx_insert_string(j,"owner",owner);
 	jx_insert_string(j,"version",CCTOOLS_VERSION);
@@ -2233,8 +2317,8 @@ static work_queue_msg_code_t process_queue_status( struct work_queue *q, struct 
 	target->hostname = xxstrdup("QUEUE_STATUS");
 
 	//do not count a status connection as a worker
-	q->stats->total_workers_joined--;
-	q->stats->total_workers_removed--;
+	q->stats->workers_joined--;
+	q->stats->workers_removed--;
 
 	if(sscanf(line, "%[^_]_status", request) != 1) {
 		return MSG_FAILURE;
@@ -2262,9 +2346,9 @@ static work_queue_msg_code_t process_queue_status( struct work_queue *q, struct 
 					jx_insert_string(j, "address_port", w->addrport);
 
 					// Timestamps on running task related events
-					jx_insert_integer(j, "submit_to_queue_time", t->time_task_submit);
-					jx_insert_integer(j, "send_input_start_time", t->time_send_input_start);
-					jx_insert_integer(j, "execute_cmd_start_time", t->time_execute_cmd_start);
+					jx_insert_integer(j, "time_when_submitted", t->time_when_submitted);
+					jx_insert_integer(j, "time_when_commit_start", t->time_when_commit_start);
+					jx_insert_integer(j, "time_when_commit_end", t->time_when_commit_end);
 					jx_insert_integer(j, "current_time", timestamp_get());
 
 					jx_array_insert(a, j);
@@ -2315,8 +2399,6 @@ static work_queue_msg_code_t process_resource( struct work_queue *q, struct work
 	{
 		/* Shortcut, total has the tag, as "resources tag" only sends one value */
 		w->resources->tag = r.total;
-		log_worker_stats(q);
-
 	} else if(n == 4) {
 
 		/* inuse is computed by the master, so we save it here */
@@ -2350,7 +2432,7 @@ static work_queue_msg_code_t process_resource( struct work_queue *q, struct work
 	return MSG_PROCESSED;
 }
 
-static void handle_worker(struct work_queue *q, struct link *l)
+static work_queue_result_code_t handle_worker(struct work_queue *q, struct link *l)
 {
 	char line[WORK_QUEUE_LINE_MAX];
 	char key[WORK_QUEUE_LINE_MAX];
@@ -2368,13 +2450,16 @@ static void handle_worker(struct work_queue *q, struct link *l)
 		worker_failure = 1;
 	} else if(result == MSG_FAILURE){
 		debug(D_WQ, "Failed to read from worker %s (%s)", w->hostname, w->addrport);
-		q->stats->total_workers_lost++;
+		q->stats->workers_lost++;
 		worker_failure = 1;
 	} // otherwise do nothing..message was consumed and processed in recv_worker_msg()
 
 	if(worker_failure) {
 		handle_worker_failure(q, w);
+		return WORKER_FAILURE;
 	}
+
+	return SUCCESS;
 }
 
 static int build_poll_table(struct work_queue *q, struct link *master)
@@ -2722,15 +2807,13 @@ static work_queue_result_code_t send_input_file(struct work_queue *q, struct wor
 		timestamp_t close_time = timestamp_get();
 		timestamp_t elapsed_time = close_time-open_time;
 
-		t->total_bytes_sent += total_bytes;
-		t->total_bytes_transferred += total_bytes;
-		t->total_transfer_time += elapsed_time;
+		t->bytes_sent        += total_bytes;
+		t->bytes_transferred += total_bytes;
 
 		w->total_bytes_transferred += total_bytes;
-		w->total_transfer_time += elapsed_time;
+		w->total_transfer_time     += elapsed_time;
 
-		q->stats->total_bytes_sent += total_bytes;
-		q->stats->total_send_time += elapsed_time;
+		q->stats->bytes_sent += total_bytes;
 
 		// Avoid division by zero below.
 		if(elapsed_time==0) elapsed_time = 1;
@@ -2839,16 +2922,12 @@ static work_queue_result_code_t start_one_task(struct work_queue *q, struct work
 		command_line = xxstrdup(t->command_line);
 	}
 
-	t->time_send_input_start = timestamp_get();
 	work_queue_result_code_t result = send_input_files(q, w, t);
-	t->time_send_input_finish = timestamp_get(); //record end time in case we return prematurely below.
 
 	if (result != SUCCESS) {
 		free(command_line);
 		return result;
 	}
-
-	t->time_execute_cmd_start = timestamp_get();
 
 	send_worker_msg(q,w, "task %lld\n",  (long long) t->taskid);
 
@@ -2911,7 +2990,6 @@ static work_queue_result_code_t start_one_task(struct work_queue *q, struct work
 	// zero to indicate errors. We are lazy here, we only check the last
 	// message we sent to the worker (other messages may have failed above).
 	int result_msg = send_worker_msg(q,w, "end\n");
-	t->time_send_input_finish = timestamp_get();
 
 	if(result_msg > -1)
 	{
@@ -2979,7 +3057,7 @@ static double compute_capacity( const struct work_queue *q )
 
 	// Compute the average time spent outside of work_queue_wait
 	if(q->stats->total_tasks_complete==0) return WORK_QUEUE_DEFAULT_CAPACITY;
-	timestamp_t avg_app_time = q->stats->total_app_time / q->stats->total_tasks_complete;
+	timestamp_t avg_app_time = q->stats->time_application / q->stats->total_tasks_complete;
 
 	// Capacity is the ratio of task execution time to time spent in the master doing other things.
 	if(avg_transfer_time==0) return WORK_QUEUE_DEFAULT_CAPACITY;
@@ -3298,19 +3376,20 @@ static void find_max_worker(struct work_queue *q) {
 
 static void commit_task_to_worker(struct work_queue *q, struct work_queue_worker *w, struct work_queue_task *t)
 {
-	t->time_committed = timestamp_get();
-
 	t->hostname = xxstrdup(w->hostname);
 	t->host = xxstrdup(w->addrport);
 
+	t->time_when_commit_start = timestamp_get();
 	work_queue_result_code_t result = start_one_task(q, w, t);
+	t->time_when_commit_end = timestamp_get();
 
 	itable_insert(w->current_tasks, t->taskid, t);
 	itable_insert(q->worker_task_map, t->taskid, w); //add worker as execution site for t.
 
 	change_task_state(q, t, WORK_QUEUE_TASK_RUNNING);
 
-	t->total_submissions += 1;
+	t->try_count += 1;
+	q->stats->tasks_dispatched += 1;
 
 	count_worker_resources(q, w);
 
@@ -3318,8 +3397,6 @@ static void commit_task_to_worker(struct work_queue *q, struct work_queue_worker
 		debug(D_WQ, "Failed to send task %d to worker %s (%s).", t->taskid, w->hostname, w->addrport);
 		handle_failure(q, w, t, result);
 	}
-
-	log_worker_stats(q);
 }
 
 static void reap_task_from_worker(struct work_queue *q, struct work_queue_worker *w, struct work_queue_task *t, work_queue_task_state_t new_state)
@@ -3329,6 +3406,8 @@ static void reap_task_from_worker(struct work_queue *q, struct work_queue_worker
 	if(wr != w)
 	{
 		debug(D_WQ, "Cannot reap task %d from worker. It is not being run by %s (%s)\n", t->taskid, w->hostname, w->addrport);
+	} else {
+		w->total_task_time += t->time_workers_execute_last;
 	}
 
 	//update tables.
@@ -3342,8 +3421,6 @@ static void reap_task_from_worker(struct work_queue *q, struct work_queue_worker
 	change_task_state(q, t, new_state);
 
 	count_worker_resources(q, w);
-
-	log_worker_stats(q);
 }
 
 static int send_one_task( struct work_queue *q )
@@ -3437,7 +3514,7 @@ static void ask_for_workers_updates(struct work_queue *q) {
 	}
 }
 
-static void abort_slow_workers(struct work_queue *q)
+static int abort_slow_workers(struct work_queue *q)
 {
 	struct category *c;
 	char *category_name;
@@ -3445,6 +3522,8 @@ static void abort_slow_workers(struct work_queue *q)
 	struct work_queue_worker *w;
 	struct work_queue_task *t;
 	uint64_t taskid;
+
+	int removed = 0;
 
 	/* optimization. If no category has a fast abort multiplier, simply return. */
 	int fast_abort_flag = 0;
@@ -3462,14 +3541,14 @@ static void abort_slow_workers(struct work_queue *q)
 			continue;
 		}
 
-		c->average_task_time = (stats->total_good_execute_time + stats->total_good_transfer_time) / c->total_tasks;
+		c->average_task_time = (stats->time_workers_execute_good + stats->time_send_good + stats->time_receive_good) / c->total_tasks;
 
 		if(c->fast_abort > 0)
 			fast_abort_flag = 1;
 	}
 
 	if(!fast_abort_flag)
-		return;
+		return 0;
 
 	struct category *c_def = work_queue_category_lookup_or_create(q, "default");
 
@@ -3483,7 +3562,7 @@ static void abort_slow_workers(struct work_queue *q)
 		if(c->fast_abort == 0)
 			continue;
 
-		timestamp_t runtime = current - t->time_send_input_start;
+		timestamp_t runtime = current - t->time_when_commit_start;
 		timestamp_t average_task_time = c->average_task_time;
 
 		/* Not enough samples, skip the task. */
@@ -3510,17 +3589,23 @@ static void abort_slow_workers(struct work_queue *q)
 				debug(D_WQ, "Removing worker %s (%s): takes too long to execute the current task - %.02lf s (average task execution time by other workers is %.02lf s)", w->hostname, w->addrport, runtime / 1000000.0, average_task_time / 1000000.0);
 				work_queue_blacklist_add_with_timeout(q, w->hostname, wq_option_blacklist_slow_workers_timeout);
 				remove_worker(q, w);
-				q->stats->total_workers_fast_aborted++;
+				q->stats->workers_fast_aborted++;
+				removed++;
 			}
 		}
 	}
+
+	return removed;
 }
 
 static int shut_down_worker(struct work_queue *q, struct work_queue_worker *w)
 {
 	if(!w) return 0;
+
 	send_worker_msg(q,w,"exit\n");
 	remove_worker(q, w);
+	q->stats->workers_released++;
+
 	return 1;
 }
 
@@ -4436,6 +4521,7 @@ struct work_queue *work_queue_create(int port)
 
 	q->stats                      = calloc(1, sizeof(struct work_queue_stats));
 	q->stats_disconnected_workers = calloc(1, sizeof(struct work_queue_stats));
+	q->stats_measure              = calloc(1, sizeof(struct work_queue_stats));
 
 	q->workers_with_available_results = hash_table_create(0, 0);
 
@@ -4449,7 +4535,7 @@ struct work_queue *work_queue_create(int port)
 	q->short_timeout = 5;
 	q->long_timeout = 3600;
 
-	q->stats->start_time = timestamp_get();
+	q->stats->time_when_started = timestamp_get();
 	q->task_reports = list_create();
 
 	q->catalog_hosts = 0;
@@ -4682,6 +4768,9 @@ void work_queue_delete(struct work_queue *q)
 			release_worker(q, w);
 			hash_table_firstkey(q->worker_table);
 		}
+
+		log_queue_stats(q);
+
 		if(q->name) {
 			update_catalog(q, NULL, 1);
 		}
@@ -4715,6 +4804,7 @@ void work_queue_delete(struct work_queue *q)
 
 		free(q->stats);
 		free(q->stats_disconnected_workers);
+		free(q->stats_measure);
 
 		if(q->name)
 			free(q->name);
@@ -4880,6 +4970,34 @@ work_queue_task_state_t work_queue_task_state(struct work_queue *q, int taskid) 
 	return (int)(uintptr_t)itable_lookup(q->task_state_map, taskid);
 }
 
+static void fill_deprecated_tasks_stats(struct work_queue_task *t) {
+	t->time_task_submit = t->time_when_submitted;
+	t->time_task_finish = t->time_when_done;
+	t->time_committed   = t->time_when_commit_start;
+
+	t->time_send_input_start      = t->time_when_commit_start;
+	t->time_send_input_finish     = t->time_when_commit_end;
+	t->time_receive_result_start  = t->time_when_retrieval;
+	t->time_receive_result_finish = t->time_when_done;
+	t->time_receive_output_start  = t->time_when_retrieval;
+	t->time_receive_output_finish = t->time_when_done;
+
+	t->time_execute_cmd_start  = t->time_when_commit_start;
+	t->time_execute_cmd_finish = t->time_when_retrieval;
+
+	t->total_transfer_time = (t->time_when_commit_end - t->time_when_commit_start) - (t->time_when_done - t->time_when_retrieval);
+
+	t->cmd_execution_time = t->time_workers_execute_last;
+	t->total_cmd_execution_time = t->time_workers_execute_all;
+	t->total_cmd_exhausted_execute_time = t->time_workers_execute_exhaustion;
+	t->total_time_until_worker_failure = t->time_workers_execute_failure;
+
+	t->total_bytes_received = t->bytes_received;
+	t->total_bytes_sent = t->bytes_sent;
+	t->total_bytes_transferred = t->bytes_transferred;
+}
+
+
 /* Changes task state. Returns old state */
 /* State of the task. One of WORK_QUEUE_TASK(UNKNOWN|READY|RUNNING|WAITING_RETRIEVAL|RETRIEVED|DONE) */
 static work_queue_task_state_t change_task_state( struct work_queue *q, struct work_queue_task *t, work_queue_task_state_t new_state ) {
@@ -4904,6 +5022,7 @@ static work_queue_task_state_t change_task_state( struct work_queue *q, struct w
 		case WORK_QUEUE_TASK_DONE:
 		case WORK_QUEUE_TASK_CANCELED:
 			/* tasks are freed when returned to user, thus we remove them from our local record */
+			fill_deprecated_tasks_stats(t);
 			itable_remove(q->tasks, t->taskid);
 			break;
 		default:
@@ -5038,8 +5157,8 @@ int work_queue_submit_internal(struct work_queue *q, struct work_queue_task *t)
 
 	change_task_state(q, t, WORK_QUEUE_TASK_READY);
 
-	t->time_task_submit = timestamp_get();
-	q->stats->total_tasks_dispatched++;
+	t->time_when_submitted = timestamp_get();
+	q->stats->tasks_submitted++;
 
 	if(q->monitor_mode != MON_DISABLED)
 		work_queue_monitor_add_files(q, t);
@@ -5068,6 +5187,8 @@ void work_queue_blacklist_add_with_timeout(struct work_queue *q, const char *hos
 		info->times_blacklisted = 0;
 		info->blacklisted       = 0;
 	}
+
+	q->stats->workers_blacklisted++;
 
 	/* count the times the worker goes from active to blacklisted. */
 	if(!info->blacklisted)
@@ -5142,18 +5263,32 @@ static void print_password_warning( struct work_queue *q )
 	}
 }
 
+#define BEGIN_ACCUM_TIME(q, stat) {\
+	if(q->stats_measure->stat != 0) {\
+		fatal("Double-counting stat %s. This should not happen, and it is Work Queue bug.");\
+	} else {\
+		q->stats_measure->stat = timestamp_get();\
+	}\
+}
+
+#define END_ACCUM_TIME(q, stat) {\
+	q->stats->stat += timestamp_get() - q->stats_measure->stat;\
+	q->stats_measure->stat = 0;\
+}
+
 struct work_queue_task *work_queue_wait(struct work_queue *q, int timeout)
 {
 	return work_queue_wait_internal(q, timeout, NULL, NULL);
 }
 
+/* return number of workers lost */
 static int poll_active_workers(struct work_queue *q, int stoptime, struct link *foreman_uplink, int *foreman_uplink_active)
 {
 	int n = build_poll_table(q, foreman_uplink);
 
-	// We poll in at most small time segments (1/4 of a second). This lets
+	// We poll in at most small time segments (of a second). This lets
 	// promptly dispatch tasks, while avoiding busy waiting.
-	int msec = q->busy_waiting_flag ? 250 : 0;
+	int msec = q->busy_waiting_flag ? 1000 : 0;
 	if(stoptime) {
 		msec = MIN(msec, (stoptime - time(0)) * 1000);
 	}
@@ -5163,10 +5298,10 @@ static int poll_active_workers(struct work_queue *q, int stoptime, struct link *
 	}
 
 	// Poll all links for activity.
-	timestamp_t link_poll_start = timestamp_get();
-	int result = link_poll(q->poll_table, n, msec);
+	BEGIN_ACCUM_TIME(q, time_polling);
+	link_poll(q->poll_table, n, msec);
 	q->link_poll_end = timestamp_get();
-	q->stats->total_idle_time += q->link_poll_end - link_poll_start;
+	END_ACCUM_TIME(q, time_polling);
 
 	int i, j = 1;
 	// Consider the foreman_uplink passed into the function and disregard if inactive.
@@ -5179,10 +5314,15 @@ static int poll_active_workers(struct work_queue *q, int stoptime, struct link *
 		j++;
 	}
 
+	int workers_removed = 0;
+
+	BEGIN_ACCUM_TIME(q, time_status_msgs);
 	// Then consider all existing active workers
 	for(i = j; i < n; i++) {
 		if(q->poll_table[i].revents) {
-			handle_worker(q, q->poll_table[i].link);
+			if(handle_worker(q, q->poll_table[i].link) == WORKER_FAILURE) {
+				workers_removed++;
+			}
 		}
 	}
 
@@ -5196,10 +5336,9 @@ static int poll_active_workers(struct work_queue *q, int stoptime, struct link *
 			hash_table_firstkey(q->workers_with_available_results);
 		}
 	}
+	END_ACCUM_TIME(q, time_status_msgs);
 
-	work_queue_blacklist_clear_by_time(q, time(0));
-
-	return result;
+	return workers_removed;
 }
 
 
@@ -5207,7 +5346,7 @@ static int connect_new_workers(struct work_queue *q, int stoptime, int max_new_w
 {
 	int new_workers = 0;
 
-	// If the master link was awake, then accept as many workers as possible.
+	// If the master link was awake, then accept at most max_new_workers.
 	// Note we are using the information gathered in poll_active_workers, which
 	// is a little ugly.
 	if(q->poll_table[0].revents) {
@@ -5238,8 +5377,10 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
    - go to S
 */
 {
-	if(q->last_outside_waiting!=0) {
-		q->stats->total_app_time += timestamp_get() - q->last_outside_waiting;
+	int events = 0;
+
+	if(q->last_outside_waiting != 0) {
+		q->stats->time_application += timestamp_get() - q->last_outside_waiting;
 	}
 
 	print_password_warning(q);
@@ -5247,6 +5388,7 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 	// compute stoptime
 	time_t stoptime = (timeout == WORK_QUEUE_WAITFORTASK) ? 0 : time(0) + timeout;
 
+	int result;
 	struct work_queue_task *t = NULL;
 	// time left?
 	while( (stoptime == 0) || (time(0) <= stoptime) ) {
@@ -5256,18 +5398,19 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 		if(t) {
 			change_task_state(q, t, WORK_QUEUE_TASK_DONE);
 
-			q->last_outside_waiting = timestamp_get();
-
 			if( t->result != WORK_QUEUE_RESULT_SUCCESS )
 			{
-				q->stats->total_tasks_failed++;
+				q->stats->tasks_failed++;
 			}
 
 			// return completed task (t) to the user. We do not return right
 			// away, and instead break out of the loop to correctly update the
 			// queue time statistics.
+			events++;
 			break;
 		}
+
+		BEGIN_ACCUM_TIME(q, time_internal);
 
 		 // update catalog if appropriate
 		if(q->name) {
@@ -5277,42 +5420,81 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 		if(q->monitor_mode)
 			update_resource_report(q);
 
+		END_ACCUM_TIME(q, time_internal);
+
 		// retrieve worker status messages
-		poll_active_workers(q, stoptime, foreman_uplink, foreman_uplink_active);
+		if(poll_active_workers(q, stoptime, foreman_uplink, foreman_uplink_active) > 0) {
+			//at least one worker was removed.
+			events++;
+			// note we keep going, and we do not restart the loop as we do in
+			// further events. This is because we give top priority to
+			// returning and retrieving tasks.
+		}
+
 		q->busy_waiting_flag = 0;
 
 		// tasks waiting to be retrieved?
-		if(receive_one_task(q)) {
-			// retrieve one task and go to start.
+		BEGIN_ACCUM_TIME(q, time_receive);
+		result = receive_one_task(q);
+		END_ACCUM_TIME(q, time_receive);
+		if(result) {
+			// retrieved at least one task
+			events++;
 			continue;
 		}
 
 		// expired tasks
-		if(expire_waiting_tasks(q)) {
-			// mark expired as retrieved, and go to start.
+		BEGIN_ACCUM_TIME(q, time_internal);
+		result = expire_waiting_tasks(q);
+		END_ACCUM_TIME(q, time_internal);
+		if(result) {
+			// expired at least one task
+			events++;
 			continue;
 		}
 
 		// tasks waiting to be dispatched?
-		if(send_one_task(q)) {
-			// send one task and go to start.
+		BEGIN_ACCUM_TIME(q, time_send);
+		result = send_one_task(q);
+		END_ACCUM_TIME(q, time_send);
+		if(result) {
+			// sent at least one task
+			events++;
 			continue;
 		}
 
 		// send keepalives to appropriate workers
+		BEGIN_ACCUM_TIME(q, time_status_msgs);
 		ask_for_workers_updates(q);
+		END_ACCUM_TIME(q, time_status_msgs);
 
 		// If fast abort is enabled, kill off slow workers.
-		abort_slow_workers(q);
-
-		// if new workers, connect n of them
-		if(connect_new_workers(q, stoptime, MAX_NEW_WORKERS)) {
+		BEGIN_ACCUM_TIME(q, time_internal);
+		result = abort_slow_workers(q);
+		work_queue_blacklist_clear_by_time(q, time(0));
+		END_ACCUM_TIME(q, time_internal);
+		if(result) {
+			// removed at least one worker
+			events++;
 			continue;
 		}
 
-		// return if queue is empty.
-		if( q->process_pending_check && process_pending() )
+		// if new workers, connect n of them
+		BEGIN_ACCUM_TIME(q, time_status_msgs);
+		result = connect_new_workers(q, stoptime, MAX_NEW_WORKERS);
+		END_ACCUM_TIME(q, time_status_msgs);
+		if(result) {
+			// accepted at least one worker
+			events++;
+			continue;
+		}
+
+		if( q->process_pending_check && process_pending() ) {
+			events++;
 			break;
+		}
+
+		// return if queue is empty.
 		if(!task_state_any(q, WORK_QUEUE_TASK_RUNNING) && !task_state_any(q, WORK_QUEUE_TASK_READY) && !task_state_any(q, WORK_QUEUE_TASK_WAITING_RETRIEVAL) && !(foreman_uplink))
 			break;
 
@@ -5326,6 +5508,10 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 		}
 	}
 
+	if(events > 0) {
+		log_queue_stats(q);
+	}
+
 	q->last_outside_waiting = timestamp_get();
 
 	return t;
@@ -5333,8 +5519,8 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 
 int work_queue_hungry(struct work_queue *q)
 {
-	if(q->stats->total_tasks_dispatched < 100)
-		return (100 - q->stats->total_tasks_dispatched);
+	if(q->stats->tasks_dispatched < 100)
+		return (100 - q->stats->tasks_dispatched);
 
 	//BUG: fix this so that it actually looks at the number of cores available.
 
@@ -5397,7 +5583,7 @@ struct work_queue_task *work_queue_cancel_by_taskid(struct work_queue *q, int ta
 	/* change state even if task is not running on a worker. */
 	change_task_state(q, matched_task, WORK_QUEUE_TASK_CANCELED);
 
-	q->stats->total_tasks_cancelled++;
+	q->stats->tasks_cancelled++;
 
 	return matched_task;
 }
@@ -5453,7 +5639,7 @@ struct list * work_queue_cancel_all_tasks(struct work_queue *q) {
 			reap_task_from_worker(q, w, t, WORK_QUEUE_TASK_CANCELED);
 
 			list_push_tail(l, t);
-			q->stats->total_tasks_cancelled++;
+			q->stats->tasks_cancelled++;
 			itable_firstkey(w->current_tasks);
 		}
 	}
@@ -5572,6 +5758,53 @@ double work_queue_get_effective_bandwidth(struct work_queue *q)
 	return queue_bandwidth;
 }
 
+static void fill_deprecated_queue_stats(struct work_queue *q, struct work_queue_stats *s) {
+	s->total_workers_connected = s->workers_connected;
+	s->total_workers_joined = s->workers_joined;
+	s->total_workers_removed = s->workers_removed;
+	s->total_workers_lost = s->workers_lost;
+	s->total_workers_idled_out = s->workers_idled_out;
+	s->total_workers_fast_aborted = s->workers_fast_aborted;
+
+	s->tasks_complete = s->tasks_with_results;
+
+	s->total_tasks_dispatched = s->tasks_dispatched;
+	s->total_tasks_complete = s->tasks_done;
+	s->total_tasks_failed = s->tasks_failed;
+	s->total_tasks_cancelled = s->tasks_cancelled;
+	s->total_exhausted_attempts = s->tasks_exhausted_attempts;
+
+	s->start_time = s->time_when_started;
+	s->total_send_time = s->time_send;
+	s->total_receive_time = s->time_receive;
+	s->total_good_transfer_time = s->time_send_good + s->time_receive_good;
+
+	s->total_execute_time = s->time_workers_execute;
+	s->total_good_execute_time = s->time_workers_execute_good;
+	s->total_exhausted_execute_time = s->time_workers_execute_exhaustion;
+
+	s->total_bytes_sent = s->bytes_sent;
+	s-> total_bytes_received = s->bytes_received;
+
+	s->capacity = s->capacity_cores;
+
+	s->port = q->port;
+	s->priority = q->priority;
+	s->workers_ready = s->workers_idle;
+	s->workers_full  = s->workers_busy;
+	s->total_worker_slots = s->tasks_dispatched;
+	s->avg_capacity = s->capacity_cores;
+
+	timestamp_t wall_clock_time = timestamp_get() - q->stats->time_when_started;
+	if(wall_clock_time > 0 && s->workers_connected > 0) {
+		s->efficiency = (double) (q->stats->time_workers_execute_good) / (wall_clock_time * s->workers_connected);
+	}
+
+	if(wall_clock_time>0) {
+		s->idle_percentage = (double) q->stats->time_polling / wall_clock_time;
+	}
+}
+
 void work_queue_get_stats(struct work_queue *q, struct work_queue_stats *s)
 {
 	struct work_queue_stats *qs;
@@ -5579,46 +5812,66 @@ void work_queue_get_stats(struct work_queue *q, struct work_queue_stats *s)
 
 	memset(s, 0, sizeof(*s));
 
-	//info about workers
-	s->total_workers_connected = hash_table_size(q->worker_table);
-	s->workers_init = hash_table_size(q->worker_table) - known_workers(q);
-	s->workers_idle = known_workers(q) - workers_with_tasks(q); //returns workers that are not running any tasks.
-	s->workers_busy = workers_with_tasks(q);
+	int known = known_workers(q);
 
-	s->total_workers_joined       = qs->total_workers_joined;
-	s->total_workers_removed      = qs->total_workers_removed;
-	s->total_workers_idled_out    = qs->total_workers_idled_out;
-	s->total_workers_lost         = qs->total_workers_lost;
-	s->total_workers_fast_aborted = qs->total_workers_fast_aborted;
+	//info about workers
+	s->workers_connected = hash_table_size(q->worker_table);
+	s->workers_init      = s->workers_connected - known;
+	s->workers_busy      = workers_with_tasks(q);
+	s->workers_idle      = known - s->workers_busy;
+	// s->workers_able computed below.
+
+	s->workers_joined       = qs->workers_joined;
+	s->workers_removed      = qs->workers_removed;
+	s->workers_idled_out    = qs->workers_idled_out;
+	s->workers_fast_aborted = qs->workers_fast_aborted;
+	s->workers_lost         = qs->workers_lost;
 
 	//info about tasks
-	s->tasks_waiting = task_state_count(q, NULL, WORK_QUEUE_TASK_READY);
-	s->tasks_running = task_state_count(q, NULL, WORK_QUEUE_TASK_RUNNING) + task_state_count(q, NULL, WORK_QUEUE_TASK_WAITING_RETRIEVAL);
-	s->tasks_complete = task_state_count(q, NULL, WORK_QUEUE_TASK_RETRIEVED);
+	s->tasks_waiting      = task_state_count(q, NULL, WORK_QUEUE_TASK_READY);
+	s->tasks_on_workers   = task_state_count(q, NULL, WORK_QUEUE_TASK_RUNNING) + task_state_count(q, NULL, WORK_QUEUE_TASK_WAITING_RETRIEVAL);
+	s->tasks_with_results = task_state_count(q, NULL, WORK_QUEUE_TASK_WAITING_RETRIEVAL);
 
-	s->total_tasks_dispatched = qs->total_tasks_dispatched;
-	s->total_tasks_complete = qs->total_tasks_complete;
-	s->total_tasks_cancelled = qs->total_tasks_cancelled;
-
-	//info about queue
-	s->start_time = qs->start_time;
-	s->total_send_time = qs->total_send_time;
-	s->total_receive_time = qs->total_receive_time;
-	s->total_bytes_sent = qs->total_bytes_sent;
-	s->total_bytes_received = qs->total_bytes_received;
-	s->total_execute_time = qs->total_execute_time;
-	s->total_good_execute_time = qs->total_good_execute_time;
-	s->total_exhausted_attempts = qs->total_exhausted_attempts;
-	s->total_exhausted_execute_time = qs->total_exhausted_execute_time;
-
-	timestamp_t wall_clock_time = timestamp_get() - qs->start_time;
-	if(wall_clock_time>0 && s->total_workers_connected>0) {
-		s->efficiency = (double) (qs->total_good_execute_time) / (wall_clock_time * s->total_workers_connected);
+	{
+		//accumulate tasks running, from workers:
+		char *key;
+		struct work_queue_worker *w;
+		s->tasks_running = 0;
+		hash_table_firstkey(q->worker_table);
+		while(hash_table_nextkey(q->worker_table, &key, (void **) &w)) {
+			accumulate_stat(s, w->stats, tasks_running);
+		}
+		/* (see work_queue_get_stats_hierarchy for an explanation on the
+		 * following line) */
+		s->tasks_running = MIN(s->tasks_running, s->tasks_on_workers);
 	}
-	if(wall_clock_time>0) {
-		s->idle_percentage = (double) q->stats->total_idle_time / wall_clock_time;
-	}
-	s->capacity = compute_capacity(q);
+
+	s->tasks_submitted          = qs->tasks_submitted;
+	s->tasks_dispatched         = qs->tasks_dispatched;
+	s->tasks_done               = qs->tasks_done;
+	s->tasks_failed             = qs->tasks_failed;
+	s->tasks_cancelled          = qs->tasks_cancelled;
+	s->tasks_exhausted_attempts = qs->tasks_exhausted_attempts;
+
+	// Master time statistics:
+	s->time_when_started        = qs->time_when_started;
+	s->time_send         = qs->time_send;
+	s->time_receive      = qs->time_receive;
+	s->time_send_good    = qs->time_send_good;
+	s->time_receive_good = qs->time_receive_good;
+	s->time_application  = qs->time_application;
+	s->time_polling      = qs->time_polling;
+
+	// Workers time statistics:
+	s->time_workers_execute            = qs->time_workers_execute;
+	s->time_workers_execute_good       = qs->time_workers_execute_good;
+	s->time_workers_execute_exhaustion = qs->time_workers_execute_exhaustion;
+
+	s->bytes_sent     = qs->bytes_sent;
+	s->bytes_received = qs->bytes_received;
+
+	//s->capacity_ratio, s->capacity_cores, s->capacity_memory, s->capacity_disk:
+	compute_capacity(q, s);
 
 	//info about resources
 	s->bandwidth = work_queue_get_effective_bandwidth(q);
@@ -5644,24 +5897,20 @@ void work_queue_get_stats(struct work_queue *q, struct work_queue_stats *s)
 	s->min_gpus = r.gpus.smallest;
 	s->max_gpus = r.gpus.largest;
 
-	//deprecated fields
-	s->port = q->port;
-	s->priority = q->priority;
-	s->workers_ready = s->workers_idle;
-	s->workers_full = 0;
-	s->total_worker_slots = s->tasks_running;
-	s->avg_capacity = s->capacity;
+	{
+		struct rmsummary *rmax = largest_waiting_measured_resources(q, NULL);
+		char *key;
+		struct category *c;
+		hash_table_firstkey(q->categories);
+		while(hash_table_nextkey(q->categories, &key, (void **) &c)) {
+			rmsummary_merge_max(rmax, c->max_allocation);
+		}
 
-	struct rmsummary *rmax = largest_waiting_measured_resources(q, NULL);
-	char *key;
-	struct category *c;
-	hash_table_firstkey(q->categories);
-	while(hash_table_nextkey(q->categories, &key, (void **) &c)) {
-		rmsummary_merge_max(rmax, c->max_allocation);
+		s->workers_able = count_workers_for_waiting_tasks(q, rmax);
+		rmsummary_delete(rmax);
 	}
 
-	s->workers_able = count_workers_for_waiting_tasks(q, rmax);
-	rmsummary_delete(rmax);
+	fill_deprecated_queue_stats(q, s);
 }
 
 void work_queue_get_stats_hierarchy(struct work_queue *q, struct work_queue_stats *s)
@@ -5673,46 +5922,63 @@ void work_queue_get_stats_hierarchy(struct work_queue *q, struct work_queue_stat
 
 	/* Consider running only if reported by some hand. */
 	s->tasks_running = 0;
-	s->total_workers_connected = 0;
+	s->workers_connected = 0;
 
 	hash_table_firstkey(q->worker_table);
 	while(hash_table_nextkey(q->worker_table, &key, (void **) &w)) {
 		if(w->foreman)
 		{
-			accumulate_stat(s, w->stats, total_workers_joined);
-			accumulate_stat(s, w->stats, total_workers_removed);
-			accumulate_stat(s, w->stats, total_workers_idled_out);
-			accumulate_stat(s, w->stats, total_workers_lost);
-			accumulate_stat(s, w->stats, total_workers_fast_aborted);
-			accumulate_stat(s, w->stats, total_send_time);
-			accumulate_stat(s, w->stats, total_receive_time);
-			accumulate_stat(s, w->stats, total_execute_time);
-			accumulate_stat(s, w->stats, total_bytes_sent);
-			accumulate_stat(s, w->stats, total_bytes_received);
+			accumulate_stat(s, w->stats, workers_joined);
+			accumulate_stat(s, w->stats, workers_removed);
+			accumulate_stat(s, w->stats, workers_idled_out);
+			accumulate_stat(s, w->stats, workers_fast_aborted);
+			accumulate_stat(s, w->stats, workers_lost);
+
+			accumulate_stat(s, w->stats, time_send);
+			accumulate_stat(s, w->stats, time_receive);
+			accumulate_stat(s, w->stats, time_send_good);
+			accumulate_stat(s, w->stats, time_receive_good);
+
+			accumulate_stat(s, w->stats, time_workers_execute);
+			accumulate_stat(s, w->stats, time_workers_execute_good);
+			accumulate_stat(s, w->stats, time_workers_execute_exhaustion);
+
+			accumulate_stat(s, w->stats, bytes_sent);
+			accumulate_stat(s, w->stats, bytes_received);
 		}
 
 		accumulate_stat(s, w->stats, tasks_waiting);
 		accumulate_stat(s, w->stats, tasks_running);
 	}
 
+	/* we rely on workers messages to update tasks_running. such data are
+	 * attached to keepalive messages, thus tasks_running is not always
+	 * current. Here we simply enforce that there can be more tasks_running
+	 * that tasks_on_workers. */
+	s->tasks_running = MIN(s->tasks_running, s->tasks_on_workers);
+
 	/* Account also for workers connected directly to the master. */
-	s->total_workers_connected = s->total_workers_joined - s->total_workers_removed;
+	s->workers_connected = s->workers_joined - s->workers_removed;
 
-	s->total_workers_joined  += q->stats_disconnected_workers->total_workers_joined;
-	s->total_workers_removed += q->stats_disconnected_workers->total_workers_removed;
-	s->total_workers_idled_out    += q->stats_disconnected_workers->total_workers_idled_out;
-	s->total_workers_lost         += q->stats_disconnected_workers->total_workers_lost;
-	s->total_workers_fast_aborted += q->stats_disconnected_workers->total_workers_fast_aborted;
-	s->total_send_time       += q->stats_disconnected_workers->total_send_time;
-	s->total_receive_time    += q->stats_disconnected_workers->total_receive_time;
-	s->total_execute_time    += q->stats_disconnected_workers->total_execute_time;
-	s->total_bytes_sent      += q->stats_disconnected_workers->total_bytes_sent;
-	s->total_bytes_received  += q->stats_disconnected_workers->total_bytes_received;
+	s->workers_joined       += q->stats_disconnected_workers->workers_joined;
+	s->workers_removed      += q->stats_disconnected_workers->workers_removed;
+	s->workers_idled_out    += q->stats_disconnected_workers->workers_idled_out;
+	s->workers_fast_aborted += q->stats_disconnected_workers->workers_fast_aborted;
+	s->workers_lost         += q->stats_disconnected_workers->workers_lost;
 
-	timestamp_t wall_clock_time = timestamp_get() - q->stats->start_time;
-	if(wall_clock_time>0 && s->total_workers_connected>0) {
-		s->efficiency = (double) (q->stats->total_good_execute_time) / (wall_clock_time * s->total_workers_connected);
-	}
+	s->time_send         += q->stats_disconnected_workers->time_send;
+	s->time_receive      += q->stats_disconnected_workers->time_receive;
+	s->time_send_good    += q->stats_disconnected_workers->time_send_good;
+	s->time_receive_good += q->stats_disconnected_workers->time_receive_good;
+
+	s->time_workers_execute            += q->stats_disconnected_workers->time_workers_execute;
+	s->time_workers_execute_good       += q->stats_disconnected_workers->time_workers_execute_good;
+	s->time_workers_execute_exhaustion += q->stats_disconnected_workers->time_workers_execute_exhaustion;
+
+	s->bytes_sent      += q->stats_disconnected_workers->bytes_sent;
+	s->bytes_received  += q->stats_disconnected_workers->bytes_received;
+
+	fill_deprecated_queue_stats(q, s);
 }
 
 void work_queue_get_stats_category(struct work_queue *q, const char *category, struct work_queue_stats *s)
@@ -5722,9 +5988,9 @@ void work_queue_get_stats_category(struct work_queue *q, const char *category, s
 	memcpy(s, cs, sizeof(*s));
 
 	//info about tasks
-	s->tasks_waiting = task_state_count(q, category, WORK_QUEUE_TASK_READY);
-	s->tasks_running = task_state_count(q, category, WORK_QUEUE_TASK_RUNNING) + task_state_count(q, category, WORK_QUEUE_TASK_WAITING_RETRIEVAL);
-	s->tasks_complete = task_state_count(q, category, WORK_QUEUE_TASK_RETRIEVED);
+	s->tasks_waiting      = task_state_count(q, category, WORK_QUEUE_TASK_READY);
+	s->tasks_running      = task_state_count(q, category, WORK_QUEUE_TASK_RUNNING) + task_state_count(q, category, WORK_QUEUE_TASK_WAITING_RETRIEVAL);
+	s->tasks_with_results = task_state_count(q, category, WORK_QUEUE_TASK_WAITING_RETRIEVAL);
 
 	struct rmsummary *rmax = largest_waiting_measured_resources(q, c->name);
 
@@ -5764,28 +6030,36 @@ int work_queue_specify_log(struct work_queue *q, const char *logfile)
 {
 	q->logfile = fopen(logfile, "a");
 	if(q->logfile) {
-		setvbuf(q->logfile, NULL, _IOLBF, 1024); // line buffered, we don't want incomplete lines
+		setvbuf(q->logfile, NULL, _IOLBF, 2048); // line buffered, we don't want incomplete lines
 		fprintf(q->logfile,
 				// start with a comment
 				"#"
 			// time:
-			"timestamp "
-			//workers:
-			"total_workers_connected workers_init workers_idle workers_busy total_workers_joined total_workers_removed "
-			// tasks:
-			"tasks_waiting tasks_running tasks_complete total_tasks_dispatched total_tasks_complete total_tasks_cancelled "
-			// queue:
-			"start_time total_send_time total_receive_time total_bytes_sent total_bytes_received efficiency idle_percentage capacity "
-			// resource totals:
-			"bandwidth total_cores total_memory total_disk total_gpus "
-			//mins/maxs:
-			"min_cores max_cores min_memory max_memory min_disk max_disk min_gpus max_gpus "
-			//execute/good execute time
-			"total_execute_time total_good_execute_time "
-			//end with a newline
+			" timestamp"
+			// workers current:
+			" workers_connected workers_init workers_idle workers_busy workers_able"
+			// workers cummulative:
+			" workers_joined workers_removed workers_released workers_idled_out workers_blacklisted workers_fast_aborted workers_lost"
+			// tasks current:
+			" tasks_waiting tasks_on_workers tasks_running tasks_with_results"
+			// tasks cummulative
+			" tasks_submitted tasks_dispatched tasks_done tasks_failed tasks_cancelled tasks_exhausted_attempts"
+			// master time statistics:
+			" time_when_started time_send time_receive time_send_good time_receive_good time_status_msgs time_internal time_polling time_application"
+			// workers time statistics:
+			" time_execute time_execute_good time_execute_exhaustion"
+			// bandwidth:
+			" bytes_sent bytes_received bandwidth"
+			// resources:
+			" capacity_tasks capacity_cores capacity_memory capacity_disk"
+			" total_cores total_memory total_disk"
+			" committed_cores committed_memory committed_disk"
+			" max_cores max_memory max_disk"
+			" min_cores min_memory min_disk"
+			// end with a newline
 			"\n"
 			);
-		log_worker_stats(q);
+		log_queue_stats(q);
 		debug(D_WQ, "log enabled and is being written to %s\n", logfile);
 		return 1;
 	}
@@ -5951,30 +6225,48 @@ int work_queue_specify_transactions_log(struct work_queue *q, const char *logfil
 	}
 }
 
-void work_queue_category_accumulate_task(struct work_queue *q, struct work_queue_task *t) {
+void work_queue_accumulate_task(struct work_queue *q, struct work_queue_task *t) {
 	const char *name   = t->category ? t->category : "default";
 	struct category *c = work_queue_category_lookup_or_create(q, name);
 
 	struct work_queue_stats *s = c->wq_stats;
 
-	s->total_bytes_sent     += t->total_bytes_sent;
-	s->total_bytes_received += t->total_bytes_received;
-	s->total_execute_time   += t->cmd_execution_time;
+	s->bytes_sent     += t->bytes_sent;
+	s->bytes_received += t->bytes_received;
 
-	s->total_send_time      += (t->time_send_input_finish     - t->time_send_input_start);
-	s->total_receive_time   += (t->time_receive_output_finish - t->time_receive_output_start);
+	s->time_workers_execute += t->time_workers_execute_last;
 
-	s->bandwidth = (1.0*MEGABYTE*(s->total_bytes_sent + s->total_bytes_received))/(s->total_send_time + s->total_receive_time + 1);
+	s->time_send    += t->time_when_commit_end - t->time_when_commit_start;
+	s->time_receive += t->time_when_done - t->time_when_retrieval;
+
+	s->bandwidth = (1.0*MEGABYTE*(s->bytes_sent + s->bytes_received))/(s->time_send + s->time_receive + 1);
+
+	q->stats->tasks_done++;
 
 	if(t->result == WORK_QUEUE_RESULT_SUCCESS)
 	{
+		q->stats->time_workers_execute_good += t->time_workers_execute_last;
+		q->stats->time_send_good            += t->time_when_commit_end - t->time_when_commit_end;
+		q->stats->time_receive_good         += t->time_when_done - t->time_when_retrieval;
+
 		c->total_tasks++;
 
-		s->total_tasks_complete      = c->total_tasks;
-		s->total_good_execute_time  += t->cmd_execution_time;
-		s->total_good_transfer_time += t->total_transfer_time;
+		s->tasks_done                 = c->total_tasks;
+		s->time_workers_execute_good += t->time_workers_execute_last;
+		s->time_send_good            += t->time_when_commit_end - t->time_when_commit_end;
+		s->time_receive_good         += t->time_when_done - t->time_when_retrieval;
 	} else {
-		s->total_tasks_failed++;
+		s->tasks_failed++;
+
+		if(t->result == WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION) {
+			s->time_workers_execute_exhaustion += t->time_workers_execute_last;
+
+			q->stats->time_workers_execute_exhaustion += t->time_workers_execute_last;
+			q->stats->tasks_exhausted_attempts++;
+
+			t->time_workers_execute_exhaustion += t->time_workers_execute_last;
+			t->exhausted_attempts++;
+		}
 	}
 
 	if(category_accumulate_summary(c, t->resources_measured, q->current_max_worker)) {

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -102,59 +102,81 @@ extern int wq_option_scheduler;	               /**< Initial setting for algorith
  * examine (but not modify) this structure once a task has completed.
 */
 struct work_queue_task {
-	char *tag;                                             /**< An optional user-defined logical name for the task. */
-	char *command_line;                                    /**< The program(s) to execute, as a shell command line. */
+	char *tag;                                        /**< An optional user-defined logical name for the task. */
+	char *command_line;                               /**< The program(s) to execute, as a shell command line. */
 	work_queue_schedule_t worker_selection_algorithm; /**< How to choose worker to run the task. */
-	char *output;                                          /**< The standard output of the task. */
-	struct list *input_files;                              /**< The files to transfer to the worker and place in the executing directory. */
-	struct list *output_files;                             /**< The output files (other than the standard output stream) created by the program to be retrieved from the task. */
-	struct list *env_list;                                 /**< Environment variables applied to the task. */
-	int taskid;                                            /**< A unique task id number. */
-	int return_status;                                     /**< The exit code of the command line. */
+	char *output;                                     /**< The standard output of the task. */
+	struct list *input_files;                         /**< The files to transfer to the worker and place in the executing directory. */
+	struct list *output_files;                        /**< The output files (other than the standard output stream) created by the program to be retrieved from the task. */
+	struct list *env_list;                            /**< Environment variables applied to the task. */
+	int taskid;                                       /**< A unique task id number. */
+	int return_status;                                /**< The exit code of the command line. */
 	work_queue_result_t result;                       /**< The result of the task (see @ref work_queue_result_t */
-	char *host;                                            /**< The address and port of the host on which it ran. */
-	char *hostname;                                        /**< The name of the host on which it ran. */
+	char *host;                                       /**< The address and port of the host on which it ran. */
+	char *hostname;                                   /**< The name of the host on which it ran. */
 
-	timestamp_t time_committed;                            /**< The time at which a task was committed to a worker. */
+	char *category;                         /**< User-provided label for the task. It is expected that all task with the same category will have similar resource usage. See @ref work_queue_task_specify_category. If no explicit category is given, the label "default" is used. **/
+	category_allocation_t resource_request; /**< See @ref category_allocation_t */
 
-	timestamp_t time_task_submit;                          /**< The time at which this task was added to the queue. */
-	timestamp_t time_task_finish;                          /**< The time at which the task is mark as retrieved, after transfering output files and other final processing. */
-	timestamp_t time_send_input_start;                     /**< The time at which it started to transfer input files. */
-	timestamp_t time_send_input_finish;                    /**< The time at which it finished transferring input files. */
-	timestamp_t time_execute_cmd_start;                    /**< The time at which the task began executing at a worker. */
-	timestamp_t time_execute_cmd_finish;                   /**< The time at which the task finished executing at a worker (as known by the master). */
-	timestamp_t time_receive_result_start;                 /**< The time at which it started to transfer the results. */
-	timestamp_t time_receive_result_finish;                /**< The time at which it finished transferring the results. */
-	timestamp_t time_receive_output_start;                 /**< The time at which it started to transfer output files. */
-	timestamp_t time_receive_output_finish;                /**< The time at which it finished transferring output files. */
+	double priority;        /**< The priority of this task relative to others in the queue: higher number run earlier. */
+	int max_retries;        /**< Number of times the task is tried to be executed on some workers until success. If less than one, the task is retried indefinitely. See try_count below.*/
 
-	int64_t total_bytes_received;                          /**< Number of bytes received since task has last started receiving input data. */
-	int64_t total_bytes_sent;                              /**< Number of bytes sent since task has last started sending input data. */
-	int64_t total_bytes_transferred;                       /**< Number of bytes transferred since task has last started transferring input data. */
-	timestamp_t total_transfer_time;                       /**< Time comsumed in microseconds for transferring total_bytes_transferred. */
-	timestamp_t cmd_execution_time;                        /**< Time spent in microseconds for executing the command until completion on a single worker. */
-	int total_submissions;                                 /**< The number of times the task has been submitted. */
-	timestamp_t total_cmd_execution_time;                  /**< Accumulated time spent in microseconds for executing the command on any worker, regardless of whether the task finished (i.e., this includes time running on workers that disconnected). */
-	timestamp_t total_cmd_exhausted_execute_time;          /**< Accumulated time spent in microseconds spent in attempts that executed resources. */
+	int try_count;          /**< The number of times the task has been dispatched to a worker. If larger than max_retries, the task failes with @ref WORK_QUEUE_RESULT_MAX_RETRIES. */
+	int exhausted_attempts; /**< Number of times the task failed given exhausted resources. */
 
-	timestamp_t total_time_until_worker_failure;           /**< Accumulated time for runs that terminated in worker failure/disconnection. */
+	/* All times in microseconds */
+	/* A time_when_* refers to an instant in time, otherwise it refers to a length of time. */
+	timestamp_t time_when_submitted;    /**< The time at which this task was added to the queue. */
+	timestamp_t time_when_done;         /**< The time at which the task is mark as retrieved, after transfering output files and other final processing. */
 
-	int exhausted_attempts;                                /**< Number of times the task failed given exhausted resources. */
 	int disk_allocation_exhausted;                        /**< Non-zero if a task filled its loop device allocation, zero otherwise. */
 
-	double priority;                                       /**< The priority of this task relative to others in the queue: higher number run earlier. */
+	timestamp_t time_when_commit_start; /**< The time when the task starts to be transfered to a worker. */
+	timestamp_t time_when_commit_end;   /**< The time when the task is completely transfered to a worker. */
 
-	int max_retries;                                       /**< Number of times the task is retried on worker errors until success. If less than one, the task is retried indefinitely. */
+	timestamp_t time_when_retrieval;    /**< The time when output files start to be transfered back to the master. time_done - time_when_retrieval is the time taken to transfer output files. */
+
+	timestamp_t time_workers_execute_last;                 /**< Duration of the last complete execution for this task. */
+	timestamp_t time_workers_execute_all;                  /**< Accumulated time for executing the command on any worker, regardless of whether the task completed (i.e., this includes time running on workers that disconnected). */
+	timestamp_t time_workers_execute_exhaustion;           /**< Accumulated time spent in attempts that exhausted resources. */
+	timestamp_t time_workers_execute_failure;              /**< Accumulated time for runs that terminated in worker failure/disconnection. */
+
+	int64_t bytes_received;                                /**< Number of bytes received since task has last started receiving input data. */
+	int64_t bytes_sent;                                    /**< Number of bytes sent since task has last started sending input data. */
+	int64_t bytes_transferred;                             /**< Number of bytes transferred since task has last started transferring input data. */
 
 	struct rmsummary *resources_allocated;                 /**< Resources allocated to the task its latest attempt. */
 	struct rmsummary *resources_measured;                  /**< When monitoring is enabled, it points to the measured resources used by the task in its latest attempt. */
 	struct rmsummary *resources_requested;                 /**< Number of cores, disk, memory, time, etc. the task requires. */
-
-	category_allocation_t resource_request;                /**< See @ref category_allocation_t */
-
-	char *category;                                        /**< User-provided label for the task. It is expected that all task with the same category will have similar resource usage. See @ref work_queue_task_specify_category. If no explicit category is given, the label "default" is used. **/
-
 	char *monitor_output_directory;                        /**< Custom output directory for the monitoring output files. If NULL, save to directory from @ref work_queue_enable_monitoring */
+
+	/* deprecated fields */
+	//int total_submissions;                                 /**< @deprecated Use try_count. */
+
+	timestamp_t time_task_submit;                          /**< @deprecated Use time_when_submitted. */
+	timestamp_t time_task_finish;                          /**< @deprecated Use time_when_done. */
+	timestamp_t time_committed;                            /**< @deprecated Use time_when_commit_start. */
+
+	timestamp_t time_send_input_start;                     /**< @deprecated Use time_when_commit_start. */
+	timestamp_t time_send_input_finish;                    /**< @deprecated Use time_when_commit_end. */
+	timestamp_t time_receive_result_start;                 /**< @deprecated Use time_when_retrieval instead. */
+	timestamp_t time_receive_result_finish;                /**< @deprecated Use time_when_done instead. */
+	timestamp_t time_receive_output_start;                 /**< @deprecated Use time_when_retrieval. */
+	timestamp_t time_receive_output_finish;                /**< @deprecated Use time_when_done instead. */
+
+	timestamp_t time_execute_cmd_start;                    /**< @deprecated Use time_when_commit_end instead. */
+	timestamp_t time_execute_cmd_finish;                   /**< @deprecated Use time_when_retrieval instead. */
+
+	timestamp_t total_transfer_time;                       /**< @deprecated Use (time_when_commit_end - time_when_commit_start) + (time_when_done - time_when_retrieval). */
+
+	timestamp_t cmd_execution_time;                        /**< @deprecated Use time_workers_execute_last instead. */
+	timestamp_t total_cmd_execution_time;                  /**< @deprecated Use time_workers_execute_all instead. */
+	timestamp_t total_cmd_exhausted_execute_time;          /**< @deprecated Use time_workers_execute_exhaustion instead. */
+	timestamp_t total_time_until_worker_failure;           /**< @deprecated Use time_workers_execute_failure instead. */
+
+	int64_t total_bytes_received;                          /**< @deprecated Use bytes_received instead. */
+	int64_t total_bytes_sent;                              /**< @deprecated Use bytes_sent instead. */
+	int64_t total_bytes_transferred;                       /**< @deprecated Use bytes_transferred instead. */
 
 	timestamp_t time_app_delay;                            /**< @deprecated The time spent in upper-level application (outside of work_queue_wait). */
 };
@@ -162,73 +184,125 @@ struct work_queue_task {
 /** Statistics describing a work queue. */
 
 struct work_queue_stats {
-	int total_workers_connected;	/**< Total number of workers currently connected to the master. */
-	int workers_init;               /**< Number of workers initializing.*/
-	int workers_idle;               /**< Number of workers that are not running a task. */
-	int workers_busy;               /**< Number of workers that are running at least one task. */
+	/* Stats for the current state of workers: */
+	int workers_connected;	  /**< Number of workers currently connected to the master. */
+	int workers_init;         /**< Number of workers connected, but that have not send their available resources report yet.*/
+	int workers_idle;         /**< Number of workers that are not running a task. */
+	int workers_busy;         /**< Number of workers that are running at least one task. */
+	int workers_able;         /**< Number of workers on which the largest task can run. */
 
-	int total_workers_joined;       /**< Total number of worker connections that were established to the master. */
-	int total_workers_removed;      /**< Total number of worker connections that were lost or terminated by the master. */
-	int total_workers_lost;         /**< Total number of worker connections that were unexpectedly lost. */
-	int total_workers_idled_out;    /**< Total number of worker that disconnected for being idle. */
-	int total_workers_fast_aborted; /**< Total number of worker connections terminated for being too slow. (see @ref work_queue_activate_fast_abort) */
+	/* Cumulative stats for workers: */
+	int workers_joined;       /**< Total number of worker connections that were established to the master. */
+	int workers_removed;      /**< Total number of worker connections that were released by the master, idled-out, fast-aborted, or lost. */
+	int workers_released;     /**< Total number of worker connections that were asked by the master to disconnect. */
+	int workers_idled_out;    /**< Total number of worker that disconnected for being idle. */
+	int workers_fast_aborted; /**< Total number of worker connections terminated for being too slow. (see @ref work_queue_activate_fast_abort) */
+	int workers_blacklisted ; /**< Total number of workers blacklisted by the master. (Includes workers_fast_aborted.) */
+	int workers_lost;         /**< Total number of worker connections that were unexpectedly lost. (does not include idled-out or fast-aborted) */
 
 	/* Stats for the current state of tasks: */
-	int tasks_waiting;              /**< Number of tasks waiting to be run. */
-	int tasks_running;              /**< Number of tasks currently running. */
-	int tasks_complete;             /**< Number of tasks waiting to be returned to user. */
+	int tasks_waiting;        /**< Number of tasks waiting to be dispatched. */
+	int tasks_on_workers;     /**< Number of tasks currently dispatched to some worker. */
+	int tasks_running;        /**< Number of tasks currently executing at some worker. */
+	int tasks_with_results;   /**< Number of tasks with retrieved results and waiting to be returned to user. */
 
-	/* Cummulative stats for tasks: */
-	int total_tasks_dispatched;     /**< Total number of tasks dispatch to workers. */
-	int total_tasks_complete;       /**< Total number of tasks completed and returned to user. */
-	int total_tasks_failed;         /**< Total number of tasks completed and returned to user with result other than WQ_RESULT_SUCCESS. */
-	int total_tasks_cancelled;      /**< Total number of tasks cancelled. */
-	int total_exhausted_attempts;   /**< Total number of task executions that failed given resource exhaustion. */
+	/* Cumulative stats for tasks: */
+	int tasks_submitted;           /**< Total number of tasks submitted to the queue. */
+	int tasks_dispatched;          /**< Total number of tasks dispatch to workers. */
+	int tasks_done;                /**< Total number of tasks completed and returned to user. (includes tasks_failed) */
+	int tasks_failed;              /**< Total number of tasks completed and returned to user with result other than WQ_RESULT_SUCCESS. */
+	int tasks_cancelled;           /**< Total number of tasks cancelled. */
+	int tasks_exhausted_attempts;  /**< Total number of task executions that failed given resource exhaustion. */
 
-	timestamp_t start_time;         /**< Absolute time at which the master started. */
-	timestamp_t total_send_time;    /**< Total time in microseconds spent in sending data to workers. */
-	timestamp_t total_receive_time; /**< Total time in microseconds spent in receiving data from workers. */
-	timestamp_t total_good_transfer_time;    /**< Total time in microseconds spent in sending and receiving data to workers for tasks with result WQ_RESULT_SUCCESS. */
+	/* All times in microseconds */
+	/* A time_when_* refers to an instant in time, otherwise it refers to a length of time. */
 
-	timestamp_t total_execute_time;      /**< Total time in microseconds workers spent executing completed tasks. */
-	timestamp_t total_good_execute_time; /**< Total time in microseconds workers spent executing successful tasks. */
-	timestamp_t total_exhausted_execute_time; /**< Total time in microseconds workers spent on tasks that exhausted resources. */
+	/* Master time statistics: */
+	timestamp_t time_when_started; /**< Absolute time at which the master started. */
+	timestamp_t time_send;         /**< Total time spent in sending tasks to workers (tasks descriptions, and input files.). */
+	timestamp_t time_receive;      /**< Total time spent in receiving results from workers (output files.). */
+	timestamp_t time_send_good;    /**< Total time spent in sending data to workers for tasks with result WQ_RESULT_SUCCESS. */
+	timestamp_t time_receive_good; /**< Total time spent in sending data to workers for tasks with result WQ_RESULT_SUCCESS. */
+	timestamp_t time_status_msgs;  /**< Total time spent sending and receiving status messages to and from workers, including workers' standard output, new workers connections, resources updates, etc. */
+	timestamp_t time_internal;     /**< Total time the queue spents in internal processing. */
+	timestamp_t time_polling;      /**< Total time blocking waiting for worker communications (i.e., master idle waiting for a worker message). */
+	timestamp_t time_application;  /**< Total time spent outside work_queue_wait. */
 
-	timestamp_t total_app_time;     /**< Total time in microseconds spent outside work_queue_wait. */
-	timestamp_t total_idle_time;    /**< Total time in microseconds polling workers. */
+	/* Workers time statistics: */
+	timestamp_t time_workers_execute;            /**< Total time workers spent executing done tasks. */
+	timestamp_t time_workers_execute_good;       /**< Total time workers spent executing done tasks with result WQ_RESULT_SUCCESS. */
+	timestamp_t time_workers_execute_exhaustion; /**< Total time workers spent executing tasks that exhausted resources. */
 
-	int64_t total_bytes_sent;       /**< Total number of file bytes (not including protocol control msg bytes) sent out to the workers by the master. */
-	int64_t total_bytes_received;   /**< Total number of file bytes (not including protocol control msg bytes) received from the workers by the master. */
-	double efficiency;              /**< Parallel efficiency of the system, sum(task execution times) / sum(worker lifetimes) */
-	double idle_percentage;         /**< The fraction of time that the master is idle waiting for workers to respond. */
-	int capacity;                   /**< The estimated number of workers that this master can effectively support. */
+	/* BW statistics */
+	int64_t bytes_sent;     /**< Total number of file bytes (not including protocol control msg bytes) sent out to the workers by the master. */
+	int64_t bytes_received; /**< Total number of file bytes (not including protocol control msg bytes) received from the workers by the master. */
+	double  bandwidth;      /**< Average network bandwidth in MB/S observed by the master when transferring to workers. */
 
-	double  bandwidth;              /**< Average network bandwidth in MB/S observed by the master when transferring to workers. */
-	int64_t total_cores;            /**< Total number of cores aggregated across the connected workers. */
-	int64_t total_memory;           /**< Total memory in MB aggregated across the connected workers. */
-	int64_t total_disk;	            /**< Total disk space in MB aggregated across the connected workers. */
-	int64_t total_gpus;             /**< Total number of GPUs aggregated across the connected workers. */
-	int64_t committed_cores;        /**< Committed number of cores aggregated across the connected workers. */
-	int64_t committed_memory;       /**< Committed memory in MB aggregated across the connected workers. */
-	int64_t committed_disk;	        /**< Committed disk space in MB aggregated across the connected workers. */
-	int64_t committed_gpus;         /**< Committed number of GPUs aggregated across the connected workers. */
-	int64_t min_cores;              /**< The lowest number of cores observed among the connected workers. */
-	int64_t max_cores;              /**< The highest number of cores observed among the connected workers. */
-	int64_t min_memory;             /**< The smallest memory size in MB observed among the connected workers. */
-	int64_t max_memory;             /**< The largest memory size in MB observed among the connected workers. */
-	int64_t min_disk;               /**< The smallest disk space in MB observed among the connected workers. */
-	int64_t max_disk;               /**< The largest disk space in MB observed among the connected workers. */
-	int64_t min_gpus;               /**< The lowest number of GPUs observed among the connected workers. */
-	int64_t max_gpus;               /**< The highest number of GPUs observed among the connected workers. */
+	/* resources statistics */
+	int capacity_tasks;     /**< The estimated number of tasks that this master can effectively support. */
+	int capacity_cores;     /**< The estimated number of workers' cores that this master can effectively support.*/
+	int capacity_memory;    /**< The estimated number of workers' MB of RAM that this master can effectively support.*/
+	int capacity_disk;      /**< The estimated number of workers' MB of disk that this master can effectively support.*/
 
-	int workers_able;               /**< Number of workers on which the largest task can run. */
+	int64_t total_cores;      /**< Total number of cores aggregated across the connected workers. */
+	int64_t total_memory;     /**< Total memory in MB aggregated across the connected workers. */
+	int64_t total_disk;	      /**< Total disk space in MB aggregated across the connected workers. */
 
-	int port;                       /**< @deprecated Use ref work_queue_port Port of the queue. */
+	int64_t committed_cores;  /**< Committed number of cores aggregated across the connected workers. */
+	int64_t committed_memory; /**< Committed memory in MB aggregated across the connected workers. */
+	int64_t committed_disk;	  /**< Committed disk space in MB aggregated across the connected workers. */
+
+	int64_t max_cores;        /**< The highest number of cores observed among the connected workers. */
+	int64_t max_memory;       /**< The largest memory size in MB observed among the connected workers. */
+	int64_t max_disk;         /**< The largest disk space in MB observed among the connected workers. */
+
+	int64_t min_cores;        /**< The lowest number of cores observed among the connected workers. */
+	int64_t min_memory;       /**< The smallest memory size in MB observed among the connected workers. */
+	int64_t min_disk;         /**< The smallest disk space in MB observed among the connected workers. */
+
+	/**< deprecated fields: */
+	int total_workers_connected;    /**< @deprecated Use workers_connected instead. */
+	int total_workers_joined;       /**< @deprecated Use workers_joined instead. */
+	int total_workers_removed;      /**< @deprecated Use workers_removed instead. */
+	int total_workers_lost;         /**< @deprecated Use workers_lost instead. */
+	int total_workers_idled_out;    /**< @deprecated Use workers_idled_out instead. */
+	int total_workers_fast_aborted; /**< @deprecated Use workers_fast_aborted instead. */
+
+	int tasks_complete;             /**< @deprecated Use tasks_with_results. */
+
+	int total_tasks_dispatched;     /**< @deprecated Use tasks_dispatched instead. */
+	int total_tasks_complete;       /**< @deprecated Use tasks_done instead. */
+	int total_tasks_failed;         /**< @deprecated Use tasks_failed instead. */
+	int total_tasks_cancelled;      /**< @deprecated Use tasks_cancelled instead. */
+	int total_exhausted_attempts;   /**< @deprecated Use tasks_exhausted_attempts instead. */
+	timestamp_t start_time;               /**< @deprecated Use time_when_started. */
+	timestamp_t total_send_time;          /**< @deprecated Use time_send.    */
+	timestamp_t total_receive_time;       /**< @deprecated Use time_receive. */
+	timestamp_t total_good_transfer_time; /**< @deprecated Use time_send_good + time_receive_good. */
+
+	timestamp_t total_execute_time;           /**< @deprecated Use time_workers_execute. */
+	timestamp_t total_good_execute_time;      /**< @deprecated Use time_workers_execute_good. */
+	timestamp_t total_exhausted_execute_time; /**< @deprecated Use time_workers_execute_exhaustion. */
+
+	int64_t total_bytes_sent;     /**< @deprecated Use bytes_sent. */
+	int64_t total_bytes_received; /**< @deprecated Use bytes_received. */
+
+	double capacity; /**< @deprecated Use capacity_cores. */
+
+	double efficiency;      /**< @deprecated. broken. */
+	double idle_percentage; /**< @deprecated. */
+
+	int64_t total_gpus;       /**< @deprecated: broken. */
+	int64_t committed_gpus;   /**< @deprecated: broken. */
+	int64_t max_gpus;         /**< @deprecated: broken. */
+	int64_t min_gpus;         /**< @deprecated: broken. */
+
+	int port;                       /**< @deprecated Use @ref work_queue_port Port of the queue. */
 	int priority;                   /**< @deprecated Not used. */
-	int workers_ready;              /**< @deprecated Use @ref workers_idle instead. */
-	int workers_full;               /**< @deprecated Use @ref workers_busy insead. */
-	int total_worker_slots;         /**< @deprecated Use @ref tasks_running instead. */
-	int avg_capacity;               /**< @deprecated Use @ref capacity instead. */
+	int workers_ready;              /**< @deprecated Use workers_idle instead. */
+	int workers_full;               /**< @deprecated Use workers_busy insead. */
+	int total_worker_slots;         /**< @deprecated Use tasks_running instead. */
+	int avg_capacity;               /**< @deprecated Use capacity_cores instead. */
 };
 
 

--- a/work_queue/src/work_queue_graph_log
+++ b/work_queue/src/work_queue_graph_log
@@ -12,239 +12,288 @@ import getopt
 from subprocess import Popen, PIPE
 
 gnuplot_cmd   = 'gnuplot'
-format        = 'png'
+format        = 'svg'
 extension     = format
-resolution    = 1000000      # this many useconds to one log entry. Default is one second.
-x_range       = None         # If unspecified, then plot all the valid range.
+resolution    = 30          # this many seconds to one log entry. Default is 30 seconds.
+x_range       = None        # If unspecified, then plot all the valid range.
 
 log_entries   = None
 times         = None
 
-unit_labels   = {'s' : 'seconds', 'm' : 'minutes', 'h' : 'hours', 'd' : 'days'}
-unit_factors  = {'s' : 1, 'm' : 60, 'h' : 3600, 'd' : 86400}
+unit_labels   = {'s' : 'seconds', 'm' : 'minutes', 'h' : 'hours', 'd' : 'days', 'GB' : 'GB' }
+unit_factors  = {'s' : 1, 'm' : 60, 'h' : 3600, 'd' : 86400, 'GB' : 1073741824}
 x_units       = 'm'          # Default is minutes.
 
 def read_fields(file, lines_patience = 10):
-  for line in file:
-    if line[0] != '#':
-      lines_patience = lines_patience - 1
-    else:
-      return line.strip('#\n\r\t ').split()
-    if lines_patience < 1:
-      break
-  sys.stderr.write("Could not find fields descriptions (a line such as # timestamp total_....)\n")
-  sys.exit(1)
+    for line in file:
+        if line[0] != '#':
+            lines_patience = lines_patience - 1
+        else:
+            return line.strip('#\n\r\t ').split()
+        if lines_patience < 1:
+            break
+    sys.stderr.write("Could not find fields descriptions (a line such as # timestamp workers_....)\n")
+    sys.exit(1)
 
 def time_to_resolution(t):
-	return (t - (t % resolution)) / resolution
+    return (t - (t % (resolution * 1000000))) / 1000000
 
 def time_field_p(field):
-  return (field == 'timestamp' or re.search('.*_time$', field))
+    return (field == 'timestamp' or re.search('^time_.*$', field))
 
 def read_log_entries(file, fields):
-  log_entries = {}
-  idxs  = range(0, len(fields))
-  pairs = zip(idxs, fields)
-  epoch = None
-  count_lines = 0
+    log_entries = {}
+    idxs  = range(0, len(fields))
+    pairs = zip(idxs, fields)
+    epoch = None
+    count_lines = 0
 
-  for line in file:
-    count_lines = count_lines + 1
-    try:
-      numbers = [float(x) for x in line.split()]
-      record  = {}
+    for line in file:
+        count_lines = count_lines + 1
+        try:
+            numbers = [float(x) for x in line.split()]
+            record  = {}
 
 
-      for (i, field) in pairs:
-        if time_field_p(field):
-          numbers[i] = time_to_resolution(numbers[i])
-        if field == 'timestamp':
-          if not epoch:
-            epoch = numbers[i]
-          numbers[i] = numbers[i] - epoch
-        record[field] = numbers[i]
+            for (i, field) in pairs:
+                if time_field_p(field):
+                    numbers[i] = time_to_resolution(numbers[i])
+                if field == 'timestamp':
+                    if not epoch:
+                        epoch = numbers[i]
+                    numbers[i] = numbers[i] - epoch
+                record[field] = numbers[i]
 
-      record['total_transfer_time']    = record['total_send_time'] + record['total_receive_time']
-      record['total_master_time']      = record['timestamp'] - record['total_transfer_time']
-      log_entries[record['timestamp']] = record
+            record['time_transfer'] = record['time_send'] + record['time_receive']
+            record['time_master']   = record['time_status_msgs'] + record['time_internal'] + record['time_polling'] + record['time_application']
+            record['bytes_sent'] /= unit_factors['GB']
+            record['bytes_received'] /= unit_factors['GB']
+            record['bytes_transfered'] = record['bytes_sent'] + record['bytes_received']
 
-    except ValueError:
-      sys.stderr.write('Line %d has an invalid value. Ignoring.\n' % (count_lines, ))
-      continue
-    except IndexError:
-      sys.stderr.write('Line %d has less than %d fields. Aborting.\n' % (count_lines, len(fields)))
-      sys.exit(1)
+            try:
+                record['capacity_tasks'] = (record['time_execute'] + record['time_polling']) / (record['time_transfer'] + record['time_master'] - record['time_polling'])
+            except ArithmeticError:
+                record['capacity_tasks'] = record['capacity_tasks']
 
-  return log_entries
+            log_entries[record['timestamp']] = record
+
+        except ValueError:
+            sys.stderr.write('Line %d has an invalid value. Ignoring.\n' % (count_lines, ))
+            continue
+        except IndexError:
+            sys.stderr.write('Line %d has less than %d fields. Aborting.\n' % (count_lines, len(fields)))
+            sys.exit(1)
+
+    return log_entries
 
 def sort_time(log_entries):
-  times = []
-  for k in log_entries.keys():
-    times.append(k)
-  times.sort()
-  return times
+    times = []
+    for k in log_entries.keys():
+        times.append(k)
+    times.sort()
+    return times
 
 def pout(file, str):
-  file.write(str)
-  file.write('\n')
+    file.write(str)
+    file.write('\n')
 
 class WQPlot:
-  def __init__(self, ylabel, fields, labels=None, x_units = x_units, range = x_range):
-    self.fields      = fields
-    self.labels      = labels or self.fields
-    self.x_units     = x_units
-    self.ylabel      = ylabel
-    self.range       = range
+    def __init__(self, title, ylabel, fields, labels=None, x_units = x_units, y_units = x_units, range = x_range):
+        self.title   = title
+        self.fields  = fields
+        self.labels  = labels or self.fields
+        self.x_units = x_units
+        self.y_units = y_units
+        self.ylabel  = ylabel
+        self.range   = range
 
-  def preamble(self, file):
-    self.__preamble_common(file)
+    def preamble(self, file):
+        self.__preamble_common(file)
 
-  def __preamble_common(self, file):
-    pout(file, """
-set term %s linewidth 2;
-set xlabel '%s';
-set ylabel '%s';
-set noborder;
-set tics nomirror;
-set key right top;
-  """ % (format, unit_labels[self.x_units], self.ylabel))
-    if self.range:
-      pout(file, 'set xrange [%s]' % (self.range,))
+    def __preamble_common(self, file):
+        pout(file, """
+set term {fmt} butt linewidth 1
+set title  '{title}'
+set xlabel '{x_units}'
+set ylabel '{y_units}'
+set noborder
+set tics nomirror out
+set key left top
+""".format(fmt=format, title=self.title, x_units=unit_labels[self.x_units], y_units=self.ylabel))
 
-  def __data_one_time_field(self, file, field):
-    time_scale = unit_factors[self.x_units]
-    # if a time field, then scale
-    mod = time_field_p(field) and time_scale or 1
+        intervals = [len(log_entries.keys())/x for x in [19,17,13,11,7,5,3]]
 
-    for t in times:
-      r = log_entries[t]
-      try:
-        pout(file, '%lf %lf' % (t/time_scale, r[field]/mod))
-      except KeyError:
-        sys.stderr.write("Field '%s' does not exist in the log\n" % (field,))
-        break
-    pout(file, 'EOF')
+        pout(file, """
+set style line 1 pt 5   lc rgb '#1b9e77' pointinterval {0}
+set style line 2 pt 13  lc rgb '#d95f02' pointinterval {1}
+set style line 3 pt 7   lc rgb '#7570b3' pointinterval {2}
+set style line 4 pt 9   lc rgb '#e7298a' pointinterval {3}
+set style line 5 pt 10  lc rgb '#66a61e' pointinterval {4}
+set style line 6 pt 2   lc rgb '#e6ab02' pointinterval {5}
+set style line 7 pt 1   lc rgb '#a6761d' pointinterval {6}
+""".format(*intervals))
 
-  def plot_line(self, label):
-   return "'-' using 1:2 title '%s' with lines" % (label,)
+        if self.range:
+            pout(file, 'set xrange [%s]' % (self.range,))
 
-  def write_plot(self, file):
-    self.preamble(file)
+    def __data_one_time_field(self, file, field):
+        time_scale = unit_factors[self.x_units]
+        # if a time field, then scale
+        mod = time_field_p(field) and unit_factors[self.y_units] or 1
 
-    plots = [ self.plot_line(label) for label in self.labels ]
-    pout(file, 'plot %s;' % (',\\\n'.join(plots),))
+        for t in times:
+            r = log_entries[t]
+            try:
+                pout(file, '%lf %lf' % (t/time_scale, r[field]/mod))
+            except KeyError:
+                sys.stderr.write("Field '%s' does not exist in the log\n" % (field,))
+                break
+        pout(file, 'EOF')
 
-    for field in self.fields:
-      self.__data_one_time_field(file, field)
+    def plot_line(self, label, place):
+        return "'-' using 1:2 title '%s' with linespoints ls %d lw 3" % (label,place+1)
 
-  def __plot_internal(self, output, command):
-      sys.stdout.write("Generating '%s'.\n" % (output,))
-      fout = open(output, 'w')
-      gnuplot = Popen(command, stdin = PIPE, stdout = fout)
-      self.write_plot(gnuplot.stdin)
-      gnuplot.stdin.close()
-      gnuplot.wait()
+    def write_plot(self, file):
+        self.preamble(file)
 
-  def plot(self, output):
-    try:
-      self.__plot_internal(output, command = gnuplot_cmd)
-    except IOError:
-      sys.stderr.write("Could not generate file %s.\n" % (output,))
-      exit(1)
-    except OSError:
-      sys.stderr.write("Could not execute '%s'. Please try again specifying -c <gnuplot-path>, or -Ttext\n" % (gnuplot_cmd, ))
-      exit(1)
+        plots = []
+        for i in range(len(self.labels)):
+            plots.append(self.plot_line(self.labels[i], i))
+
+        pout(file, 'plot %s;' % (',\\\n'.join(plots),))
+
+        for field in self.fields:
+            self.__data_one_time_field(file, field)
+
+    def __plot_internal(self, output, command):
+        sys.stdout.write("Generating '%s'.\n" % (output,))
+        fout = open(output, 'w')
+        gnuplot = Popen(command, stdin = PIPE, stdout = fout)
+        self.write_plot(gnuplot.stdin)
+        gnuplot.stdin.close()
+        gnuplot.wait()
+
+    def plot(self, output):
+        try:
+            self.__plot_internal(output, command = gnuplot_cmd)
+        except IOError:
+            sys.stderr.write("Could not generate file %s.\n" % (output,))
+            exit(1)
+        except OSError:
+            sys.stderr.write("Could not execute '%s'. Please try again specifying -c <gnuplot-path>, or -Ttext\n" % (gnuplot_cmd, ))
+            exit(1)
 
 
 class WQPlotLog(WQPlot):
-  def preamble(self, file):
-    WQPlot.preamble(self, file)
-    pout(file, 'set logscale y')
-    pout(file, '')
+    def preamble(self, file):
+        WQPlot.preamble(self, file)
+        pout(file, 'set logscale y')
+        pout(file, '')
 
 def show_usage():
-  print '%s [options] <work-queue-log>\n' % (os.path.basename(sys.argv[0],))
-  print '\t-h\t\t\tThis message.'
-  print '\t-c <gnuplot-path>\tSpecify the location of the gnuplot executable.'
-  print '\t\t\t\tDefault is gnuplot.'
-  print '\t-o <prefix-output>\tGenerate prefix-output.{time,time-log,tasks,tasks-log}.%s.' % (format,)
-  print '\t\t\t\tDefault is <work-queue-log>.'
-  print '\t-r <range>\t\tRange of time to plot, in time units (see -u) from'
-  print '\t\t\t\tthe start of execution. Of the form: min:max, min:, or :max.'
-  print '\t-T <output-format>\tSet output format. Default is png.'
-  print '\t\t\t\tIf \'text\', then the gnuplot scripts are written instead of the images.'
-  print '\t-u <time-unit>\t\tTime scale to output. One of s,m,h or d, for seconds,'
-  print '\t\t\t\tminutes (default), hours or days.'
+    print '%s [options] <work-queue-log>\n' % (os.path.basename(sys.argv[0],))
+    print '\t-h\t\t\tThis message.'
+    print '\t-c <gnuplot-path>\tSpecify the location of the gnuplot executable.'
+    print '\t\t\t\tDefault is gnuplot.'
+    print '\t-o <prefix-output>\tGenerate prefix-output.{workers,workers-accum,tasks,tasks-accum,time-master,time-workers,transfer,cores}.%s.' % (format,)
+    print '\t\t\t\tDefault is <work-queue-log>.'
+    print '\t-s <seconds>\t\tSample log every <seconds> (default is %f).\n' % (resolution,)
+    print '\t-r <range>\t\tRange of time to plot, in time units (see -u) from'
+    print '\t\t\t\tthe start of execution. Of the form: min:max, min:, or :max.'
+    print '\t-T <output-format>\tSet output format. Default is png.'
+    print '\t\t\t\tIf \'text\', then the gnuplot scripts are written instead of the images.'
+    print '\t-u <time-unit>\t\tTime scale to output. One of s,m,h or d, for seconds,'
+    print '\t\t\t\tminutes (default), hours or days.'
 
 if __name__ == '__main__':
 
-  try:
-    optlist, args = getopt.getopt(sys.argv[1:], 'c:ho:r:T:u:')
-  except getopt.GetoptError as e:
-    sys.stderr.write(str(e) + '\n')
-    show_usage()
-    sys.exit(1)
+    try:
+        optlist, args = getopt.getopt(sys.argv[1:], 'c:ho:r:s:T:u:')
+    except getopt.GetoptError as e:
+        sys.stderr.write(str(e) + '\n')
+        show_usage()
+        sys.exit(1)
 
-  if len(args) < 1:
-    show_usage()
-    sys.exit(1)
+    if len(args) < 1:
+        show_usage()
+        sys.exit(1)
 
-  logname = args[0]
-  prefix  = logname
+    logname = args[0]
+    prefix  = logname
 
-  for opt, arg in optlist:
-    if   opt == '-c':
-      gnuplot_cmd = arg
-    elif opt == '-o':
-      prefix = arg
-    elif opt == '-h':
-      show_usage()
-      sys.exit(0)
-    elif opt == '-r':
-      x_range = arg
-    elif opt == '-T':
-      if arg == 'text':
-        gnuplot_cmd = 'cat'
-        extension   = format + '.gnuplot'
-      else:
-        format    = arg
-        extension = format
-    elif opt == '-u':
-      if arg in unit_factors:
-        x_units = arg
-      else:
-        sys.stderr.write("Time scale factor '%s' is not valid. Options: s,m,h or d.\n"  % (arg,))
-        exit(1)
+    for opt, arg in optlist:
+        if   opt == '-c':
+            gnuplot_cmd = arg
+        elif opt == '-o':
+            prefix = arg
+        elif opt == '-h':
+            show_usage()
+            sys.exit(0)
+        elif opt == '-r':
+            x_range = arg
+        elif opt == '-s':
+            resolution = float(arg)
+        elif opt == '-T':
+            if arg == 'text':
+                gnuplot_cmd = 'cat'
+                extension   = format + '.gnuplot'
+            else:
+                format    = arg
+                extension = format
+        elif opt == '-u':
+            if arg in unit_factors:
+                x_units = arg
+            else:
+                sys.stderr.write("Time scale factor '%s' is not valid. Options: s,m,h or d.\n"  % (arg,))
+                exit(1)
 
-  try:
-    file        = open(logname)
-    log_entries = read_log_entries(file, read_fields(file))
-    times       = sort_time(log_entries)
-    file.close()
+    try:
+        file        = open(logname)
+        log_entries = read_log_entries(file, read_fields(file))
+        times       = sort_time(log_entries)
+        file.close()
 
-    plot_of_times = WQPlot(x_units = x_units, ylabel = unit_labels[x_units], range = x_range,
-        fields = ['timestamp', 'total_transfer_time', 'total_master_time',
-                  'total_send_time', 'total_receive_time'],
-        labels = ['wall time', 'sent+recv', 'master', 'sent', 'rec'])
+        plots = {}
+        plots['workers'] = WQPlot(x_units = x_units, ylabel = 'workers', range = x_range,
+                title = "workers instantaneous counts",
+                fields = ['workers_connected', 'workers_idle', 'workers_busy'],
+                labels = ['connected', 'idle', 'busy'])
 
-    plot_of_times_log = WQPlotLog(x_units = x_units, ylabel = unit_labels[x_units], range = x_range,
-        fields = ['timestamp', 'total_transfer_time', 'total_master_time',
-                  'total_send_time', 'total_receive_time', 'total_execute_time'],
-        labels = ['wall time', 'sent+recv', 'master', 'sent', 'rec', 'exec'])
+        plots['workers-accum'] = WQPlot(x_units = x_units, ylabel = 'workers', range = x_range,
+                title = "workers cumulative counts",
+                fields = ['workers_joined', 'workers_removed', 'workers_released', 'workers_fast_aborted', 'workers_idled_out', 'workers_lost'],
+                labels = ['joined', 'removed', 'released', 'fast aborted', 'idled out,', 'lost'])
 
-    plot_of_tasks = WQPlot(x_units = x_units, ylabel = 'number of tasks/workers/cores', range = x_range,
-        fields =['tasks_running', 'tasks_waiting', 'total_workers_connected', 'workers_busy', 'total_cores'],
-        labels = ['tasks running', 'tasks waiting', 'workers connected', 'workers busy', 'cores'])
+        plots['tasks'] = WQPlot(x_units = x_units, ylabel = 'tasks', range = x_range,
+                title = "tasks instantaneous counts",
+                fields = ['tasks_waiting', 'tasks_on_workers', 'tasks_running', 'tasks_with_results', 'capacity_tasks'],
+                labels = ['waiting', 'on workers', 'running', 'with results', 'capacity'])
 
-    plot_of_tasks_log = WQPlotLog(x_units = x_units, ylabel = 'number of tasks/workers/cores', range = x_range,
-        fields =['tasks_running', 'tasks_waiting', 'total_workers_connected', 'workers_busy', 'total_cores', 'total_tasks_complete'],
-        labels = ['tasks running', 'tasks waiting', 'workers connected', 'workers busy', 'cores', 'tasks completed'])
+        plots['tasks-accum'] = WQPlot(x_units = x_units, ylabel = 'tasks', range = x_range,
+                title = "tasks cumulative counts",
+                fields = ['tasks_submitted', 'tasks_dispatched', 'tasks_done', 'tasks_failed', 'tasks_cancelled', 'tasks_exhausted_attempts'],
+                labels = ['submitted', 'dispatched', 'done', 'failed', 'cancelled', 'exhausted attempts'])
 
-    plot_of_times.plot(prefix     + '.time.'      + extension)
-    plot_of_times_log.plot(prefix + '.time-log.'  + extension)
-    plot_of_tasks.plot(prefix     + '.tasks.'     + extension)
-    plot_of_tasks_log.plot(prefix + '.tasks-log.' + extension)
+        plots['time-master'] = WQPlot(x_units = x_units, ylabel = unit_labels[x_units], range = x_range,
+            title = "cumulative times at the master",
+            fields = ['time_send', 'time_receive', 'time_transfer', 'time_polling', 'time_status_msgs', 'time_application', 'time_master'],
+            labels = ['send', 'receive', 'send+recv', 'master polling', 'master status msgs', 'master external', 'msgs+external+idle'])
 
-  except IOError:
-    sys.stderr.write("Could not open file %s\n" % (logname,))
-    sys.exit(1)
+        plots['time-workers'] = WQPlot(x_units = x_units, y_units = 'h', ylabel = unit_labels['h'], range = x_range,
+            title = "cumulative times at workers",
+            fields = ['time_execute', 'time_execute_good', 'time_execute_exhaustion'],
+            labels = ['execute', 'execute good', 'execute exhaustion'])
+
+        plots['transfer'] = WQPlot(x_units = x_units, y_units = 'GB', ylabel = 'GB', range = x_range,
+            title = "master data transfer",
+            fields = ['bytes_sent', 'bytes_received', 'bytes_transfered'],
+            labels = ['sent', 'received', 'transfered'])
+
+        for name in plots.keys():
+            plots[name].plot(prefix     + '.' + name + '.' + extension)
+
+    except IOError:
+        sys.stderr.write("Could not open file %s\n" % (logname,))
+        sys.exit(1)
+
+# vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab shiftround autoindent

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -354,19 +354,31 @@ static void send_stats_update(struct link *master)
 		struct work_queue_stats s;
 		work_queue_get_stats_hierarchy(foreman_q, &s);
 
-		send_master_message(master, "info total_workers_joined %lld\n", (long long) s.total_workers_joined);
-		send_master_message(master, "info total_workers_removed %lld\n", (long long) s.total_workers_removed);
-		send_master_message(master, "info total_workers_lost %lld\n", (long long) s.total_workers_lost);
-		send_master_message(master, "info total_workers_idled_out %lld\n", (long long) s.total_workers_idled_out);
-		send_master_message(master, "info total_workers_fast_aborted %lld\n", (long long) s.total_workers_fast_aborted);
-		send_master_message(master, "info total_send_time %lld\n", (long long) s.total_send_time);
-		send_master_message(master, "info total_receive_time %lld\n", (long long) s.total_receive_time);
-		send_master_message(master, "info total_execute_time %lld\n", (long long) s.total_execute_time);
-		send_master_message(master, "info total_bytes_sent %lld\n", (long long) s.total_bytes_sent);
-		send_master_message(master, "info total_bytes_received %lld\n", (long long) s.total_bytes_received);
+		send_master_message(master, "info workers_joined %lld\n", (long long) s.workers_joined);
+		send_master_message(master, "info workers_removed %lld\n", (long long) s.workers_removed);
+		send_master_message(master, "info workers_released %lld\n", (long long) s.workers_released);
+		send_master_message(master, "info workers_idled_out %lld\n", (long long) s.workers_idled_out);
+		send_master_message(master, "info workers_fast_aborted %lld\n", (long long) s.workers_fast_aborted);
+		send_master_message(master, "info workers_blacklisted %lld\n", (long long) s.workers_blacklisted);
+		send_master_message(master, "info workers_lost %lld\n", (long long) s.workers_lost);
 
 		send_master_message(master, "info tasks_waiting %lld\n", (long long) s.tasks_waiting);
+		send_master_message(master, "info tasks_on_workers %lld\n", (long long) s.tasks_on_workers);
 		send_master_message(master, "info tasks_running %lld\n", (long long) s.tasks_running);
+		send_master_message(master, "info tasks_waiting %lld\n", (long long) list_size(procs_waiting));
+		send_master_message(master, "info tasks_with_results %lld\n", (long long) s.tasks_with_results);
+
+		send_master_message(master, "info time_send %lld\n", (long long) s.time_send);
+		send_master_message(master, "info time_receive %lld\n", (long long) s.time_receive);
+		send_master_message(master, "info time_send_good %lld\n", (long long) s.time_send_good);
+		send_master_message(master, "info time_receive_good %lld\n", (long long) s.time_receive_good);
+
+		send_master_message(master, "info time_workers_execute %lld\n", (long long) s.time_workers_execute);
+		send_master_message(master, "info time_workers_execute_good %lld\n", (long long) s.time_workers_execute_good);
+		send_master_message(master, "info time_workers_execute_exhaustion %lld\n", (long long) s.time_workers_execute_exhaustion);
+
+		send_master_message(master, "info bytes_sent %lld\n", (long long) s.bytes_sent);
+		send_master_message(master, "info bytes_received %lld\n", (long long) s.bytes_received);
 	}
 	else {
 		send_master_message(master, "info tasks_running %lld\n", (long long) itable_size(procs_running));
@@ -530,12 +542,12 @@ static void report_task_complete( struct link *master, struct work_queue_process
 		} else {
 			output_length = 0;
 		}
-		send_master_message(master, "result %d %d %lld %llu %d\n", t->result, t->return_status, (long long) output_length, (unsigned long long) t->cmd_execution_time, t->taskid);
+		send_master_message(master, "result %d %d %lld %llu %d\n", t->result, t->return_status, (long long) output_length, (unsigned long long) t->time_workers_execute_last, t->taskid);
 		if(output_length) {
 			link_putlstring(master, t->output, output_length, time(0)+active_timeout);
 		}
 
-		total_task_execution_time += t->cmd_execution_time;
+		total_task_execution_time += t->time_workers_execute_last;
 		total_tasks_executed++;
 	}
 


### PR DESCRIPTION
Added fill_deprecated_stats_{queue,task} so that old application can run without change.

The new stats for the queue, are:

```C
/* Stats for the current state of workers: */
    int workers_connected;    /**< Number of workers currently connected to the master. */
    int workers_init;         /**< Number of workers connected, but that have not send their available resources report yet.*/
    int workers_idle;         /**< Number of workers that are not running a task. */
    int workers_busy;         /**< Number of workers that are running at least one task. */
    int workers_able;         /**< Number of workers on which the largest task can run. */

    /* Cumulative stats for workers: */
    int workers_joined;       /**< Total number of worker connections that were established to the master. */
    int workers_removed;      /**< Total number of worker connections that were lost or terminated by the master. */
     int workers_released;     /**< Total number of worker connections that were asked by the master to disconnect. */
    int workers_idled_out;    /**< Total number of worker that disconnected for being idle. */
    int workers_fast_aborted; /**< Total number of worker connections terminated for being too slow. (see @ref work_queue_activate_fast_abort) */
    int workers_blacklisted ; /**< Total number of workers blacklisted by the master. (Includes workers_fast_aborted.) */
    int workers_lost;         /**< Total number of worker connections that were unexpectedly lost. (does not include idled-out or fast-aborted) */

    /* Stats for the current state of tasks: */
    int tasks_waiting;        /**< Number of tasks waiting to be dispatched. */
    int tasks_on_workers;     /**< Number of tasks currently dispatched to some worker. */
    int tasks_running;        /**< Number of tasks currently executing at some worker. */
    int tasks_with_results;   /**< Number of tasks with retrieved results and waiting to be returned to user. */

    /* Cumulative stats for tasks: */
    int tasks_submitted;           /**< Total number of tasks submitted to the queue. */
    int tasks_dispatched;          /**< Total number of tasks dispatch to workers. */
    int tasks_done;                /**< Total number of tasks completed and returned to user. (includes tasks_failed) */
    int tasks_failed;              /**< Total number of tasks completed and returned to user with result other than WQ_RESULT_SUCCESS. */
    int tasks_cancelled;           /**< Total number of tasks cancelled. */
    int tasks_exhausted_attempts;  /**< Total number of task executions that failed given resource exhaustion. */

    /* All times in microseconds */
    /* A time_when_* refers to an instant in time, otherwise it refers to a length of time. */

    /* Master time statistics: */
    timestamp_t time_when_started; /**< Absolute time at which the master started. */
    timestamp_t time_send;         /**< Total time spent in sending data to workers (tasks descriptions, input files, requests for status, etc.). */
    timestamp_t time_receive;      /**< Total time spent in receiving data from workers (output files, status reports, etc.). */
    timestamp_t time_send_good;    /**< Total time spent in sending data to workers for tasks with result WQ_RESULT_SUCCESS. */
    timestamp_t time_receive_good; /**< Total time spent in sending data to workers for tasks with result WQ_RESULT_SUCCESS. */
    timestamp_t time_status_msgs;  /**< Total time spent sending and receiving status messages to and from workers . */
    timestamp_t time_internal;     /**< Total time the queue spents in internal processing. */
    timestamp_t time_polling;         /**< Total time blocking waiting for worker communications (i.e., polling workers). */
    timestamp_t time_application;  /**< Total time spent outside work_queue_wait. */
 time statistics: */
    timestamp_t time_workers_execute;            /**< Total time workers spent executing done tasks. */
    timestamp_t time_workers_execute_good;       /**< Total time workers spent executing done tasks with result WQ_RESULT_SUCCESS. */
    timestamp_t time_workers_execute_exhaustion; /**< Total time workers spent executing tasks that exhausted resources. */
 /* BW statistics */
    int64_t bytes_sent;     /**< Total number of file bytes (not including protocol control msg bytes) sent out to the workers by the master. */
    int64_t bytes_received; /**< Total number of file bytes (not including protocol control msg bytes) received from the workers by the master. */
    double  bandwidth;      /**< Average network bandwidth in MB/S observed by the master when transferring to workers. */

    /* resources statistics */
    double efficiency;      /**< Parallel efficiency of the system, sum(task execution times) / sum(worker lifetimes) */
    double idle_percentage; /**< The fraction of time that the master is idle waiting for workers to respond. */

    int capacity_tasks;     /**< The estimated number of tasks that this master can effectively support.  */
    int capacity_cores;     /**< The estimated number of workers' cores that this master can effectively support. */
    int capacity_memory;    /**< The estimated number of workers' MB of RAM that this master can effectively support. */
    int capacity_disk;      /**< The estimated number of workers' MB of disk that this master can effectively support. */

    int64_t total_cores;      /**< Total number of cores aggregated across the connected workers. */
    int64_t total_memory;     /**< Total memory in MB aggregated across the connected workers. */
    int64_t total_disk;       /**< Total disk space in MB aggregated across the connected workers. */

    int64_t committed_cores;  /**< Committed number of cores aggregated across the connected workers. */
    int64_t committed_memory; /**< Committed memory in MB aggregated across the connected workers. */
    int64_t committed_disk;   /**< Committed disk space in MB aggregated across the connected workers. */

    int64_t max_cores;        /**< The highest number of cores observed among the connected workers. */
    int64_t max_memory;       /**< The largest memory size in MB observed among the connected workers. */
    int64_t max_disk;         /**< The largest disk space in MB observed among the connected workers. */

    int64_t min_cores;        /**< The lowest number of cores observed among the connected workers. */
    int64_t min_memory;       /**< The smallest memory size in MB observed among the connected workers. */
    int64_t min_disk;         /**< The smallest disk space in MB observed among the connected workers. */
```

For the task, the stats are:
```C
/* All times in microseconds */
    /* A time_when_* refers to an instant in time, otherwise it refers to a length of time. */
    timestamp_t time_when_submitted;                       /**< The time at which this task was added to the queue. */
    timestamp_t time_when_done;                            /**< The time at which the task is mark as retrieved, after transfering output files and other final processing. */

     /* All times in microseconds */
    /* A time_when_* refers to an instant in time, otherwise it refers to a length of time. */
    timestamp_t time_when_submitted;    /**< The time at which this task was added to the queue. */
    timestamp_t time_when_done;         /**< The time at which the task is mark as retrieved, after transfering output files and other final processing. */

    timestamp_t time_when_commit_start; /**< The time when the task starts to be transfered to a worker. */
    timestamp_t time_when_commit_end;   /**< The time when the task is completely transfered to a worker. */

    timestamp_t time_when_retrieval;    /**< The time when output files start to be transfered back to the master. time_done - time_when_retrieval is the time taken to transfer output files. */

    timestamp_t time_workers_execute_last;                 /**< Duration of the last complete execution for this task. */
    timestamp_t time_workers_execute_all;                  /**< Accumulated time for executing the command on any worker, regardless of whether the task completed (i.e., this includes time running on workers that disconnected). */
    timestamp_t time_workers_execute_exhaustion;           /**< Accumulated time spent in attempts that exhausted resources. */
    timestamp_t time_workers_execute_failure;              /**< Accumulated time for runs that terminated in worker failure/disconnection. */

    int64_t bytes_received;                                /**< Number of bytes received since task has last started receiving input data. */
    int64_t bytes_sent;                                    /**< Number of bytes sent since task has last started sending input data. */
    int64_t bytes_transferred;                             /**< Number of bytes transferred since task has last started transferring input data. */
```
