### PR TITLE
Fix dag file sizes

### DIFF
--- a/makeflow/src/dag_file.c
+++ b/makeflow/src/dag_file.c
@@ -9,6 +9,7 @@ See the file COPYING for details.
 
 #include "xxmalloc.h"
 #include "list.h"
+#include "macros.h"
 
 #include <stdlib.h>
 
@@ -18,8 +19,11 @@ struct dag_file * dag_file_create( const char *filename )
 	f->filename = xxstrdup(filename);
 	f->needed_by = list_create();
 	f->created_by = 0;
-	f->ref_count = 0;
+	f->actual_size = 0;
+	f->estimated_size = 0;
+	f->reference_count = 0;
 	f->state = DAG_FILE_STATE_UNKNOWN;
+	f->type = DAG_FILE_TYPE_INTERMEDIATE;
 	return f;
 }
 
@@ -46,6 +50,7 @@ const char *dag_file_state_name(dag_file_state_t state)
 	}
 }
 
+/* Returns whether the file is created in the DAG or not */
 int dag_file_is_source( const struct dag_file *f )
 {
 	if(f->created_by)
@@ -54,6 +59,7 @@ int dag_file_is_source( const struct dag_file *f )
 		return 1;
 }
 
+/* Returns whether the file is used in any rule */
 int dag_file_is_sink( const struct dag_file *f )
 {
 	if(list_size(f->needed_by) > 0)
@@ -62,7 +68,7 @@ int dag_file_is_sink( const struct dag_file *f )
 		return 1;
 }
 
-/* Reports is a file is expeced to exist, does not guarantee existence
+/* Reports if a file is expeced to exist, does not guarantee existence
  * if files are altered outside of Makeflow */
 int dag_file_should_exist( const struct dag_file *f )
 {
@@ -74,6 +80,8 @@ int dag_file_should_exist( const struct dag_file *f )
 		return 0;
 }
 
