### PR TITLE
Work Queue Display Resources

### DIFF
--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -152,7 +152,7 @@ static struct work_queue_resources * total_resources = 0;
 static struct work_queue_resources * total_resources_last = 0;
 
 static int64_t last_task_received  = 0;
-static int64_t manual_cores_option = 0;
+static int64_t manual_cores_option = 1;
 static int64_t manual_disk_option = 0;
 static int64_t manual_memory_option = 0;
 static int64_t manual_gpus_option = 0;

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -152,7 +152,7 @@ static struct work_queue_resources * total_resources = 0;
 static struct work_queue_resources * total_resources_last = 0;
 
 static int64_t last_task_received  = 0;
-static int64_t manual_cores_option = 1;
+static int64_t manual_cores_option = 0;
 static int64_t manual_disk_option = 0;
 static int64_t manual_memory_option = 0;
 static int64_t manual_gpus_option = 0;
@@ -2503,6 +2503,13 @@ int main(int argc, char *argv[])
 
 	int backoff_interval = init_backoff_interval;
 	connect_stoptime = time(0) + connect_timeout;
+
+	measure_worker_resources();
+	printf("work_queue_worker: using %"PRId64 " cores, %"PRId64 " MB memory, %"PRId64 " MB disk, %"PRId64 " gpus\n",
+		total_resources->cores.total,
+		total_resources->memory.total,
+		total_resources->disk.total,
+		total_resources->gpus.total);
 
 	while(1) {
 		int result;


### PR DESCRIPTION
This is a small commit, but a potentially big change.

I propose that the time has come to make WQ multi-core by default.

Currently, a WQ worker only advertises one core, unless someone explicitly overrides this.
As machines are getting bigger and fatter, it is more naturally the case that we are either
(a) running multiple single core tasks on a machine or (b) matching multicore tasks to multicore machines.

This patch causes WQ to advertise all the cores available, unless overriden by the factory,
the batch system or the user.

Also, we explicitly printf the resources at startup, since this is a significant operational concern
and debugging challenge for the naive user.

Thoughts?
Concerns?

