### PR TITLE
use avail_thresholds in largest resources reported

### DIFF
--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -332,13 +332,17 @@ static void send_resource_update(struct link *master)
 	time_t stoptime = time(0) + active_timeout;
 
 	if(worker_mode == WORKER_MODE_FOREMAN) {
-		total_resources->disk.total = local_resources->disk.total;
+		total_resources->disk.total = local_resources->disk.total - disk_avail_threshold;
 		total_resources->disk.inuse = local_resources->disk.inuse;
 	} else {
-		total_resources->memory.total = MAX(0, local_resources->memory.total - memory_avail_threshold);
-	}
+		total_resources->memory.total    = MAX(0, local_resources->memory.total    - memory_avail_threshold);
+		total_resources->memory.largest  = MAX(0, local_resources->memory.largest  - memory_avail_threshold);
+		total_resources->memory.smallest = MAX(0, local_resources->memory.smallest - memory_avail_threshold);
 
-	total_resources->disk.total   = MAX(0, local_resources->disk.total - disk_avail_threshold);
+		total_resources->disk.total    = MAX(0, local_resources->disk.total    - disk_avail_threshold);
+		total_resources->disk.largest  = MAX(0, local_resources->disk.largest  - disk_avail_threshold);
+		total_resources->disk.smallest = MAX(0, local_resources->disk.smallest - disk_avail_threshold);
+	}
 
 	work_queue_resources_send(master,total_resources,stoptime);
 	send_master_message(master, "info end_of_resource_update %d\n", 0);


### PR DESCRIPTION
With the recent change of using largest instead of total, some tasks were not being dispatched. This is because 'largest' was not being discounted the avail_threshold values.