### PR TITLE
Worker message enhacements

### DIFF
--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -111,6 +111,9 @@ static double worker_volatility = 0.0;
 // This can be set by Ctrl-C or by any condition that prevents further progress.
 static int abort_flag = 0;
 
+// Record the signal received, to inform the master if appropiate.
+static int abort_signal_received = 0;
+
 // Flag used to indicate a child must be waited for.
 static int sigchld_received_flag = 0;
 
@@ -1666,6 +1669,7 @@ static void foreman_for_master(struct link *master) {
 
 		if(time(0) > idle_stoptime && work_queue_empty(foreman_q)) {
 			debug(D_NOTICE, "giving up because did not receive any task in %d seconds.\n", idle_timeout);
+			send_master_message(master, "info idle-disconnecting %lld\n", (long long) idle_timeout);
 			break;
 		}
 
@@ -1870,6 +1874,10 @@ static int serve_master_by_hostport( const char *host, int port, const char *ver
 		work_for_master(master);
 	}
 
+	if(abort_signal_received) {
+		send_master_message(master, "info vacating %d\n", abort_signal_received);
+	}
+
 	last_task_received     = 0;
 	results_to_be_sent_msg = 0;
 
@@ -1947,6 +1955,7 @@ void set_worker_id() {
 static void handle_abort(int sig)
 {
 	abort_flag = 1;
+	abort_signal_received = sig;
 }
 
 static void handle_sigchld(int sig)


### PR DESCRIPTION
worker informs the master of terminating signal with: info vacating %d

Also, when new tasks start to run, the worker sends a message to the master. Before, such message would be sent when the master asked for a keepalive, but this made the task_running stat to be off by about 3 minutes (the keepalive interval). The master still asks for keepalives, this change only resets the timeout.
