### PR TITLE
Don't follow namespace symlinks

### DIFF
--- a/dttools/src/stringtools.c
+++ b/dttools/src/stringtools.c
@@ -141,7 +141,7 @@ int whole_string_match_regex(const char *text, const char *pattern)
 }
 
 
-int string_match_regex(const char *text, char *pattern)
+int string_match_regex(const char *text, const char *pattern)
 {
 	int ret = 0;
 	regex_t re;

--- a/dttools/src/stringtools.h
+++ b/dttools/src/stringtools.h
@@ -33,7 +33,7 @@ char *string_escape_shell (const char *str);
 char *string_escape_condor( const char *str);
 void string_chomp(char *str);
 int whole_string_match_regex(const char *text, const char *pattern);
-int string_match_regex(const char *text, char *pattern);
+int string_match_regex(const char *text, const char *pattern);
 int string_match(const char *pattern, const char *text);
 char *string_front(const char *str, int max);
 const char *string_back(const char *str, int max);

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -396,6 +396,15 @@ void pfs_table::follow_symlink( struct pfs_name *pname, mode_t mode, int depth )
 	char *name_to_resolve = link_target;
 	struct pfs_name new_pname = *pname;
 
+	if (string_prefix_is(pname->path, "/proc/self/ns/") || string_match_regex(pname->path, "^/proc/[0-9]+/ns/")) {
+		/*
+		 * Depending on kernel version, these might be magical dangling symlinks that can
+		 * nonetheless be opened as usual. If Parrot tries to follow them, it will return
+		 * erroneous ENOENT.
+		 */
+		return;
+	}
+
 	int rlres = new_pname.service->readlink(pname,link_target,PFS_PATH_MAX-1);
 	if (rlres > 0) {
 		/* readlink does not NULL-terminate */

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -487,29 +487,7 @@ int pfs_table::resolve_name(int is_special_syscall, const char *cname, struct pf
 		}
 	}
 
-	if(pattern_match(full_logical_name, "^/proc/self/?()", &n) >= 0) {
-		snprintf(pname->path, sizeof pname->path, "/proc/%d/%s", pfs_process_getpid(), &full_logical_name[n]);
-		strcpy(pname->logical_name, pname->path);
-		strcpy(pname->rest, pname->path);
-		pname->service = pfs_service_lookup_default();
-		strcpy(pname->service_name,"local");
-		strcpy(pname->host,"localhost");
-		strcpy(pname->hostport,"localhost");
-		pname->is_local = 1;
-		return 1;
-	} else if (pattern_match(full_logical_name, "^/dev/fd/?()", &n) >= 0) {
-		snprintf(pname->path, sizeof pname->path, "/proc/%d/fd/%s", pfs_process_getpid(), &full_logical_name[n]);
-		strcpy(pname->logical_name, pname->path);
-		strcpy(pname->rest, pname->path);
-		pname->service = pfs_service_lookup_default();
-		strcpy(pname->service_name,"local");
-		strcpy(pname->host,"localhost");
-		strcpy(pname->hostport,"localhost");
-		pname->is_local = 1;
-		return 1;
-	} else {
-		result = pfs_resolve(pname->logical_name,pname->path,mode,time(0)+pfs_master_timeout);
-	}
+	result = pfs_resolve(pname->logical_name,pname->path,mode,time(0)+pfs_master_timeout);
 
 	if(namelist_table) {
 		namelist_table_insert(pname->path, is_special_syscall);
@@ -568,6 +546,29 @@ int pfs_table::resolve_name(int is_special_syscall, const char *cname, struct pf
 		if (do_follow_symlink && pfs_follow_symlinks) {
 			follow_symlink(pname, mode, depth + 1);
 		}
+
+	if(pattern_match(pname->path, "^/proc/self/?()", &n) >= 0) {
+		strncpy(full_logical_name, pname->path, sizeof(full_logical_name));
+		snprintf(pname->path, sizeof(pname->path), "/proc/%d/%s", pfs_process_getpid(), &full_logical_name[n]);
+		strcpy(pname->logical_name, pname->path);
+		strcpy(pname->rest, pname->path);
+		pname->service = pfs_service_lookup_default();
+		strcpy(pname->service_name,"local");
+		strcpy(pname->host,"localhost");
+		strcpy(pname->hostport,"localhost");
+		pname->is_local = 1;
+	} else if (pattern_match(pname->path, "^/dev/fd/?()", &n) >= 0) {
+		strncpy(full_logical_name, pname->path, sizeof(full_logical_name));
+		snprintf(pname->path, sizeof(pname->path), "/proc/%d/fd/%s", pfs_process_getpid(), &full_logical_name[n]);
+		strcpy(pname->logical_name, pname->path);
+		strcpy(pname->rest, pname->path);
+		pname->service = pfs_service_lookup_default();
+		strcpy(pname->service_name,"local");
+		strcpy(pname->host,"localhost");
+		strcpy(pname->hostport,"localhost");
+		pname->is_local = 1;
+	}
+
 		return 1;
 	}
 }


### PR DESCRIPTION
This addresses #1559

Since the namespace symlinks have some unusual behaviour, Parrot shouldn't try to follow them by itself. Also, this pull request changes the handling of `/proc/self` and `/dev/fd`. Previously, these paths short circuited name resolution, so for example, mount lists simply wouldn't be applied to any path with those prefixes. This moves the substitution as late as possible, after name resolution and symlink following.