### PR TITLE
Close chirp binding

### DIFF
--- a/chirp/src/chirp_reli.h
+++ b/chirp/src/chirp_reli.h
@@ -788,6 +788,11 @@ After forking, each process will maintain its own connection to each Chirp serve
 
 void chirp_reli_cleanup_before_fork();
 
+/** Closes the link to the host, if active.
+@param host A hostname may be a domain name or an IP address, followed by an optional colon and port number.
+*/
+void chirp_reli_disconnect( const char *host );
+
 #endif
 
 /* vim: set noexpandtab tabstop=4: */

--- a/chirp/src/perl/Chirp/Client.pm
+++ b/chirp/src/perl/Chirp/Client.pm
@@ -74,6 +74,11 @@ sub Chirp::Client::new {
 	return $c;
 }
 
+sub DESTROY {
+    my ($self) = @_;
+    chirp_reli_disconnect($self->hostport);
+}
+
 sub __set_tickets {
 	my ($self, $tickets) = @_;
 

--- a/chirp/src/python/chirp.binding.py
+++ b/chirp/src/python/chirp.binding.py
@@ -56,6 +56,12 @@ class Client:
         if self.identity is '':
             raise AuthenticationFailure(authentication)
 
+    def __exit__(self):
+        chirp_reli_disconnect(self.hostport)
+
+    def __del__(self):
+        chirp_reli_disconnect(self.hostport)
+
     def __stoptime(self, absolute_stop_time=None, timeout=None):
         if timeout is None:
             timeout = self.timeout


### PR DESCRIPTION
As reported by @matz-e. 

Chirp clients keep the connection open once the python object was destroyed.