### PR TITLE
Reset the input files of makeflow umbrella wrapper for each rule

### DIFF
--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -530,6 +530,8 @@ static void makeflow_node_submit(struct dag *d, struct dag_node *n)
 		queue = remote_queue;
 	}
 
+	makeflow_wrapper_umbrella_set_input_files(wrapper_umbrella, queue, n);
+
 	struct list *input_list  = makeflow_generate_input_files(n, wrapper, monitor, enforcer, wrapper_umbrella);
 	struct list *output_list = makeflow_generate_output_files(n, wrapper, monitor, enforcer, wrapper_umbrella);
 

--- a/makeflow/src/makeflow_wrapper_umbrella.h
+++ b/makeflow/src/makeflow_wrapper_umbrella.h
@@ -25,6 +25,8 @@ void makeflow_wrapper_umbrella_set_log_prefix(struct makeflow_wrapper_umbrella *
 
 void makeflow_wrapper_umbrella_set_mode(struct makeflow_wrapper_umbrella *w, const char *mode);
 
+void makeflow_wrapper_umbrella_set_input_files(struct makeflow_wrapper_umbrella *w, struct batch_queue *queue, struct dag_node *n);
+
 void makeflow_wrapper_umbrella_preparation(struct makeflow_wrapper_umbrella *w, struct batch_queue *queue, struct dag *d);
 
 char *makeflow_wrap_umbrella(char *result, struct dag_node *n, struct makeflow_wrapper_umbrella *w, struct batch_queue *queue, char *input_files, char *output_files);


### PR DESCRIPTION
Every rule in a makefile may have its own umbrella spec file.
To avoid `w->wrapper->input_files` accumulating umbrella spec files for different rules, first clean it up and then recreate it.