### PR TITLE
remove waiting_resubmission state

### DIFF
--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -78,7 +78,6 @@ typedef enum {
 	WORK_QUEUE_TASK_RETRIEVED,         /**< Task results are available at the master **/
 	WORK_QUEUE_TASK_DONE,              /**< Task is done, and returned through work_queue_wait >**/
 	WORK_QUEUE_TASK_CANCELED,           /**< Task was canceled before completion **/
-	WORK_QUEUE_TASK_WAITING_RESUBMISSION /**< Worker gave up on the task, and task will be resubmitted >**/
 } work_queue_task_state_t;
 
 typedef enum {


### PR DESCRIPTION
WAITING_RESBUMISSION state was not used anymore. Tasks marked with such state were never rescheduled.