### PR TITLE
Fix doc for makeflow linking deps

### DIFF
--- a/doc/makeflow.html
+++ b/doc/makeflow.html
@@ -570,7 +570,7 @@ path are renamed when copied into the bundle:</p>
 
 <p>Example usage:</p>
 
-<code>makeflow -b some_output_directory example.makeflow</code>
+<code>makeflow_analyze -b some_output_directory example.makeflow</code>
 
 <h2 id="garbage">Garbage Collection<a class="sectionlink" href="#garbage" title="Link to this section.">&#x21d7;</a></h2>
 


### PR DESCRIPTION
The dependency tracking of makeflow has been removed from `makeflow` into `makeflow_analyze`.
This PR updates the Makeflow user manual to reflect this change.