### PR TITLE
Update makeflow_blast/bwa README

### DIFF
--- a/apps/makeflow_blast/README
+++ b/apps/makeflow_blast/README
@@ -10,20 +10,20 @@ To build Makeflow:
 ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/
 2. Install CCTools.
 3. Copy makeflow_blast from cctools/apps to the location the makeflow will be executed.
-4. Run './makeflow_blast -p blastx -d database_name -i input.fa -o output.txt --makeflow Makeflow'
-This produces a file called Makeflow.
+4. Run './makeflow_blast -p blastx -d database_name -i input.fa -o output.txt --makeflow blast_makeflow'
+This produces a file called blast_makeflow.
 
 To run:
 
 1. Run 'makeflow'
 Note if the --makeflow option is specified with a MAKEFLOWFILE, run
-makeflow <MAKEFLOWFILE>
+makeflow blast_makeflow
 
 This step runs the makeflow locally on the machine on which it is executed.
 
 2. If you want to run with a distributed execution engine (Work Queue, Condor,
 or SGE), specify the '-T' option. For example, to run with Work Queue,
-makeflow -T wq
+makeflow blast_makeflow -T wq
 
 3. Start Workers
 work_queue_workers -d all <HOSTNAME> <PORT>
@@ -32,7 +32,7 @@ where <HOSTNAME> is the name of the host on which the master is running
 
 Alternatively, you can also specify a project name for the master and use that
 to start workers:
-1. makeflow -T wq -N BLAST
+1. makeflow blast_makeflow -T wq -N BLAST
 2. work_queue_worker -d all -N BLAST
 
 For listing the command-line options, do:

--- a/apps/makeflow_bwa/Makeflow
+++ b/apps/makeflow_bwa/Makeflow
@@ -1,2 +1,0 @@
-CATEGORY="analysis"
-CORES=1

--- a/apps/makeflow_bwa/README
+++ b/apps/makeflow_bwa/README
@@ -10,14 +10,14 @@ To build Makeflow:
 http://sourceforge.net/projects/bio-bwa/files/
 2. Install CCTools.
 3. Copy makeflow_bwa from cctools/apps to the location the makeflow will be executed.
-4. Run './makeflow_bwa --ref test_ref.fa --fastq test_query.fq --output_SAM output.sam --algoalign bwa_{backtrack|bwasw|mem} --makeflow Makeflow'
-This produces a file called Makeflow.
+4. Run './makeflow_bwa --ref test_ref.fa --query test_query.fq --output_SAM output.sam --algo mem --makeflow bwa_makeflow'
+This produces a file called bwa_makeflow.
 
 To run:
 
 1. Run 'makeflow'
 Note if the --makeflow option is specified with a MAKEFLOWFILE, run
-makeflow <MAKEFLOWFILE>
+makeflow bwa_makeflow
 
 This step runs the makeflow locally on the machine on which it is executed.
 
@@ -32,7 +32,7 @@ where <HOSTNAME> is the name of the host on which the master is running
 
 Alternatively, you can also specify a project name for the master and use that
 to start workers:
-1. makeflow -T wq -N BWA
+1. makeflow bwa_makeflow -T wq -N BWA
 2. work_queue_worker -d all -N BWA
 
 For listing the command-line options, do:


### PR DESCRIPTION
Updates bwa from fastq to query.

Also moves examples to using named makeflow file instead of Makeflow.