### PR TITLE
set the minimum desired taskid

### DIFF
--- a/work_queue/src/perl/Work_Queue.pm
+++ b/work_queue/src/perl/Work_Queue.pm
@@ -156,6 +156,11 @@ sub specify_name {
 	return work_queue_specify_name($self->{_work_queue}, $name);
 }
 
+sub specify_min_taskid {
+	my ($self, $minid) = @_;
+	return work_queue_specify_min_taskid($self->{_work_queue}, $minid);
+}
+
 sub specify_priority {
 	my ($self, $priority) = @_;
 	return work_queue_specify_priority($self->{_work_queue}, $priority);
@@ -596,6 +601,31 @@ Change the project name for the given queue.
 =item name
 
 The new project name.
+
+=back
+
+=head3 C<specify_min_taskid>
+
+
+Set the minimum taskid of future submitted tasks.
+
+Further submitted tasks are guaranteed to have a taskid larger or equal to
+minid.  This function is useful to make taskids consistent in a workflow that
+consists of sequential masters. (Note: This function is rarely used).  If the
+minimum id provided is smaller than the last taskid computed, the minimum id
+provided is ignored.
+
+Returns the actual minimum taskid for future tasks.
+
+=over 12
+
+=item q
+
+A work queue object.
+
+=item minid
+
+Minimum desired taskid
 
 =back
 

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -939,6 +939,21 @@ class WorkQueue(_object):
         return work_queue_specify_name(self._work_queue, name)
 
     ##
+    # Set the minimum taskid of future submitted tasks.
+    #
+    # Further submitted tasks are guaranteed to have a taskid larger or equal
+    # to minid.  This function is useful to make taskids consistent in a
+    # workflow that consists of sequential masters. (Note: This function is
+    # rarely used).  If the minimum id provided is smaller than the last taskid
+    # computed, the minimum id provided is ignored.
+    #
+    # @param self   Reference to the current work queue object.
+    # @param minid  Minimum desired taskid
+    # @return Returns the actual minimum taskid for future tasks.
+    def specify_min_taskid(self, minid):
+        return work_queue_specify_min_taskid(self._work_queue, minid)
+
+    ##
     # Change the project priority for the given queue.
     #
     # @param self       Reference to the current work queue object.

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -556,6 +556,19 @@ Once returned, it is safe to re-submit the same take object via @ref work_queue_
 */
 int work_queue_submit(struct work_queue *q, struct work_queue_task *t);
 
+
+/** Set the minimum taskid of future submitted tasks.
+Further submitted tasks are guaranteed to have a taskid larger or equal to
+minid.  This function is useful to make taskids consistent in a workflow that
+consists of sequential masters. (Note: This function is rarely used).  If the
+minimum id provided is smaller than the last taskid computed, the minimum id
+provided is ignored.
+@param q A work queue object.
+@param minid Minimum desired taskid
+@return Returns the actual minimum taskid for future tasks.
+*/
+int work_queue_specify_min_taskid(struct work_queue *q, int minid);
+
 /** Blacklist hostname from a queue.
 @param q A work queue object.
 @param hostname A string for hostname.


### PR DESCRIPTION
Some projects, such as lobster, sometimes use several sequential masters to finish a single workflow. The current pr adds the API specify_min_taskid so that taskids can be made consistent across the different masters. wq guarantees that the taskid of future submitted tasks is at least the minimum desired (it could be larger).  Most users will never need this function.

@dthain, @matz-e, @annawoodard