### PR TITLE
Allow --umbrella-spec option and LOCAL tag used together

### DIFF
--- a/makeflow/src/makeflow_wrapper_umbrella.c
+++ b/makeflow/src/makeflow_wrapper_umbrella.c
@@ -145,7 +145,7 @@ void makeflow_wrapper_umbrella_preparation(struct makeflow_wrapper_umbrella *w, 
 		// Therefore, we stop check the existence of umbrella_logfile here.
 
 		// add umbrella_logfile into the target files of a dag_node
-		if(remote_rename_support) {
+		if(remote_rename_support && !cur->local_job) {
 			dag_node_add_target_file(cur, umbrella_logfile, umbrella_logfile);
 		} else {
 			dag_node_add_target_file(cur, umbrella_logfile, NULL);

--- a/makeflow/src/makeflow_wrapper_umbrella.c
+++ b/makeflow/src/makeflow_wrapper_umbrella.c
@@ -145,11 +145,7 @@ void makeflow_wrapper_umbrella_preparation(struct makeflow_wrapper_umbrella *w, 
 		// Therefore, we stop check the existence of umbrella_logfile here.
 
 		// add umbrella_logfile into the target files of a dag_node
-		if(remote_rename_support && !cur->local_job) {
-			dag_node_add_target_file(cur, umbrella_logfile, umbrella_logfile);
-		} else {
-			dag_node_add_target_file(cur, umbrella_logfile, NULL);
-		}
+		dag_node_add_target_file(cur, umbrella_logfile, NULL);
 		free(umbrella_logfile);
 		cur = cur->next;
 	}


### PR DESCRIPTION
Currently, using the `--umbrella-spec` option of makeflow and the `LOCAL` tag in a makefile together would cause the following error:
```
makeflow[175943] error: Remote renaming is not supported with -Tlocal or LOCAL execution. Rule 1.
```
Problem:
the umbrella log file is added into the target files of a dag node with a remote name even if the rule is marked as `LOCAL`.

Solution:
If the job is marked as `LOCAL`, adding the umbrella log file into the target file without the rename name.