### PR TITLE
Fix for rmonitor opening too many files

### DIFF
--- a/dttools/src/rmonitor_poll.c
+++ b/dttools/src/rmonitor_poll.c
@@ -723,6 +723,7 @@ char *rmonitor_get_command_line(pid_t pid)
 		if(cmdline[i] == '\0')
 			cmdline[i] = ' ';
 	}
+        fclose(fline);
 
 	return xxstrdup(cmdline);
 }


### PR DESCRIPTION
Fixed the issue in rmonitor_get_command_line which didn't have an "fclose" before terminating.