### PR TITLE
Factory Fixes

### DIFF
--- a/batch_job/src/batch_job_cluster.c
+++ b/batch_job/src/batch_job_cluster.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <ctype.h>
 
 #include <sys/stat.h>
 
@@ -115,7 +116,7 @@ static batch_job_id_t batch_job_cluster_submit (struct batch_queue * q, const ch
 	if(end) *end = 0;
 		
 	char *submit_job_name = strdup(string_front(path_basename(firstword),15));
-	if(!isalpha(submit_job_name[0])) submit_job_name = 'X';
+	if(!isalpha(submit_job_name[0])) submit_job_name[0] = 'X';
 
 	free(firstword);
 

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -953,8 +953,18 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+	/*
+	Careful here: most of the supported batch systems expect
+	that jobs are submitting from a single shared filesystem.
+	Changing to /tmp only works in the case of Condor.
+	*/
+
 	if(!scratch_dir) {
-		scratch_dir = string_format("/tmp/wq-pool-%d",getuid());
+		if(batch_queue_type==BATCH_QUEUE_TYPE_CONDOR) {
+			scratch_dir = string_format("/tmp/wq-pool-%d",getuid());
+		} else {
+			scratch_dir = string_format("wq-pool-%d",getuid());
+		}
 	}
 
 	if(!create_dir(scratch_dir,0777)) {


### PR DESCRIPTION
Fixes two problems that were preventing correct operation at Arizona:
* -N batch name cannot be more than 15 characters
* scratch directory of factory needs to be on a shared filesystem.
