### PR TITLE
Support specifying umbrella specs in makefile

### DIFF
--- a/doc/makeflow.html
+++ b/doc/makeflow.html
@@ -297,6 +297,23 @@ following three modes: local, parrot, and docker. The default value of the
 docker mode, and tries to utilize the parrot mode if the docker mode is not
 available. </p>
 
+<h2 id="umbrella_in_makefile">Specify Umbrella in Makefile<a class="sectionlink" href="#umbrella_in_makefile" title="Link to this section.">&#x21d7;</a></h2>
+
+<p> You can also specify an Umbrella specification for a group of rule(s) in the
+Makefile by putting the following directives before the rule(s) you want to apply
+the Umbrella spec to: </p>
+<code>
+.MAKEFLOW CATEGORY 1
+.UMBRELLA SPEC convert_S.umbrella
+</code>
+
+<p>In this case, the specified Umbrella spec will be applied to all the
+following rules until a new ".MAKEFLOW CATEGORY ..." directive is declared. All
+the rules before the first ".MAKEFLOW CATEGORY ..." directive will use the
+Umbrella spec specified by the <tt>--umbrella-spec</tt> option. If the
+<tt>--umbrella-spec</tt> option is not specified, these rules will run without being
+wrapped by Umbrella. </p>
+
 <h2 id="details">More Language Details<a class="sectionlink" href="#details" title="Link to this section.">&#x21d7;</a></h2>
 
 <p>The Makeflow language is very similar to Make, but it does have a few important differences that you should be aware of.</p>

--- a/makeflow/example/example.categories.makeflow
+++ b/makeflow/example/example.categories.makeflow
@@ -19,7 +19,7 @@ MAKEFLOW_OUTPUTS=capitol.montage.gif
 # Similar rules can be arbitrarily labeled to form sets, called categories. In
 # this example we define three categories: preprocess, analysis, and merge.
 # Rules belong to the category of the most recent CATEGORY statement.
-.RESOURCE CATEGORY merge
+.MAKEFLOW CATEGORY merge
 
 # To provide accurate assessment of the output size, estimated file sizes can
 # be specified via the .SIZE directive.
@@ -33,7 +33,7 @@ MAKEFLOW_OUTPUTS=capitol.montage.gif
 capitol.montage.gif: capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg
 	$CONVERT -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.montage.gif
 
-.RESOURCE CATEGORY analysis
+.MAKEFLOW CATEGORY analysis
 .RESOURCE CORES 1
 .RESOURCE MEMORY 10
 .RESOURCE DISK 20
@@ -50,7 +50,7 @@ capitol.360.jpg: capitol.jpg
 	$CONVERT -swirl 360 capitol.jpg capitol.360.jpg
 
 # If a rule is preceded by LOCAL, it executes at the local site.
-.RESOURCE CATEGORY preprocess
+.MAKEFLOW CATEGORY preprocess
 .RESOURCE CORES 1
 .RESOURCE MEMORY 10
 .RESOURCE DISK 20

--- a/makeflow/example/makeflow_umbrella/README
+++ b/makeflow/example/makeflow_umbrella/README
@@ -1,7 +1,19 @@
 This example illustrates how to running makeflow with the help of umbrella.
 
 The user can specify the umbrella binary through the `--umbrella-binary`
-option; and specify the umbrella spec through the `--umbrella-spec` option.
+option; and specify the umbrella spec through the `--umbrella-spec` option,
+which will be the default umbrella specifcation for each rule. You can also
+specify an Umbrella specification for a group of rule(s) in the Makefile by
+putting the following directives before the rule(s) you want to apply the Umbrella
+spec to:
+.MAKEFLOW CATEGORY 1
+.UMBRELLA SPEC convert_S.umbrella
+
+In this case, the specified Umbrella spec will be applied to all the following
+rules until a new ".MAKEFLOW CATEGORY..." directive is declared. All the rules
+before the first ".MAKEFLOW CATEGORY ..." directive will use the Umbrella spec
+specified by the `--umbrella-spec` option. If the `--umbrella-spec` option is
+not specified, these rules will run without being wrapped by Umbrella.
 
 To test makeflow with umbrella using local execution engine:
 $ makeflow --umbrella-binary $(which umbrella) --umbrella-spec convert_S.umbrella example.makeflow
