### PR TITLE
Fix forsaken stop

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1764,7 +1764,8 @@ static work_queue_result_code_t get_result(struct work_queue *q, struct work_que
 
 	if(task_status == WORK_QUEUE_RESULT_FORSAKEN) {
 		/* task will be resubmitted, so we do not update any of the execution stats */
-		change_task_state(q, t, WORK_QUEUE_TASK_WAITING_RESUBMISSION);
+		reap_task_from_worker(q, w, t, WORK_QUEUE_TASK_WAITING_RESUBMISSION);
+
 		return SUCCESS;
 	}
 

--- a/work_queue/src/work_queue_resources.c
+++ b/work_queue/src/work_queue_resources.c
@@ -50,7 +50,7 @@ void work_queue_resources_measure_locally( struct work_queue_resources *r, const
 	r->disk.largest = r->disk.smallest = r->disk.total;
 
 	host_memory_info_get(&avail,&total);
-	r->memory.total = (avail / (UINT64_T) MEGA) + r->memory.inuse; // Free + whatever we are using.
+	r->memory.total = (total / (UINT64_T) MEGA);
 	r->memory.largest = r->memory.smallest = r->memory.total;
 
 	if(!gpu_check)


### PR DESCRIPTION
Two fixes for #1495:

1) When a task was forsaken, we did not update the accounting for that worker at the master.
2) Memory available at the worker is reported as the total memory, rather than the free memory at the time of measurement. 