### PR TITLE
Fix histogram edge

### DIFF
--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -137,7 +137,7 @@ OBJECTS = $(SOURCES:%.c=%.o)
 PROGRAMS = catalog_update catalog_server catalog_query watchdog disk_allocator
 SCRIPTS = cctools_gpu_autodetect cctools_python
 TARGETS = $(LIBRARIES) $(PRELOAD_LIBRARIES) $(PROGRAMS) $(TEST_PROGRAMS)
-TEST_PROGRAMS = auth_test disk_alloc_test jx_test microbench multirun jx_count_obj_test histogram_test
+TEST_PROGRAMS = auth_test disk_alloc_test jx_test microbench multirun jx_count_obj_test histogram_test category_test
 
 all: $(TARGETS)
 

--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -321,11 +321,6 @@ int64_t category_first_allocation_min_waste(struct histogram *h, int assume_inde
 			continue;
 		}
 
-		if(a > top_resource) {
-			a_1 = top_resource;
-			break;
-		}
-
 		double Pa = 1 - counts_cdp[i];
 
 		if(assume_independence) {
@@ -381,11 +376,6 @@ int64_t category_first_allocation_max_throughput(struct histogram *h, int64_t to
 
 		if(a < 1) {
 			continue;
-		}
-
-		if(a > top_resource) {
-			a_1 = top_resource;
-			break;
 		}
 
 		double Pbef = counts_cdp[i];

--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -221,9 +221,8 @@ void category_delete(struct hash_table *categories, const char *name) {
 	free(c);
 }
 
-void category_inc_histogram_count_aux(struct histogram *h, double value, double walltime) {
-
-	if(value >= 0 && walltime >= 0) {
+void category_inc_histogram_count_aux(struct histogram *h, double value, double wall_time) {
+	if(value >= 0 && wall_time >= 0) {
 
 		histogram_insert(h, value);
 		double *time_accum = (double *) histogram_get_data(h, value);
@@ -236,16 +235,16 @@ void category_inc_histogram_count_aux(struct histogram *h, double value, double 
 		}
 
 		// accumulate time (in seconds) for this bucket
-		*time_accum += walltime/USECOND;
+		*time_accum += wall_time/USECOND;
 	}
 }
 
 #define category_inc_histogram_count(c, field, summary)\
 {\
 	double value        = (summary)->field;\
-	double walltime     = (summary)->wall_time;\
+	double wall_time    = (summary)->wall_time;\
 	struct histogram *h = c->field##_histogram;\
-	category_inc_histogram_count_aux(h, value, walltime);\
+	category_inc_histogram_count_aux(h, value, wall_time);\
 }
 
 void category_first_allocation_accum_times(struct histogram *h, double *keys, double *tau_mean, double *counts_cdp, double *times_accum) {

--- a/dttools/src/category_test.c
+++ b/dttools/src/category_test.c
@@ -1,0 +1,96 @@
+/*
+   Copyright (C) 2016- The University of Notre Dame
+   This software is distributed under the GNU General Public License.
+   See the file COPYING for details.
+   */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "category_internal.h"
+#include "rmsummary.h"
+#include "debug.h"
+
+const char *category = "test";
+
+
+void print_times(struct category *c) {
+    struct histogram *h = c->disk_histogram;
+    int64_t n = histogram_size(h);
+
+    double *keys = histogram_buckets(h);
+
+    double tau_mean;
+    double *counts_cdp  = malloc(n*sizeof(double));
+    double *times_accum = malloc(n*sizeof(double));
+
+    category_first_allocation_accum_times(h, keys, &tau_mean, counts_cdp, times_accum);    
+
+    fprintf(stdout, "%-6s %-8s %-8s %-16s %-16s %-16s\n", "alloc", "count", "cdp", "times_acc", "W (min best)", "T (max best)");
+
+    int i;
+    for(i = 0; i < n; i++) {
+
+        double a  = keys[i];
+        double a_m = keys[n-1];
+
+        int count = histogram_count(h, a);
+
+        double Ea = a*tau_mean + a_m*times_accum[i];
+
+        double Pbef = counts_cdp[i];
+        double Paft = 1 - Pbef;
+
+        double numerator   = (Pbef*a_m)/a + Paft;
+        double denominator = tau_mean + times_accum[i];
+
+        double  Ta = numerator/denominator;
+
+        fprintf(stdout, "%6.0lf %8d %8.5lf %16.6lf %16.6lf %12.6lf \n", a, count, counts_cdp[i], times_accum[i], Ea, Ta);
+    }
+
+    return;
+}
+
+
+int main(int argc, char **argv) {
+
+    const char *input_name = argv[1];
+
+    FILE *input_f = fopen(input_name, "r");
+    if(!input_f) {
+        fatal("Could not open '%s'", input_name);
+    }
+
+    double wall_time;
+    char   state[64], id[64];
+    int    disk;
+
+    struct hash_table *cs = hash_table_create(0, 0);
+    struct category *c = category_lookup_or_create(cs, category);
+
+    category_specify_allocation_mode(c, CATEGORY_ALLOCATION_MODE_MAX_THROUGHPUT);
+
+    while(fscanf(input_f, "%s %s %lf %d", id, state, &wall_time, &disk) == 4) {
+        struct rmsummary *s = rmsummary_create(-1);
+
+        s->category  = strdup(category);
+        s->taskid    = strdup(id);
+        s->disk      = disk;
+        s->wall_time = wall_time;
+
+        if(strcmp(state, "SUCCESS") != 0) {
+            continue;
+        }
+
+        category_accumulate_summary(c, s, NULL);
+    }
+
+    category_update_first_allocation(c, NULL);
+
+    if(c->first_allocation) {
+        print_times(c);
+        fprintf(stdout, "%" PRId64 "\n", c->first_allocation->disk);
+    }
+}
+

--- a/dttools/src/histogram.c
+++ b/dttools/src/histogram.c
@@ -90,9 +90,11 @@ double histogram_bucket_size(struct histogram *h) {
 }
 
 
+/* buckets are: (start, end], with end as the key. */
 uint64_t bucket_of(struct histogram *h, double value) {
 
-	uint64_t b = abs(floor(value/h->bucket_size));
+	uint64_t b = ceil(value/h->bucket_size);
+	b = abs(b);
 
 	/*
 	 * times 2 so that we can intercalate negative and positive values. itable
@@ -112,8 +114,8 @@ uint64_t bucket_of(struct histogram *h, double value) {
 	return b;
 }
 
-/* return the smallest value that would fall inside the bucket id */
-double start_of(struct histogram *h, uint64_t b) {
+/* return the largest value that would fall inside the bucket id */
+double end_of(struct histogram *h, uint64_t b) {
 
 	/* even b's correspond to negative values */
 	int is_negative = (b % 2 == 0);
@@ -151,7 +153,7 @@ int histogram_insert(struct histogram *h, double value) {
 	}
 
 	if(box->count > mode_count) {
-		h->mode       = start_of(h, bucket);
+		h->mode       = end_of(h, bucket);
 	}
 
 	return box->count;
@@ -200,7 +202,7 @@ double *histogram_buckets(struct histogram *h) {
 
 	itable_firstkey(h->buckets);
 	while(itable_nextkey(h->buckets, &key, (void **) &box)) {
-		values[i] = start_of(h, key);
+		values[i] = end_of(h, key);
 		i++;
 	}
 

--- a/dttools/src/histogram_test.c
+++ b/dttools/src/histogram_test.c
@@ -14,27 +14,27 @@ int main(int argc, char **argv) {
 	// use bucket size of .5
 	struct histogram *h = histogram_create(.5);
 
-	// bucket [3.0, 3.5)
-	histogram_insert(h, 3.00);
-	histogram_insert(h, 3.14);
+	// bucket (3.0, 3.5]
+	histogram_insert(h, 3.01);
+	histogram_insert(h, 3.5);
 
-	// bucket [21.5, 22.0)
+	// bucket (21.5, 22.0]
 	histogram_insert(h, 21.99);
 
-	// bucket [22.0, 22.5)
-	histogram_insert(h, 22.00);
+	// bucket (22.0, 22.5]
+	histogram_insert(h, 22.01);
 	histogram_insert(h, 22.20);
-	histogram_insert(h, 22.49);
-
-	// bucket [22.5, 23.0)
 	histogram_insert(h, 22.50);
+
+	// bucket (22.5, 23.0]
+	histogram_insert(h, 22.51);
 	histogram_insert(h, 22.99);
 
-	// bucket [-22.0, -21.5)
-	histogram_insert(h, -21.51);
-	histogram_insert(h, -22.00);
+	// bucket (-22.0, -21.5]
+	histogram_insert(h, -21.50);
+	histogram_insert(h, -21.99);
 
-	// bucket [-21.5, -21.0)
+	// bucket (-21.5, -21.0]
 	histogram_insert(h, -21.49);
 	histogram_insert(h, -21.20);
 	histogram_insert(h, -21.01);
@@ -47,19 +47,19 @@ int main(int argc, char **argv) {
 	int i;
 	for(i = 0; i < histogram_size(h); i++) {
 
-		double start = buckets[i];
-		int count    = histogram_count(h, start);
+		double end = buckets[i];
+		int count  = histogram_count(h, end);
 
 		if(expected_counts[i] != count) {
 			fprintf(stderr, "Expected a count of %d, got %d.", expected_counts[i], count);
 			return -1;
 		}
 
-		fprintf(stdout, "[%6.2lf, %6.2f) count: %d\n", start, start + b, histogram_count(h, start));
+		fprintf(stdout, "(%6.2lf, %6.2f] count: %d\n", end - b, end, histogram_count(h, end));
 	}
 
-	fprintf(stdout, "max: %6.2lf\n",    histogram_max_value(h));
-	fprintf(stdout, "min: %6.2lf\n",    histogram_min_value(h));
+	fprintf(stdout, "max:  %6.2lf\n",    histogram_max_value(h));
+	fprintf(stdout, "min:  %6.2lf\n",    histogram_min_value(h));
 	fprintf(stdout, "mode: %6.2lf\n",   histogram_mode(h));
 	fprintf(stdout, "mode count: %d\n", histogram_count(h, histogram_mode(h)));
 

--- a/dttools/test/TR_category.sh
+++ b/dttools/test/TR_category.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+. ../../dttools/test/test_runner_common.sh
+
+prepare()
+{
+	return 0
+}
+
+run()
+{
+	value=$(../src/category_test disk-test.data | tail -n1)
+
+	test "$value" = 1300
+	return $?
+}
+
+clean()
+{
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -1598,6 +1598,8 @@ int main(int argc, char **argv)
 
 	debug(D_RMON, "Reading summaries.");
 
+	category_tune_bucket_size("category-steady-n-tasks", 10000000000);
+
 	if(input_list)
 	{
 		parse_summary_from_filelist(all_summaries, input_list, categories);


### PR DESCRIPTION
As found by @klannon, first allocations were being rounded down as we were using the bottom edge of the histogram buckets. This pr changes allocations to use top edges, and adds a test for the category code.