@@ -13,6 +25,11 @@ To test the case when `--wrapper` and `--umbrella-spec|binary` are used at the s
 $ makeflow --wrapper 'time -p /bin/sh -c []'  --umbrella-binary $(which umbrella) --umbrella-spec convert_S.umbrella example.makeflow
 $ makeflow -T wq --wrapper 'time -p /bin/sh -c []'  --umbrella-binary $(which umbrella) --umbrella-spec convert_S.umbrella example.makeflow
 
+To test makefile with umbrella (without a default umbrella spec):
+$ makeflow example_in_makefile.makeflow
+
+To test makefile with umbrella (with a default umbrella spec):
+$ makeflow --umbrella-binary $(which umbrella) --umbrella-spec convert_S.umbrella example_in_makefile.makeflow
 
 Usage of the `--umbrella-log-prefix` option of makeflow:
 $ makeflow --umbrella-binary $(which umbrella) --umbrella-spec convert_S.umbrella --umbrella-log-prefix myumbrella.log example.makeflow

--- a/makeflow/example/makeflow_umbrella/example_in_makefile.makeflow
+++ b/makeflow/example/makeflow_umbrella/example_in_makefile.makeflow
@@ -1,0 +1,25 @@
+# if the `--umbrella-spec` option is set, then these two rules will use it as their umbrella specs;
+# otherwise, they will run as it is without being wrapped by the umbrella wrapper.
+capitol.montage.gif: capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg
+	convert -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.montage.gif
+
+capitol.90.jpg: capitol.jpg
+	convert -swirl 90 capitol.jpg capitol.90.jpg
+
+# the following three rules will use umbrella_specs/convert_S_category1.umbrella as their umbrella specs
+.MAKEFLOW CATEGORY 1
+.UMBRELLA SPEC umbrella_specs/convert_S_category1.umbrella
+capitol.180.jpg: capitol.jpg
+	convert -swirl 180 capitol.jpg capitol.180.jpg
+
+capitol.270.jpg: capitol.jpg
+	convert -swirl 270 capitol.jpg capitol.270.jpg
+
+capitol.360.jpg: capitol.jpg
+	convert -swirl 360 capitol.jpg capitol.360.jpg
+
+# the following rule will use umbrella_specs/convert_S_category2.umbrella as its umbrella spec
+.MAKEFLOW CATEGORY 2
+.UMBRELLA SPEC umbrella_specs/convert_S_category2.umbrella
+capitol.jpg:
+	curl -o capitol.jpg http://ccl.cse.nd.edu/images/capitol.jpg

--- a/makeflow/example/makeflow_umbrella/umbrella_specs/convert_S_category1.umbrella
+++ b/makeflow/example/makeflow_umbrella/umbrella_specs/convert_S_category1.umbrella
@@ -1,0 +1,26 @@
+{
+    "comment": "Converting an image.",
+    "kernel": {
+        "version": ">=2.6.18",
+        "name": "linux"
+    },
+    "os": {
+       "name": "centos",
+        "format": "tgz",
+        "checksum": "93284f9e50040fe5704c0c795d72df61",
+		"note": "this os image = `docker pull centos:6` + `yum install ImageMagick`. Using yum is becuase ImageMagick is not relocatable.",
+        "source": [
+            "http://ccl.cse.nd.edu/research/data/hep-case-study/93284f9e50040fe5704c0c795d72df61/centos-6.8-x86_64.tar.gz"
+        ],
+        "version": "6.8",
+        "uncompressed_size": "309442560",
+        "id": "93284f9e50040fe5704c0c795d72df61",
+        "size": "104706192"
+    },
+    "hardware": {
+        "cores": "1",
+        "disk": "2GB",
+        "arch": "x86_64",
+        "memory": "1GB"
+    }
+}

