### PR TITLE
Resource Monitor file directories in Condor

### DIFF
--- a/batch_job/src/batch_job.c
+++ b/batch_job/src/batch_job.c
@@ -74,6 +74,7 @@ struct batch_queue *batch_queue_create(batch_queue_type_t type)
 	q->data = NULL;
 
 	batch_queue_set_feature(q, "local_job_queue", "yes");
+	batch_queue_set_feature(q, "output_directories", "yes");
 	batch_queue_set_feature(q, "batch_log_name", "%s.batchlog");
 	batch_queue_set_feature(q, "gc_size", "yes");
 

--- a/batch_job/src/batch_job_condor.c
+++ b/batch_job/src/batch_job_condor.c
@@ -339,6 +339,7 @@ static int batch_job_condor_remove (struct batch_queue *q, batch_job_id_t jobid)
 static int batch_queue_condor_create (struct batch_queue *q)
 {
 	strncpy(q->logfile, "condor.logfile", sizeof(q->logfile));
+	batch_queue_set_feature(q, "output_directories", NULL);
 	batch_queue_set_feature(q, "batch_log_name", "%s.condorlog");
 	batch_queue_set_feature(q, "autosize", "yes");
 

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -480,7 +480,7 @@ static void makeflow_node_submit(struct dag *d, struct dag_node *n)
 	/* Apply the wrapper(s) to the command, if it is (they are) enabled. */
 	char *command = strdup(n->command);
 	command = makeflow_wrap_wrapper(command, n, wrapper);
-	command = makeflow_wrap_monitor(command, n, monitor);
+	command = makeflow_wrap_monitor(command, n, queue, monitor);
 
 	/* Before setting the batch job options (stored in the "BATCH_OPTIONS"
 	 * variable), we must save the previous global queue value, and then
@@ -625,7 +625,7 @@ int makeflow_node_check_file_was_created(struct dag_node *n, struct dag_file *f)
 Mark the given task as completing, using the batch_job_info completion structure provided by batch_job.
 */
 
-static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct batch_job_info *info)
+static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct batch_queue *queue, struct batch_job_info *info)
 {
 	struct dag_file *f;
 	int job_failed = 0;
@@ -636,7 +636,13 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 
 	if(monitor) {
 		char *nodeid = string_format("%d",n->nodeid);
-		char *log_name_prefix = string_replace_percents(monitor->log_prefix, nodeid);
+		char *output_prefix = NULL;
+		if(batch_queue_supports_feature(queue, "output_directories")) {
+			output_prefix = xxstrdup(monitor->log_prefix);
+		} else {
+			output_prefix = xxstrdup(path_basename(monitor->log_prefix));
+		}
+		char *log_name_prefix = string_replace_percents(output_prefix, nodeid);
 		char *summary_name = string_format("%s.summary", log_name_prefix);
 
 		if(n->resources_measured)
@@ -644,6 +650,8 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 		n->resources_measured = rmsummary_parse_file_single(summary_name);
 
 		category_accumulate_summary(n->category, n->resources_measured, NULL);
+
+		makeflow_monitor_move_output_if_needed(n, queue, monitor);
 
 		free(nodeid);
 		free(log_name_prefix);
@@ -827,7 +835,7 @@ static void makeflow_run( struct dag *d )
 				debug(D_MAKEFLOW_RUN, "Job %" PRIbjid " has returned.\n", jobid);
 				n = itable_remove(d->remote_job_table, jobid);
 				if(n)
-					makeflow_node_complete(d, n, &info);
+					makeflow_node_complete(d, n, remote_queue, &info);
 			}
 		}
 
@@ -846,7 +854,7 @@ static void makeflow_run( struct dag *d )
 				debug(D_MAKEFLOW_RUN, "Job %" PRIbjid " has returned.\n", jobid);
 				n = itable_remove(d->local_job_table, jobid);
 				if(n)
-					makeflow_node_complete(d, n, &info);
+					makeflow_node_complete(d, n, remote_queue, &info);
 			}
 		}
 

--- a/makeflow/src/makeflow_wrapper_monitor.h
+++ b/makeflow/src/makeflow_wrapper_monitor.h
@@ -28,6 +28,7 @@ struct makeflow_monitor {
 
 struct makeflow_monitor * makeflow_monitor_create();
 void makeflow_prepare_for_monitoring( struct makeflow_monitor *m, struct batch_queue *queue, char *log_dir, char *log_format);
-char *makeflow_wrap_monitor( char *result, struct dag_node *n, struct makeflow_monitor *m );
+char *makeflow_wrap_monitor( char *result, struct dag_node *n, struct batch_queue *queue, struct makeflow_monitor *m );
+int makeflow_monitor_move_output_if_needed(struct dag_node *n, struct batch_queue *queue, struct makeflow_monitor *m);
 
 #endif


### PR DESCRIPTION
Fix that uses the basename of Resource Monitor files remotely on condor. 

If resource monitor is enabled with Condor, we write the monitor command to use a file in the cwd, not in a directory. This way the monitor output if sent back by Condor. As Condor does the actual transport of the files, there isn't code in batch_job_condor to intercept and rename the files. To put them in the correct location a move function is used to rename the files in the expected directory prior to checking if the output exist.

@btovar Give this a look, though it is not an ideal solution. 

Continuation fix for Issue #1364 