+/* Reports if a file is in the process of being created, downloaded,
+ * or uploaded. As in file in transition */
 int dag_file_in_trans( const struct dag_file *f )
 {
 	if(f->state == DAG_FILE_STATE_EXPECT
@@ -82,6 +90,52 @@ int dag_file_in_trans( const struct dag_file *f )
 		return 1;
 	else
 		return 0;
+}
+
+/* If the file exists, return actual size, else return estimated
+ * size. In the default case that size is 1GB */
+uint64_t dag_file_size( const struct dag_file *f )
+{
+	if(dag_file_should_exist(f))
+		return f->actual_size;
+	return f->estimated_size;
+}
+
+/* Returns the sum of results for dag_file_size for each file
+ * in list. */
+uint64_t dag_file_list_size(struct list *s)
+{
+	struct dag_file *f;
+	uint64_t size = 0;
+	list_first_item(s);
+	while((f = list_next_item(s)))
+		size += dag_file_size(f);
+
+	return size;
+}
+
+/* Returns the sum of results for dag_file_size for each file
+ * in set. */
+uint64_t dag_file_set_size(struct set *s)
+{
+	struct dag_file *f;
+	uint64_t size = 0;
+	set_first_element(s);
+	while((f = set_next_element(s)))
+		size += dag_file_size(f);
+
+	return size;
+}
+
+int dag_file_coexist_files(struct set *s, struct dag_file *f)
+{
+	struct dag_node *n;
+	list_first_item(f->needed_by);
+	while((n = list_next_item(f->needed_by))){
+		if(set_lookup(s, n))
+			return 1;
+	}
+	return 0;
 }
 
 /* vim: set noexpandtab tabstop=4: */

--- a/makeflow/src/dag_file.c
+++ b/makeflow/src/dag_file.c
@@ -20,7 +20,7 @@ struct dag_file * dag_file_create( const char *filename )
 	f->needed_by = list_create();
 	f->created_by = 0;
 	f->actual_size = 0;
-	f->estimated_size = 0;
+	f->estimated_size = GIGABYTE;
 	f->reference_count = 0;
 	f->state = DAG_FILE_STATE_UNKNOWN;
 	f->type = DAG_FILE_TYPE_INTERMEDIATE;

--- a/makeflow/src/dag_file.h
+++ b/makeflow/src/dag_file.h
@@ -17,31 +17,100 @@ See the file COPYING for details.
  */
 
 typedef enum {
-	DAG_FILE_STATE_UNKNOWN,
-	DAG_FILE_STATE_EXPECT,
-	DAG_FILE_STATE_EXISTS,
-	DAG_FILE_STATE_COMPLETE,
-	DAG_FILE_STATE_DELETE,
-	DAG_FILE_STATE_DOWN,
-	DAG_FILE_STATE_UP
+	DAG_FILE_STATE_UNKNOWN,   /* Initial State indicates the file is in DAG */
+	DAG_FILE_STATE_EXPECT,    /* Rule that creates this file is in progress */
+	DAG_FILE_STATE_EXISTS,    /* File has been successfully completed and is used elsewhere */
+	DAG_FILE_STATE_COMPLETE,  /* File exists, but no unfinished rule needs the file */
+	DAG_FILE_STATE_DELETE,    /* File was deleted as it was no longer needed, only intermediate files */
+	DAG_FILE_STATE_DOWN,      /* UNUSED STATE, included for when files can be downloaded */
+	DAG_FILE_STATE_UP         /* UNUSED STATE, included for when files can be uploaded */
 } dag_file_state_t;
 
+typedef enum {
+	DAG_FILE_TYPE_INPUT,       /* File has no rule that creates it or is specified as input.
+                                  No input files are cleaned in garbage collection */
+	DAG_FILE_TYPE_OUTPUT,      /* If outputs are specified with MAKEFLOW_OUTPUTS then the specified
+                                  files are this category, otherwise all sink files are included.
+                                  No output files are cleaned in garbage collection */
+	DAG_FILE_TYPE_INTERMEDIATE /* Files that are created and used in DAG, but can be deleted */
+} dag_file_type_t;
 
 struct dag_file {
 	const char *filename;
-	struct list     *needed_by;              /* List of nodes that have this file as a source */
-	struct dag_node *created_by;             /* The node (if any) that created the file */
-	int    ref_count;                        /* How many nodes still to run need this file */
-	time_t creation_logged;                  /* Time that file creation is logged */
-	dag_file_state_t state;                  /* Enum: DAG_FILE_STATE_{INTIAL,EXPECT,...} */
+	struct list     *needed_by;     /* List of nodes that have this file as a source */
+	struct dag_node *created_by;    /* The node (if any) that created the file */
+	uint64_t actual_size;           /* File size reported by stat */
+	uint64_t estimated_size;        /* File size estimation provided prior to execution */
+	int    reference_count;         /* How many nodes still to run need this file */
+	time_t creation_logged;         /* Time that file creation is logged */
+	dag_file_state_t state;         /* Enum: DAG_FILE_STATE_{INTIAL,EXPECT,...} */
+	dag_file_type_t type;           /* Enum: DAG_FILE_TYPE_{INPUT,...} */
 };
 
+/** Create dag file struct.
+@param filename A const pointer to the unique filename.
+@return dag_file struct.
+*/
 struct dag_file *dag_file_create( const char *filename );
 
+/** Returns the string defining the files state, intended for logging.
+@param Enum DAG_FILE_STATE_* for the printable name of the state.
+@return Const char of the name.
+*/
 const char *dag_file_state_name(dag_file_state_t state);
+
+/** Boolean to expressing if the file is created by DAG.
+@param f dag_file.
+@return Zero if created by DAG, one if not.
+*/
 int dag_file_is_source( const struct dag_file *f );
+
+/** Boolean to expressing if the file is used by DAG.
+@param f dag_file.
+@return Zero if used by DAG, one if not.
+*/
 int dag_file_is_sink( const struct dag_file *f );
+
+/** Boolean if the file is expected to exist, based on dag_file_state.
+@param f dag_file.
+@return One if expected to exist, zero if not.
+*/
 int dag_file_should_exist( const struct dag_file *f );
+
+/** Boolean if the file is in transit, based on dag_file_state. UNUSED.
+@param f dag_file.
+@return One if in transit state, zero if not.
+*/
 int dag_file_in_trans( const struct dag_file *f );
+
+/** Report the size of file. If no actual size exists, estimated size will be used.
+@param f dag_file.
+@return Size of file.
+*/
+uint64_t dag_file_size( const struct dag_file *f );
+
+
+
+/** Report the sum of file sizes in list. Estimated size is used if actual 
+does not exist.
+@param s Pointer to list of dag_files.
+@return Sum of dag_file sizes.
+*/
+uint64_t dag_file_list_size(struct list *s);
+
+/** Report the sum of file sizes in set. Estimated size is used if actual 
+does not exist.
+@param s Pointer to set of dag_files.
+@return Sum of dag_file sizes.
+*/
+uint64_t dag_file_set_size(struct set *s);
+
+/** Given a f and set of nodes, determine if that file is used in that 
+set of nodes.
+@param s Pointer to set of dag_nodes.
+@param f dag_file.
+@return One if used, zero if not.
+*/
+int dag_file_coexist_files(struct set *s, struct dag_file *f);
 
 #endif

--- a/makeflow/src/dag_node.c
+++ b/makeflow/src/dag_node.c
@@ -200,7 +200,7 @@ void dag_node_add_source_file(struct dag_node *n, const char *filename, const ch
 	/* register this file as a requirement of the node */
 	list_push_head(source->needed_by, n);
 
-	source->ref_count++;
+	source->reference_count++;
 }
 
 /* Adds the local name as a target of the node, and register the

--- a/makeflow/src/dag_variable.c
+++ b/makeflow/src/dag_variable.c
@@ -109,6 +109,8 @@ void dag_variable_add_value(const char *name, struct hash_table *current_table, 
 	{
 		var->count++;
 		var->values = realloc(var->values, var->count * sizeof(struct dag_variable_value *));
+	} else {
+		dag_variable_value_free(var->values[var->count-1]);
 	}
 
 	//possible memory leak...

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -605,6 +605,7 @@ int makeflow_node_check_file_was_created(struct dag_node *n, struct dag_file *f)
 		else {
 			/* File was created and has length larger than zero. */
 			debug(D_MAKEFLOW_RUN, "File %s created by rule %d.\n", f->filename, n->nodeid);
+			f->actual_size = buf.st_size;
 			makeflow_log_file_state_change(n->d, f, DAG_FILE_STATE_EXISTS);
 			file_created = 1;
 			break;

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -311,7 +311,7 @@ void makeflow_node_force_rerun(struct itable *rerun_table, struct dag *d, struct
 		p = f1->created_by;
 		if(p) {
 			makeflow_node_force_rerun(rerun_table, d, p);
-			f1->ref_count += 1;
+			f1->reference_count += 1;
 		}
 	}
 
@@ -753,8 +753,8 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 		/* Mark source files that have been used by this node */
 		list_first_item(n->source_files);
 		while((f = list_next_item(n->source_files))) {
-			f->ref_count+= -1;
-			if(f->ref_count == 0 && f->state == DAG_FILE_STATE_EXISTS)
+			f->reference_count+= -1;
+			if(f->reference_count == 0 && f->state == DAG_FILE_STATE_EXISTS)
 				makeflow_log_file_state_change(d, f, DAG_FILE_STATE_COMPLETE);
 		}
 

--- a/makeflow/src/makeflow_gc.c
+++ b/makeflow/src/makeflow_gc.c
@@ -97,6 +97,7 @@ void makeflow_parse_input_outputs( struct dag *d )
 			d->completed_files += 1;
 			f = dag_file_lookup_or_create(d, argv[i]);
 			set_insert(d->inputs, f);
+			f->type = DAG_FILE_TYPE_INPUT;
 			debug(D_MAKEFLOW_RUN, "Added %s to input list", f->filename);
 		}
 		free(input_list);
