### PR TITLE
Give error code when no more tickets are available.

### DIFF
--- a/dttools/src/auth_ticket.c
+++ b/dttools/src/auth_ticket.c
@@ -278,7 +278,7 @@ static int auth_ticket_accept(struct link *link, char **subject, time_t stoptime
 		}
 	}
 
-	rc = 0;
+	rc = 1;
 	goto out;
 out:
 	if (tmpf[0])


### PR DESCRIPTION
Fixes #1477.

The problem was that chirp_auth_ticket always returned success. Now it returns failure by default, unless a success is explicitly stated.