### PR TITLE
Parrot Timewarp Mode

### DIFF
--- a/doc/man/parrot_run.m4
+++ b/doc/man/parrot_run.m4
@@ -52,6 +52,9 @@ OPTION_ITEM(`-S, --session-caching')Enable whole session caching for all protoco
 OPTION_ITEM(`    --syscall-disable-debug')Disable tracee access to the Parrot debug syscall.
 OPTION_TRIPLET(-t, tempdir, dir)Where to store temporary files.
 OPTION_TRIPLET(-T, timeout, time)Maximum amount of time to retry failures.
+time)Maximum amount of time to retry failures.
+OPTION_ITEM(--time-stop) Stop virtual time at midnight, Jan 1st, UTC.
+OPTION_ITEM(--time-warp) Warp virtual time starting from midnight, Jan 1st, UTC.
 OPTION_TRIPLET(-U, uid, num)Fake this unix uid; Real uid stays the same.
 OPTION_TRIPLET(-u, username, name)Use this extended username.
 OPTION_ITEM(`    --fake-setuid')Track changes from setuid and setgid.

--- a/doc/man/parrot_run.m4
+++ b/doc/man/parrot_run.m4
@@ -16,40 +16,40 @@ For complete details with examples, see the LINK(Parrot User's Manual,http://ccl
 
 SECTION(OPTIONS)
 OPTIONS_BEGIN
-OPTION_ITEM('--check-driver <driver>') Check for the presence of a given driver (e.g. http, ftp, etc) and return success if it is currently enabled.
+OPTION_PAIR(--check-driver,driver) Check for the presence of a given driver (e.g. http, ftp, etc) and return success if it is currently enabled.
 OPTION_TRIPLET(-a,chirp-auth,unix|hostname|ticket|globus|kerberos)Use this Chirp authentication method.  May be invoked multiple times to indicate a preferred list, in order.
 OPTION_TRIPLET(-b, block-size, bytes)Set the I/O block size hint.
 OPTION_TRIPLET(-c, status-file, file)Print exit status information to file.
-OPTION_ITEM(`-C, channel-auth')Enable data channel authentication in GridFTP.
+OPTION_ITEM(-C, channel-auth)Enable data channel authentication in GridFTP.
 OPTION_TRIPLET(-d, debug, flag)Enable debugging for this sub-system.
-OPTION_ITEM(`-D, --no-optimize')Disable small file optimizations.
-OPTION_ITEM('    --dynamic-mounts') Enable the use of parot_mount in this session.
-OPTION_ITEM(`-F, --with-snapshots')Enable file snapshot caching for all protocols.
-OPTION_ITEM(`-f, --no-follow-symlinks')Disable following symlinks.
+OPTION_ITEM(-D, --no-optimize)Disable small file optimizations.
+OPTION_ITEM(--dynamic-mounts) Enable the use of parot_mount in this session.
+OPTION_ITEM(-F, --with-snapshots)Enable file snapshot caching for all protocols.
+OPTION_ITEM(-f, --no-follow-symlinks)Disable following symlinks.
 OPTION_TRIPLET(-G,gid,num)Fake this gid; Real gid stays the same.
-OPTION_ITEM(`-h, --help')Show this screen.
-OPTION_ITEM(`    --helper')Enable use of helper library.
+OPTION_ITEM(-h, --help)Show this screen.
+OPTION_ITEM(--helper)Enable use of helper library.
 OPTION_TRIPLET(-i, tickets, files)Comma-delimited list of tickets to use for authentication.
 OPTION_TRIPLET(-I, debug-level-irods, num)Set the iRODS driver internal debug level.
-OPTION_ITEM(`-K, --with-checksums')Checksum files where available.
-OPTION_ITEM(`-k, --no-checksums')Do not checksum files.
+OPTION_ITEM(-K, --with-checksums)Checksum files where available.
+OPTION_ITEM(-k, --no-checksums)Do not checksum files.
 OPTION_TRIPLET(-l, ld-path, path)Path to ld.so to use.
 OPTION_TRIPLET(-m, ftab-file, file)Use this file as a mountlist.
 OPTION_TRIPLET(-M, mount, /foo=/bar)Mount (redirect) /foo to /bar.
 OPTION_TRIPLET(-e, env-list, path)Record the environment variables.
 OPTION_TRIPLET(-n, name-list, path)Record all the file names.
-OPTION_ITEM(`    --no-set-foreground')Disable changing the foreground process group of the session.
+OPTION_ITEM(--no-set-foreground)Disable changing the foreground process group of the session.
 OPTION_TRIPLET(-N, hostname, name)Pretend that this is my hostname.
 OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
 OPTION_TRIPLET(-O, debug-rotate-max, bytes)Rotate debug files of this size.
 OPTION_TRIPLET(-p, proxy, host:port)Use this proxy server for HTTP requests.
-OPTION_ITEM(`-Q, --no-chirp-catalog')Inhibit catalog queries to list /chirp.
+OPTION_ITEM(-Q, --no-chirp-catalog)Inhibit catalog queries to list /chirp.
 OPTION_TRIPLET(-r, cvmfs-repos, repos)CVMFS repositories to enable (PARROT_CVMFS_REPO).
 OPTION_ITEM(--cvmfs-repo-switching) Allow repository switching with CVMFS.
 OPTION_TRIPLET(-R, root-checksum, cksum)Enforce this root filesystem checksum, where available.
-OPTION_ITEM(`-s, --stream-no-cache')Use streaming protocols without caching.
-OPTION_ITEM(`-S, --session-caching')Enable whole session caching for all protocols.
-OPTION_ITEM(`    --syscall-disable-debug')Disable tracee access to the Parrot debug syscall.
+OPTION_ITEM(-s, --stream-no-cache)Use streaming protocols without caching.
+OPTION_ITEM(-S, --session-caching)Enable whole session caching for all protocols.
+OPTION_ITEM(--syscall-disable-debug)Disable tracee access to the Parrot debug syscall.
 OPTION_TRIPLET(-t, tempdir, dir)Where to store temporary files.
 OPTION_TRIPLET(-T, timeout, time)Maximum amount of time to retry failures.
 time)Maximum amount of time to retry failures.
@@ -57,14 +57,14 @@ OPTION_ITEM(--time-stop) Stop virtual time at midnight, Jan 1st, UTC.
 OPTION_ITEM(--time-warp) Warp virtual time starting from midnight, Jan 1st, UTC.
 OPTION_TRIPLET(-U, uid, num)Fake this unix uid; Real uid stays the same.
 OPTION_TRIPLET(-u, username, name)Use this extended username.
-OPTION_ITEM(`    --fake-setuid')Track changes from setuid and setgid.
-OPTION_ITEM(`    --valgrind')Enable valgrind support for Parrot.
-OPTION_ITEM(`-v, --version')Display version number.
-OPTION_ITEM(`    --is-running')Test is Parrot is already running.
+OPTION_ITEM(--fake-setuid)Track changes from setuid and setgid.
+OPTION_ITEM(--valgrind)Enable valgrind support for Parrot.
+OPTION_ITEM(-v, --version)Display version number.
+OPTION_ITEM(--is-running)Test is Parrot is already running.
 OPTION_TRIPLET(-w, work-dir, dir)Initial working directory.
-OPTION_ITEM(`-W, --syscall-table')Display table of system calls trapped.
-OPTION_ITEM(`-Y, --sync-write')Force synchronous disk writes.
-OPTION_ITEM(`-Z, --auto-decompress')Enable automatic decompression on .gz files.
+OPTION_ITEM(-W, --syscall-table)Display table of system calls trapped.
+OPTION_ITEM(-Y, --sync-write)Force synchronous disk writes.
+OPTION_ITEM(-Z, --auto-decompress)Enable automatic decompression on .gz files.
 OPTIONS_END
 
 SECTION(ENVIRONMENT VARIABLES)

--- a/doc/manual.h
+++ b/doc/manual.h
@@ -4,36 +4,36 @@ define(COPYRIGHT_BOILERPLATE,The Cooperative Computing Tools are Copyright (C) 2
 dnl
 define(SEE_ALSO_MAKEFLOW,
 `LIST_BEGIN
-LIST_ITEM MANUAL(Cooperative Computing Tools Documentation,"../index.html")
-LIST_ITEM MANUAL(Makeflow User Manual,"../makeflow.html")
-LIST_ITEM MANPAGE(makeflow,1), MANPAGE(makeflow_monitor,1), MANPAGE(makeflow_analyze,1), MANPAGE(makeflow_viz,1), MANPAGE(makeflow_graph_log,1), MANPAGE(starch,1)
+LIST_ITEM(MANUAL(Cooperative Computing Tools Documentation,"../index.html"))
+LIST_ITEM(MANUAL(Makeflow User Manual,"../makeflow.html"))
+LIST_ITEM(MANPAGE(makeflow,1), MANPAGE(makeflow_monitor,1), MANPAGE(makeflow_analyze,1), MANPAGE(makeflow_viz,1), MANPAGE(makeflow_graph_log,1), MANPAGE(starch,1))
 LIST_END')dnl
 dnl
 define(SEE_ALSO_WORK_QUEUE,
 `LIST_BEGIN
-LIST_ITEM MANUAL(Cooperative Computing Tools Documentation,"../index.html")
-LIST_ITEM MANUAL(Work Queue User Manual,"../workqueue.html")
-LIST_ITEM MANPAGE(work_queue_worker,1), MANPAGE(work_queue_status,1), MANPAGE(work_queue_factory,1), MANPAGE(condor_submit_workers,1), MANPAGE(sge_submit_workers,1), MANPAGE(torque_submit_workers,1), MANPAGE(ec2_submit_workers,1), MANPAGE(ec2_remove_workers,1)
+LIST_ITEM(MANUAL(Cooperative Computing Tools Documentation,"../index.html"))
+LIST_ITEM(MANUAL(Work Queue User Manual,"../workqueue.html"))
+LIST_ITEM(MANPAGE(work_queue_worker,1), MANPAGE(work_queue_status,1), MANPAGE(work_queue_factory,1), MANPAGE(condor_submit_workers,1), MANPAGE(sge_submit_workers,1), MANPAGE(torque_submit_workers,1), MANPAGE(ec2_submit_workers,1), MANPAGE(ec2_remove_workers,1))
 LIST_END')dnl
 dnl
 define(SEE_ALSO_PARROT,
 `LIST_BEGIN
-LIST_ITEM MANUAL(Cooperative Computing Tools Documentation,"../index.html")
-LIST_ITEM MANUAL(Parrot User Manual,"../parrot.html")
-LIST_ITEM MANPAGE(parrot_run,1), MANPAGE(parrot_run_hdfs,1), MANPAGE(parrot_cp,1), MANPAGE(parrot_getacl,1), MANPAGE(parrot_setacl,1), MANPAGE(parrot_mkalloc,1), MANPAGE(parrot_lsalloc,1), MANPAGE(parrot_locate,1), MANPAGE(parrot_timeout,1), MANPAGE(parrot_whoami,1), MANPAGE(parrot_mount,1), MANPAGE(parrot_md5,1), MANPAGE(parrot_package_create,1), MANPAGE(parrot_package_run,1), MANPAGE(chroot_package_run,1)
+LIST_ITEM(MANUAL(Cooperative Computing Tools Documentation,"../index.html"))
+LIST_ITEM(MANUAL(Parrot User Manual,"../parrot.html"))
+LIST_ITEM(MANPAGE(parrot_run,1), MANPAGE(parrot_run_hdfs,1), MANPAGE(parrot_cp,1), MANPAGE(parrot_getacl,1), MANPAGE(parrot_setacl,1), MANPAGE(parrot_mkalloc,1), MANPAGE(parrot_lsalloc,1), MANPAGE(parrot_locate,1), MANPAGE(parrot_timeout,1), MANPAGE(parrot_whoami,1), MANPAGE(parrot_mount,1), MANPAGE(parrot_md5,1), MANPAGE(parrot_package_create,1), MANPAGE(parrot_package_run,1), MANPAGE(chroot_package_run,1))
 LIST_END')dnl
 define(SEE_ALSO_CHIRP,
 `LIST_BEGIN
-LIST_ITEM MANUAL(Cooperative Computing Tools Documentation,"../index.html")
-LIST_ITEM MANUAL(Chirp User Manual,"../chirp.html")
-LIST_ITEM MANPAGE(chirp,1), MANPAGE(chirp_status,1), MANPAGE(chirp_fuse,1), MANPAGE(chirp_get,1), MANPAGE(chirp_put,1), MANPAGE(chirp_stream_files,1), MANPAGE(chirp_distribute,1), MANPAGE(chirp_benchmark,1), MANPAGE(chirp_server,1)
+LIST_ITEM(MANUAL(Cooperative Computing Tools Documentation,"../index.html"))
+LIST_ITEM(MANUAL(Chirp User Manual,"../chirp.html"))
+LIST_ITEM(MANPAGE(chirp,1), MANPAGE(chirp_status,1), MANPAGE(chirp_fuse,1), MANPAGE(chirp_get,1), MANPAGE(chirp_put,1), MANPAGE(chirp_stream_files,1), MANPAGE(chirp_distribute,1), MANPAGE(chirp_benchmark,1), MANPAGE(chirp_server,1))
 LIST_END')dnl
 dnl
 define(SEE_ALSO_SAND,
 `LIST_BEGIN
-LIST_ITEM MANUAL(Cooperative Computing Tools Documentation,"../index.html")
-LIST_ITEM MANUAL(SAND User Manual,"../sand.html")
-LIST_ITEM MANPAGE(sand_filter_master,1), MANPAGE(sand_filter_kernel,1), MANPAGE(sand_align_master,1), MANPAGE(sand_align_kernel,1), MANPAGE(sand_compress_reads,1), MANPAGE(sand_uncompress_reads,1), MANPAGE(work_queue_worker,1)
+LIST_ITEM(MANUAL(Cooperative Computing Tools Documentation,"../index.html"))
+LIST_ITEM(MANUAL(SAND User Manual,"../sand.html"))
+LIST_ITEM(MANPAGE(sand_filter_master,1), MANPAGE(sand_filter_kernel,1), MANPAGE(sand_align_master,1), MANPAGE(sand_align_kernel,1), MANPAGE(sand_compress_reads,1), MANPAGE(sand_uncompress_reads,1), MANPAGE(work_queue_worker,1))
 LIST_END')dnl
 define(SEE_ALSO_LINKER,
 `LIST_BEGIN
@@ -41,7 +41,7 @@ LIST_ITEM MANPAGE(makeflow,1), MANPAGE(perl,1), MANPAGE(python,1), MANPAGE(ldd,1
 LIST_END')dnl
 define(SEE_ALSO_CATALOG,
 `LIST_BEGIN
-LIST_ITEM MANUAL(Cooperative Computing Tools Documentation,"../index.html")
-LIST_ITEM MANPAGE(catalog_server,1), MANPAGE(catalog_update,1), MANPAGE(catalog_query,1), MANPAGE(chirp_status,1), MANPAGE(work_queue_status,1),  MANPAGE(deltadb_query,1)
+LIST_ITEM(MANUAL(Cooperative Computing Tools Documentation,"../index.html"))
+LIST_ITEM(MANPAGE(catalog_server,1), MANPAGE(catalog_update,1), MANPAGE(catalog_query,1), MANPAGE(chirp_status,1), MANPAGE(work_queue_status,1),  MANPAGE(deltadb_query,1))
 LIST_END')dnl
 dnl

--- a/parrot/src/Makefile
+++ b/parrot/src/Makefile
@@ -4,7 +4,7 @@ include ../../rules.mk
 EXTERNAL_DEPENDENCIES = ../../ftp_lite/src/libftp_lite.a ../../chirp/src/libchirp.a ../../dttools/src/libdttools.a
 LIBRARIES = libparrot_helper.$(CCTOOLS_DYNAMIC_SUFFIX) libparrot_client.a
 OBJECTS = $(OBJECTS_PARROT_RUN) parrot_client.o
-OBJECTS_PARROT_RUN = pfs_main.o tracer.o pfs_paranoia.o pfs_dispatch.o pfs_dispatch64.o pfs_process.o pfs_channel.o pfs_sys.o pfs_table.o pfs_resolve.o pfs_service.o pfs_file.o pfs_file_cache.o pfs_dir.o pfs_dircache.o pfs_pointer.o pfs_location.o ibox_acl.o pfs_service_local.o pfs_service_http.o pfs_service_grow.o pfs_service_chirp.o pfs_service_multi.o pfs_service_nest.o pfs_service_ftp.o pfs_service_irods.o irods_reli.o pfs_service_hdfs.o pfs_service_bxgrid.o pfs_service_xrootd.o pfs_service_cvmfs.o
+OBJECTS_PARROT_RUN = pfs_main.o tracer.o pfs_paranoia.o pfs_dispatch.o pfs_dispatch64.o pfs_process.o pfs_channel.o pfs_sys.o pfs_time.o pfs_table.o pfs_resolve.o pfs_service.o pfs_file.o pfs_file_cache.o pfs_dir.o pfs_dircache.o pfs_pointer.o pfs_location.o ibox_acl.o pfs_service_local.o pfs_service_http.o pfs_service_grow.o pfs_service_chirp.o pfs_service_multi.o pfs_service_nest.o pfs_service_ftp.o pfs_service_irods.o irods_reli.o pfs_service_hdfs.o pfs_service_bxgrid.o pfs_service_xrootd.o pfs_service_cvmfs.o
 PROGRAMS = parrot_run $(UTILITIES)
 HEADERS_PUBLIC = parrot_client.h
 SCRIPTS = make_growfs parrot_identity_box parrot_run_hdfs parrot_package_run chroot_package_run

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -1115,7 +1115,6 @@ static void decode_syscall( struct pfs_process *p, int entering )
 		case SYSCALL64_sync:
 		case SYSCALL64_sysinfo:
 		case SYSCALL64_syslog:
-		case SYSCALL64_time:
 		case SYSCALL64_timer_create:
 		case SYSCALL64_timer_delete:
 		case SYSCALL64_timer_getoverrun:
@@ -1126,6 +1125,22 @@ static void decode_syscall( struct pfs_process *p, int entering )
 		case SYSCALL64_vhangup:
 		case SYSCALL64_wait4:
 		case SYSCALL64_waitid:
+			break;
+
+		case SYSCALL64_time:
+			if(entering) {
+				switch(pfs_time_mode) {
+					case PFS_TIME_MODE_STOP:
+						divert_to_dummy(p,0);
+						break;
+					case PFS_TIME_MODE_WARP:
+						divert_to_dummy(p,0);
+						break;
+					case PFS_TIME_MODE_NORMAL:
+						default:
+						break;
+				}
+			}
 			break;
 
 		case SYSCALL64_execve:

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -13,6 +13,7 @@ See the file COPYING for details.
 #include "pfs_process.h"
 #include "pfs_service.h"
 #include "pfs_table.h"
+#include "pfs_time.h"
 #include "ptrace.h"
 
 extern "C" {
@@ -97,8 +98,6 @@ int set_foreground = 1;
 int pfs_syscall_disable_debug = 0;
 int pfs_allow_dynamic_mounts = 0;
 
-pfs_time_mode_t pfs_time_mode = PFS_TIME_MODE_NORMAL;
-
 char sys_temp_dir[PATH_MAX] = "/tmp";
 char pfs_temp_dir[PATH_MAX];
 char pfs_temp_per_instance_dir[PATH_MAX];
@@ -160,6 +159,8 @@ enum {
 	LONG_OPT_FAKE_SETUID,
 	LONG_OPT_DYNAMIC_MOUNTS,
 	LONG_OPT_IS_RUNNING,
+	LONG_OPT_TIME_STOP,
+	LONG_OPT_TIME_WARP
 };
 
 static void get_linux_version(const char *cmd)
@@ -1065,10 +1066,11 @@ int main( int argc, char *argv[] )
 		}
 		case LONG_OPT_TIME_STOP:
 			pfs_time_mode = PFS_TIME_MODE_STOP;
+			pfs_use_helper = 1;
 			break;
 		case LONG_OPT_TIME_WARP:
 			pfs_time_mode = PFS_TIME_MODE_WARP;
-			pfs_time_warp_start = time(0);
+			pfs_use_helper = 1;
 			break;
 		default:
 			show_help(argv[0]);

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -250,6 +250,8 @@ static void show_help( const char *cmd )
 	printf( " %-30s Disable changing the foreground process group of the session.\n","   --no-set-foreground");
 	printf( " %-30s Pretend that this is my hostname.          (PARROT_HOST_NAME)\n", "-N,--hostname=<name>");
 	printf( " %-30s Enable paranoid mode for identity boxing mode.\n", "-P,--paranoid");
+	printf( " %-30s Stop virtual time at midnight, Jan 1st, UTC.\n", "   --time-stop");
+	printf( " %-30s Warp virtual time starting from midnight, Jan 1st, UTC.\n","   --time-warp");
 	printf( " %-30s Fake this unix uid; Real uid stays the same.     (PARROT_UID)\n", "-U,--uid=<num>");
 	printf( " %-30s Use this extended username.                 (PARROT_USERNAME)\n", "-u,--username=<name>");
 	printf( " %-30s Enable valgrind support for Parrot.\n", "   --valgrind");

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -97,6 +97,8 @@ int set_foreground = 1;
 int pfs_syscall_disable_debug = 0;
 int pfs_allow_dynamic_mounts = 0;
 
+pfs_time_mode_t pfs_time_mode = PFS_TIME_MODE_NORMAL;
+
 char sys_temp_dir[PATH_MAX] = "/tmp";
 char pfs_temp_dir[PATH_MAX];
 char pfs_temp_per_instance_dir[PATH_MAX];
@@ -836,6 +838,8 @@ int main( int argc, char *argv[] )
 		{"with-checksums", no_argument, 0, 'K'},
 		{"with-snapshots", no_argument, 0, 'F'},
 		{"work-dir", required_argument, 0, 'w'},
+		{"time-stop", no_argument, 0, LONG_OPT_TIME_STOP},
+		{"time-warp", no_argument, 0, LONG_OPT_TIME_WARP},
 		{0,0,0,0}
 	};
 
@@ -1059,6 +1063,13 @@ int main( int argc, char *argv[] )
 			}
 			break;
 		}
+		case LONG_OPT_TIME_STOP:
+			pfs_time_mode = PFS_TIME_MODE_STOP;
+			break;
+		case LONG_OPT_TIME_WARP:
+			pfs_time_mode = PFS_TIME_MODE_WARP;
+			pfs_time_warp_start = time(0);
+			break;
 		default:
 			show_help(argv[0]);
 			break;

--- a/parrot/src/pfs_time.cc
+++ b/parrot/src/pfs_time.cc
@@ -58,7 +58,7 @@ int pfs_emulate_clock_gettime( clockid_t clockid, struct timespec *ts )
 			break;
 		case PFS_TIME_MODE_WARP:
 			*ts = emulated_time;
-			emulated_time.tv_nsec += 100000000;
+			emulated_time.tv_nsec += 10000000;
 			if(emulated_time.tv_nsec >= 1000000000) {
 				emulated_time.tv_nsec -= 1000000000;
 				emulated_time.tv_sec++;

--- a/parrot/src/pfs_time.cc
+++ b/parrot/src/pfs_time.cc
@@ -1,0 +1,74 @@
+/*
+Copyright (C) 2016- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include "pfs_time.h"
+
+#include <string.h>
+#include <errno.h>
+
+pfs_time_mode_t pfs_time_mode = PFS_TIME_MODE_NORMAL;
+
+/*
+For time stop and time warp modes, this is the emulated
+time, which begins at midnight, Monday, January 1st, 2001 UTC
+In time-warp mode, this is incremented by .01s at every request.
+*/
+
+static struct timespec emulated_time = { 978307200,0 };
+
+time_t pfs_emulate_time( time_t *t )
+{
+	struct timespec ts;
+	pfs_emulate_clock_gettime(CLOCK_REALTIME,&ts);
+
+	if(t) *t = ts.tv_sec;
+
+	return ts.tv_sec;
+}
+
+int pfs_emulate_gettimeofday( struct timeval *tv, struct timezone *tz )
+{
+	struct timespec ts;
+	pfs_emulate_clock_gettime(CLOCK_REALTIME,&ts);
+
+	if(tv) {
+		tv->tv_sec = ts.tv_sec;
+		tv->tv_usec = ts.tv_nsec/1000;
+	}
+
+	if(tz) {
+		memset(tz,0,sizeof(*tz));
+	}
+
+	return 0;
+}
+
+int pfs_emulate_clock_gettime( clockid_t clockid, struct timespec *ts )
+{
+       	switch(pfs_time_mode) {
+		case PFS_TIME_MODE_NORMAL:
+			return clock_gettime(clockid,ts);
+			break;
+		case PFS_TIME_MODE_STOP:
+			*ts = emulated_time;
+			return 0;
+			break;
+		case PFS_TIME_MODE_WARP:
+			*ts = emulated_time;
+			emulated_time.tv_nsec += 100000000;
+			if(emulated_time.tv_nsec >= 1000000000) {
+				emulated_time.tv_nsec -= 1000000000;
+				emulated_time.tv_sec++;
+			}
+			return 0;
+			break;
+	}
+
+	errno = ENOSYS;
+	return -1;
+}
+
+

--- a/parrot/src/pfs_time.h
+++ b/parrot/src/pfs_time.h
@@ -1,0 +1,25 @@
+/*
+Copyright (C) 2016- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#ifndef PFS_TIME_H
+#define PFS_TIME_H
+
+#include <time.h>
+#include <sys/time.h>
+
+typedef enum {
+	PFS_TIME_MODE_NORMAL,
+	PFS_TIME_MODE_STOP,
+	PFS_TIME_MODE_WARP
+} pfs_time_mode_t;
+
+extern pfs_time_mode_t pfs_time_mode;
+
+time_t pfs_emulate_time( time_t *t );
+int    pfs_emulate_gettimeofday( struct timeval *tv, struct timezone *tz );
+int    pfs_emulate_clock_gettime( clockid_t clockid, struct timespec *ts );
+
+#endif

--- a/parrot/src/pfs_types.h
+++ b/parrot/src/pfs_types.h
@@ -25,6 +25,12 @@ typedef INT64_T pfs_ssize_t;
 typedef INT64_T pfs_size_t;
 typedef INT64_T pfs_off_t;
 
+typedef enum {
+	PFS_TIME_MODE_NORMAL,
+	PFS_TIME_MODE_WARP
+	PFS_TIME_MODE_STOP,
+} pfs_time_mode_t;
+
 #define PFS_SIZE_FORMAT "lld"
 
 struct pfs_stat {

--- a/parrot/src/pfs_types.h
+++ b/parrot/src/pfs_types.h
@@ -25,12 +25,6 @@ typedef INT64_T pfs_ssize_t;
 typedef INT64_T pfs_size_t;
 typedef INT64_T pfs_off_t;
 
-typedef enum {
-	PFS_TIME_MODE_NORMAL,
-	PFS_TIME_MODE_WARP
-	PFS_TIME_MODE_STOP,
-} pfs_time_mode_t;
-
 #define PFS_SIZE_FORMAT "lld"
 
 struct pfs_stat {

--- a/parrot/test/TR_parrot_time_stop.sh
+++ b/parrot/test/TR_parrot_time_stop.sh
@@ -1,0 +1,32 @@
+#! /bin/sh
+
+. ../../dttools/test/test_runner_common.sh
+. ./parrot-test.sh
+
+prepare()
+{
+	$0 clean
+	cat > output.expected <<EOF
+Mon Jan  1 00:00:00 UTC 2001
+EOF
+}
+
+run()
+{
+	if parrot --time-stop -- date --utc 2>&1 > output.actual
+	then
+		require_identical_files output.actual output.expected
+		return 0
+	else
+		return 1
+	fi
+}
+
+clean()
+{
+	rm -f output.actual output.expected
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:


### PR DESCRIPTION
Added a new mode to Parrot that allows one to control the time, so as to support experiments in reproducibility:
`parrot_run --time-stop` forces the current time to midnight, January 1st, 2001 UTC.
`parrot_run --time-warp` does the same thing, but advances the clock by .01s upon every request for the current time.