@@ -118,7 +119,8 @@ void makeflow_parse_input_outputs( struct dag *d )
 		for(i = 0; i < argc; i++) {
 			/* Must initialize to non-zero for hash_table functions to work properly. */
 			f = dag_file_lookup_or_create(d, argv[i]);
-			set_remove(d->outputs, f);
+			set_insert(d->outputs, f);
+			f->type = DAG_FILE_TYPE_OUTPUT;
 			debug(D_MAKEFLOW_RUN, "Added %s to output list", f->filename);
 		}
 		free(output_list);
@@ -130,6 +132,7 @@ void makeflow_parse_input_outputs( struct dag *d )
 		while((hash_table_nextkey(d->files, &filename, (void **) &f)))
 			if(dag_file_is_sink(f)) {
 				set_insert(d->outputs, f);
+				f->type = DAG_FILE_TYPE_OUTPUT;
 				debug(D_MAKEFLOW_RUN, "Added %s to output list", f->filename);
 			}
 	}

--- a/makeflow/src/makeflow_log.c
+++ b/makeflow/src/makeflow_log.c
@@ -105,25 +105,25 @@ static void makeflow_log_sync( struct dag *d, int force )
 
 void makeflow_log_started_event( struct dag *d )
 {
-	fprintf(d->logfile, "# STARTED\t%" PRIu64 "\n", timestamp_get());
+	fprintf(d->logfile, "# STARTED %" PRIu64 "\n", timestamp_get());
 	makeflow_log_sync(d,1);
 }
 
 void makeflow_log_aborted_event( struct dag *d )
 {
-	fprintf(d->logfile, "# ABORTED\t%" PRIu64 "\n", timestamp_get());
+	fprintf(d->logfile, "# ABORTED %" PRIu64 "\n", timestamp_get());
 	makeflow_log_sync(d,1);
 }
 
 void makeflow_log_failed_event( struct dag *d )
 {
-	fprintf(d->logfile, "# FAILED\t%" PRIu64 "\n", timestamp_get());
+	fprintf(d->logfile, "# FAILED %" PRIu64 "\n", timestamp_get());
 	makeflow_log_sync(d,1);
 }
 
 void makeflow_log_completed_event( struct dag *d )
 {
-	fprintf(d->logfile, "# COMPLETED\t%" PRIu64 "\n", timestamp_get());
+	fprintf(d->logfile, "# COMPLETED %" PRIu64 "\n", timestamp_get());
 	makeflow_log_sync(d,1);
 }
 
