### PR TITLE
Use Mersenne Twister in string_cookie

### DIFF
--- a/dttools/src/random.c
+++ b/dttools/src/random.c
@@ -18,10 +18,9 @@
 #include <string.h>
 #include <time.h>
 
-int random_initialized = 0;
-
 void random_init (void)
 {
+	static int random_initialized = 0;
 	if (random_initialized) return;
 	int fd = open("/dev/urandom", O_RDONLY);
 	if (fd == -1) {

--- a/dttools/src/random.c
+++ b/dttools/src/random.c
@@ -18,8 +18,11 @@
 #include <string.h>
 #include <time.h>
 
+int random_initialized = 0;
+
 void random_init (void)
 {
+	if (random_initialized) return;
 	int fd = open("/dev/urandom", O_RDONLY);
 	if (fd == -1) {
 		fd = open("/dev/random", O_RDONLY);
@@ -33,12 +36,14 @@ void random_init (void)
 	} else {
 		uint64_t seed;
 nasty_fallback:
+		fprintf(stderr, "warning: falling back to low-quality entropy");
 		seed = (uint64_t)getpid() ^ (uint64_t)time(NULL);
 		seed |= (((uint64_t)(uintptr_t)&seed) << 32); /* using ASLR */
 		srand(seed);
 		twister_init_genrand64(seed);
 	}
 	close(fd);
+	random_initialized = 1;
 	return;
 }
 

--- a/dttools/src/random.c
+++ b/dttools/src/random.c
@@ -7,6 +7,7 @@
 #include "full_io.h"
 #include "random.h"
 #include "twister.h"
+#include "debug.h"
 
 #include <fcntl.h>
 #include <unistd.h>
@@ -35,7 +36,7 @@ void random_init (void)
 	} else {
 		uint64_t seed;
 nasty_fallback:
-		fprintf(stderr, "warning: falling back to low-quality entropy");
+		debug(D_NOTICE, "warning: falling back to low-quality entropy");
 		seed = (uint64_t)getpid() ^ (uint64_t)time(NULL);
 		seed |= (((uint64_t)(uintptr_t)&seed) << 32); /* using ASLR */
 		srand(seed);

--- a/dttools/src/stringtools.c
+++ b/dttools/src/stringtools.c
@@ -6,6 +6,7 @@ See the file COPYING for details.
 */
 
 #include "debug.h"
+#include "random.h"
 #include "stringtools.h"
 #include "timestamp.h"
 #include "xxmalloc.h"
@@ -472,9 +473,10 @@ char *string_pad_left(char *old, int length)
 void string_cookie(char *s, int length)
 {
 	int i;
+	random_init();
 
 	for(i = 0; i < length; i++) {
-		s[i] = rand() % 26 + 'a';
+		s[i] = random_int() % 26 + 'a';
 	}
 
 	s[length - 1] = 0;


### PR DESCRIPTION
This is for #1506 

A CSPRNG might be nice, but I agree it's not really necessary for our use. We wouldn't want to use a `string_cookie` for any sort of key material or anything beyond the simple handshake. It looks like Mersenne Twister was added fairly recently and hasn't made it all the way through the codebase, so thanks for the issue @bbockelm