### PR TITLE
Makeflow prevent absolute paths in WQ

### DIFF
--- a/batch_job/src/batch_job.c
+++ b/batch_job/src/batch_job.c
@@ -74,6 +74,7 @@ struct batch_queue *batch_queue_create(batch_queue_type_t type)
 	q->data = NULL;
 
 	batch_queue_set_feature(q, "local_job_queue", "yes");
+	batch_queue_set_feature(q, "absolute_path", "yes");
 	batch_queue_set_feature(q, "batch_log_name", "%s.batchlog");
 	batch_queue_set_feature(q, "gc_size", "yes");
 

--- a/batch_job/src/batch_job_work_queue.c
+++ b/batch_job/src/batch_job_work_queue.c
@@ -25,12 +25,12 @@ static void specify_files(struct work_queue_task *t, const char *input_files, co
 			if(p) {
 				*p = 0;
 				if(!work_queue_task_specify_file(t, f, p + 1, WORK_QUEUE_INPUT, caching_flag)){
-					fatal("Failed to specify file %s->%s in Work Queue", f, p+1);
+					fatal("Error while specifying file: %s->%s.", f, p+1);
 				}
 				*p = '=';
 			} else {
 				if(!work_queue_task_specify_file(t, f, f, WORK_QUEUE_INPUT, caching_flag)){
-					fatal("Failed to specify file %s in Work Queue", f);
+					fatal("Error while specifying file: %s.", f);
 				}
 			}
 			f = strtok(0, " \t,");
@@ -46,12 +46,12 @@ static void specify_files(struct work_queue_task *t, const char *input_files, co
 			if(p) {
 				*p = 0;
 				if(!work_queue_task_specify_file(t, f, p + 1, WORK_QUEUE_OUTPUT, caching_flag)){
-					fatal("Failed to specify file %s->%s in Work Queue", f, p+1);
+					fatal("Error while specifying file: %s->%s.", f, p+1);
 				}
 				*p = '=';
 			} else {
 				if(!work_queue_task_specify_file(t, f, f, WORK_QUEUE_OUTPUT, caching_flag)){
-					fatal("Failed to specify file %s in Work Queue", f);
+					fatal("Error while specifying file: %s.", f);
 				}
 			}
 			f = strtok(0, " \t,");

--- a/batch_job/src/batch_job_work_queue.c
+++ b/batch_job/src/batch_job_work_queue.c
@@ -25,12 +25,12 @@ static int specify_files(struct work_queue_task *t, const char *input_files, con
 			if(p) {
 				*p = 0;
 				if(!work_queue_task_specify_file(t, f, p + 1, WORK_QUEUE_INPUT, caching_flag)){
-					exit(1);
+					fatal("Failed to specify file %s->%s in Work Queue", f, p+1);
 				}
 				*p = '=';
 			} else {
 				if(!work_queue_task_specify_file(t, f, f, WORK_QUEUE_INPUT, caching_flag)){
-					exit(1);
+					fatal("Failed to specify file %s in Work Queue", f);
 				}
 			}
 			f = strtok(0, " \t,");
@@ -46,12 +46,12 @@ static int specify_files(struct work_queue_task *t, const char *input_files, con
 			if(p) {
 				*p = 0;
 				if(!work_queue_task_specify_file(t, f, p + 1, WORK_QUEUE_OUTPUT, caching_flag)){
-					exit(1);
+					fatal("Failed to specify file %s->%s in Work Queue", f, p+1);
 				}
 				*p = '=';
 			} else {
 				if(!work_queue_task_specify_file(t, f, f, WORK_QUEUE_OUTPUT, caching_flag)){
-					exit(1);
+					fatal("Failed to specify file %s in Work Queue", f);
 				}
 			}
 			f = strtok(0, " \t,");

--- a/batch_job/src/batch_job_work_queue.c
+++ b/batch_job/src/batch_job_work_queue.c
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <errno.h>
 
-static int specify_files(struct work_queue_task *t, const char *input_files, const char *output_files, int caching_flag )
+static void specify_files(struct work_queue_task *t, const char *input_files, const char *output_files, int caching_flag )
 {
 	char *f, *p, *files;
 
@@ -58,7 +58,6 @@ static int specify_files(struct work_queue_task *t, const char *input_files, con
 		}
 		free(files);
 	}
-	return 0;
 }
 
 static void specify_envlist( struct work_queue_task *t, struct jx *envlist )
@@ -85,8 +84,7 @@ static batch_job_id_t batch_job_wq_submit (struct batch_queue * q, const char *c
 
 	t = work_queue_task_create(cmd);
 
-	if(specify_files(t, extra_input_files, extra_output_files, caching_flag))
-		return -1;
+	specify_files(t, extra_input_files, extra_output_files, caching_flag);
 	specify_envlist(t,envlist);
 
 	if(envlist) {

--- a/batch_job/src/batch_job_work_queue.c
+++ b/batch_job/src/batch_job_work_queue.c
@@ -24,14 +24,10 @@ static void specify_files(struct work_queue_task *t, const char *input_files, co
 			p = strchr(f, '=');
 			if(p) {
 				*p = 0;
-				if(!work_queue_task_specify_file(t, f, p + 1, WORK_QUEUE_INPUT, caching_flag)){
-					fatal("Error while specifying file: %s->%s.", f, p+1);
-				}
+				work_queue_task_specify_file(t, f, p + 1, WORK_QUEUE_INPUT, caching_flag);
 				*p = '=';
 			} else {
-				if(!work_queue_task_specify_file(t, f, f, WORK_QUEUE_INPUT, caching_flag)){
-					fatal("Error while specifying file: %s.", f);
-				}
+				work_queue_task_specify_file(t, f, f, WORK_QUEUE_INPUT, caching_flag);
 			}
 			f = strtok(0, " \t,");
 		}
@@ -45,14 +41,10 @@ static void specify_files(struct work_queue_task *t, const char *input_files, co
 			p = strchr(f, '=');
 			if(p) {
 				*p = 0;
-				if(!work_queue_task_specify_file(t, f, p + 1, WORK_QUEUE_OUTPUT, caching_flag)){
-					fatal("Error while specifying file: %s->%s.", f, p+1);
-				}
+				work_queue_task_specify_file(t, f, p + 1, WORK_QUEUE_OUTPUT, caching_flag);
 				*p = '=';
 			} else {
-				if(!work_queue_task_specify_file(t, f, f, WORK_QUEUE_OUTPUT, caching_flag)){
-					fatal("Error while specifying file: %s.", f);
-				}
+				work_queue_task_specify_file(t, f, f, WORK_QUEUE_OUTPUT, caching_flag);
 			}
 			f = strtok(0, " \t,");
 		}

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -785,7 +785,7 @@ static int makeflow_check_batch_consistency(struct dag *d)
 
 		if(itable_size(n->remote_names) > 0 || (wrapper && wrapper->uses_remote_rename)){
 			if(n->local_job) {
-				debug(D_ERROR, "remote renaming is not supported locally. Rule %d.\n", n->nodeid);
+				debug(D_ERROR, "remote renaming is not supported with -Tlocal or LOCAL execution. Rule %d.\n", n->nodeid);
 				error = 1;
 				break;
 			} else if (!batch_queue_supports_feature(remote_queue, "remote_rename")) {

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -785,22 +785,22 @@ static int makeflow_check_batch_consistency(struct dag *d)
 
 		if(itable_size(n->remote_names) > 0 || (wrapper && wrapper->uses_remote_rename)){
 			if(n->local_job) {
-				debug(D_ERROR, "remote renaming is not supported with -Tlocal or LOCAL execution. Rule %d.\n", n->nodeid);
+				debug(D_ERROR, "Remote renaming is not supported with -Tlocal or LOCAL execution. Rule %d.\n", n->nodeid);
 				error = 1;
 				break;
 			} else if (!batch_queue_supports_feature(remote_queue, "remote_rename")) {
-				debug(D_ERROR, "remote renaming is not supported on selected batch system. Rule %d.\n", n->nodeid);
+				debug(D_ERROR, "Remote renaming is not supported on selected batch system. Rule %d.\n", n->nodeid);
 				error = 1;
 				break;
 			}
 		}
 
-		if(!batch_queue_supports_feature(remote_queue, "absolute_path")){
+		if(!batch_queue_supports_feature(remote_queue, "absolute_path") && !n->local_job){
 			list_first_item(n->source_files);
 			while((f = list_next_item(n->source_files)) && !error) {
 				const char *remotename = dag_node_get_remote_name(n, f->filename);
 				if((remotename && *remotename == '/') || (*f->filename == '/' && !remotename)) {
-					debug(D_ERROR, "remote renaming is not supported on selected batch system. Rule %d.\n", n->nodeid);
+					debug(D_ERROR, "Absolute paths are not supported on selected batch system. Rule %d.\n", n->nodeid);
 					error = 1;
 					break;
 				}
@@ -810,7 +810,7 @@ static int makeflow_check_batch_consistency(struct dag *d)
 			while((f = list_next_item(n->target_files)) && !error) {
 				const char *remotename = dag_node_get_remote_name(n, f->filename);
 				if((remotename && *remotename == '/') || (*f->filename == '/' && !remotename)) {
-					debug(D_ERROR, "remote renaming is not supported on selected batch system. Rule %d.\n", n->nodeid);
+					debug(D_ERROR, "Absolute paths are not supported on selected batch system. Rule %d.\n", n->nodeid);
 					error = 1;
 					break;
 				}

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -2379,7 +2379,6 @@ static int build_poll_table(struct work_queue *q, struct link *master)
 		if(!q->poll_table) {
 			//if we can't allocate a poll table, we can't do anything else.
 			fatal("allocating memory for poll table failed.");
-			return 0;
 		}
 	}
 
@@ -2407,7 +2406,6 @@ static int build_poll_table(struct work_queue *q, struct link *master)
 			if(q->poll_table == NULL) {
 				//if we can't allocate a poll table, we can't do anything else.
 				fatal("reallocating memory for poll table failed.");
-				return 0;
 			}
 		}
 
@@ -3866,7 +3864,6 @@ int work_queue_task_specify_url(struct work_queue_task *t, const char *file_url,
 	}
 	if(remote_name[0] == '/') {
 		fatal("Error: Remote name %s is an absolute path.\n", remote_name);
-		return 0;
 	}
 
 	if(type == WORK_QUEUE_INPUT) {
@@ -3935,7 +3932,6 @@ int work_queue_task_specify_file(struct work_queue_task *t, const char *local_na
 	// be known. Thus @param remote_name should not be an absolute path.
 	if(remote_name[0] == '/') {
 		fatal("Error: Remote name %s is an absolute path.\n", remote_name);
-		return 0;
 	}
 
 
@@ -4004,7 +4000,6 @@ int work_queue_task_specify_directory(struct work_queue_task *t, const char *loc
 	// be known. Thus @param remote_name should not be an absolute path.
 	if(remote_name[0] == '/') {
 		fatal("Error: Remote name %s is an absolute path.\n", remote_name);
-		return 0;
 	}
 
 	if(type == WORK_QUEUE_OUTPUT || recursive) {
@@ -4045,7 +4040,6 @@ int work_queue_task_specify_file_piece(struct work_queue_task *t, const char *lo
 	// work_queue_task_specify_file
 	if(remote_name[0] == '/') {
 		fatal("Error: Remote name %s is an absolute path.\n", remote_name);
-		return 0;
 	}
 
 	if(end_byte < start_byte) {
@@ -4117,7 +4111,6 @@ int work_queue_task_specify_buffer(struct work_queue_task *t, const char *data, 
 	// work_queue_task_specify_file
 	if(remote_name[0] == '/') {
 		fatal("Error: Remote name %s is an absolute path.\n", remote_name);
-		return 0;
 	}
 
 	list_first_item(t->input_files);
@@ -4166,7 +4159,6 @@ int work_queue_task_specify_file_command(struct work_queue_task *t, const char *
 	// work_queue_task_specify_file
 	if(remote_name[0] == '/') {
 		fatal("Error: Remote name %s is an absolute path.\n", remote_name);
-		return 0;
 	}
 
 	if(type == WORK_QUEUE_INPUT) {

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -3865,7 +3865,7 @@ int work_queue_task_specify_url(struct work_queue_task *t, const char *file_url,
 		return 0;
 	}
 	if(remote_name[0] == '/') {
-		fatal("Error: Remote name %s contains absolute path.\n", remote_name);
+		fatal("Error: Remote name %s is an absolute path.\n", remote_name);
 		return 0;
 	}
 
@@ -3934,7 +3934,7 @@ int work_queue_task_specify_file(struct work_queue_task *t, const char *local_na
 	// the worker(the worker on which the task will be executed) is unlikely to
 	// be known. Thus @param remote_name should not be an absolute path.
 	if(remote_name[0] == '/') {
-		fatal("Error: Remote name %s contains absolute path.\n", remote_name);
+		fatal("Error: Remote name %s is an absolute path.\n", remote_name);
 		return 0;
 	}
 
@@ -4003,7 +4003,7 @@ int work_queue_task_specify_directory(struct work_queue_task *t, const char *loc
 	// the worker(the worker on which the task will be executed) is unlikely to
 	// be known. Thus @param remote_name should not be an absolute path.
 	if(remote_name[0] == '/') {
-		fatal("Error: Remote name %s contains absolute path.\n", remote_name);
+		fatal("Error: Remote name %s is an absolute path.\n", remote_name);
 		return 0;
 	}
 
@@ -4044,7 +4044,7 @@ int work_queue_task_specify_file_piece(struct work_queue_task *t, const char *lo
 	// @param remote_name should not be an absolute path. @see
 	// work_queue_task_specify_file
 	if(remote_name[0] == '/') {
-		fatal("Error: Remote name %s contains absolute path.\n", remote_name);
+		fatal("Error: Remote name %s is an absolute path.\n", remote_name);
 		return 0;
 	}
 
@@ -4116,7 +4116,7 @@ int work_queue_task_specify_buffer(struct work_queue_task *t, const char *data, 
 	// @param remote_name should not be an absolute path. @see
 	// work_queue_task_specify_file
 	if(remote_name[0] == '/') {
-		fatal("Error: Remote name %s contains absolute path.\n", remote_name);
+		fatal("Error: Remote name %s is an absolute path.\n", remote_name);
 		return 0;
 	}
 
@@ -4165,7 +4165,7 @@ int work_queue_task_specify_file_command(struct work_queue_task *t, const char *
 	// @param remote_name should not be an absolute path. @see
 	// work_queue_task_specify_file
 	if(remote_name[0] == '/') {
-		fatal("Error: Remote name %s contains absolute path.\n", remote_name);
+		fatal("Error: Remote name %s is an absolute path.\n", remote_name);
 		return 0;
 	}
 

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -3865,7 +3865,7 @@ int work_queue_task_specify_url(struct work_queue_task *t, const char *file_url,
 		return 0;
 	}
 	if(remote_name[0] == '/') {
-		fprintf(stderr, "Error: Remote name %s contains absolute path.\n", remote_name);
+		fatal("Error: Remote name %s contains absolute path.\n", remote_name);
 		return 0;
 	}
 
@@ -3934,7 +3934,7 @@ int work_queue_task_specify_file(struct work_queue_task *t, const char *local_na
 	// the worker(the worker on which the task will be executed) is unlikely to
 	// be known. Thus @param remote_name should not be an absolute path.
 	if(remote_name[0] == '/') {
-		fprintf(stderr, "Error: Remote name %s contains absolute path.\n", remote_name);
+		fatal("Error: Remote name %s contains absolute path.\n", remote_name);
 		return 0;
 	}
 

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4003,7 +4003,7 @@ int work_queue_task_specify_directory(struct work_queue_task *t, const char *loc
 	// the worker(the worker on which the task will be executed) is unlikely to
 	// be known. Thus @param remote_name should not be an absolute path.
 	if(remote_name[0] == '/') {
-		fprintf(stderr, "Error: Remote name %s contains absolute path.\n", remote_name);
+		fatal("Error: Remote name %s contains absolute path.\n", remote_name);
 		return 0;
 	}
 
@@ -4044,7 +4044,7 @@ int work_queue_task_specify_file_piece(struct work_queue_task *t, const char *lo
 	// @param remote_name should not be an absolute path. @see
 	// work_queue_task_specify_file
 	if(remote_name[0] == '/') {
-		fprintf(stderr, "Error: Remote name %s contains absolute path.\n", remote_name);
+		fatal("Error: Remote name %s contains absolute path.\n", remote_name);
 		return 0;
 	}
 
@@ -4116,7 +4116,7 @@ int work_queue_task_specify_buffer(struct work_queue_task *t, const char *data, 
 	// @param remote_name should not be an absolute path. @see
 	// work_queue_task_specify_file
 	if(remote_name[0] == '/') {
-		fprintf(stderr, "Error: Remote name %s contains absolute path.\n", remote_name);
+		fatal("Error: Remote name %s contains absolute path.\n", remote_name);
 		return 0;
 	}
 
@@ -4165,7 +4165,7 @@ int work_queue_task_specify_file_command(struct work_queue_task *t, const char *
 	// @param remote_name should not be an absolute path. @see
 	// work_queue_task_specify_file
 	if(remote_name[0] == '/') {
-		fprintf(stderr, "Error: Remote name %s contains absolute path.\n", remote_name);
+		fatal("Error: Remote name %s contains absolute path.\n", remote_name);
 		return 0;
 	}
 


### PR DESCRIPTION
Checks that the batch job system supports absolute path filenames/remote-names. Exits with message and rule number of first encountered problem.

Also exits if specify file fails. I can make this a fatal error w/message, but did not as WQ already prints error message.

@btovar take a look.