### PR TITLE
expand parrot packaging tool

### DIFF
--- a/doc/man/chroot_package_run.m4
+++ b/doc/man/chroot_package_run.m4
@@ -13,6 +13,7 @@ If CODE(chroot) is used to help repeat one experiment, common directories like B
 SECTION(OPTIONS)
 OPTIONS_BEGIN
 OPTION_ITEM(`-p, --package-path')The path of the package.
+OPTION_ITEM(`-e, --env-list')The path of the environment file. (Default: package-path/env_list)
 OPTION_ITEM(`-h, --help')Show this help message.
 OPTIONS_END
 

--- a/doc/man/parrot_package_create.m4
+++ b/doc/man/parrot_package_create.m4
@@ -8,11 +8,13 @@ SECTION(SYNOPSIS)
 CODE(BOLD(parrot_package_create [options]))
 
 SECTION(DESCRIPTION)
-After recording the accessed files and environment variables of one program with the help of the CODE(--name-list) parameter and the CODE(--env-list) of CODE(parrot_run), CODE(parrot_package_create) can generate a package containing all the accessed files.
+After recording the accessed files and environment variables of one program with the help of the CODE(--name-list) parameter and the CODE(--env-list) of CODE(parrot_run), CODE(parrot_package_create) can generate a package containing all the accessed files. You can also add the dependencies recorded in a new namelist file into an existing package.
 
 SECTION(OPTIONS)
 OPTIONS_BEGIN
+OPTION_TRIPLET(-a, add, path)The path of an existing package.
 OPTION_TRIPLET(-e, env-list, path)The path of the environment variables.
+OPTION_ITEM(`    --new-env')The relative path of the environment variable file under the package.
 OPTION_TRIPLET(-n, name-list, path)The path of the namelist list.
 OPTION_TRIPLET(-p, package-path, path)The path of the package.
 OPTION_TRIPLET(-d, debug, flag)Enable debugging for this sub-system.
@@ -59,6 +61,12 @@ After the execution of this command, one shell will be returned, where you can r
 LONGCODE_BEGIN
 % exit
 LONGCODE_END
+
+You can also add the dependencies recorded in a new namelist file, BOLD(namelist1), into an existing package:
+LONGCODE_BEGIN
+% parrot_package_create --name-list namelist1 --env-list envlist1 --new-env envlist1  --add /tmp/package
+LONGCODE_END
+After executing this command, all the new dependencies mentioned in BOLD(namelist1) will be added into BOLD(/tmp/package), the new envlist, BOLD(envlist1), will also be added into BOLD(/tmp/package) with the name specified by the BOLD(--new-env) option.
 
 SECTION(COPYRIGHT)
 

--- a/doc/man/parrot_package_run.m4
+++ b/doc/man/parrot_package_run.m4
@@ -13,6 +13,7 @@ If CODE(parrot_run) is used to repeat one experiment, one mountlist must be crea
 SECTION(OPTIONS)
 OPTIONS_BEGIN
 OPTION_ITEM(`-p, --package-path')The path of the package.
+OPTION_ITEM(`-e, --env-list')The path of the environment file. (Default: package-path/env_list)
 OPTION_ITEM(`-h, --help')Show this help message.
 OPTIONS_END
 

--- a/doc/parrot.html
+++ b/doc/parrot.html
@@ -326,7 +326,13 @@ using the <tt>stat</tt> system call.</p>
 <h2 id="parrot_package_create">Generate a Package based on the Accessed Files<a class="sectionlink" href="#parrot_package_create" title="Link to this section.">&#x21d7;</a></h2>
 <p>After recording the accessed files of one program with the help of the <b>--name-list</b> parameter of <tt>parrot_run</tt> and the environment variables with the help of the <b>--env-list</b> parameter of <tt>parrot_run</tt>, <tt>parrot_package_create</tt> can generate a package containing all the accessed files and the environment variables. <tt>parrot_package_create</tt> shares the same <b>--name-list</b> and <b>--env-list</b> parameters with <tt>parrot_run</tt>. <b>--package-path</b> parameter is used to specify the location of package.</p>
 <code>% parrot_package_create --name-list namelist --env-list envlist --package-path /tmp/package</code>
-<p>After executing this command, one package with the path of <b>/tmp/package</b> will be generated.</p>
+<p>After executing this command, one package with the path of <b>/tmp/package</b> will be generated.
+The envlist file, <b>envlist</b> will be put under <b>/tmp/package</b> with the name of <b>env_list</b>.</p>
+
+<p>You can also add the dependencies recorded in a new namelist file into an existing package:
+<code>% parrot_package_create --name-list namelist1 --env-list envlist1 --new-env envlist1  --add /tmp/package</code>
+<p> After executing this command, all the new dependencies mentioned in <b>namelist1</b> will be added into <b>/tmp/package</b>,
+the new envlist, <b>envlist1</b>, will also be added into <b>/tmp/package</b> with the name specified by the <b>--new-env</b> option.</p>
 
 <h2 id="parrot_package_run">Repeat one Program within the Package<a class="sectionlink" href="#parrot_package_run" title="Link to this section.">&#x21d7;</a></h2>
 <p>Once a package is generated with the help of <tt>parrot_package_create</tt>, we can use <tt>parrot_package_run</tt> to repeat the program within the package. <tt>parrot_package_run</tt> is based on the mountlist redirection mechanism of <tt>parrot_run</tt>. One mountlist wll be created so that the file access request of your program can be redirected into the package. <b>--package-path</b> parameter specifies the paht of the package. If no command is given, a /bin/sh shell will be returned.</p>
@@ -335,6 +341,9 @@ using the <tt>stat</tt> system call.</p>
 <code>% exit</code>
 <p>You can also directly set your command as the arguments of <tt>parrot_package_run</tt>. In this case, <tt>parrot_package_run</tt> will exit automatically after the command is finished, and you do not need to use <tt>exit</tt> to exit. However, your command must belong to the original command set executed inside <tt>parrot_run</tt> and preserved by <tt>parrot_package_create</tt>.</p>
 <code>% parrot_package_run --package-path /tmp/package ls -al</code>
+
+<p>You can also specify a different environment file to run programs inside a package with the <b>--env-list</b> option.
+<code>% parrot_package_run -env-list /tmp/package/envlist1 --package-path /tmp/package ls -al</code>
 
 <h2 id="reflink">Reflink Copy<a class="sectionlink" href="#reflink" title="Link to this section.">&#x21d7;</a></h2>
 <p>


### PR DESCRIPTION
Add `--add` and `--new-env` option to `parrot_package_create` to allow the user to add new dependencies into an existing package.