--- a/makeflow/example/makeflow_umbrella/umbrella_specs/convert_S_category2.umbrella
+++ b/makeflow/example/makeflow_umbrella/umbrella_specs/convert_S_category2.umbrella
@@ -1,0 +1,26 @@
+{
+    "comment": "Converting an image.",
+    "kernel": {
+        "version": ">=2.6.18",
+        "name": "linux"
+    },
+    "os": {
+       "name": "centos",
+        "format": "tgz",
+        "checksum": "93284f9e50040fe5704c0c795d72df61",
+		"note": "this os image = `docker pull centos:6` + `yum install ImageMagick`. Using yum is becuase ImageMagick is not relocatable.",
+        "source": [
+            "http://ccl.cse.nd.edu/research/data/hep-case-study/93284f9e50040fe5704c0c795d72df61/centos-6.8-x86_64.tar.gz"
+        ],
+        "version": "6.8",
+        "uncompressed_size": "309442560",
+        "id": "93284f9e50040fe5704c0c795d72df61",
+        "size": "104706192"
+    },
+    "hardware": {
+        "cores": "1",
+        "disk": "2GB",
+        "arch": "x86_64",
+        "memory": "1GB"
+    }
+}

--- a/makeflow/src/dag_node.c
+++ b/makeflow/src/dag_node.c
@@ -14,6 +14,7 @@ See the file COPYING for details.
 #include "xxmalloc.h"
 #include "jx.h"
 
+#include <errno.h>
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -103,7 +104,17 @@ const char *dag_node_get_local_name(struct dag_node *n, const char *filename)
 
 void dag_node_set_umbrella_spec(struct dag_node *n, const char *umbrella_spec)
 {
+	struct stat st;
+
 	if(!n) return;
+
+	if(lstat(umbrella_spec, &st) == -1) {
+		fatal("lstat(`%s`) failed: %s\n", umbrella_spec, strerror(errno));
+	}
+	if((st.st_mode & S_IFMT) != S_IFREG) {
+		fatal("the umbrella spec (`%s`) should specify a regular file\n", umbrella_spec);
+	}
+
 	n->umbrella_spec = umbrella_spec;
 }
 

--- a/makeflow/src/parser.c
+++ b/makeflow/src/parser.c
@@ -480,9 +480,6 @@ static int dag_parse_directive(struct lexer *bk, struct dag_node *n)
 				|| (!strcmp("MEMORY", t->lexeme))) {
 			if(!(string_metric_parse(t2->lexeme) >= 0))
 				lexer_report_error(bk, "Expected numeric value for %s, got: %s\n", t->lexeme, t2->lexeme);
-		} else if(!strcmp("CATEGORY", t->lexeme)) {
-			if(!(t2->lexeme))
-				lexer_report_error(bk, "Expected name for CATEGORY");
 		} else if(!strcmp("MODE", t->lexeme)) {
 			set_var = 0;
 			if(!(t2->lexeme)) {
@@ -498,6 +495,7 @@ static int dag_parse_directive(struct lexer *bk, struct dag_node *n)
 			}
 		} else {
 			lexer_report_error(bk, "Unsupported .RESOURCE type, got: %s\n", t->lexeme);
+			free(name);
 			return 0;
 		}
 
@@ -507,6 +505,56 @@ static int dag_parse_directive(struct lexer *bk, struct dag_node *n)
 
 			dag_parse_variable_wmode(bk, n, '=');
 		}