@@ -149,7 +149,7 @@ void makeflow_log_file_state_change( struct dag *d, struct dag_file *f, int news
 	f->state = newstate;
 
 	timestamp_t time = timestamp_get();
-	fprintf(d->logfile, "# %d %s %" PRIu64 "\n", f->state, f->filename, time);
+	fprintf(d->logfile, "# FILE %" PRIu64 " %s %d %" PRIu64 "\n", time, f->filename, f->state, dag_file_size(f));
 	if(f->state == DAG_FILE_STATE_EXISTS){
 		d->completed_files += 1;
 		f->creation_logged = (time_t) (time / 1000000);
@@ -161,7 +161,7 @@ void makeflow_log_file_state_change( struct dag *d, struct dag_file *f, int news
 
 void makeflow_log_gc_event( struct dag *d, int collected, timestamp_t elapsed, int total_collected )
 {
-	fprintf(d->logfile, "# GC\t%" PRIu64 "\t%d\t%" PRIu64 "\t%d\n", timestamp_get(), collected, elapsed, total_collected);
+	fprintf(d->logfile, "# GC %" PRIu64 " %d %" PRIu64 " %d\n", timestamp_get(), collected, elapsed, total_collected);
 	makeflow_log_sync(d,0);
 }
 
@@ -177,6 +177,7 @@ void makeflow_log_recover(struct dag *d, const char *filename, int verbose_mode,
 	struct dag_file *f;
 	struct stat buf;
 	timestamp_t previous_completion_time;
+	uint64_t size;
 
 	d->logfile = fopen(filename, "r");
 	if(d->logfile) {
@@ -188,7 +189,7 @@ void makeflow_log_recover(struct dag *d, const char *filename, int verbose_mode,
 		while((line = get_line(d->logfile))) {
 			linenum++;
 
-			if(sscanf(line, "# %d %s %" SCNu64 "", &file_state, file, &previous_completion_time) == 3) {
+			if(sscanf(line, "# FILE %" SCNu64 " %s %d %" SCNu64 "", &previous_completion_time, file, &file_state, &size) == 4) {
 
 				f = dag_file_lookup_or_create(d, file);
 				f->state = file_state;
@@ -198,10 +199,13 @@ void makeflow_log_recover(struct dag *d, const char *filename, int verbose_mode,
 				} else if(file_state == DAG_FILE_STATE_DELETE){
 					d->deleted_files += 1;
 				}
+				free(line);
 				continue;
 			}
-			if(line[0] == '#')
+			if(line[0] == '#'){
+				free(line);
 				continue;
+			}
 			if(sscanf(line, "%" SCNu64 " %d %d %d", &previous_completion_time, &nodeid, &state, &jobid) == 4) {
 				n = itable_lookup(d->node_table, nodeid);
 				if(n) {
@@ -209,11 +213,13 @@ void makeflow_log_recover(struct dag *d, const char *filename, int verbose_mode,
 					n->jobid = jobid;
 					/* Log timestamp is in microseconds, we need seconds for diff. */
 					n->previous_completion = (time_t) (previous_completion_time / 1000000);
+					free(line);
 					continue;
 				}
 			}
 
 			fprintf(stderr, "makeflow: %s appears to be corrupted on line %d\n", filename, linenum);
+			free(line);
 			exit(1);
 		}
 		fclose(d->logfile);

--- a/makeflow/src/makeflow_log.c
+++ b/makeflow/src/makeflow_log.c
@@ -312,7 +312,7 @@ void makeflow_log_recover(struct dag *d, const char *filename, int verbose_mode,
 			struct dag_file *f;
 			list_first_item(n->source_files);
 			while((f = list_next_item(n->source_files)))
-				f->ref_count += -1;
+				f->reference_count += -1;
 		}
 	}
 }

--- a/makeflow/src/parser.c
+++ b/makeflow/src/parser.c
@@ -279,7 +279,6 @@ static int dag_parse_process_special_variable(struct lexer *bk, struct dag_node 
 			/* set value of current category */
 			bk->category = category;
 			dag_variable_add_value("CATEGORY", bk->category->mf_variables, nodeid, value);
-		}
 	}
 	/* else if some other special variable .... */
 	/* ... */

--- a/makeflow/src/parser.c
+++ b/makeflow/src/parser.c
@@ -279,6 +279,7 @@ static int dag_parse_process_special_variable(struct lexer *bk, struct dag_node 
 			/* set value of current category */
 			bk->category = category;
 			dag_variable_add_value("CATEGORY", bk->category->mf_variables, nodeid, value);
+		}
 	}
 	/* else if some other special variable .... */
 	/* ... */


### PR DESCRIPTION
Update variable names and add file size information to dag_file.

Mechanism for setting estimated size: 
FILE=something
FILESIZE=estimatedsize

also required a small fix to prevent segfault when setting the same variable several times in the same rule/node context.

Also, cleans up makeflow logging to be slightly more consistent.