### PR TITLE
IPV6 Support

### DIFF
--- a/chirp/src/chirp_client.c
+++ b/chirp/src/chirp_client.c
@@ -25,6 +25,7 @@ See the file COPYING for details.
 #include "string_array.h"
 #include "url_encode.h"
 #include "xxmalloc.h"
+#include "address.h"
 
 #if defined(HAS_ATTR_XATTR_H)
 #	include <attr/xattr.h>
@@ -341,59 +342,6 @@ struct chirp_client *chirp_client_connect_condor(time_t stoptime)
 	return client;
 }
 
-static int strcount( const char *s, char c )
-{
-	int count=0;
-	while(*s) {
-		if(*s++==c) count++;
-	}
-	return count;
-}
-
-/*
-The hostport parameter may have an optional port number
-separated from the host by a colon.  The meaning of this
-was clear in the IPV4 days, because the possible formats
-were this:
-
-domain.name
-domain.name:1234
-100.200.300.400
-100.200.300.400:1234
-
-Now that IPV6 is a possibility, parsing is complicated b/c
-the address itself can contain colons.  The custom is to
-surround the address with brackets when a port is given.
-So, we must also catch these formats:
-
-100:200:300::400:500
-[100:200:300::400:500]:1234
-*/
-
-static int parse_hostport( const char *hostport, char *host, int * port )
-{
-	*port = CHIRP_PORT;
-
-	int c = strcount(hostport,':');
-	if(c==0) {
-		strcpy(host,hostport);
-		return 1;
-	} else if(c==1) {
-		if(sscanf(hostport,"%[^:]:%d",host,port)==2) {
-			return 1;
-		} else {
-			return 0;
-		}
-	} else {
-		if(sscanf(hostport,"[%[^]]]:%d",host,port)==2) {
-			return 1;
-		} else {
-			strcpy(host,hostport);
-			return 1;
-		}
-	}
-}
-
 struct chirp_client *chirp_client_connect(const char *hostport, int negotiate_auth, time_t stoptime)
 {
 	struct chirp_client *c;
@@ -402,7 +350,7 @@ struct chirp_client *chirp_client_connect(const char *hostport, int negotiate_au
 	int save_errno;
 	int port;
 
-	if(!parse_hostport(hostport,host,&port)) {
+	if(!address_parse_hostport(hostport,host,&port,CHIRP_PORT)) {
 		errno = EINVAL;
 		return 0;
 	}

--- a/doc/index.html
+++ b/doc/index.html
@@ -19,11 +19,13 @@
 
 <h1>Cooperative Computing Tools Documentation</h1>
 
-<h2><a style="font-size: 20px;" href="install.html">CCTools Installation Instructions</a></h2>
-<h2><a style="font-size: 20px;" href="api/html/index.html">CCTools API Documentation</a></h2>
-
-<h2>Individual Tool Documents</h2>
 <table>
+<tr style="vertical-align: top;">
+<td colspan=3>
+<b><a style="font-size: 20px;" href="install.html">CCTools Installation Instructions</a></b>
+<p>
+<b><a style="font-size: 20px;" href="api/html/index.html">CCTools API Documentation</a></b>
+
 <tr style="vertical-align: top;">
     <td>
         <a href=makeflow.html><b>Makeflow User's Manual</b></a>
@@ -52,7 +54,6 @@
             <li><a class="man" href="man/ec2_submit_workers.html">ec2_submit_workers(1)</a></li>
             <li><a class="man" href="man/ec2_remove_workers.html">ec2_remove_workers(1)</a></li>
         </ul>
-	<a href=network.html><b>Network Options</b></a>
     </td>
 
     <td>
@@ -129,7 +130,16 @@
             <li><a class="man" href="man/sand_compress_reads.html">sand_compress_reads(1)</a></li>
             <li><a class="man" href="man/sand_uncompress_reads.html">sand_uncompress_reads(1)</a></li>
         </ul>
-        <a href=jx.html><b>JX Manual</b></a>
+        <a href=jx.html><b>JSON Expressions (JX) Manual</b></a>
+	<p>
+        <a href=network.html><b>Networking Options</b></a>
+        <ul>
+                <li> <a href=network.html#ipv6>IPV6 Support</a>
+                <li> <a href=network.html#tcp_port_ranges>TCP Port Ranges</a>
+                <li> <a href=network.html#tcp_window_size>TCP Window Size</a>
+                <li> <a href=network.html#http_proxies>HTTP Proxies</a>
+        </ul>
+
     </td>
 </tr>
 </table>

--- a/doc/index.html
+++ b/doc/index.html
@@ -52,6 +52,7 @@
             <li><a class="man" href="man/ec2_submit_workers.html">ec2_submit_workers(1)</a></li>
             <li><a class="man" href="man/ec2_remove_workers.html">ec2_remove_workers(1)</a></li>
         </ul>
+	<a href=network.html><b>Network Options</b></a>
     </td>
 
     <td>

--- a/doc/network.html
+++ b/doc/network.html
@@ -17,7 +17,7 @@ used to shape the network behavior of
 Makeflow, Work Queue, Parrot, Chirp, and other tools,
 so as to work correctly in these environments.
 
-<h2>IPV6 Support</h2>
+<h2><a name=ipv6>IPV6 Support</a></h2>
 
 IPV6 is supported by all of the CCTools components, however it is not turned
 on by default because IPV6 is not reliably deployed at all sites.  You can
@@ -48,7 +48,7 @@ But an IPV6 combination looks like this:
 [1234::abcd]:9094
 </pre>
 
-<h2>Firewall Port Ranges</h2>
+<h2><a name=tcp_port_ranges>TCP Port Ranges</a></h2>
 
 When creating a listening TCP port, the CCTools will, by default, pick any
 port available on the machine.  However, some computing sites set up firewall
@@ -63,7 +63,21 @@ export TCP_LOW_PORT=8000
 export TCP_HIGH_PORT=9000
 </pre>
 
-<h2>HTTP Proxies</h2>
+<h2><a name=tcp_window_size>TCP Window Size</a></h2>
+
+The performance of TCP connections over wide area links can be significantly
+affected by the "window size" used within the kernel.  Ideally, the window size
+is set to the product of the network bandwidth and latency, and is managed
+automatically by the kernel.  In certain cases, you may wish to set it manually
+with the <tt>TCP_WINDOW_SIZE</tt> environment variable, which gives the window
+size in bytes.
+<p>
+For example, to se the window size to 1MB:
+<pre>
+export TCP_WINDOW_SIZE=1048576
+</pre>
+
+<h2><a name=http_proxies>HTTP Proxies</a></h2>
 
 if your computing site requires all HTTP requests to be routed through a proxy,
 specify that proxy with the <tt>HTTP_PROXY</tt> environment variable.

--- a/doc/network.html
+++ b/doc/network.html
@@ -1,0 +1,81 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en">
+
+<head>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+<link rel="stylesheet" type="text/css" href="manual.css">
+<title>CCTools Network Options</title>
+<body>
+
+<div id="manual">
+<h1>CCTools Network Options</h2>
+
+When working in a cloud or HPC environment, you may find complex
+network conditions such as multiple network interfaces, firewalls,
+and other conditions.  The following environment variables can be
+used to shape the network behavior of 
+Makeflow, Work Queue, Parrot, Chirp, and other tools,
+so as to work correctly in these environments.
+
+<h2>IPV6 Support</h2>
+
+IPV6 is supported by all of the CCTools components, however it is not turned
+on by default because IPV6 is not reliably deployed at all sites.  You can
+enable IPV6 support with the <tt>CCTOOLS_IP_MODE</tt> environment variable.
+<p>
+To enable both IPV4 and IPV6 support according to the local system configuration: (recommended use)
+<pre>
+export CCTOOLS_IP_MODE=AUTO
+</pre>
+
+To enable <b>only</b> IPV4 support: (the default)
+<pre>
+export CCTOOLS_IP_MODE=IPV4
+</pre>
+
+To enable <b>only</b> IPV6 support: (not recommended; use only for testing IPV6)
+<pre>
+export CCTOOLS_IP_MODE=IPV6
+</pre>
+
+Where it is necessary to combine an address and port together into a single string, an IPV4 combination looks like this:
+<pre>
+192.168.0.1:9094
+</pre>
+
+But an IPV6 combination looks like this:
+<pre>
+[1234::abcd]:9094
+</pre>
+
+<h2>Firewall Port Ranges</h2>
+
+When creating a listening TCP port, the CCTools will, by default, pick any
+port available on the machine.  However, some computing sites set up firewall
+rules that only permit connections within certain port ranges.  To accommodate
+this, set the <tt>TCP_LOW_PORT</tt> and <tt>TCP_HIGH_PORT</tt> environment variables,
+and the CCTools will only use ports within that range.
+<p>
+For example, if your site firewall only allows ports 8000-9000, do this:
+
+<pre>
+export TCP_LOW_PORT=8000
+export TCP_HIGH_PORT=9000
+</pre>
+
+<h2>HTTP Proxies</h2>
+
+if your computing site requires all HTTP requests to be routed through a proxy,
+specify that proxy with the <tt>HTTP_PROXY</tt> environment variable.
+The value should be a semi-colon separated list of proxy URLs, in order
+of preference.  The final entry may be <tt>DIRECT</tt> indicating that
+a direct connection should be attempted if all proxy connections fail.
+<p>
+For example:
+<pre>
+export HTTP_PROXY=http://proxy01.nd.edu:3128;http://proxy02.nd.edu:3129;DIRECT
+</pre>
+
+</div>
+</body>
+</html>

--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -2,6 +2,7 @@ include ../../config.mk
 include ../../rules.mk
 
 SOURCES = \
+	address.c \
 	auth.c \
 	auth_address.c \
 	auth_all.c \

--- a/dttools/src/address.c
+++ b/dttools/src/address.c
@@ -1,0 +1,45 @@
+#include "address.h"
+#include <string.h>
+#include <arpa/inet.h>
+
+int address_to_sockaddr( const char *str, int port, struct sockaddr_storage *addr, SOCKLEN_T *length )
+{
+	memset(addr,0,sizeof(*addr));
+
+	struct sockaddr_in *ipv4 = (struct sockaddr_in *)addr;
+	struct sockaddr_in6 *ipv6 = (struct sockaddr_in6 *)addr;
+
+	if(!str) {
+		// When the address is unspecified, we are
+		// attempting to bind a listening socket to
+		// any avaialble address.  IN6ADDR_ANY accepts
+		// both ipv4 and ipv6 binds.
+		*length = sizeof(*ipv6);
+		ipv6->sin6_family = AF_INET6;
+		ipv6->sin6_addr = in6addr_any;
+		ipv6->sin6_port = htons(port);
+#if defined(CCTOOLS_OPSYS_DARWIN)
+		ipv6->sin6_len = sizeof(*ipv6);
+#endif
+		return AF_INET6;
+	} else if(inet_pton(AF_INET,str,&ipv4->sin_addr)==1) {
+		*length = sizeof(*ipv4);
+		ipv4->sin_family = AF_INET;
+		ipv4->sin_port = htons(port);
+#if defined(CCTOOLS_OPSYS_DARWIN)
+		ipv4->sin_len = sizeof(*ipv4);
+#endif
+		return AF_INET;
+	} else if(inet_pton(AF_INET6,str,&ipv6->sin6_addr)==1) {
+		*length = sizeof(*ipv6);
+		ipv6->sin6_family = AF_INET6;
+		ipv6->sin6_port = htons(port);
+#if defined(CCTOOLS_OPSYS_DARWIN)
+		ipv6->sin6_len = sizeof(*ipv6);
+#endif
+		return AF_INET6;
+	} else {
+		return 0;
+	}
+}
+

--- a/dttools/src/address.c
+++ b/dttools/src/address.c
@@ -44,6 +44,23 @@ int address_to_sockaddr( const char *str, int port, struct sockaddr_storage *add
 	}
 }
 
+int address_from_sockaddr( char *str, struct sockaddr *saddr )
+{
+	if(saddr->sa_family==AF_INET) {
+		struct sockaddr_in *sin = (struct sockaddr_in *)saddr;
+		struct in_addr *ipaddr = &(sin->sin_addr);
+		inet_ntop(saddr->sa_family, ipaddr, str, IP_ADDRESS_MAX);
+		return 1;
+	} else if(saddr->sa_family==AF_INET6) {
+		struct sockaddr_in6 *sin = (struct sockaddr_in6 *)saddr;
+		struct in6_addr *ipaddr = &(sin->sin6_addr);
+		inet_ntop(saddr->sa_family, ipaddr, str, IP_ADDRESS_MAX);
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
 static int strcount( const char *s, char c )
 {
 	int count=0;

--- a/dttools/src/address.h
+++ b/dttools/src/address.h
@@ -14,4 +14,6 @@
 
 int address_to_sockaddr( const char *addr, int port, struct sockaddr_storage *s, SOCKLEN_T *length );
 
+int address_parse_hostport( const char *hostport, char *host, int *port, int default_port );
+
 #endif

--- a/dttools/src/address.h
+++ b/dttools/src/address.h
@@ -1,0 +1,17 @@
+#ifndef ADDRESS_H
+#define ADDRESS_H
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#ifndef SOCKLEN_T
+#if defined(__GLIBC__) || defined(CCTOOLS_OPSYS_DARWIN) || defined(CCTOOLS_OPSYS_AIX) || defined(__MUSL__)
+#define SOCKLEN_T socklen_t
+#else
+#define SOCKLEN_T int
+#endif
+#endif
+
+int address_to_sockaddr( const char *addr, int port, struct sockaddr_storage *s, SOCKLEN_T *length );
+
+#endif

--- a/dttools/src/address.h
+++ b/dttools/src/address.h
@@ -12,8 +12,10 @@
 #endif
 #endif
 
-int address_to_sockaddr( const char *addr, int port, struct sockaddr_storage *s, SOCKLEN_T *length );
+#define IP_ADDRESS_MAX 48
 
+int address_to_sockaddr( const char *addr, int port, struct sockaddr_storage *s, SOCKLEN_T *length );
+int address_from_sockaddr( char *str, struct sockaddr *saddr );
 int address_parse_hostport( const char *hostport, char *host, int *port, int default_port );
 
 #endif

--- a/dttools/src/catalog_query.c
+++ b/dttools/src/catalog_query.c
@@ -19,6 +19,7 @@ See the file COPYING for details.
 #include "domain_name.h"
 #include "set.h"
 #include "list.h"
+#include "address.h"
 
 struct catalog_query {
 	struct jx *data;
@@ -41,16 +42,9 @@ static struct set *down_hosts = NULL;
 const char *parse_hostlist(const char *hosts, char *host, int *port)
 {
 	const char *next = strchr(hosts, ',');
-	switch (sscanf(hosts, "%[^:,]:%d", host, port)) {
-	case 1:
-		*port = CATALOG_PORT;
-		break;
-	case 2:
-		break;
-	default:
+	if(!address_parse_hostport(hosts,host,port,CATALOG_PORT)) {
 		debug(D_DEBUG, "bad host specification: %s", hosts);
 		return NULL;
-		break;
 	}
 	return next ? next + 1 : NULL;
 }

--- a/dttools/src/domain_name.c
+++ b/dttools/src/domain_name.c
@@ -65,14 +65,16 @@ int domain_name_lookup(const char *name, char *addr)
 	hints.ai_socktype = SOCK_STREAM;
 
 	const char *mode_str = getenv("CCTOOLS_IP_MODE");
-	if(!mode_str || !strcmp(mode_str,"ANY")) {
+	if(!mode_str) mode_str = "IPV4";
+
+	if(!strcmp(mode_str,"AUTO")) {
 		hints.ai_family = AF_UNSPEC;
 	} else if(!strcmp(mode_str,"IPV4")) {
 		hints.ai_family = AF_INET;
 	} else if(!strcmp(mode_str,"IPV6")) {
 		hints.ai_family = AF_INET6;
 	} else {
-		debug(D_NOTICE,"CCTOOLS_IP_MODE has invalid value (%s).  Choices are IPV4, IPV6, or ANY",mode_str);
+		debug(D_NOTICE,"CCTOOLS_IP_MODE has invalid value (%s).  Choices are IPV4, IPV6, or AUTO",mode_str);
 		hints.ai_family = AF_UNSPEC;
 	}
 

--- a/dttools/src/link.h
+++ b/dttools/src/link.h
@@ -50,7 +50,7 @@ link_close(link);
 #include <stdio.h>
 #include <time.h>
 
-/** Maximum number of characters in the text representation of a link address.  This must be large enough to accomodate ipv6 in the future. */
+/** Maximum number of characters in the text representation of a link address, whether ipv4 or ipv6. */
 #define LINK_ADDRESS_MAX 48
 
 /** Value to usewhen any listen port is acceptable */

--- a/dttools/src/stringtools.c
+++ b/dttools/src/stringtools.c
@@ -94,51 +94,6 @@ char *string_escape_condor( const char *str )
 	return result;
 }
 
-void string_from_ip_address(const unsigned char *bytes, char *str)
-{
-	sprintf(str, "%u.%u.%u.%u", (unsigned) bytes[0], (unsigned) bytes[1], (unsigned) bytes[2], (unsigned) bytes[3]);
-}
-
-int string_to_ip_address(const char *str, unsigned char *bytes)
-{
-	unsigned a, b, c, d;
-	int fields;
-
-	fields = sscanf(str, "%u.%u.%u.%u", &a, &b, &c, &d);
-	if(fields != 4)
-		return 0;
-
-	if(a > 255 || b > 255 || c > 255 || d > 255)
-		return 0;
-
-	bytes[0] = a;
-	bytes[1] = b;
-	bytes[2] = c;
-	bytes[3] = d;
-
-	return 1;
-}
-
-int string_ip_subnet(const char *addr, char *subnet)
-{
-	unsigned bytes[4];
-	int fields;
-
-	fields = sscanf(addr, "%u.%u.%u.%u", &bytes[0], &bytes[1], &bytes[2], &bytes[3]);
-	if(fields != 4)
-		return 0;
-
-	if(bytes[0] < 128) {
-		sprintf(subnet, "%u", bytes[0]);
-	} else if(bytes[0] < 192) {
-		sprintf(subnet, "%u.%u", bytes[0], bytes[1]);
-	} else {
-		sprintf(subnet, "%u.%u.%u", bytes[0], bytes[1], bytes[2]);
-	}
-
-	return 1;
-}
-
 void string_chomp(char *start)
 {
 	char *s = start;

--- a/dttools/src/stringtools.h
+++ b/dttools/src/stringtools.h
@@ -31,9 +31,6 @@ char *string_escape_shell (const char *str);
   @return String with special characters escaped.
   */
 char *string_escape_condor( const char *str);
-void string_from_ip_address(const unsigned char *ip_addr_bytes, char *str);
-int string_to_ip_address(const char *str, unsigned char *ip_addr_bytes);
-int string_ip_subnet(const char *addr, char *subnet);
 void string_chomp(char *str);
 int whole_string_match_regex(const char *text, const char *pattern);
 int string_match_regex(const char *text, char *pattern);


### PR DESCRIPTION
Second pass at IPV6 support.

Expanded address handling in `datagram` and `link` to handle both `AF_INET` and `AF_INET6`.
By default, `domain_name` will return the OS preference for address modes.
This can be overridden by setting `CCTOOLS_IP_MODE` to `IPV4` or `IPV6` or `AUTO`, which may be helpful for testing/debugging in networking environments.

Issue #1201 