+	} else if(!strcmp(".UMBRELLA", name)) {
+		struct token *t2;
+
+		t = lexer_next_token(bk);
+		if(t->type != TOKEN_LITERAL)
+		{
+			lexer_report_error(bk, "Expected LITERAL token, got: %s\n", lexer_print_token(t));
+		}
+
+		if(strcmp("SPEC", t->lexeme)) {
+			lexer_report_error(bk, "Unsupported .UMBRELLA type, got: %s\n", t->lexeme);
+			free(name);
+			return 0;
+		}
+
+		t2 = lexer_next_token(bk);
+		if(t2->type != TOKEN_LITERAL)
+		{
+			lexer_report_error(bk, "Expected LITERAL token, got: %s\n", lexer_print_token(t2));
+		}
+
+		lexer_preppend_token(bk, t2);
+		lexer_preppend_token(bk, t);
+		dag_parse_variable_wmode(bk, n, '=');
+	} else if(!strcmp(".MAKEFLOW", name)) {
+		struct token *t2;
+
+		t = lexer_next_token(bk);
+		if(t->type != TOKEN_LITERAL)
+		{
+			lexer_report_error(bk, "Expected LITERAL token, got: %s\n", lexer_print_token(t));
+		}
+
+		if(strcmp("CATEGORY", t->lexeme)) {
+			lexer_report_error(bk, "Unsupported .MAKEFLOW type, got: %s\n", t->lexeme);
+			free(name);
+			return 0;
+		}
+
+		t2 = lexer_next_token(bk);
+		if(t2->type != TOKEN_LITERAL)
+		{
+			lexer_report_error(bk, "Expected LITERAL token, got: %s\n", lexer_print_token(t2));
+		}
+
+		if(!(t2->lexeme)) lexer_report_error(bk, "Expected name for CATEGORY");
+
+		lexer_preppend_token(bk, t2);
+		lexer_preppend_token(bk, t);
+		dag_parse_variable_wmode(bk, n, '=');
 	} else {
 		lexer_report_error(bk, "Unknown DIRECTIVE type, got: %s\n", name);
 		result = 0;

--- a/makeflow/test/syntax/directives.makeflow
+++ b/makeflow/test/syntax/directives.makeflow
@@ -19,7 +19,7 @@ MAKEFLOW_OUTPUTS=capitol.montage.gif
 # Similar rules can be arbitrarily labeled to form sets, called categories. In
 # this example we define three categories: preprocess, analysis, and merge.
 # Rules belong to the category of the most recent CATEGORY statement.
-.RESOURCE CATEGORY merge
+.MAKEFLOW CATEGORY merge
 
 # To provide accurate assessment of the output size, estimated file sizes can
 # be specified via the .SIZE directive.
@@ -33,7 +33,7 @@ MAKEFLOW_OUTPUTS=capitol.montage.gif
 capitol.montage.gif: capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg
 	$CONVERT -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.montage.gif
 
-.RESOURCE CATEGORY analysis
+.MAKEFLOW CATEGORY analysis
 .RESOURCE CORES 1
 .RESOURCE MEMORY 10
 .RESOURCE DISK 20
@@ -50,7 +50,7 @@ capitol.360.jpg: capitol.jpg
 	$CONVERT -swirl 360 capitol.jpg capitol.360.jpg
 
 # If a rule is preceded by LOCAL, it executes at the local site.
-.RESOURCE CATEGORY preprocess
+.MAKEFLOW CATEGORY preprocess
 .RESOURCE CORES 1
 .RESOURCE MEMORY 10
 .RESOURCE DISK 20

--- a/makeflow/test/syntax/directives_bad_value.makeflow
+++ b/makeflow/test/syntax/directives_bad_value.makeflow
@@ -19,7 +19,7 @@ MAKEFLOW_OUTPUTS=capitol.montage.gif
 # Similar rules can be arbitrarily labeled to form sets, called categories. In
 # this example we define three categories: preprocess, analysis, and merge.
 # Rules belong to the category of the most recent CATEGORY statement.
-.RESOURCE CATEGORY merge
+.MAKEFLOW CATEGORY merge
 
 # To provide accurate assessment of the output size, estimated file sizes can
 # be specified via the .SIZE directive.
@@ -33,7 +33,7 @@ MAKEFLOW_OUTPUTS=capitol.montage.gif
 capitol.montage.gif: capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg
 	$CONVERT -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.montage.gif
 
-.RESOURCE CATEGORY analysis
+.MAKEFLOW CATEGORY analysis
 .RESOURCE CORES 1
 .RESOURCE MEMORY 10
 .RESOURCE DISK 20
@@ -50,7 +50,7 @@ capitol.360.jpg: capitol.jpg
 	$CONVERT -swirl 360 capitol.jpg capitol.360.jpg
 
 # If a rule is preceded by LOCAL, it executes at the local site.
-.RESOURCE CATEGORY preprocess
+.MAKEFLOW CATEGORY preprocess
 .RESOURCE CORES 1
 .RESOURCE MEMORY 10
 .RESOURCE DISK 20

--- a/makeflow/test/syntax/directives_unsupported.makeflow
+++ b/makeflow/test/syntax/directives_unsupported.makeflow
@@ -33,7 +33,7 @@ MAKEFLOW_OUTPUTS=capitol.montage.gif
 capitol.montage.gif: capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg
 	$CONVERT -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.montage.gif
 
-.RESOURCE CATEGORY analysis
+.MAKEFLOW CATEGORY analysis
 .RESOURCE CORES 1
 .RESOURCE MEMORY 10
 .RESOURCE DISK 20
@@ -50,7 +50,7 @@ capitol.360.jpg: capitol.jpg
 	$CONVERT -swirl 360 capitol.jpg capitol.360.jpg
 
 # If a rule is preceded by LOCAL, it executes at the local site.
-.RESOURCE CATEGORY preprocess
+.MAKEFLOW CATEGORY preprocess
 .RESOURCE CORES 1
 .RESOURCE MEMORY 10
 .RESOURCE DISK 20


### PR DESCRIPTION
This PR adds the support to allow the user to specify an Umbrella specification for a group of rule(s) in the Makefile by putting the following directives before the rule(s) you want to apply the Umbrella spec to:

```
.UMBRELLA CATEGORY 1
.UMBRELLA SPEC convert_S.umbrella
```

In this case, the specified Umbrella spec will be applied to all the following rules until a new `.UMBRELLA CATEGORY...` directive is declared. All the rules before the first `.RESOURCE CATEGORY ...` directive will use the Umbrella spec specified by the `--umbrella-spec` option. If the `--umbrella-spec` option is not specified, these rules will run without being wrapped by Umbrella.

An example makefile with umbrella specs can be found at `cctools/makeflow/example/makeflow_umbrella/example_in_makefile.makeflow`:

```
# if the `--umbrella-spec` option is set, then these two rules will use it as their umbrella specs;
# otherwise, they will run as it is without being wrapped by the umbrella wrapper.
capitol.montage.gif: capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg
        convert -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.montage.gif

capitol.90.jpg: capitol.jpg
        convert -swirl 90 capitol.jpg capitol.90.jpg

# the following three rules will use umbrella_specs/convert_S_category1.umbrella as their umbrella specs
.UMBRELLA CATEGORY 1
.UMBRELLA SPEC umbrella_specs/convert_S_category1.umbrella
capitol.180.jpg: capitol.jpg
        convert -swirl 180 capitol.jpg capitol.180.jpg

capitol.270.jpg: capitol.jpg
        convert -swirl 270 capitol.jpg capitol.270.jpg

capitol.360.jpg: capitol.jpg
        convert -swirl 360 capitol.jpg capitol.360.jpg

# the following rule will use umbrella_specs/convert_S_category2.umbrella as its umbrella spec
.UMBRELLA CATEGORY 2
.UMBRELLA SPEC umbrella_specs/convert_S_category2.umbrella
capitol.jpg:
        curl -o capitol.jpg http://ccl.cse.nd.edu/images/capitol.jpg
```

To test makefile with umbrella (without a default umbrella spec):

```
$ makeflow example_in_makefile.makeflow
```

To test makefile with umbrella (with a default umbrella spec):

```
$ makeflow --umbrella-binary $(which umbrella) --umbrella-spec convert_S.umbrella example_in_makefile.makeflow
```
