### PR TITLE
Handle bind()/connect() on abstract AF_UNIX sockets

### DIFF
--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -1918,7 +1918,10 @@ static void decode_syscall( struct pfs_process *p, int entering )
 				}
 				addr.sun_path[sizeof(addr.sun_path)-1] = '\0';
 
-				if (addr.sun_family == AF_UNIX) {
+				/* If addr.sun_path is an abstract AF_UNIX socket name, it will be prefixed with a null byte.
+				 * Since abstract sockets don't have any connection to the filesystem, we don't care about them.
+				 */
+				if (addr.sun_family == AF_UNIX && addr.sun_path[0] != '\0') {
 					assert(sizeof(p->tmp) >= sizeof(addr));
 					memcpy(p->tmp, &addr, sizeof(addr)); /* save a copy of original addr structure */
 

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -1655,7 +1655,10 @@ static void decode_syscall( struct pfs_process *p, int entering )
 				}
 				addr.sun_path[sizeof(addr.sun_path)-1] = '\0';
 
-				if (addr.sun_family == AF_UNIX) {
+				/* If addr.sun_path is an abstract AF_UNIX socket name, it will be prefixed with a null byte.
+				 * Since abstract sockets don't have any connection to the filesystem, we don't care about them.
+				 */
+				if (addr.sun_family == AF_UNIX && addr.sun_path[0] != '\0') {
 					assert(sizeof(p->tmp) >= sizeof(addr));
 					memcpy(p->tmp, &addr, sizeof(addr)); /* save a copy of original addr structure */
 

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -191,8 +191,7 @@ int pfs_table::bind( int fd, char *lpath, size_t len )
 {
 	if (!isnative(fd))
 		return (errno = EBADF, -1);
-	if (strlen(lpath) == 0)
-		return (errno = ENOENT, -1);
+	assert(strlen(lpath) > 0);
 
 	/* Resolve the path... */
 	struct pfs_name pname;


### PR DESCRIPTION
This addresses #1548

I've been testing on `xstream-ln02.stanford.edu`. I can confirm that the program mentioned in the original bug report works as expected with these changes. 