### PR TITLE
Honor COLUMNS env var when printing work_queue_status

### DIFF
--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -274,8 +274,8 @@ void remove_all_workers( struct batch_queue *queue, struct itable *job_table )
 }
 
 static struct jx_table queue_headers[] = {
-{"project",       "PROJECT", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 18},
-{"name",          "HOST",    JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 21},
+{"project",       "PROJECT", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, -18},
+{"name",          "HOST",    JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, -21},
 {"port",          "PORT",    JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 5},
 {"tasks_waiting", "WAITING", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 7},
 {"tasks_running", "RUNNING", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 7},
@@ -312,7 +312,14 @@ void print_stats(struct list *masters, struct list *foremen, int submitted, int 
 		return;
 	}
 
-	jx_table_print_header(queue_headers,stdout);
+	int columns = 80;
+	char *column_str = getenv("COLUMNS");
+	if(column_str) {
+		columns = atoi(column_str);
+		columns = columns < 1 ? 80 : columns;
+	}
+
+	jx_table_print_header(queue_headers,stdout,columns);
 
 	struct jx *j;
 	if(masters && list_size(masters) > 0)
@@ -322,7 +329,7 @@ void print_stats(struct list *masters, struct list *foremen, int submitted, int 
 		list_first_item(masters);
 		while((j = list_next_item(masters)))
 		{
-			jx_table_print(queue_headers, j, stdout);
+			jx_table_print(queue_headers, j, stdout, columns);
 		}
 	}
 
@@ -333,7 +340,7 @@ void print_stats(struct list *masters, struct list *foremen, int submitted, int 
 		list_first_item(foremen);
 		while((j = list_next_item(foremen)))
 		{
-			jx_table_print(queue_headers, j, stdout);
+			jx_table_print(queue_headers, j, stdout, columns);
 
 		}
 	}

--- a/chirp/src/chirp_status.c
+++ b/chirp/src/chirp_status.c
@@ -30,7 +30,7 @@ enum {
 
 static struct jx_table headers[] = {
 	{"type", "TYPE", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 8},
-	{"name", "NAME", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 25},
+	{"name", "NAME", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, -25},
 	{"port", "PORT", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 5},
 	{"owner", "OWNER", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 10},
 	{"version", "VERSION", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 8},
@@ -202,6 +202,13 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+	int columns = 80;
+	char *column_str = getenv("COLUMNS");
+	if(column_str) {
+		columns = atoi(column_str);
+		columns = columns < 1 ? 80 : columns;
+	}
+
 	stoptime = time(0) + timeout;
 
 	const char *query_expr;
@@ -225,7 +232,7 @@ int main(int argc, char *argv[])
 	}
 
 	if(mode == MODE_TABLE) {
-		jx_table_print_header(headers,stdout);
+		jx_table_print_header(headers,stdout,columns);
 	} else if(mode==MODE_LONG) {
 		printf("[\n");
 	}
@@ -266,7 +273,7 @@ int main(int argc, char *argv[])
 			if(i!=0) printf(",\n");
 			jx_print_stream(table[i],stdout);
 		} else if(mode == MODE_TABLE) {
-			jx_table_print(headers, table[i], stdout);
+			jx_table_print(headers, table[i], stdout, columns);
 		} else if(mode == MODE_TOTAL) {
 			sum_avail += jx_lookup_integer(table[i], "avail");
 			sum_total += jx_lookup_integer(table[i], "total");
@@ -283,7 +290,7 @@ int main(int argc, char *argv[])
 		printf("AVAIL: %6sB\n", string_metric(sum_avail, -1, 0));
 		printf("INUSE: %6sB\n", string_metric(sum_total - sum_avail, -1, 0));
 	} else if(mode == MODE_TABLE) {
-		jx_table_print_footer(headers,stdout);
+		jx_table_print_footer(headers,stdout,columns);
 	} else if(mode==MODE_LONG) {
 		printf("\n]\n");
 	}

--- a/dttools/src/jx_table.c
+++ b/dttools/src/jx_table.c
@@ -8,47 +8,101 @@ See the file COPYING for details.
 #include "jx_print.h"
 
 #include "stringtools.h"
+#include "macros.h"
 
 #include <stdlib.h>
 #include <string.h>
 
-static void fill_string(const char *str, char *buf, int buflen, jx_table_align_t align)
+static char *fill_string(const char *str, int width, jx_table_align_t align, int columns_left, int columns_extra)
 {
+	/* no more columns available */
+	if(columns_left < 1 || width == 0) {
+		return NULL;
+	}
+
+	/* this field autoexpands */
+	if(width < 0) {
+		width = abs(width) + columns_extra;
+	}
+
 	int stlen = strlen(str);
-	memset(buf, ' ', buflen);
-	buf[buflen] = 0;
+
+	char *buf_init = malloc(width + 1);
+	memset(buf_init, ' ', width);
+	buf_init[width] = 0;
+
+	char *buf = buf_init;
 	if(align == JX_TABLE_ALIGN_LEFT) {
-		while(stlen > 0 && buflen > 0) {
+		while(stlen > 0 && width > 0) {
 			*buf++ = *str++;
 			stlen--;
-			buflen--;
+			width--;
 		}
 	} else {
 		str = str + stlen - 1;
-		buf = buf + buflen - 1;
-		while(stlen > 0 && buflen > 0) {
+		buf = buf + width - 1;
+		while(stlen > 0 && width > 0) {
 			*buf-- = *str--;
 			stlen--;
-			buflen--;
+			width--;
 		}
+	}
+
+	return buf_init;
+}
+
+void count_columns(struct jx_table *t, int columns_max, int *columns_total, int *columns_extra) {
+	int proportional_fields = 0;
+
+	*columns_total      = 0;
+	*columns_extra      = 0;
+
+	while(t->name) {
+		if(t->width < 0) {
+			proportional_fields++;
+		}
+
+		/* + 1 for the space separating the columns */
+		*columns_total += abs(t->width) + 1;
+		t++;
+	}
+
+	if(proportional_fields > 0) {
+		*columns_extra = MAX(0, columns_max - *columns_total)/proportional_fields;
+	}
+
+	if(columns_max > 0) {
+		*columns_total = MIN(*columns_total, columns_max);
 	}
 }
 
-void jx_table_print_header( struct jx_table *t, FILE *f )
+void jx_table_print_header( struct jx_table *t, FILE *f, int columns_max )
 {
+	int columns_total, columns_extra;
+	count_columns(t, columns_max, &columns_total, &columns_extra);
+
 	while(t->name) {
-		char *n = malloc(t->width + 1);
-		fill_string(t->title, n, t->width, t->align);
-		string_toupper(n);
-		fprintf(f,"%s ", n);
-		free(n);
+		char *n = fill_string(t->title, t->width, t->align, columns_total, columns_extra);
+
+		if(n) {
+			string_toupper(n);
+			fprintf(f,"%s ", n);
+			free(n);
+		}
+
 		t++;
+
+		/* + 1 because of the space separating the columns. */
+		columns_total -= (abs(t->width) + 1);
 	}
 	fprintf(f,"\n");
 }
 
-void jx_table_print( struct jx_table *t, struct jx *j, FILE * f )
+void jx_table_print( struct jx_table *t, struct jx *j, FILE * f, int columns_max )
 {
+	int columns_total, columns_extra;
+	count_columns(t, columns_max, &columns_total, &columns_extra);
+
 	while(t->name) {
 		char *line;
 		if(t->mode == JX_TABLE_MODE_METRIC) {
@@ -69,16 +123,22 @@ void jx_table_print( struct jx_table *t, struct jx *j, FILE * f )
 				line = jx_print_string(v);
 			}
 		}
-		char *aligned = malloc(t->width + 1);
-		fill_string(line, aligned, t->width, t->align);
-		fprintf(f,"%s ", aligned);
+		char *aligned = fill_string(line, t->width, t->align, columns_total, columns_extra);
+
+		if(aligned) {
+			fprintf(f,"%s ", aligned);
+			free(aligned);
+		}
+
 		free(line);
-		free(aligned);
 		t++;
+
+		/* + 1 because of the space separating the columns. */
+		columns_total -= (abs(t->width) + 1);
 	}
 	fprintf(f,"\n");
 }
 
-void jx_table_print_footer( struct jx_table *t, FILE * f )
+void jx_table_print_footer( struct jx_table *t, FILE * f, int columns )
 {
 }

--- a/dttools/src/jx_table.h
+++ b/dttools/src/jx_table.h
@@ -23,8 +23,8 @@ struct jx_table {
 	int width;
 };
 
-void jx_table_print_header( struct jx_table *t, FILE *f );
-void jx_table_print( struct jx_table *t, struct jx *j, FILE *f );
-void jx_table_print_footer( struct jx_table *t, FILE *f );
+void jx_table_print_header( struct jx_table *t, FILE *f, int columns );
+void jx_table_print( struct jx_table *t, struct jx *j, FILE *f, int columns );
+void jx_table_print_footer( struct jx_table *t, FILE *f, int columns );
 
 #endif


### PR DESCRIPTION
When declaring tables, negative widths indicate minimum sizes that may
expand if columns available.

Fixes #1384 