### PR TITLE
Change default memory from 1024 to 512 MB in condor_submit_workers

### DIFF
--- a/work_queue/src/condor_submit_workers
+++ b/work_queue/src/condor_submit_workers
@@ -27,8 +27,8 @@ parse_arguments()
 {
 	# set default values:
 	cores=${cores:-1}
-	memory=${memory:-1024}   # MB, e.g. 1 GB
-	disk=${disk:-1024}      # MB, e.g. 1 GB
+	memory=${memory:-512}   # MB, e.g. 0.5 GB
+	disk=${disk:-1024}      # MB, e.g. 1   GB
 
 	# convert disk to kB to make what follows easier, as condor want disk in kB
 	disk=$((disk*1024))


### PR DESCRIPTION
Turns out that 1GB of memory per core eliminated many machines at ND pool.

Note that the original 1024MB has never been included in an official release.