### PR TITLE
Add `mode` attr into umbrella specs

### DIFF
--- a/doc/umbrella.html
+++ b/doc/umbrella.html
@@ -403,6 +403,7 @@ System                  2                   2
             ],
             "mountpoint": "/tmp/4_cubes.pov",
             "id": "c65266cd2b672854b821ed93028a877a",
+            "mode": "0644",
             "size": "1757"
         },
         "WRC_RubiksCube.inc": {
@@ -413,6 +414,7 @@ System                  2                   2
             ],
             "mountpoint": "/tmp/WRC_RubiksCube.inc",
             "id": "2f8afdd09fc3a6177c6f1977bb3bdae7",
+            "mode": "0755",
             "size": "28499"
         }
     },
@@ -509,6 +511,8 @@ System                  2                   2
 				dedendency as it is. <tt>unpack</tt> uncompresses the dependency. Default: unpack. Not case
 				sensitive.</li>
 
+				<li><b>mode</b> (optional): the file mode set as a string, such as <tt>"0644"</tt>. </li>
+
 				<li><b>mountpoint</b> (optional): the mountpoint of the software. Case
 				sensitive.</li>
 
@@ -554,6 +558,8 @@ System                  2                   2
 				Options: <tt>none</tt>, <tt>unpack</tt>. <tt>none</tt> leaves the downloaded
 				dedendency as it is. <tt>unpack</tt> uncompresses the dependency. Default: unpack. Not case
 				sensitive.</li>
+
+				<li><b>mode</b> (optional): the file mode set as a string, such as <tt>"0644"</tt>. </li>
 
 				<li><b>mountpoint</b> (optional): the mountpoint of the data dependency. The same as
 				the mountpoint attribute of the software section. Case sensitive.</li>

--- a/umbrella/src/umbrella.py
+++ b/umbrella/src/umbrella.py
@@ -1007,6 +1007,10 @@ def software_install(mount_dict, env_para_dict, software_spec, meta_json, sandbo
 				else:
 					mount_dict[mountpoint] = mount_value
 
+				if software_spec[item].has_key('mode'):
+					mode = int(software_spec[item]['mode'], 8)
+					os.chmod(mount_value, mode)
+					logging.debug("Change the file mode of `%s` to `%s`", mount_value, oct(mode))
 
 def data_install(data_spec, meta_json, sandbox_dir, mount_dict, env_para_dict, osf_auth, cwd_setting, name=None):
 	"""Process data section of the specification.
@@ -1053,6 +1057,11 @@ def data_install(data_spec, meta_json, sandbox_dir, mount_dict, env_para_dict, o
 			mount_dict[mountpoint] = mount_value
 			if mount_env and mountpoint:
 				env_para_dict[mount_env] = mountpoint
+
+			if data_spec[item].has_key('mode'):
+				mode = int(data_spec[item]['mode'], 8)
+				os.chmod(mount_value, mode)
+				logging.debug("Change the file mode of `%s` to `%s`", mount_value, oct(mode))
 
 def get_linker_path(hardware_platform, os_image_dir):
 	"""Return the path of ld-linux.so within the downloaded os image dependency


### PR DESCRIPTION
This is useful for the case when an executable is downloaded as a plain file instead of a tarball. 

By default, the python `urllib` library turns off the execute mode of a file, which can not be found by searching the `$PATH` env. 

Using the new `mode` attr allows the user to set the file mode of a plain file.