### PR TITLE
Enhance DAGtoDOT options

### DIFF
--- a/makeflow/src/dag_visitors.c
+++ b/makeflow/src/dag_visitors.c
@@ -675,7 +675,7 @@ void dag_to_cyto(struct dag *d, int condense_display, int change_size)
 }
 
 
-void dag_to_dot(struct dag *d, int condense_display, int change_size, int with_labels, int with_details )
+void dag_to_dot(struct dag *d, int condense_display, int change_size, int with_labels, int task_id, int with_details, char *graph_attr, char *node_attr, char *edge_attr, char *task_attr, char *file_attr )
 {
 	struct dag_node *n;
 	struct dag_file *f;
@@ -710,11 +710,20 @@ void dag_to_dot(struct dag *d, int condense_display, int change_size, int with_l
 		}
 	}
 
+	if(graph_attr)
+		printf( "graph [%s]\n", graph_attr);
+	if(node_attr)
+		printf( "node [%s]\n", node_attr);
+	if(edge_attr)
+		printf( "edge [%s]\n", edge_attr);
 
 	h = hash_table_create(0, 0);
 
-	printf( "node [shape=ellipse,color = green,style = %s,fixedsize = false];\n", with_labels ? "unfilled" : "filled" );
-
+	if(task_attr)
+		printf( "\nnode [shape=ellipse,color = green,style = %s,%s];\n", with_labels ? "unfilled" : "filled", task_attr );
+	else
+		printf( "\nnode [shape=ellipse,color = green,style = %s,fixedsize = false];\n", with_labels ? "unfilled" : "filled" );
+  
 	for(n = d->nodes; n; n = n->next) {
 		name = xxstrdup(n->command);
 		label = strtok(name, " \t\n");
@@ -810,9 +819,17 @@ void dag_to_dot(struct dag *d, int condense_display, int change_size, int with_l
 			}
 
 			if((t->count == 1) || !condense_display) {
-				printf( "N%d [label=\"%s\"];\n", condense_display ? t->id : n->nodeid, with_labels ? label : "");
+				if(task_id && with_labels){
+					printf( "N%d [label=\"%d\"];\n", condense_display ? t->id : n->nodeid, n->nodeid);
+				} else {
+					printf( "N%d [label=\"%s\"];\n", condense_display ? t->id : n->nodeid, with_labels ? label : "");
+				}
 			} else {
-				printf( "N%d [label=\"%s x%d\"];\n", t->id, with_labels ? label : "", t->count);
+				if(task_id && with_labels){
+					printf( "N%d [label=\"%d x%d\"];\n", t->id, n->nodeid, t->count);
+				} else {
+					printf( "N%d [label=\"%s x%d\"];\n", t->id, with_labels ? label : "", t->count);
+				}
 			}
 
 			if(with_details) {
@@ -825,7 +842,10 @@ void dag_to_dot(struct dag *d, int condense_display, int change_size, int with_l
 		free(name);
 	}
 
-	printf( "node [shape=box,color=blue,style=%s,fixedsize=false];\n",with_labels ? "unfilled" : "filled" );
+	if(file_attr)
+		printf( "\nnode [shape=box,color=blue,style=%s,%s];\n", with_labels ? "unfilled" : "filled", task_attr );
+	else
+		printf( "\nnode [shape=box,color=blue,style=%s,fixedsize=false];\n", with_labels ? "unfilled" : "filled" );
 
 	hash_table_firstkey(g);
 	while(hash_table_nextkey(g, &label, (void **) &e)) {

--- a/makeflow/src/dag_visitors.c
+++ b/makeflow/src/dag_visitors.c
@@ -710,19 +710,23 @@ void dag_to_dot(struct dag *d, int condense_display, int change_size, int with_l
 		}
 	}
 
-	if(graph_attr)
+	if(graph_attr){
 		printf( "graph [%s]\n", graph_attr);
-	if(node_attr)
+	}
+	if(node_attr){
 		printf( "node [%s]\n", node_attr);
-	if(edge_attr)
+	}
+	if(edge_attr){
 		printf( "edge [%s]\n", edge_attr);
+	}
 
 	h = hash_table_create(0, 0);
 
-	if(task_attr)
+	if(task_attr){
 		printf( "\nnode [shape=ellipse,color = green,style = %s,%s];\n", with_labels ? "unfilled" : "filled", task_attr );
-	else
+	} else {
 		printf( "\nnode [shape=ellipse,color = green,style = %s,fixedsize = false];\n", with_labels ? "unfilled" : "filled" );
+	}
   
 	for(n = d->nodes; n; n = n->next) {
 		name = xxstrdup(n->command);
@@ -842,10 +846,11 @@ void dag_to_dot(struct dag *d, int condense_display, int change_size, int with_l
 		free(name);
 	}
 
-	if(file_attr)
+	if(file_attr){
 		printf( "\nnode [shape=box,color=blue,style=%s,%s];\n", with_labels ? "unfilled" : "filled", task_attr );
-	else
+	} else {
 		printf( "\nnode [shape=box,color=blue,style=%s,fixedsize=false];\n", with_labels ? "unfilled" : "filled" );
+	}
 
 	hash_table_firstkey(g);
 	while(hash_table_nextkey(g, &label, (void **) &e)) {

--- a/makeflow/src/dag_visitors.h
+++ b/makeflow/src/dag_visitors.h
@@ -24,7 +24,7 @@ int dag_to_dax(const struct dag *d, const char *name );
 /* The dag_to_dot function writes a struct dag in memory to a dot
  * file (graphviz), giving the graphical presentation of the makeflow.
  */
-void dag_to_dot(struct dag *d, int condense_display, int change_size, int with_labels, int with_detail );
+void dag_to_dot(struct dag *d, int condense_display, int change_size, int with_labels, int task_id, int with_detail, char *graph_attr, char *node_attr, char *edge_attr, char *task_attr, char *file_attr );
 
 /* The dag_to_ppm function writes a struct dag in memory to a ppm
  * file, giving a graphical presentation of the makeflow

--- a/makeflow/src/makeflow_viz.c
+++ b/makeflow/src/makeflow_viz.c
@@ -64,8 +64,14 @@ enum { LONG_OPT_PPM_ROW,
 	   LONG_OPT_DOT_CONDENSE,
 	   LONG_OPT_DOT_LABELS,
 	   LONG_OPT_DOT_NO_LABELS,
+	   LONG_OPT_DOT_TASK_ID,
 	   LONG_OPT_DOT_DETAILS,
-	   LONG_OPT_DOT_NO_DETAILS
+	   LONG_OPT_DOT_NO_DETAILS,
+	   LONG_OPT_DOT_GRAPH,
+	   LONG_OPT_DOT_NODE,
+	   LONG_OPT_DOT_EDGE,
+	   LONG_OPT_DOT_TASK,
+	   LONG_OPT_DOT_FILE
 };
 
 static void show_help_viz(const char *cmd)
@@ -84,6 +90,13 @@ static void show_help_viz(const char *cmd)
 	fprintf(stdout, " %-30s Change the size of the boxes proportional to file size.\n", "--dot-proportional");
 	fprintf(stdout, " %-30s Show only shapes with no text labels.\n","--dot-no-labels");
 	fprintf(stdout, " %-30s Include extra details in graph.\n","--dot-details");
+	fprintf(stdout, " %-30s Set task label to ID number instead of command.\n","--dot-task-id");
+	fprintf(stdout, " %-30s Set graph attributes.\n","--dot-graph-attr");
+	fprintf(stdout, " %-30s Set node attributes.\n","--dot-node-attr");
+	fprintf(stdout, " %-30s Set edge attributes.\n","--dot-edge-attr");
+	fprintf(stdout, " %-30s Set task attributes.\n","--dot-task-attr");
+	fprintf(stdout, " %-30s Set file attributes.\n","--dot-file-attr");
+
 	fprintf(stdout, "\nThe following options for ppm generation are mutually exclusive:\n\n");
 	fprintf(stdout, " %-30s Highlight row <row> in completion grap\n", "--ppm-highlight-row=<row>");
 	fprintf(stdout, " %-30s Highlight node that creates file <file> in completion graph\n", "--ppm-highlight-file=<file>");
@@ -106,6 +119,12 @@ int main(int argc, char *argv[])
 	int ppm_mode = 0;
 	int dot_labels = 1;
 	int dot_details = 0;
+	int dot_task_id = 0;
+	char *graph_attr = NULL;
+	char *node_attr = NULL;
+	char *edge_attr = NULL;
+	char *task_attr = NULL;
+	char *file_attr = NULL;
 	char *ppm_option = NULL;
 
 	static const struct option long_options_viz[] = {
@@ -115,8 +134,14 @@ int main(int argc, char *argv[])
 		{"dot-proportional",  no_argument, 0,  LONG_OPT_DOT_PROPORTIONAL},
 		{"dot-no-labels", no_argument, 0, LONG_OPT_DOT_NO_LABELS},
 		{"dot-labels", no_argument, 0, LONG_OPT_DOT_LABELS},
+		{"dot-task-id", no_argument, 0, LONG_OPT_DOT_TASK_ID},
 		{"dot-details", no_argument, 0, LONG_OPT_DOT_DETAILS},
 		{"dot-no-details", no_argument, 0, LONG_OPT_DOT_NO_DETAILS},
+		{"dot-graph-attr", required_argument, 0, LONG_OPT_DOT_GRAPH},
+		{"dot-node-attr", required_argument, 0, LONG_OPT_DOT_NODE},
+		{"dot-edge-attr", required_argument, 0, LONG_OPT_DOT_EDGE},
+		{"dot-task-attr", required_argument, 0, LONG_OPT_DOT_TASK},
+		{"dot-file-attr", required_argument, 0, LONG_OPT_DOT_FILE},
 		{"ppm-highlight-row", required_argument, 0, LONG_OPT_PPM_ROW},
 		{"ppm-highlight-exe", required_argument, 0, LONG_OPT_PPM_EXE},
 		{"ppm-highlight-file", required_argument, 0, LONG_OPT_PPM_FILE},
@@ -158,11 +183,29 @@ int main(int argc, char *argv[])
 			case LONG_OPT_DOT_NO_LABELS:
 				dot_labels = 0;
 				break;
+			case LONG_OPT_DOT_TASK_ID:
+				dot_task_id = 1;
+				break;
 			case LONG_OPT_DOT_DETAILS:
 				dot_details = 1;
 				break;
 			case LONG_OPT_DOT_NO_DETAILS:
 				dot_details = 0;
+				break;
+			case LONG_OPT_DOT_GRAPH:
+				graph_attr = xxstrdup(optarg);
+				break;
+			case LONG_OPT_DOT_NODE:
+				node_attr = xxstrdup(optarg);
+				break;
+			case LONG_OPT_DOT_EDGE:
+				edge_attr = xxstrdup(optarg);
+				break;
+			case LONG_OPT_DOT_TASK:
+				task_attr = xxstrdup(optarg);
+				break;
+			case LONG_OPT_DOT_FILE:
+				file_attr = xxstrdup(optarg);
 				break;
 			case LONG_OPT_PPM_EXE:
 				display_mode = SHOW_DAG_PPM;
@@ -216,7 +259,8 @@ int main(int argc, char *argv[])
 		switch(display_mode)
 		{
 			case SHOW_DAG_DOT:
-				dag_to_dot(d, condense_display, change_size, dot_labels, dot_details );
+				dag_to_dot(d, condense_display, change_size, dot_labels, dot_task_id, dot_details,
+							graph_attr, node_attr, edge_attr, task_attr, file_attr );
 				break;
 			case SHOW_DAG_PPM:
 				dag_to_ppm(d, ppm_mode, ppm_option);

--- a/makeflow/test/TR_makeflow_viz.sh
+++ b/makeflow/test/TR_makeflow_viz.sh
@@ -11,8 +11,10 @@ EOF
 
 cat >test.dot.expected <<EOF
 digraph {
+
 node [shape=ellipse,color = green,style = unfilled,fixedsize = false];
 N0 [label="echo"];
+
 node [shape=box,color=blue,style=unfilled,fixedsize=false];
 F1 [label = "a"];
 F0 [label = "b"];


### PR DESCRIPTION
Adds more options for better control of DOT options when creating Makeflow graph. This was used for SC 16 paper.