### PR TITLE
Let bindings

### DIFF
--- a/doc/jx.html
+++ b/doc/jx.html
@@ -412,6 +412,25 @@ join(["a", "b", "c"], ", ")
 =&gt; "a, b, c"
 </code></pre>
 
+<h3 id="let">let<a class="sectionlink" href="#let" title="Link to this section.">&#x21d7;</a></h3>
+
+<blockquote>
+<pre><code>let(A, B) -&gt; C
+</code></pre>
+
+<p>where A = Object</p>
+</blockquote>
+
+<p>Evaluates an expression with local name bindings. The first argument is an object whose keys will be bound variable names when evaluating the second argument.
+Names specified in a local scope may shadow names in the enclosing scope.</p>
+
+<pre><code>let({"x": 10}, 1 + x)
+=&gt; 11
+
+let({"x": 10, "y": 20}, let({"x": 1}, x + y))
+=&gt; 21
+</code></pre>
+
 <h3 id="dbg">dbg<a class="sectionlink" href="#dbg" title="Link to this section.">&#x21d7;</a></h3>
 
 <blockquote>

--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -628,6 +628,7 @@ const char *jx_error_name(int code) {
 	case 4: return "range error";
 	case 5: return "arithmetic error";
 	case 6: return "invalid arguments";
+	case 7: return "invalid context";
 	default: return "unknown error";
 	}
 }

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -87,7 +87,7 @@ typedef enum {
 	JX_OP_OR,
 	JX_OP_NOT,
 	JX_OP_LOOKUP,
-	JX_OP_INVALID
+	JX_OP_INVALID,
 } jx_operator_t;
 
 struct jx_operator {
@@ -98,11 +98,12 @@ struct jx_operator {
 
 typedef enum {
 	JX_FUNCTION_INVALID = 0,
+	JX_FUNCTION_DBG,
 	JX_FUNCTION_RANGE,
 	JX_FUNCTION_STR,
 	JX_FUNCTION_FOREACH,
 	JX_FUNCTION_JOIN,
-	JX_FUNCTION_DBG,
+	JX_FUNCTION_LET,
 } jx_function_t;
 
 struct jx_function {

--- a/dttools/src/jx_eval.c
+++ b/dttools/src/jx_eval.c
@@ -354,6 +354,8 @@ static struct jx *jx_eval_function( struct jx_function *f, struct jx *context )
 {
 	if(!f) return NULL;
 	switch(f->function) {
+		case JX_FUNCTION_DBG:
+			return jx_function_dbg(f, context);
 		case JX_FUNCTION_RANGE:
 			return jx_function_range(f, context);
 		case JX_FUNCTION_FOREACH:
@@ -362,8 +364,8 @@ static struct jx *jx_eval_function( struct jx_function *f, struct jx *context )
 			return jx_function_str(f, context);
 		case JX_FUNCTION_JOIN:
 			return jx_function_join(f, context);
-		case JX_FUNCTION_DBG:
-			return jx_function_dbg(f, context);
+		case JX_FUNCTION_LET:
+			return jx_function_let(f, context);
 		case JX_FUNCTION_INVALID:
 			return NULL;
 	}

--- a/dttools/src/jx_eval.c
+++ b/dttools/src/jx_eval.c
@@ -527,6 +527,17 @@ struct jx * jx_eval( struct jx *j, struct jx *context )
 {
 	if(!j) return 0;
 
+	if (context && !jx_istype(context, JX_OBJECT)) {
+		struct jx *err = jx_object(NULL);
+		int code = 7;
+		jx_insert_integer(err, "code", code);
+		jx_insert(err, jx_string("context"), jx_copy(context));
+		jx_insert_string(err, "message", "context must be an object");
+		jx_insert_string(err, "name", jx_error_name(code));
+		jx_insert_string(err, "source", "jx_eval");
+		return jx_error(err);
+	}
+
 	switch(j->type) {
 		case JX_SYMBOL:
 			if(context) {

--- a/dttools/src/jx_function.c
+++ b/dttools/src/jx_function.c
@@ -277,7 +277,6 @@ struct jx *jx_function_let(struct jx_function *f, struct jx *context) {
 	struct jx *body = NULL;
 	struct jx *scratch = NULL;
 	struct jx *err = NULL;
-	struct jx *ctx = NULL;
 
 	if (jx_match_array(f->arguments, &bindings, JX_ANY, &body, JX_ANY, &scratch, JX_ANY, NULL) != 2) {
 		jx_delete(bindings);
@@ -310,10 +309,14 @@ struct jx *jx_function_let(struct jx_function *f, struct jx *context) {
 		return jx_error(err);
 	}
 
-	ctx = jx_merge(context, bindings, NULL);
-	jx_delete(bindings);
-	scratch = jx_eval(body, ctx);
-	jx_delete(ctx);
+	if (context) {
+		context = jx_merge(context, bindings, NULL);
+		jx_delete(bindings);
+	} else {
+		context = bindings;
+	}
+	scratch = jx_eval(body, context);
+	jx_delete(context);
 	jx_delete(body);
 	return scratch;
 }

--- a/dttools/src/jx_function.h
+++ b/dttools/src/jx_function.h
@@ -15,6 +15,7 @@ struct jx *jx_function_range(struct jx_function *f, struct jx *context);
 struct jx *jx_function_foreach(struct jx_function *f, struct jx *context);
 struct jx *jx_function_str(struct jx_function *f, struct jx *context);
 struct jx *jx_function_join(struct jx_function *f, struct jx *context);
+struct jx *jx_function_let(struct jx_function *f, struct jx *context);
 struct jx *jx_function_dbg(struct jx_function *f, struct jx *context);
 
 #endif

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -328,10 +328,10 @@ expression: join(["a","b",c])
 value:      Error{"source":"jx_eval","name":"undefined symbol","message":"undefined symbol","context":{"outfile":"results","infile":"mydata","a":true,"b":false,"f":0.5,"g":3.14159,"x":10,"y":20,"list":[100,200,300],"object":{"house":"home"}},"symbol":c,"code":0}
 
 expression: join([1,2])
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"joined items must be strings","func":join([1,2]),"code":6}
+value:      Error{"source":"jx_eval","name":"invalid arguments","message":"joined items must be strings","function":join([1,2]),"code":6}
 
 expression: join(["a",2])
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"joined items must be strings","func":join(["a",2]),"code":6}
+value:      Error{"source":"jx_eval","name":"invalid arguments","message":"joined items must be strings","function":join(["a",2]),"code":6}
 
 expression: join([])
 value:      ""
@@ -383,4 +383,7 @@ value:      true
 
 expression: Error{"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"}
 value:      Error{"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"}
+
+expression: let({"f":2.2,"g":4.5},f+y)
+value:      22.2
 

--- a/dttools/test/jx.input
+++ b/dttools/test/jx.input
@@ -170,3 +170,5 @@ dbg(join(dbg(foreach(x, dbg(range(dbg(3))), dbg(dbg(str(dbg(x))) + dbg(".") + db
 ;[1,2,[3,4]] == [1,2,[3,4]]
 
 Error{"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"}
+
+let({"f": 2.2, "g": 4.5}, f + y)

--- a/makeflow/example/example.jx
+++ b/makeflow/example/example.jx
@@ -1,11 +1,10 @@
-{
+let({
+  "CURL":"/usr/bin/curl"
+}, {
   "comment":[
     "This is a sample Makeflow script that retrieves an image from the web",
     "creates four variations of it, and then combines them into an animation"
   ],
-  "variables":{
-    "CURL":"/usr/bin/curl"
-  },
   "environment":{
     "CONVERT":"/usr/bin/convert"
   },
@@ -35,15 +34,13 @@
       "outputs":["capitol.360.jpg"],
       "inputs":["capitol.jpg"]
     },
-    {
+    let({
+      "URL":"http://ccl.cse.nd.edu/images/capitol.jpg"
+    }, {
       "command":CURL + " -o capitol.jpg " + URL,
       "outputs":["capitol.jpg"],
-      "variables":{
-        "URL":"http://ccl.cse.nd.edu/images/capitol.jpg"
-      },
       "comment":"If a rule is specified with local_job, it executes at the local site",
       "local_job":true
-    }
+    })
   ]
-}
-
+})

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -29,6 +29,7 @@ See the file COPYING for details.
 #include "jx.h"
 #include "jx_print.h"
 #include "jx_parse.h"
+#include "jx_eval.h"
 
 #include "dag.h"
 #include "dag_visitors.h"
@@ -1638,8 +1639,12 @@ if (enforcer && wrapper_umbrella) {
 	struct dag *d;
 	if (json_input) {
 		struct jx *j = jx_parse_file(dagfile);
-		d = dag_from_jx(j);
+		if (!j) fatal("couldn't parse %s\n", dagfile);
+		struct jx *k = jx_eval(j, NULL);
+		if (!k) fatal("couldn't evaluate %s\n", dagfile);
+		d = dag_from_jx(k);
 		jx_delete(j);
+		jx_delete(k);
 	} else {
 		d = dag_from_file(dagfile);
 	}

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -123,6 +123,7 @@ static int skip_file_check = 0;
 static int cache_mode = 1;
 
 static int jx_input = 0;
+static char *jx_context = NULL;
 
 static container_mode_t container_mode = CONTAINER_MODE_NONE;
 static char *container_image = NULL;
@@ -1103,6 +1104,7 @@ static void show_help_run(const char *cmd)
 	printf(" %-30s Path to parrot_run (defaults to current directory).\n", "--parrot-path=<path>");
 	printf(" %-30s Indicate preferred master connection. Choose one of by_ip or by_hostname. (default is by_ip)\n", "--work-queue-preferred-connection");
 	printf(" %-30s Use JX format rather than Make-style format for the input file.\n", "--jx");
+	printf(" %-30s Evaluate the JX input in the given context.\n", "--jx-context");
         printf(" %-30s Wrap execution of all rules in a singularity container.\n","--singularity=<image>");
 
 	printf("\n*Monitor Options:\n\n");
@@ -1205,6 +1207,7 @@ int main(int argc, char *argv[])
 		LONG_OPT_AMAZON_CREDENTIALS,
 		LONG_OPT_AMAZON_AMI,
 		LONG_OPT_JX,
+		LONG_OPT_JX_CONTEXT,
 		LONG_OPT_SKIP_FILE_CHECK,
 		LONG_OPT_UMBRELLA_BINARY,
 		LONG_OPT_UMBRELLA_LOG_PREFIX,
@@ -1283,6 +1286,7 @@ int main(int argc, char *argv[])
 		{"amazon-credentials", required_argument, 0, LONG_OPT_AMAZON_CREDENTIALS},
 		{"amazon-ami", required_argument, 0, LONG_OPT_AMAZON_AMI},
 		{"jx", no_argument, 0, LONG_OPT_JX},
+		{"jx-context", required_argument, 0, LONG_OPT_JX_CONTEXT},
 		{"enforcement", no_argument, 0, LONG_OPT_ENFORCEMENT},
 		{"parrot-path", required_argument, 0, LONG_OPT_PARROT_PATH},
         {"singularity", required_argument, 0, LONG_OPT_SINGULARITY},
@@ -1551,6 +1555,9 @@ int main(int argc, char *argv[])
 			case LONG_OPT_JX:
 				jx_input = 1;
 				break;
+			case LONG_OPT_JX_CONTEXT:
+				jx_context = xxstrdup(optarg);
+				break;
 			case LONG_OPT_UMBRELLA_BINARY:
 				if(!wrapper_umbrella) wrapper_umbrella = makeflow_wrapper_umbrella_create();
 				makeflow_wrapper_umbrella_set_binary(wrapper_umbrella, (const char *)xxstrdup(optarg));
@@ -1638,13 +1645,22 @@ if (enforcer && wrapper_umbrella) {
 	printf("parsing %s...\n",dagfile);
 	struct dag *d;
 	if (jx_input) {
-		struct jx *j = jx_parse_file(dagfile);
-		struct jx *k = jx_eval(j, NULL);
-		d = dag_from_jx(k);
-		jx_delete(j);
-		jx_delete(k);
 		// JX doesn't really use errno, so give something generic
 		errno = EINVAL;
+		struct jx *t = NULL;
+		if (jx_context) {
+			printf("using JX context %s\n", jx_context);
+			t = jx_parse_file(jx_context);
+			if (!t) fatal("couldn't parse context: %s\n", strerror(errno));
+		}
+		struct jx *ctx = jx_eval(t, NULL);
+		jx_delete(t);
+		t = jx_parse_file(dagfile);
+		struct jx *dag = jx_eval(t, ctx);
+		jx_delete(t);
+		jx_delete(ctx);
+		d = dag_from_jx(dag);
+		jx_delete(dag);
 	} else {
 		d = dag_from_file(dagfile);
 	}

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -122,7 +122,7 @@ static int skip_file_check = 0;
 
 static int cache_mode = 1;
 
-static int json_input = 0;
+static int jx_input = 0;
 
 static container_mode_t container_mode = CONTAINER_MODE_NONE;
 static char *container_image = NULL;
@@ -1102,7 +1102,7 @@ static void show_help_run(const char *cmd)
 	printf(" %-30s Use Parrot to restrict access to the given inputs/outputs.\n", "--enforcement");
 	printf(" %-30s Path to parrot_run (defaults to current directory).\n", "--parrot-path=<path>");
 	printf(" %-30s Indicate preferred master connection. Choose one of by_ip or by_hostname. (default is by_ip)\n", "--work-queue-preferred-connection");
-	printf(" %-30s Use JSON format rather than Make-style format for the input file.\n", "--json");
+	printf(" %-30s Use JX format rather than Make-style format for the input file.\n", "--jx");
         printf(" %-30s Wrap execution of all rules in a singularity container.\n","--singularity=<image>");
 
 	printf("\n*Monitor Options:\n\n");
@@ -1204,7 +1204,7 @@ int main(int argc, char *argv[])
 		LONG_OPT_DOCKER_TAR,
 		LONG_OPT_AMAZON_CREDENTIALS,
 		LONG_OPT_AMAZON_AMI,
-		LONG_OPT_JSON,
+		LONG_OPT_JX,
 		LONG_OPT_SKIP_FILE_CHECK,
 		LONG_OPT_UMBRELLA_BINARY,
 		LONG_OPT_UMBRELLA_LOG_PREFIX,
@@ -1282,7 +1282,7 @@ int main(int argc, char *argv[])
 		{"docker-tar", required_argument, 0, LONG_OPT_DOCKER_TAR},
 		{"amazon-credentials", required_argument, 0, LONG_OPT_AMAZON_CREDENTIALS},
 		{"amazon-ami", required_argument, 0, LONG_OPT_AMAZON_AMI},
-		{"json", no_argument, 0, LONG_OPT_JSON},
+		{"jx", no_argument, 0, LONG_OPT_JX},
 		{"enforcement", no_argument, 0, LONG_OPT_ENFORCEMENT},
 		{"parrot-path", required_argument, 0, LONG_OPT_PARROT_PATH},
         {"singularity", required_argument, 0, LONG_OPT_SINGULARITY},
@@ -1548,8 +1548,8 @@ int main(int argc, char *argv[])
 				} else {
 					fatal("Allocation mode '%s' is not valid. Use one of: throughput waste fixed");
 				}
-			case LONG_OPT_JSON:
-				json_input = 1;
+			case LONG_OPT_JX:
+				jx_input = 1;
 				break;
 			case LONG_OPT_UMBRELLA_BINARY:
 				if(!wrapper_umbrella) wrapper_umbrella = makeflow_wrapper_umbrella_create();
@@ -1637,14 +1637,14 @@ if (enforcer && wrapper_umbrella) {
 
 	printf("parsing %s...\n",dagfile);
 	struct dag *d;
-	if (json_input) {
+	if (jx_input) {
 		struct jx *j = jx_parse_file(dagfile);
-		if (!j) fatal("couldn't parse %s\n", dagfile);
 		struct jx *k = jx_eval(j, NULL);
-		if (!k) fatal("couldn't evaluate %s\n", dagfile);
 		d = dag_from_jx(k);
 		jx_delete(j);
 		jx_delete(k);
+		// JX doesn't really use errno, so give something generic
+		errno = EINVAL;
 	} else {
 		d = dag_from_file(dagfile);
 	}

--- a/makeflow/src/parser_jx.c
+++ b/makeflow/src/parser_jx.c
@@ -315,7 +315,7 @@ struct dag *dag_from_jx(struct jx *j) {
 	struct jx *rules = jx_lookup(j, "rules");
 	if (jx_istype(rules, JX_ARRAY)) {
 		struct jx *item;
-		void *i;
+		void *i = NULL;
 		while ((item = jx_iterate_array(rules, &i))) {
 			if (!rule_from_jx(d, item)) {
 				debug(D_MAKEFLOW_PARSER, "Failure parsing rule");

--- a/makeflow/src/parser_jx.c
+++ b/makeflow/src/parser_jx.c
@@ -194,16 +194,15 @@ static int rule_from_jx(struct dag *d, struct jx *j) {
 	d->nodes = n;
 	itable_insert(d->node_table, n->nodeid, n);
 
-	jx_match_boolean(jx_lookup(j, "local_job"), &n->local_job);
+	n->local_job = jx_lookup_boolean(j, "local_job");
 	if (n->local_job) {
 		debug(D_MAKEFLOW_PARSER, "Local job");
 	}
 
-	char *category;
-	if (jx_match_string(jx_lookup(j, "category"), &category)) {
+	const char *category = jx_lookup_string(j, "category");
+	if (category) {
 		debug(D_MAKEFLOW_PARSER, "Category %s", category);
 		n->category = makeflow_category_lookup_or_create(d, category);
-		free(category);
 	} else {
 		debug(D_MAKEFLOW_PARSER, "category malformed or missing, using default");
 		n->category = makeflow_category_lookup_or_create(d, "default");
@@ -214,8 +213,8 @@ static int rule_from_jx(struct dag *d, struct jx *j) {
 		return 0;
 	}
 
-	char *allocation;
-	if (jx_match_string(jx_lookup(j, "allocation"), &allocation)) {
+	const char *allocation = jx_lookup_string(j, "allocation");
+	if (allocation) {
 		if (!strcmp(allocation, "first")) {
 			debug(D_MAKEFLOW_PARSER, "first allocation");
 			n->resource_request = CATEGORY_ALLOCATION_FIRST;
@@ -227,10 +226,8 @@ static int rule_from_jx(struct dag *d, struct jx *j) {
 			n->resource_request = CATEGORY_ALLOCATION_ERROR;
 		} else {
 			debug(D_MAKEFLOW_PARSER, "Unknown allocation");
-			free(allocation);
 			return 0;
 		}
-		free(allocation);
 	} else {
 		debug(D_MAKEFLOW_PARSER, "Allocation malformed or missing");
 	}


### PR DESCRIPTION
Makeflow's JX representation was written to allow JX variables to be introduced at the file level and at the rule level, using special `"variables"` keys under the root object and rule objects. Unfortunately, this made evaluating the Makeflow complicated. Previously, Makeflow's parser built the contexts itself and `jx_eval`ed each rule object individually. Aside from being ugly, this precludes using a function or operator to build the list of rules, as you need to evaluate that down to an array. @nhazekam have been thinking about how to do this for some time and were coming up with quoting + multiple eval passes, some sort of partial or lazy evaluation, eval hooks, etc.


I realized that Makeflow has no business building and manipulating variable contexts, which should be part of the JX language. As of this PR, Makeflow only knows about `"environment"` mappings that it can put into the DAG. To allow local variable contexts, I added a new JX function,

    let(bindings, expr)

that binds the names in `bindings` into the context for evaluating `expr`. The bindings themselves get evaluated in the enclosing context. I think this is less surprising than the previous behavior, as there are no magic Makeflow evaluation rules; plain `jx_eval` gives the same result that Makeflow will use. Users also get more precise and straightforward control over what variables are in scope, and aren't restricted to awkward per-rule evaluation contexts.

This also brings us one function closer to Lisp...