### PR TITLE
Automatically determine terminal width.

### DIFF
--- a/work_queue/src/work_queue_status.c
+++ b/work_queue/src/work_queue_status.c
@@ -22,6 +22,7 @@ See the file COPYING for details.
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
+#include <sys/ioctl.h>
 
 typedef enum {
 	FORMAT_TABLE,
@@ -469,11 +470,14 @@ int main(int argc, char *argv[])
 
 	cctools_version_debug(D_DEBUG, argv[0]);
 
+	struct winsize window;
 	char *columns_str = getenv("COLUMNS");
 	if(columns_str) {
 		columns = atoi(columns_str);
 		/* use default of 80 columns when the value of columns_str is suspect. */
 		columns = columns < 1 ? 80 : columns;
+	} else if(ioctl(STDOUT_FILENO, TIOCGWINSZ, &window) >= 0) {
+		columns = window.ws_col > 0 ? window.ws_col : columns;
 	}
 
 


### PR DESCRIPTION
Helps enormously when master names are long and would be severly truncated
by default.  Setting the COLUMNS environment variable helps, too, but has
to be reset if the terminal changes in size.