### PR TITLE
Add Wrappers to Factory

### DIFF
--- a/doc/man/work_queue_factory.m4
+++ b/doc/man/work_queue_factory.m4
@@ -64,7 +64,8 @@ OPTION_PAIR(--factory-timeout, n)Exit after no master has been seen in <n> secon
 OPTION_TRIPLET(-d,debug,flag)Enable debugging for this subsystem.
 OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
 OPTION_PAIR(--factory-timeout, #)Set factory timeout to <#> seconds. (off by default) This will cause work queue to exit when their are no masters present after the given number of seconds.
-
+OPTION_PAIR(--wrapper,Wrap all commands with this prefix.)
+OPTION_PAIR(--wrapper-input,Add this file needed by the wrapper.)
 OPTION_ITEM(`-h, --help')Show this screen.
 OPTIONS_END
 


### PR DESCRIPTION
First pass at adding wrapping functionality to the factory.  This allows you to prefix the worker with an environmental construction tool, for example:

Run a bunch of workers inside an Umbrella environment:
```
work_queue_factory --wrapper "umbrella run myenv.spec" --wrapper-input "myenv.spec" . . .
```

Run workers inside a singularity container:
```
work_queue_factory --wrapper "/usr/bin/singularity run my.img" --wrapper-input "my.img" . . .
```

The code is not quite as elegant as I hoped; if we use the existing `string_wrap_command()`, it carefully escapes all of the dollar-dollar escapes that we want Condor to substitute.  Arg.  So, this one only allows the wrapper to be a prefix on the current command.  Needs more thought.

@btovar @klannon should come in handy for deploying Lobster in a new environment.
