### PR TITLE
Mesos mode for Makeflow 

### DIFF
--- a/batch_job/src/Makefile
+++ b/batch_job/src/Makefile
@@ -16,7 +16,9 @@ SOURCES = \
 	batch_job_blue_waters.c \
 	batch_job_condor.c \
 	batch_job_local.c \
-	batch_job_work_queue.c
+	batch_job_work_queue.c\
+	batch_job_mesos.c \
+	mesos_task.c
 
 PUBLIC_HEADERS = batch_job.h
 

--- a/batch_job/src/batch_job.c
+++ b/batch_job/src/batch_job.c
@@ -30,6 +30,7 @@ extern const struct batch_queue_module batch_queue_torque;
 extern const struct batch_queue_module batch_queue_blue_waters;
 extern const struct batch_queue_module batch_queue_slurm;
 extern const struct batch_queue_module batch_queue_wq;
+extern const struct batch_queue_module batch_queue_mesos;
 extern const struct batch_queue_module batch_queue_dryrun;
 
 static struct batch_queue_module batch_queue_unknown = {
@@ -42,7 +43,7 @@ static struct batch_queue_module batch_queue_unknown = {
 	{NULL, NULL, NULL, NULL, NULL, NULL},
 };
 
-#define BATCH_JOB_SYSTEMS  "local, wq, condor, sge, torque, moab, slurm, chirp, amazon, dryrun"
+#define BATCH_JOB_SYSTEMS  "local, wq, mesos, condor, sge, torque, moab, slurm, chirp, amazon, dryrun"
 
 const struct batch_queue_module * const batch_queue_modules[] = {
 	&batch_queue_amazon,
@@ -57,6 +58,7 @@ const struct batch_queue_module * const batch_queue_modules[] = {
 	&batch_queue_blue_waters,
 	&batch_queue_slurm,
 	&batch_queue_wq,
+	&batch_queue_mesos,
 	&batch_queue_dryrun,
 	&batch_queue_unknown
 };

--- a/batch_job/src/batch_job.h
+++ b/batch_job/src/batch_job.h
@@ -44,6 +44,7 @@ typedef enum {
 	BATCH_QUEUE_TYPE_CLUSTER,             /**< Batch jobs will be sent to a user-defined cluster manager. */
 	BATCH_QUEUE_TYPE_WORK_QUEUE,          /**< Batch jobs will be sent to the Work Queue. */
 	BATCH_QUEUE_TYPE_CHIRP,               /**< Batch jobs will be sent to Chirp. */
+    BATCH_QUEUE_TYPE_MESOS,               /**< Batch jobs will be sent to Mesos. */
 	BATCH_QUEUE_TYPE_DRYRUN,              /**< Batch jobs will not actually run. */
 	BATCH_QUEUE_TYPE_UNKNOWN = -1         /**< An invalid batch queue type. */
 } batch_queue_type_t;

--- a/batch_job/src/batch_job_mesos.c
+++ b/batch_job/src/batch_job_mesos.c
@@ -1,0 +1,422 @@
+#include "batch_job.h"
+#include "batch_job_internal.h"
+#include "debug.h"
+#include "process.h"
+#include "macros.h"
+#include "stringtools.h"
+#include "path.h"
+#include "xxmalloc.h"
+#include "jx.h"
+#include "jx_print.h"
+#include "itable.h"
+#include "mesos_task.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <time.h>
+
+#define MAX_BUF_SIZE 4096
+#define FILE_TASK_INFO "mesos_task_info"
+#define FILE_TASK_STATE "mesos_task_state"
+#define MESOS_DONE_FILE "mesos_done"
+
+/*
+ * Principle of Operation:
+ * 
+ * Each time when makeflow submit a task, the information of the task is written into 
+ * mesos_task_info file. Meanwhile, the makeflow mesos scheduler keep polling 
+ * mesos_task_info, try to find if there is new task is ready to launch on mesos. 
+ * 
+ * After the task is complete on, the makeflow mesos scheduler writes the final state
+ * of the task to mesos_task_state. And the makeflow is keep monitoring this file and 
+ * collect all finished tasks.   
+ *
+ */
+
+static int counter = 0;
+static struct itable *finished_tasks = NULL;
+static int is_mesos_py_path_known = 0;
+static int is_mesos_master_known = 0;
+static int is_scheduler_running = 0;
+static const char *mesos_py_path = NULL;
+static const char *mesos_master = NULL;
+static pid_t mesos_scheduler_pid = 0;
+
+static void start_mesos_scheduler(struct batch_queue *q)
+{
+
+	pid_t mesos_pid;
+	mesos_pid = fork();			
+	mesos_scheduler_pid = mesos_pid;
+	char *mesos_cwd;
+	mesos_cwd = path_getcwd();
+
+	char exe_path[MAX_BUF_SIZE];
+
+	if(readlink("/proc/self/exe", exe_path, MAX_BUF_SIZE) == -1) {
+		debug(D_ERROR, "read \"proc/self/exe\" fail\n");
+		exit(EXIT_FAILURE);
+	}
+
+	char exe_dir_path[MAX_BUF_SIZE];
+	path_dirname(exe_path, exe_dir_path);
+
+    char *exe_py_path = string_format("%s/mf_mesos_scheduler", exe_dir_path);
+	char *envs[] = {"LD_PRELOAD=/afs/nd.edu/user37/ccl/software/external/gcc-4.9.3/amd64_linux26/lib64/libstdc++.so.6:/afs/nd.edu/user37/ccl/software/external/svn-1.9.4/amd64_linux26/lib/libsvn_delta-1.so", "CCTOOLS=/afs/crc.nd.edu/user/c/czheng2/cctools", NULL};
+
+	char *mesos_python_path = xxstrdup(mesos_py_path);
+
+	if (mesos_python_path == NULL) {
+		debug(D_ERROR, "Please specify the mesos python path\n");
+		exit(EXIT_FAILURE);
+	}
+
+	char *mesos_py = NULL;
+	if (mesos_py_path[strlen(mesos_py_path)-1] == '/') {
+		mesos_py = string_combine(mesos_python_path, "lib/python2.6/site-packages");
+	} else {
+		mesos_py = string_combine(mesos_python_path, "/lib/python2.6/site-packages");
+	}
+
+	if (mesos_pid > 0) {
+
+		debug(D_INFO, "Start makeflow mesos scheduler.");
+
+	} else if (mesos_pid == 0) {
+
+		const char *batch_log_name = batch_queue_supports_feature(q, "batch_log_name");
+
+		int mesos_fd = open(batch_log_name, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+		if (mesos_fd == -1) {
+	    	debug(D_ERROR, "Failed to open %s \n", batch_log_name);
+	    	exit(EXIT_FAILURE);
+	    }
+
+	    if (dup2(mesos_fd, 1) == -1) {
+	    	debug(D_ERROR, "%s\n", strerror(errno));
+	    	exit(EXIT_FAILURE);
+	   	}
+
+		if (dup2(mesos_fd, 2) == -1) {
+	    	debug(D_ERROR, "%s\n", strerror(errno));
+	    	exit(EXIT_FAILURE);
+	   	}
+
+	    close(mesos_fd);
+
+// 1. child keep polling who is the parent
+
+		execle("/usr/bin/python", "python", exe_py_path, mesos_cwd, mesos_master, mesos_py, (char *) 0, envs);
+
+		_exit(127);
+
+	} else {
+
+		debug(D_ERROR, "mesos batch system couldn't create new process: %s\n", strerror(errno));
+		exit(EXIT_FAILURE);
+
+	}
+
+}
+
+
+static batch_job_id_t batch_job_mesos_submit (struct batch_queue *q, const char *cmd, \
+		const char *extra_input_files, const char *extra_output_files, \
+		struct jx *envlist, const struct rmsummary *resources )
+{
+
+	// Get the path to mesos python site-packages
+	if (is_mesos_py_path_known != 1) {
+		mesos_py_path = batch_queue_get_option(q, "mesos-path");
+		if (mesos_py_path == NULL) {
+			debug(D_ERROR, "Please set the path to mesos python library\n");
+			exit(EXIT_FAILURE);
+		} else {
+			debug(D_INFO, "Get mesos_path %s from command line\n", mesos_py_path);
+			is_mesos_py_path_known = 1;
+		}
+	}
+
+	// Get the mesos master address
+	if (is_mesos_master_known != 1) {
+		mesos_master = batch_queue_get_option(q, "mesos-master");
+		if (mesos_master == NULL) {
+			debug(D_ERROR, "Please specify the ip address of mesos master\n");
+			exit(EXIT_FAILURE);
+		} else {
+			debug(D_INFO, "Get mesos_path %s from command line\n", mesos_py_path);
+			is_mesos_master_known = 1;
+		}
+	}
+
+	if (is_mesos_py_path_known == 1 && is_mesos_master_known == 1 &&is_scheduler_running == 0) {
+		start_mesos_scheduler(q);
+		is_scheduler_running = 1;
+	}
+
+	int task_id = ++counter;
+
+	debug(D_BATCH, "task %d is ready", task_id);
+	struct batch_job_info *info = malloc(sizeof(*info));
+	memset(info, 0, sizeof(*info));
+	info->submitted = time(0);
+	info->started = time(0);
+	itable_insert(q->job_table, task_id, info);
+
+	FILE *task_info_fp;
+
+	if(access(FILE_TASK_INFO, F_OK) != -1) {
+		task_info_fp = fopen(FILE_TASK_INFO, "a+");
+	} else {
+		task_info_fp = fopen(FILE_TASK_INFO, "w+");
+	}
+	
+	struct mesos_task *mt = mesos_task_create(task_id, cmd, extra_input_files, extra_output_files);
+
+	fprintf(task_info_fp, "%d,%s,", mt->task_id, mt->task_cmd);
+
+	// Get the absolut path o Meanwhile, the makeflow mesos scheduler keep polling 
+	// mesos_task_info, try to find if there is new task is ready to launch on mesos,. 
+	// 
+	// After the task is complete on, the makeflow mesos scheduler writes the final state
+	// of the task to mesos_task_state. And the makeflow is keep monitoring this file and 
+	// collect all finished task. f each input file
+
+	if (extra_input_files != NULL && strlen(extra_input_files) != 0) {
+
+		int j = 0;
+		int num_input_files = mt->task_input_files->used_length;
+		for (j = 0; j < (num_input_files-1); j++) {
+			fprintf(task_info_fp, "%s ", (mt->task_input_files->items)[j]);
+		}
+		fprintf(task_info_fp, "%s,", (mt->task_input_files->items)[num_input_files-1]);
+
+	} else {
+		fputs(",", task_info_fp);
+	}
+    
+	if (extra_output_files != NULL && strlen(extra_output_files) != 0) {
+		int j = 0;
+		int num_output_files = mt->task_output_files->used_length;
+		for (j = 0; j < (num_output_files-1); j++) {
+			fprintf(task_info_fp, "%s ", (mt->task_output_files->items)[j]);
+		}
+		fprintf(task_info_fp, "%s,", (mt->task_output_files->items)[num_output_files-1]);
+	} else {
+		fputs(",", task_info_fp);
+	}
+
+	int64_t cores = 4;
+	int64_t memory = 5120;
+	int64_t disk = 5120;
+
+	if (resources) {
+		cores  = resources->cores  > -1 ? resources->cores  : cores;
+		memory = resources->memory > -1 ? resources->memory : memory;
+		disk   = resources->disk   > -1 ? resources->disk   : disk;
+	}
+
+	fprintf(task_info_fp, "%" PRId64 ",%" PRId64 ",%" PRId64 ",", cores, memory, disk);
+
+	fputs("submitted\n", task_info_fp);
+
+	mesos_task_delete(mt);
+	fclose(task_info_fp);
+
+	return task_id;
+}
+
+static batch_job_id_t batch_job_mesos_wait (struct batch_queue * q, struct batch_job_info * info_out, time_t stoptime)
+{
+		
+	char *line = NULL;
+	size_t len = 0;
+	ssize_t read_len;
+	FILE *task_state_fp;
+
+	if(finished_tasks == NULL) {
+		finished_tasks = itable_create(0);
+	}
+
+	while(access(FILE_TASK_STATE, F_OK) == -1) {}
+
+	task_state_fp = fopen(FILE_TASK_STATE, "r");
+
+	while(1) {
+
+		char *task_id_ch;
+		char *task_stat_str;
+		int task_id;
+				
+		while((read_len = getline(&line, &len, task_state_fp)) != -1) {
+
+			// trim the newline character
+			if (line[read_len-1] == '\n') {
+				line[read_len-1] = '\0';
+				--read_len;
+			}
+
+			task_id_ch = strtok(line, ",");
+			task_id = atoi(task_id_ch);
+
+			// There is a new task finished
+			if(itable_lookup(finished_tasks, task_id) == NULL) {
+				struct batch_job_info *info = itable_remove(q->job_table, task_id);
+			    	
+				info->finished = time(0);
+				task_stat_str = strtok(NULL, ",");
+
+				if (strcmp(task_stat_str, "finished") == 0) {
+					info->exited_normally = 1;
+				} else {
+					info->exited_normally = 0;
+				}
+
+				memcpy(info_out, info, sizeof(*info));
+				free(info);
+				fclose(task_state_fp);
+
+				int itable_val = 1;
+				itable_insert(finished_tasks, task_id, &itable_val);
+
+				return task_id;
+			}
+		}
+		sleep(1);
+
+		if(stoptime != 0 && time(0) >= stoptime) {
+			fclose(task_state_fp);
+			return -1;
+		}
+	}
+
+}
+
+static int batch_job_mesos_remove (struct batch_queue *q, batch_job_id_t jobid)
+{
+	struct batch_job_info *info = itable_lookup(q->job_table, jobid);
+	info->finished = time(0);
+	info->exited_normally = 0;
+	info->exit_signal = 0;
+	// append the new task state to the "mesos_task_info" file
+	char *cmd = string_format("awk -F \',\' \'{$(NF--)=\"aborting\"; if($1==\"%" PRIbjid "\"){for(i=1;i<NF;i+=1){printf $i\",\"}; print $NF}}\' %s >> %s", jobid, FILE_TASK_INFO, FILE_TASK_INFO);
+	system(cmd);
+	free(cmd);
+
+	char *line = NULL;
+	size_t len = 0;
+	ssize_t read_len;
+	FILE *task_state_fp;
+	char *task_id_ch;
+	char *task_stat_str;
+	int task_id;
+	// TODO what is the proper timeout?
+	int timeout = 40;
+
+	task_state_fp = fopen(FILE_TASK_STATE, "r");
+	while(1) {
+		while((read_len = getline(&line, &len, task_state_fp)) != -1) {
+			// trim the newline character
+			if (line[read_len-1] == '\n') {
+				line[read_len-1] = '\0';
+				--read_len;
+			}
+
+			task_id_ch = strtok(line, ",");
+			task_id = atoi(task_id_ch);
+			task_stat_str = strtok(NULL, ",");
+
+			if (task_id == (int)jobid && \
+					(strcmp(task_stat_str, "finished") == 0 || \
+					 strcmp(task_stat_str, "failed") == 0 || \
+					 strcmp(task_stat_str, "aborted") == 0)) {
+
+				fclose(task_state_fp);
+				return 0;
+
+			}
+		}
+		sleep(1);
+
+		if(timeout != 0 && time(0) >= timeout) {
+			fclose(task_state_fp);
+			return 1;
+		}
+	}
+}
+
+static int batch_queue_mesos_create (struct batch_queue *q)
+{
+	batch_queue_set_feature(q, "mesos_job_queue", NULL);
+	batch_queue_set_feature(q, "batch_log_name", "%s.mesoslog");
+
+	return 0;
+}
+
+static int batch_queue_mesos_free(struct batch_queue *q)
+{
+	FILE *fp;
+	fp = fopen(MESOS_DONE_FILE, "w");
+
+	if(fp == NULL) {
+		debug(D_ERROR, "Fail to clean up batch queue. %s\n", strerror(errno)); 
+		return 1;
+	}
+
+	int batch_queue_abort_flag = atoi(batch_queue_get_option(q, "batch-queue-abort-flag"));
+	int batch_queue_failed_flag = atoi(batch_queue_get_option(q, "batch-queue-failed-flag"));
+
+	if(batch_queue_abort_flag) {
+		fputs("aborted", fp);
+	} else if(batch_queue_failed_flag) {
+		fputs("failed", fp);
+	} else {
+		fputs("finished", fp);
+	}
+
+	fclose(fp);
+	return 0;
+}
+
+batch_queue_stub_port(mesos);
+batch_queue_stub_option_update(mesos);
+
+batch_fs_stub_chdir(mesos);
+batch_fs_stub_getcwd(mesos);
+batch_fs_stub_mkdir(mesos);
+batch_fs_stub_putfile(mesos);
+batch_fs_stub_stat(mesos);
+batch_fs_stub_unlink(mesos);
+
+const struct batch_queue_module batch_queue_mesos = {
+	BATCH_QUEUE_TYPE_MESOS,
+	"mesos",
+
+	batch_queue_mesos_create,
+	batch_queue_mesos_free,
+	batch_queue_mesos_port,
+	batch_queue_mesos_option_update,
+
+	{
+		batch_job_mesos_submit,
+		batch_job_mesos_wait,
+		batch_job_mesos_remove,
+	},
+
+	{
+		batch_fs_mesos_chdir,
+		batch_fs_mesos_getcwd,
+		batch_fs_mesos_mkdir,
+		batch_fs_mesos_putfile,
+		batch_fs_mesos_stat,
+		batch_fs_mesos_unlink,
+	},
+};
+
+/* vim: set noexpandtab tabstop=4: */

--- a/batch_job/src/batch_job_mesos.c
+++ b/batch_job/src/batch_job_mesos.c
@@ -81,9 +81,7 @@ static void start_mesos_scheduler(struct batch_queue *q)
 	if(mesos_preload != NULL) {
 		ld_preload_str = string_format("LD_PRELOAD=%s", mesos_preload);
 	} 
-	// TODO: Environment variables set for launching Mesos, this would not work outside ND. Ask user to specify the environments?
-	char *cctools_path = string_format("CCTOOLS=%s", getenv("CCTOOLS"));
-	char *envs[] = {cctools_path, ld_preload_str, NULL};
+	char *envs[] = {ld_preload_str, NULL};
 
 	char *mesos_python_path = xxstrdup(mesos_py_path);
 

--- a/batch_job/src/mesos_task.c
+++ b/batch_job/src/mesos_task.c
@@ -10,13 +10,13 @@ struct mesos_task *mesos_task_create(int task_id, const char *cmd, \
 	if (extra_input_files != NULL) {
 	    mt->task_input_files = text_list_load_str(extra_input_files);
 		int i = 0;
-        int num_input_files = mt->task_input_files->used_length;
+        int num_input_files = text_list_size(mt->task_input_files);
 		for(i = 0; i < num_input_files; i++) {
-			if ((mt->task_input_files->items)[i][0] != '/') {
+			if (text_list_get(mt->task_input_files, i)[0] != '/') {
 				char *path_buf = path_getcwd();
 				string_combine(path_buf, "/");
-				string_combine(path_buf, (mt->task_input_files->items)[i]);
-				(mt->task_input_files->items)[i] = path_buf;
+				string_combine(path_buf, text_list_get(mt->task_input_files, i));
+				text_list_set(mt->task_input_files, path_buf, i);
 			}
 		}	
 	} else {
@@ -39,3 +39,5 @@ void mesos_task_delete(struct mesos_task *mt)
 	free(mt->task_output_files);
 	free(mt);
 }
+
+/* vim: set noexpandtab tabstop=4: */

--- a/batch_job/src/mesos_task.c
+++ b/batch_job/src/mesos_task.c
@@ -1,0 +1,41 @@
+#include "mesos_task.h"
+
+struct mesos_task *mesos_task_create(int task_id, const char *cmd, \
+        const char *extra_input_files, const char *extra_output_files)
+{
+	struct mesos_task *mt = malloc(sizeof(*mt));
+	mt->task_id = task_id;
+	mt->task_cmd = xxstrdup(cmd);
+
+	if (extra_input_files != NULL) {
+	    mt->task_input_files = text_list_load_str(extra_input_files);
+		int i = 0;
+        int num_input_files = mt->task_input_files->used_length;
+		for(i = 0; i < num_input_files; i++) {
+			if ((mt->task_input_files->items)[i][0] != '/') {
+				char *path_buf = path_getcwd();
+				string_combine(path_buf, "/");
+				string_combine(path_buf, (mt->task_input_files->items)[i]);
+				(mt->task_input_files->items)[i] = path_buf;
+			}
+		}	
+	} else {
+		mt->task_input_files = NULL;
+	}
+
+	if (extra_output_files != NULL) {
+		mt->task_output_files = text_list_load_str(extra_output_files);
+	} else {
+		mt->task_output_files = NULL;
+	}
+
+	return mt;
+}
+
+void mesos_task_delete(struct mesos_task *mt) 
+{
+	free(mt->task_cmd);
+	free(mt->task_input_files);	
+	free(mt->task_output_files);
+	free(mt);
+}

--- a/batch_job/src/mesos_task.h
+++ b/batch_job/src/mesos_task.h
@@ -1,0 +1,23 @@
+#ifndef MESOS_TASK_H_
+#define MESOS_TASK_H_
+
+#include "stdlib.h"
+#include "text_list.h"
+#include "xxmalloc.h"
+#include "path.h"
+#include "stringtools.h"
+
+// mesos task struct
+struct mesos_task{
+	int task_id;
+	char *task_cmd;
+    struct text_list *task_input_files;
+    struct text_list *task_output_files;
+};
+
+struct mesos_task *mesos_task_create(int task_id, const char *cmd, \
+        const char *extra_input_files, const char *extra_output_files);
+
+void mesos_task_delete(struct mesos_task *mt);
+
+#endif

--- a/batch_job/src/mesos_task.h
+++ b/batch_job/src/mesos_task.h
@@ -9,8 +9,8 @@
 
 // mesos task struct
 struct mesos_task{
-	int task_id;
-	char *task_cmd;
+    int task_id;
+    char *task_cmd;
     struct text_list *task_input_files;
     struct text_list *task_output_files;
 };
@@ -21,3 +21,5 @@ struct mesos_task *mesos_task_create(int task_id, const char *cmd, \
 void mesos_task_delete(struct mesos_task *mt);
 
 #endif
+
+/* vim: set noexpandtab tabstop=4: */

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -865,7 +865,7 @@ static void show_help(const char *cmd)
 	printf(" %-30s Specify amazon machine image (AMI). (for use with -T amazon)\n", "--amazon-ami");
 	printf(" %-30s Wrap factory with this command prefix.\n","--wrapper");
 	printf(" %-30s Add this input file needed by the wrapper.\n","--wrapper-input");
-	printf(" %-30s Specify ip address to mesos master node (for use with -T mesos)\n", "--mesos-master");
+	printf(" %-30s Specify the host name to mesos master node (for use with -T mesos)\n", "--mesos-master");
 	printf(" %-30s Specify path to mesos python library(for use with -T mesos)\n", "--mesos-path");
 	printf(" %-30s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)\n", "-o,--debug-file=<file>");
 	printf(" %-30s Show this screen.\n", "-h,--help");

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -108,6 +108,7 @@ struct batch_queue *queue = 0;
 
 static const char *mesos_master = NULL;
 static const char *mesos_path = NULL;
+static const char *mesos_preload = NULL;
 
 static void handle_abort( int sig )
 {
@@ -855,7 +856,7 @@ static void show_help(const char *cmd)
 	printf(" %-30s Set the number of GPUs requested per worker.\n", "--gpus=<n>");
 	printf(" %-30s Set the amount of memory (in MB) requested per worker.\n", "--memory=<mb>           ");
 	printf(" %-30s Set the amount of disk (in MB) requested per worker.\n", "--disk=<mb>");
-	printf(" %-30s Automatically size a worker to an available slot (Condor only).\n", "--autosize");
+	printf(" %-30s Automatically size a worker to an available slot (Condor and Mesos).\n", "--autosize");
 	printf(" %-30s Manually set requirements for the workers as condor jobs. May be specified several times, with the expresions and-ed together (Condor only).\n", "--condor-requirements");
 	printf(" %-30s Exit after no master has been seen in <n> seconds.\n", "--factory-timeout");
 	printf(" %-30s Use this scratch dir for temporary files. (default is /tmp/wq-pool-$uid)\n","-S,--scratch-dir");
@@ -866,12 +867,13 @@ static void show_help(const char *cmd)
 	printf(" %-30s Wrap factory with this command prefix.\n","--wrapper");
 	printf(" %-30s Add this input file needed by the wrapper.\n","--wrapper-input");
 	printf(" %-30s Specify the host name to mesos master node (for use with -T mesos)\n", "--mesos-master");
-	printf(" %-30s Specify path to mesos python library(for use with -T mesos)\n", "--mesos-path");
+	printf(" %-30s Specify path to mesos python library (for use with -T mesos)\n", "--mesos-path");
+	printf(" %-30s Specify the linking libraries for running mesos(for use with -T mesos)\n", "--mesos-preload");
 	printf(" %-30s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)\n", "-o,--debug-file=<file>");
 	printf(" %-30s Show this screen.\n", "-h,--help");
 }
 
-enum { LONG_OPT_CORES = 255, LONG_OPT_MEMORY, LONG_OPT_DISK, LONG_OPT_GPUS, LONG_OPT_TASKS_PER_WORKER, LONG_OPT_CONF_FILE, LONG_OPT_AMAZON_CREDENTIALS, LONG_OPT_AMAZON_AMI, LONG_OPT_FACTORY_TIMEOUT, LONG_OPT_AUTOSIZE, LONG_OPT_CONDOR_REQUIREMENTS, LONG_OPT_WORKERS_PER_CYCLE, LONG_OPT_WRAPPER, LONG_OPT_WRAPPER_INPUT, LONG_OPT_MESOS_MASTER, LONG_OPT_MESOS_PATH};
+enum { LONG_OPT_CORES = 255, LONG_OPT_MEMORY, LONG_OPT_DISK, LONG_OPT_GPUS, LONG_OPT_TASKS_PER_WORKER, LONG_OPT_CONF_FILE, LONG_OPT_AMAZON_CREDENTIALS, LONG_OPT_AMAZON_AMI, LONG_OPT_FACTORY_TIMEOUT, LONG_OPT_AUTOSIZE, LONG_OPT_CONDOR_REQUIREMENTS, LONG_OPT_WORKERS_PER_CYCLE, LONG_OPT_WRAPPER, LONG_OPT_WRAPPER_INPUT, LONG_OPT_MESOS_MASTER, LONG_OPT_MESOS_PATH, LONG_OPT_MESOS_PRELOAD};
 
 static const struct option long_options[] = {
 	{"master-name", required_argument, 0, 'M'},
@@ -905,6 +907,7 @@ static const struct option long_options[] = {
 	{"wrapper-input",required_argument, 0, LONG_OPT_WRAPPER_INPUT},
 	{"mesos-master", required_argument, 0, LONG_OPT_MESOS_MASTER},
 	{"mesos-path", required_argument, 0, LONG_OPT_MESOS_PATH},
+	{"mesos-preload", required_argument, 0, LONG_OPT_MESOS_PRELOAD},
 	{0,0,0,0}
 };
 
@@ -1037,6 +1040,9 @@ int main(int argc, char *argv[])
 			case LONG_OPT_MESOS_PATH:
 				mesos_path = xxstrdup(optarg);
 				break;
+			case LONG_OPT_MESOS_PRELOAD:
+				mesos_preload = xxstrdup(optarg);
+				break;
 			default:
 				show_help(argv[0]);
 				return EXIT_FAILURE;
@@ -1157,6 +1163,7 @@ int main(int argc, char *argv[])
 	if(batch_queue_type == BATCH_QUEUE_TYPE_MESOS) {
 		batch_queue_set_option(queue, "mesos-path", mesos_path);
 		batch_queue_set_option(queue, "mesos-master", mesos_master);
+		batch_queue_set_option(queue, "mesos-preload", mesos_preload);
 		batch_queue_set_feature(queue, "batch_log_name", "work_queue_factory.mesoslog");
 	}
 

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -5,7 +5,6 @@ See the file COPYING for details.
 */
 
 #include "work_queue_catalog.h"
-
 #include "cctools.h"
 #include "batch_job.h"
 #include "hash_table.h"
@@ -106,6 +105,9 @@ static struct rmsummary *resources = NULL;
 static int64_t factory_timeout = 0;
 
 struct batch_queue *queue = 0;
+
+static const char *mesos_master = NULL;
+static const char *mesos_path = NULL;
 
 static void handle_abort( int sig )
 {
@@ -863,11 +865,13 @@ static void show_help(const char *cmd)
 	printf(" %-30s Specify amazon machine image (AMI). (for use with -T amazon)\n", "--amazon-ami");
 	printf(" %-30s Wrap factory with this command prefix.\n","--wrapper");
 	printf(" %-30s Add this input file needed by the wrapper.\n","--wrapper-input");
+	printf(" %-30s Specify ip address to mesos master node (for use with -T mesos)\n", "--mesos-master");
+	printf(" %-30s Specify path to mesos python library(for use with -T mesos)\n", "--mesos-path");
 	printf(" %-30s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)\n", "-o,--debug-file=<file>");
 	printf(" %-30s Show this screen.\n", "-h,--help");
 }
 
-enum { LONG_OPT_CORES = 255, LONG_OPT_MEMORY, LONG_OPT_DISK, LONG_OPT_GPUS, LONG_OPT_TASKS_PER_WORKER, LONG_OPT_CONF_FILE, LONG_OPT_AMAZON_CREDENTIALS, LONG_OPT_AMAZON_AMI, LONG_OPT_FACTORY_TIMEOUT, LONG_OPT_AUTOSIZE, LONG_OPT_CONDOR_REQUIREMENTS, LONG_OPT_WORKERS_PER_CYCLE, LONG_OPT_WRAPPER, LONG_OPT_WRAPPER_INPUT };
+enum { LONG_OPT_CORES = 255, LONG_OPT_MEMORY, LONG_OPT_DISK, LONG_OPT_GPUS, LONG_OPT_TASKS_PER_WORKER, LONG_OPT_CONF_FILE, LONG_OPT_AMAZON_CREDENTIALS, LONG_OPT_AMAZON_AMI, LONG_OPT_FACTORY_TIMEOUT, LONG_OPT_AUTOSIZE, LONG_OPT_CONDOR_REQUIREMENTS, LONG_OPT_WORKERS_PER_CYCLE, LONG_OPT_WRAPPER, LONG_OPT_WRAPPER_INPUT, LONG_OPT_MESOS_MASTER, LONG_OPT_MESOS_PATH};
 
 static const struct option long_options[] = {
 	{"master-name", required_argument, 0, 'M'},
@@ -899,6 +903,8 @@ static const struct option long_options[] = {
 	{"condor-requirements", required_argument, 0, LONG_OPT_CONDOR_REQUIREMENTS},
 	{"wrapper",required_argument, 0, LONG_OPT_WRAPPER},
 	{"wrapper-input",required_argument, 0, LONG_OPT_WRAPPER_INPUT},
+	{"mesos-master", required_argument, 0, LONG_OPT_MESOS_MASTER},
+	{"mesos-path", required_argument, 0, LONG_OPT_MESOS_PATH},
 	{0,0,0,0}
 };
 
@@ -1025,6 +1031,12 @@ int main(int argc, char *argv[])
 			case 'h':
 				show_help(argv[0]);
 				exit(EXIT_SUCCESS);
+			case LONG_OPT_MESOS_MASTER:
+				mesos_master = xxstrdup(optarg);
+				break;
+			case LONG_OPT_MESOS_PATH:
+				mesos_path = xxstrdup(optarg);
+				break;
 			default:
 				show_help(argv[0]);
 				return EXIT_FAILURE;
@@ -1142,7 +1154,20 @@ int main(int argc, char *argv[])
 		batch_queue_set_option(queue, "condor-requirements", condor_requirements);
 	}
 
+	if(batch_queue_type == BATCH_QUEUE_TYPE_MESOS) {
+		batch_queue_set_option(queue, "mesos-path", mesos_path);
+		batch_queue_set_option(queue, "mesos-master", mesos_master);
+		batch_queue_set_feature(queue, "batch_log_name", "work_queue_factory.mesoslog");
+	}
+
 	mainloop( queue );
+
+	if(batch_queue_type == BATCH_QUEUE_TYPE_MESOS) {
+
+		batch_queue_set_int_option(queue, "batch-queue-abort-flag", (int)abort_flag);
+		batch_queue_set_int_option(queue, "batch-queue-failed-flag", 0);
+
+	}
 
 	batch_queue_delete(queue);
 

--- a/doc/makeflow.html
+++ b/doc/makeflow.html
@@ -48,7 +48,8 @@ workflows from existing applications.</p>
 <tr><td>slurm    <td> <a href=http://slurm.schedmd.com>Slurm Workload Manager</a>
 <tr><td>moab     <td> <a href="http://www.adaptivecomputing.com/resources/docs/mwm/6-0/index.php">Moab Workload Manager</a></li>
 <tr><td>cluster  <td> Custom-defined batch submission commands, see <a href=#custom.drivers>custom drivers</a> below for details.
-<tr><td>chirp    <td> Active storage jobs on the <a href=http://ccl.cse.nd.edu/software/chirp>Chirp filesystem</a>.
+<tr><td>chirp    <td> Active storage jobs on the <a href=http://ccl.cse.nd.edu/software/chirp>Chirp filesystem</a>
+<tr><td>mesos    <td> <a href=http://mesos.apache.org/>Apache Mesos</a> cluster resource manager. 
 </table>
 </p>
 

--- a/doc/man/makeflow.m4
+++ b/doc/man/makeflow.m4
@@ -56,7 +56,7 @@ OPTION_ITEM(`-R, --retry')Automatically retry failed batch jobs up to 100 times.
 OPTION_TRIPLET(-r, retry-count, n)Automatically retry failed batch jobs up to n times.
 OPTION_PAIR(--wait-for-files-upto, #)Wait for output files to be created upto this many seconds (e.g., to deal with NFS semantics).
 OPTION_TRIPLET(-S, submission-timeout, timeout)Time to retry failed batch job submission. (default is 3600s)
-OPTION_TRIPLET(-T, batch-type, type)Batch system type: local, dryrun, condor, sge, pbs, torque, blue_waters, slurm, moab, cluster, wq, amazon. (default is local)
+OPTION_TRIPLET(-T, batch-type, type)Batch system type: local, dryrun, condor, sge, pbs, torque, blue_waters, slurm, moab, cluster, wq, amazon, mesos. (default is local)
 OPTIONS_END
 
 SUBSECTION(Debugging Options)
@@ -123,6 +123,13 @@ LONGCODE_BEGIN
 }
 LONGCODE_END
 OPTION_PAIR(--amazon-ami, image-id) Specify an amazon machine image.
+OPTIONS_END
+
+SUBSECTION(Mesos Options)
+OPTIONS_BEGIN
+OPTION_PAIR(--mesos-master, hostname) Indicate the host name of preferred mesos master.
+OPTION_PAIR(--mesos-path, filepath) Indicate the path to mesos python2 site-packages.
+OPTION_PAIR(--mesos-preload, library) Indicate the linking libraries for running mesos..
 OPTIONS_END
 
 SUBSECTION(Mountfile Support)

--- a/doc/man/work_queue_factory.m4
+++ b/doc/man/work_queue_factory.m4
@@ -47,12 +47,12 @@ SECTION(OPTIONS)
 SUBSECTION(Batch Options)
 OPTIONS_BEGIN
 OPTION_TRIPLET(-M,master-name, project)Name of a preferred project. A worker can have multiple preferred projects.
-OPTION_TRIPLET(-T,batch-type, type)Batch system type: local, condor, sge, pbs, torque, blue_waters, slurm, moab, cluster, amazon. (default is local)
+OPTION_TRIPLET(-T,batch-type, type)Batch system type: local, condor, sge, pbs, torque, blue_waters, slurm, moab, cluster, amazon, mesos. (default is local)
 OPTION_TRIPLET(-B,batch-options, options)Add these options to all batch submit files.
 OPTION_TRIPLET(-w,min-workers,workers) Minimum workers running.  (default=5)
 OPTION_TRIPLET(-W,max-workers,workers) Maximum workers running.  (default=100)
 OPTION_PAIR(--workers-per-cycle,workers) Maximum number of new workers per 30 seconds.  ( less than 1 disables limit, default=5)
-OPTION_ITEM(`--autosize')Automatically size a worker to an available slot (Condor only).
+OPTION_ITEM(`--autosize')Automatically size a worker to an available slot (Condor and Mesos).
 OPTION_ITEM(-c --capacity) Use worker capacity reported by masters.
 OPTION_TRIPLET(-P,password,file) Password file for workers to authenticate to master.
 OPTION_TRIPLET(-t,timeout,time)Abort after this amount of idle time.
@@ -66,6 +66,9 @@ OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By defaul
 OPTION_PAIR(--factory-timeout, #)Set factory timeout to <#> seconds. (off by default) This will cause work queue to exit when their are no masters present after the given number of seconds.
 OPTION_PAIR(--wrapper,Wrap all commands with this prefix.)
 OPTION_PAIR(--wrapper-input,Add this file needed by the wrapper.)
+OPTION_PAIR(--mesos-master, hostname) Specify the host name to mesos master node (for use with -T mesos)
+OPTION_PAIR(--mesos-path, filepath) Specify path to mesos python library (for use with -T mesos)
+OPTION_PAIR(--mesos-preload, library) Specify the linking libraries for running mesos(for use with -T mesos)
 OPTION_ITEM(`-h, --help')Show this screen.
 OPTIONS_END
 

--- a/dttools/src/text_list.c
+++ b/dttools/src/text_list.c
@@ -5,6 +5,12 @@
 #include "stringtools.h"
 #include "text_list.h"
 
+struct text_list {
+	char **items;
+	int alloc_length;
+	int used_length;
+};
+
 struct text_list *text_list_create()
 {
 	struct text_list *t = malloc(sizeof(*t));
@@ -85,6 +91,13 @@ void text_list_delete(struct text_list *t)
 	}
 	free(t->items);
 	free(t);
+}
+
+void text_list_set(struct text_list *t, const char *str, int i)
+{
+	char *tmp_str = strdup(str);
+	free(t->items[i]);
+	t->items[i] = tmp_str;
 }
 
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/text_list.c
+++ b/dttools/src/text_list.c
@@ -5,12 +5,6 @@
 #include "stringtools.h"
 #include "text_list.h"
 
-struct text_list {
-	char **items;
-	int alloc_length;
-	int used_length;
-};
-
 struct text_list *text_list_create()
 {
 	struct text_list *t = malloc(sizeof(*t));
@@ -37,6 +31,24 @@ struct text_list *text_list_load(const char *path)
 
 	fclose(file);
 
+	return t;
+}
+
+struct text_list *text_list_load_str(const char *inp_str)
+{
+	if (!inp_str) {
+		return NULL;
+	}
+
+	struct text_list *t = text_list_create();
+	char *pch = NULL;
+	char * tmp_str = strdup(inp_str);
+    pch = strtok(tmp_str, ",");
+	while(pch != NULL) {
+		text_list_append(t, pch);
+		pch = strtok(NULL, ",");
+	}	
+	free(tmp_str);
 	return t;
 }
 

--- a/dttools/src/text_list.h
+++ b/dttools/src/text_list.h
@@ -1,18 +1,13 @@
 #ifndef TEXT_LIST_H
 #define TEXT_LIST_H
 
-struct text_list {
-	char **items;
-	int alloc_length;
-	int used_length;
-};
-
 struct text_list *text_list_create();
 struct text_list *text_list_load(const char *path);
 struct text_list *text_list_load_str(const char *inp_str);
 char *text_list_get(struct text_list *t, int i);
 int text_list_append(struct text_list *t, const char *item);
 int text_list_size(struct text_list *t);
+void text_list_set(struct text_list *t, const char *item, int i);
 void text_list_delete(struct text_list *t);
 
 #endif

--- a/dttools/src/text_list.h
+++ b/dttools/src/text_list.h
@@ -1,12 +1,18 @@
 #ifndef TEXT_LIST_H
 #define TEXT_LIST_H
 
+struct text_list {
+	char **items;
+	int alloc_length;
+	int used_length;
+};
+
 struct text_list *text_list_create();
 struct text_list *text_list_load(const char *path);
+struct text_list *text_list_load_str(const char *inp_str);
 char *text_list_get(struct text_list *t, int i);
 int text_list_append(struct text_list *t, const char *item);
 int text_list_size(struct text_list *t);
 void text_list_delete(struct text_list *t);
-
 
 #endif

--- a/makeflow/src/Makefile
+++ b/makeflow/src/Makefile
@@ -8,7 +8,8 @@ LOCAL_LINKAGE=$(CCTOOLS_GLOBUS_LDFLAGS)
 EXTERNAL_DEPENDENCIES = ../../batch_job/src/libbatch_job.a ../../work_queue/src/libwork_queue.a ../../chirp/src/libchirp.a ../../dttools/src/libdttools.a
 OBJECTS = dag.o dag_node.o dag_file.o dag_variable.o dag_visitors.o dag_resources.o lexer.o parser.o parser_jx.o
 PROGRAMS = makeflow makeflow_viz makeflow_analyze makeflow_linker makeflow_status
-SCRIPTS = condor_submit_makeflow makeflow_graph_log makeflow_monitor starch makeflow_linker_perl_driver makeflow_linker_python_driver makeflow_archive_query
+SCRIPTS = condor_submit_makeflow makeflow_graph_log makeflow_monitor starch makeflow_linker_perl_driver makeflow_linker_python_driver makeflow_archive_query mf_mesos_scheduler mf_mesos_executor mf_mesos_setting mf-mesos-executor
+
 TARGETS = $(PROGRAMS)
 
 all: $(TARGETS)

--- a/makeflow/src/mf-mesos-executor
+++ b/makeflow/src/mf-mesos-executor
@@ -9,7 +9,7 @@
 
 PYTHON=$(/usr/bin/env python)
 
-SCRIPT=${CCTOOLS}/bin/mf_mesos_executor
+SCRIPT=${CCTOOLS_BIN}/mf_mesos_executor
 
 LD_PRELOAD="${LD_PRELOAD}" \
 exec ${PYTHON} ${SCRIPT} "${@}"

--- a/makeflow/src/mf-mesos-executor
+++ b/makeflow/src/mf-mesos-executor
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# This script uses MESOS_SOURCE_DIR and MESOS_BUILD_DIR which come
+# from configuration substitutions.
+MESOS_SOURCE_DIR=/afs/nd.edu/user37/ccl/software/external/mesos-0.26.0/src/mesos-0.26.0_build
+MESOS_BUILD_DIR=/afs/nd.edu/user37/ccl/software/external/mesos-0.26.0/src/mesos-0.26.0_build/build
+
+# Use colors for errors.
+. ${MESOS_SOURCE_DIR}/support/colors.sh
+
+# Force the use of the Python interpreter configured during building.
+test ! -z "${PYTHON}" && \
+  echo "${RED}Ignoring PYTHON environment variable (using @PYTHON@)${NORMAL}"
+
+PYTHON=/usr/bin/python
+
+SCRIPT=${CCTOOLS}/bin/mf_mesos_executor
+
+LD_PRELOAD="/afs/nd.edu/user37/ccl/software/external/gcc-4.9.3/amd64_linux26/lib64/libstdc++.so.6:/afs/nd.edu/user37/ccl/software/external/svn-1.9.4/amd64_linux26/lib/libsvn_delta-1.so" \
+exec ${PYTHON} ${SCRIPT} "${@}"

--- a/makeflow/src/mf-mesos-executor
+++ b/makeflow/src/mf-mesos-executor
@@ -1,20 +1,17 @@
 #!/usr/bin/env bash
 
-# This script uses MESOS_SOURCE_DIR and MESOS_BUILD_DIR which come
-# from configuration substitutions.
-MESOS_SOURCE_DIR=/afs/nd.edu/user37/ccl/software/external/mesos-0.26.0/src/mesos-0.26.0_build
-MESOS_BUILD_DIR=/afs/nd.edu/user37/ccl/software/external/mesos-0.26.0/src/mesos-0.26.0_build/build
+# Copyright (c) 2016- The University of Notre Dame.
+# This software is distributed under the GNU General Public License.
+# See the file COPYING for details. 
 
-# Use colors for errors.
-. ${MESOS_SOURCE_DIR}/support/colors.sh
+# This script is used to setup the system environments for 
+# mf_mesos_executor. 
 
-# Force the use of the Python interpreter configured during building.
-test ! -z "${PYTHON}" && \
-  echo "${RED}Ignoring PYTHON environment variable (using @PYTHON@)${NORMAL}"
-
-PYTHON=/usr/bin/python
+PYTHON=$(/usr/bin/env python)
 
 SCRIPT=${CCTOOLS}/bin/mf_mesos_executor
 
-LD_PRELOAD="/afs/nd.edu/user37/ccl/software/external/gcc-4.9.3/amd64_linux26/lib64/libstdc++.so.6:/afs/nd.edu/user37/ccl/software/external/svn-1.9.4/amd64_linux26/lib/libsvn_delta-1.so" \
+LD_PRELOAD="${LD_PRELOAD}" \
 exec ${PYTHON} ${SCRIPT} "${@}"
+
+# vim: set noexpandtab tabstop=4:

--- a/makeflow/src/mf_mesos_executor
+++ b/makeflow/src/mf_mesos_executor
@@ -1,0 +1,137 @@
+import os
+import sys
+import json
+import urllib2
+import logging
+import threading
+import subprocess
+
+sys.path.insert(0, sys.argv[4])
+
+from mesos.native import MesosExecutorDriver
+from mesos.interface import Executor
+from mesos.interface import mesos_pb2
+
+logging.basicConfig(filename=('{0}.log'.format(sys.argv[2])), 
+                    level=logging.INFO,
+                    format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+                    datefmt='%m-%d %H:%M',)
+
+DEFAULT_PORT = 5051
+
+class MakeflowMesosExecutor(Executor):
+
+    def __init__(self, cmd, executor_id, framework_id, hostname):
+        self.hostname = hostname
+        self.port = DEFAULT_PORT
+        self.cmd = cmd
+        self.executor_id = executor_id
+        self.framework_id = framework_id
+
+    def disconnected(self, driver):
+        driver.sendFrameworkMessage("[EXUT_STATE] {0} {1} disconnected".format(self.executor_id, self.task_id))
+
+    def get_sandbox_dir(self, hostname):
+        slave_state_uri = "http://{0}:{1}/state.json".format(hostname, self.port)
+
+        slave_state = json.load(urllib2.urlopen(slave_state_uri))
+        executors_data = slave_state['frameworks'][0]['executors']
+
+        for executor_data in executors_data:
+
+            if executor_data['id'] == self.executor_id:
+                # The task is in the completed_tasks lists
+                completed_tasks = executor_data['completed_tasks']
+                for completed_task in completed_tasks:
+                    if completed_task['id'] == self.task_id:
+                        return executor_data['directory']
+               
+                # due to the network delay, the task is in the tasks lists
+                tasks = executor_data['tasks']
+                for task in tasks:
+                    if task['id'] == self.task_id:
+                        return executor_data['directory']
+                
+                logging.error("Task {0} does not appear in the tasks list\
+                        of executor {1}.".format(self.task_id, executor_id))
+
+                return None
+
+    def launchTask(self, driver, task):
+        def run_task():
+            print "Running task %s" % task.task_id.value
+            update = mesos_pb2.TaskStatus()
+            update.task_id.value = task.task_id.value
+            update.state = mesos_pb2.TASK_RUNNING
+            self.task_id = task.task_id.value
+            driver.sendStatusUpdate(update)
+           
+            tmp_io = sys.stdout 
+            sys.stdout = sys.stderr
+            for uri in task.executor.command.uris:
+                inp_fn = os.path.basename(uri.value)
+                inp_fn_size = os.path.getsize(inp_fn)
+                print "task {0} input: {1} {2}".format(task.task_id.value, uri.value, inp_fn_size)
+            sys.stdout = tmp_io
+
+            # Launch the makeflow task
+
+            print "Sending status update..."
+            update = mesos_pb2.TaskStatus()
+            update.task_id.value = task.task_id.value
+
+            try:  
+                subprocess.check_call(self.cmd, shell=True)
+                
+                with open ("stderr", "r") as stderr_fd:
+                    stderr_msg = stderr_fd.read()   
+
+                data_msg = "stderr of task {0} \n{1}".format(self.task_id, stderr_msg)
+                update.data = data_msg; 
+                # send the sandbox URI to the scheduler
+                sandbox_dir = self.get_sandbox_dir(self.hostname)
+                get_dir_addr = "[EXECUTOR_OUTPUT] http://{0}:{1}/files/download?path={2}".format(\
+                    self.hostname, self.port, sandbox_dir)
+                print "{0}".format(get_dir_addr)
+                task_id_msg = "task_id {0}".format(task.task_id.value)
+                message = "{0} {1}".format(get_dir_addr, task_id_msg) 
+                logging.info("Sending message: {0}".format(message))
+                print "Sent output file URI" 
+                update.state = mesos_pb2.TASK_FINISHED
+                update.message = message
+
+            except subprocess.CalledProcessError as e:
+                returncode = e.returncode
+                update.state = mesos_pb2.TASK_FAILED
+                if returncode == 2:
+                    update.message = "run out of resource"
+                else:
+                    update.message = "task {0} failed not because of lacking of resource".format(task.task_id.value)
+
+            driver.sendStatusUpdate(update)
+            print "Sent status update"
+            
+            driver.sendFrameworkMessage("[EXECUTOR_STATE] {0} stopped".format(\
+                    self.executor_id))
+            driver.stop()
+
+        thread = threading.Thread(target=run_task)
+        thread.start()
+        thread.join()
+
+    def frameworkMessage(self, driver, message):
+        message_list = message.split()
+        if message_list[1].strip(' \t\n\r') == "abort":
+            logging.info("task {0} aborted".format(self.task_id))
+            driver.sendFrameworkMessage("[EXECUTOR_STATE] {0} aborted {1}".format(\
+                    self.executor_id, self.task_id))
+            driver.stop()
+            
+if __name__ == '__main__':
+    print "starting makeflow mesos executor!"
+    driver = MesosExecutorDriver(MakeflowMesosExecutor(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[5]))
+
+    status = 0 if driver.run() == mesos_pb2.DRIVER_STOPPED else 1
+
+    sys.exit(status)
+

--- a/makeflow/src/mf_mesos_executor
+++ b/makeflow/src/mf_mesos_executor
@@ -12,6 +12,7 @@ import os
 import sys
 import json
 import urllib2
+import shutil
 import logging
 import threading
 import subprocess
@@ -109,6 +110,7 @@ class MakeflowMesosExecutor(Executor):
                 print "Sent output file URI" 
                 update.state = mesos_pb2.TASK_FINISHED
                 update.message = message
+                update.executor_id.value = self.executor_id
 
             except subprocess.CalledProcessError as e:
                 returncode = e.returncode
@@ -123,18 +125,24 @@ class MakeflowMesosExecutor(Executor):
             
             driver.sendFrameworkMessage("[EXECUTOR_STATE] {0} stopped".format(\
                     self.executor_id))
-            driver.stop()
+            # driver.stop()
 
         thread = threading.Thread(target=run_task)
         thread.start()
         thread.join()
 
     def frameworkMessage(self, driver, message):
+        print "receive message {0}".format(message)
         message_list = message.split()
         if message_list[1].strip(' \t\n\r') == "abort":
             logging.info("task {0} aborted".format(self.task_id))
             driver.sendFrameworkMessage("[EXECUTOR_STATE] {0} aborted {1}".format(\
                     self.executor_id, self.task_id))
+            driver.stop()
+        if message_list[1].strip(' \t\n\r') == "retrieve":
+            print "The output of task {0} has been retrieved by master".format(self.task_id)
+            print "Removing the sandbox directory....."
+            shutil.rmtree(self.get_sandbox_dir(self.hostname))
             driver.stop()
             
 if __name__ == '__main__':

--- a/makeflow/src/mf_mesos_executor
+++ b/makeflow/src/mf_mesos_executor
@@ -1,3 +1,13 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2016- The University of Notre Dame.
+# This software is distributed under the GNU General Public License.
+# See the file COPYING for details. 
+
+# This script defined a customized mesos executor. Compare to the default executor, 
+# it can send the url of sandbox directory of each executor to the scheduler. And
+# then the Mesos scheduler is able to retrieve the outputs. 
+
 import os
 import sys
 import json
@@ -135,3 +145,4 @@ if __name__ == '__main__':
 
     sys.exit(status)
 
+# vim: set noexpandtab tabstop=4:

--- a/makeflow/src/mf_mesos_executor
+++ b/makeflow/src/mf_mesos_executor
@@ -115,10 +115,7 @@ class MakeflowMesosExecutor(Executor):
             except subprocess.CalledProcessError as e:
                 returncode = e.returncode
                 update.state = mesos_pb2.TASK_FAILED
-                if returncode == 2:
-                    update.message = "run out of resource"
-                else:
-                    update.message = "task {0} failed not because of lacking of resource".format(task.task_id.value)
+                update.message = str(returncode) 
 
             driver.sendStatusUpdate(update)
             print "Sent status update"

--- a/makeflow/src/mf_mesos_scheduler
+++ b/makeflow/src/mf_mesos_scheduler
@@ -1,5 +1,26 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2016- The University of Notre Dame.
+# This software is distributed under the GNU General Public License.
+# See the file COPYING for details. 
+
+# This script defined the MesosScheduler and MakeflowMonitor class.
+#  
+# Three threads are started when batch_job_mesos.c first try to submit tasks 
+# to Mesos. They are,
+# 
+# 1. A simple httpserver, which is responsible for handle file transfer request from  
+# 	 Mesos master.
+# 2. A workflow state monitor(i.e. MakefowMonitor), which will monitor the two files
+#    (i.e. mesos_task_info and mesos_task_state) and synchronize the workflow states
+#    of Makeflow and Mesos. 
+# 3. A Makeflow Mesos Scheduler, which submits ready tasks to Mesos master, resubmits 
+#    failed tasks and write complete tasks' states to mesos_task_state.
+#  
+# In current version, each time when scheduler submit a new task to master a new 
+# executor will be created and binded to the task. The scheduler will be terminated 
+# when the mesos_done_file is created.
+
 import os
 import sys
 import uuid
@@ -139,6 +160,7 @@ class MakeflowScheduler(Scheduler):
         executor.framework_id.value = framework_id
         executor.executor_id.value = str(uuid.uuid4())
         cctools_path = os.getenv('CCTOOLS')
+        ld_preload = os.getenv('LD_PRELOAD')
         sh_path = os.path.join(cctools_path, 'bin', 'mf-mesos-executor')
         task_cmd_sh = "task_{0}_cmd".format(mf_task.task_id)
         task_cmd_f = open(task_cmd_sh, "w+")
@@ -160,6 +182,11 @@ class MakeflowScheduler(Scheduler):
         cctools_env = executor.command.environment.variables.add()
         cctools_env.name = "CCTOOLS"
         cctools_env.value = cctools_path
+
+        # add $LD_PRELOAD as the env variables for executor command
+        ld_preload_env = executor.command.environment.variables.add()
+        ld_preload_env.name = "LD_PRELOAD"
+        ld_preload_env.value = ld_preload
 
         # add input files list to the executor_info
         for fn in mf_task.inp_fns:
@@ -315,9 +342,9 @@ class MakeflowScheduler(Scheduler):
 
     def clean_mesos_file(self, task_id): 
         mf_task = mms.tasks_info_dict[task_id]
-        #  TODO do not remove the file, if it is not exist
-        # if os.path.isfile("task_{0}_cmd".format(task_id)):
-        #   os.remove("task_{0}_cmd".format(task_id))
+        # TODO do not remove the file, if it is not exist
+        if os.path.isfile("task_{0}_cmd".format(task_id)):
+           os.remove("task_{0}_cmd".format(task_id))
         #for fn in mf_task.inp_fns:
         #    if os.path.isdir(fn):
         #        logger.info("{0} is a directory, remove the tar.gz file".format(fn))
@@ -557,13 +584,16 @@ class MakefowMonitor(threading.Thread):
 
         fn_run_tks_path = os.path.join(mms.mf_wk_dir, FILE_TASK_INFO)
         fn_finish_tks_path = os.path.join(mms.mf_wk_dir, FILE_TASK_STATE)
+        fn_slave_stderr = os.path.join(mms.mf_wk_dir, SLAVE_STDERR)
 
-        #if os.path.isfile(mf_done_fn_path):
-        #    os.remove(mf_done_fn_path)
-        #if os.path.isfile(fn_run_tks_path):
-        #    os.remove(fn_run_tks_path)
-        #if os.path.isfile(fn_finish_tks_path):
-        #    os.remove(fn_finish_tks_path)
+        if os.path.isfile(mf_done_fn_path):
+            os.remove(mf_done_fn_path)
+        if os.path.isfile(fn_run_tks_path):
+            os.remove(fn_run_tks_path)
+        if os.path.isfile(fn_finish_tks_path):
+            os.remove(fn_finish_tks_path)
+        if os.path.isfile(fn_slave_stderr):
+            os.remove(fn_slave_stderr)
         
         while(not self.is_all_executor_stopped()):
             pass
@@ -681,3 +711,5 @@ if __name__ == '__main__':
 
     httpd.shutdown()
     sys.exit(status)
+
+# vim: set noexpandtab tabstop=4:

--- a/makeflow/src/mf_mesos_scheduler
+++ b/makeflow/src/mf_mesos_scheduler
@@ -1,0 +1,683 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import uuid
+import time
+import urllib
+import urllib2
+import tarfile
+import logging
+import threading
+import json
+import imp
+import re
+import SimpleHTTPServer
+import SocketServer
+import socket
+from Queue import Queue
+
+setting_module_path = os.path.join(os.getenv('CCTOOLS'), "bin", "mf_mesos_setting")
+mms = imp.load_source("mf_mesos_setting", setting_module_path)
+
+sys.path.insert(0,sys.argv[3])
+
+from mesos.interface import Scheduler
+from mesos.native import MesosSchedulerDriver
+from mesos.interface import mesos_pb2
+
+logger = logging.getLogger('mesos_scheduler')
+logger.setLevel(logging.INFO)
+console = logging.StreamHandler()
+console.setLevel(logging.INFO)
+formatter = logging.Formatter(fmt='%(asctime)s.%(msecs)03d %(name)s %(levelname)s %(message)s',datefmt='%Y/%m/%d %H:%M:%S')
+console.setFormatter(formatter)
+logger.addHandler(console)
+
+FILE_TASK_INFO = "mesos_task_info"
+FILE_TASK_STATE = "mesos_task_state"
+SLAVE_STDERR = "mesos_slave_stderr"
+MESOS_DONE_FILE = "mesos_done"
+
+MAX_FAILED = 10
+MAX_LOST = 10
+   
+class ThreadPoolMixIn(SocketServer.ThreadingMixIn):
+    '''
+    use a thread pool instead of a new thread on every request
+    we also cache the requests
+    '''
+    queue_size = 128
+    numThreads = 30
+    allow_reuse_address = True 
+
+    def serve_forever(self):
+        '''
+        Handle one request at a time until doomsday.
+        '''
+        # set up the threadpool
+        self.requests = Queue(self.queue_size)
+
+        for x in range(self.numThreads):
+            t = threading.Thread(target = self.process_request_thread)
+            t.setDaemon(1)
+            t.start()
+
+        # server main loop
+        while True:
+            self.handle_request()
+            
+        self.server_close()
+
+    
+    def process_request_thread(self):
+        '''
+        obtain request from queue instead of directly from server socket
+        '''
+        while True:
+            SocketServer.ThreadingMixIn.process_request_thread(self, *self.requests.get())
+
+    
+    def handle_request(self):
+        '''
+        simply collect requests and put them on the queue for the workers.
+        '''
+        try:
+            request, client_address = self.get_request()
+        except socket.error:
+            return
+        if self.verify_request(request, client_address):
+            self.requests.put((request, client_address)) 
+
+def get_open_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("",0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+def start_httpserver(httpd, port):
+    logger.info("Serving a http server at {0} for directory {1}\n".format(port, os.getcwd()))
+    httpd.serve_forever()
+
+# Makeflow mesos scheduler
+class MakeflowScheduler(Scheduler):
+
+    def __init__(self, mf_wk_dir, master_addr, mf_hostname, http_port):
+        self.mf_wk_dir = mf_wk_dir
+        self.master_addr = master_addr
+        self.mf_hostname = mf_hostname
+        self.http_port = http_port
+        self.finished_tasks = 0
+        
+    # Print out the dynamic static information of mesos cluster
+    def print_mesos_info(self, task_id):
+        metrics_snapshot_url = "http://{0}/metrics/snapshot".format(self.master_addr)
+
+        master_metrics = json.load(urllib2.urlopen(metrics_snapshot_url))
+
+        cpu_offered = master_metrics['master/cpus_total'] 
+        cpu_used = master_metrics['master/cpus_used']
+        mem_offered = master_metrics['master/mem_total']
+        mem_used = master_metrics['master/mem_used']
+        disk_offered = master_metrics['master/disk_total']
+        disk_used = master_metrics['master/disk_used'] 
+        self.finished_tasks = 0
+        tasks_running = master_metrics['master/tasks_running']
+        tasks_staging = master_metrics['master/tasks_staging']
+        tasks_starting = master_metrics['master/tasks_starting']
+        tasks_finished = master_metrics['master/tasks_finished']
+
+        # treat running, staging and starting as running
+        num_running_tasks = tasks_running + tasks_staging + tasks_starting
+
+        logger.info("{0} cpu {1} used, {2} memory {3} used, {4} disk {5} used, {6} active tasks, {7} finished tasks".format(cpu_offered, cpu_used, mem_offered, mem_used, disk_offered, disk_used, num_running_tasks, self.finished_tasks))
+
+    # Create a ExecutorInfo instance for mesos task
+    def new_mesos_executor(self, mf_task, framework_id, hostname, task_cpu, task_mem, task_disk):
+        executor = mesos_pb2.ExecutorInfo()
+        executor.framework_id.value = framework_id
+        executor.executor_id.value = str(uuid.uuid4())
+        cctools_path = os.getenv('CCTOOLS')
+        sh_path = os.path.join(cctools_path, 'bin', 'mf-mesos-executor')
+        task_cmd_sh = "task_{0}_cmd".format(mf_task.task_id)
+        task_cmd_f = open(task_cmd_sh, "w+")
+        task_cmd_f.write(mf_task.cmd)
+        task_cmd_f.close()
+        os.chmod(task_cmd_sh, 0755)
+
+        uri = executor.command.uris.add()
+        uri.value = "http://{0}:{1}/{2}".format(self.mf_hostname, self.http_port, task_cmd_sh)
+        uri.executable = True
+        uri.extract = False
+
+        executor.name = "{0} makeflow mesos executor".format(mf_task.task_id) 
+        executor.source = "python executor"
+        executor.command.value = "{0} \"./{1}\" {2} {3} {4} {5}".format(sh_path, task_cmd_sh, 
+                executor.executor_id.value, executor.framework_id.value, sys.argv[3], hostname)
+        
+        # add $CCTOOLS as the env variables for executor command
+        cctools_env = executor.command.environment.variables.add()
+        cctools_env.name = "CCTOOLS"
+        cctools_env.value = cctools_path
+
+        # add input files list to the executor_info
+        for fn in mf_task.inp_fns:
+
+            logger.info("input file is: {0}".format(fn.strip(' \t\n\r')))
+            uri = executor.command.uris.add()
+
+            # if input file is a directory, compress it
+            if os.path.isdir(fn):
+                logger.info("Input {0} of task {1} is a directory".format(fn, mf_task.task_id))
+                dir_name = os.path.dirname(fn)
+                base_fn = os.path.basename(fn)
+                compressed_fn = "{0}.tar.gz".format(base_fn)
+                if not os.path.exists(compressed_fn):
+                    logger.info("The compressed file for {0} is not exist".format(fn)) 
+                    tar = tarfile.open(compressed_fn, "w:gz")
+                    tar.add(base_fn)
+                    tar.close()
+                else:
+                    logger.info("The compressed file for {0} is exist".format(fn)) 
+                fn = "http://{0}:{1}/{2}".format(self.mf_hostname, self.http_port, compressed_fn)
+                uri.value = fn
+                uri.extract = True
+            else:
+                abs_path = fn.strip(' \t\n\r')
+                base_name = os.path.basename(abs_path)
+                uri.value = "http://{0}:{1}/{2}".format(self.mf_hostname, self.http_port, base_name)
+                uri.extract = False
+                uri.executable = True
+            uri.cache = True
+        return executor
+    
+    # Create a TaskInfo instance
+    def new_mesos_task(self, offer, task_id, task_cores, task_mem, task_disk):
+        mesos_task = mesos_pb2.TaskInfo()
+        mesos_task.task_id.value = task_id
+        mesos_task.slave_id.value = offer.slave_id.value
+        mesos_task.name = "task {0}".format(str(id))
+    
+        cpus = mesos_task.resources.add()
+        cpus.name = "cpus"
+        cpus.type = mesos_pb2.Value.SCALAR
+        cpus.scalar.value = task_cores
+    
+        mem = mesos_task.resources.add()
+        mem.name = "mem"
+        mem.type = mesos_pb2.Value.SCALAR
+        mem.scalar.value = task_mem
+   
+        disk = mesos_task.resources.add()
+        disk.name = "disk"
+        disk.type = mesos_pb2.Value.SCALAR
+        disk.scalar.value = task_disk 
+    
+        return mesos_task
+
+    def launch_mesos_task(self, driver, offer, task_id, cores, mem, disk): 
+
+        mesos_task = self.new_mesos_task(offer, task_id, cores, mem, disk)
+       
+        mf_mesos_task_info = mms.tasks_info_dict[task_id] 
+
+        # initialize a ExecutorInfo instance
+        executor = self.new_mesos_executor(\
+            mf_mesos_task_info, \
+            offer.framework_id.value, \
+            offer.hostname, \
+            cores, mem, disk)
+
+        mesos_task.executor.MergeFrom(executor)
+
+        # TODO for version0 one executor only run with one task, in the future
+        # we may wanna change the number of tasks running by one executor
+        mf_mesos_executor_info = \
+                mms.MfMesosExecutorInfo(\
+                executor.executor_id, \
+                offer.slave_id.value, offer.hostname)
+
+        mf_mesos_executor_info.tasks.append(task_id)
+
+        mms.executors_info_dict[executor.executor_id.value] = \
+                mf_mesos_executor_info
+
+        # combine mesos TaskInfo with ExecutorInfo
+        mf_mesos_task_info.executor_id = \
+                executor.executor_id.value
+
+        mms.tasks_info_dict[task_id] \
+                = mf_mesos_task_info 
+        
+        # create mesos task and launch it with offer 
+        logger.info("Launching task {0} using offer {1} from {2}.".format(\
+                        task_id, offer.id.value, offer.hostname))
+
+        # one task is corresponding to one executor
+        tasks = [mesos_task]
+
+        driver.launchTasks(offer.id, tasks)
+
+    def resourceOffers(self, driver, offers):
+        logger.info("Received resource offers: {0} from {1}".format(\
+                [o.id.value for o in offers], [o.hostname for o in offers]))
+      
+        num_ready_task = 0
+
+        with mms.lock:
+            for task_info in mms.tasks_info_dict.itervalues():
+                if (task_info.action == "submitted" or task_info.action == "resubmitted"):
+                    num_ready_task += 1
+
+        for offer in offers:
+            if num_ready_task == 0:
+                driver.declineOffer(offer.id)    
+            else:
+                offer_used = False
+                offer_cpus = 0
+                offer_mem = 0
+                offer_disk = 0
+
+                for resource in offer.resources:
+                    if resource.name == "cpus":
+                        offer_cpus += resource.scalar.value
+                    if resource.name == "mem":
+                        offer_mem += resource.scalar.value
+                    if resource.name == "disk":
+                        offer_disk += resource.scalar.value
+
+                logger.info("Received resource offer {0} with cpus {1}, mem: {2} and disk {3} from {4}\
+                    ".format(offer.id.value, offer_cpus, offer_mem, offer_disk, offer.hostname))
+                
+                
+                with mms.lock:
+                    for task_info in mms.tasks_info_dict.itervalues():
+
+                        if (task_info.action == "submitted" or task_info.action == "resubmitted") \
+                            and offer_cpus >= task_info.cores \
+                            and offer_mem >= task_info.mem \
+                            and offer_disk >= task_info.disk:
+                            
+                                task_id = task_info.task_id
+                                mms.tasks_info_dict[task_id].action = "running"
+
+                                logger.info("Task {0} will use {1} cores {2} mem {3} disk".format(task_id, task_info.cores, task_info.mem, task_info.disk))
+                                
+                                self.launch_mesos_task(driver, offer, task_id, task_info.cores, task_info.mem, task_info.disk)
+                                offer_used = True
+                                num_ready_task -= 1
+                                break;
+
+                    if offer_used == False: 
+                        logger.info("Resource offer {0} with {1} cpu {2} mem {3} disk is unused.".format(offer.id, offer_cpus, offer_mem, offer_disk))
+                        driver.declineOffer(offer.id)
+
+    def clean_mesos_file(self, task_id): 
+        mf_task = mms.tasks_info_dict[task_id]
+        #  TODO do not remove the file, if it is not exist
+        # if os.path.isfile("task_{0}_cmd".format(task_id)):
+        #   os.remove("task_{0}_cmd".format(task_id))
+        #for fn in mf_task.inp_fns:
+        #    if os.path.isdir(fn):
+        #        logger.info("{0} is a directory, remove the tar.gz file".format(fn))
+        #        compressed_fn = "{0}.tar.gz".format(fn)
+        #        if os.path.isfile(compressed_fn):
+        #            os.remove(compressed_fn)
+        
+    def statusUpdate(self, driver, update):
+        if os.path.isfile(FILE_TASK_STATE): 
+            oup_fn = open(FILE_TASK_STATE, "a", 0)
+        else:
+            logger.error("{0} is not created in advanced".format(FILE_TASK_STATE))
+            exit(1)
+
+        with mms.lock:
+            if update.state == mesos_pb2.TASK_STAGING:
+                logger.info("{0} is staging".format(update.task_id.value))
+                self.print_mesos_info(update.task_id.value)
+
+            if update.state == mesos_pb2.TASK_STARTING:
+                logger.info("{0} is starting".format(update.task_id.value))
+                self.print_mesos_info(update.task_id.value)
+
+            if update.state == mesos_pb2.TASK_RUNNING:
+                logger.info("{0} is running".format(update.task_id.value))
+                self.print_mesos_info(update.task_id.value)
+
+            if update.state == mesos_pb2.TASK_FINISHED:
+                # get the resource usage snapshot
+                logger.info("{0} is finished by executor.".format(update.task_id.value))
+                self.print_mesos_info(update.task_id.value)
+
+                stderr_msg = update.data
+
+                if os.path.isfile(SLAVE_STDERR):
+                    with open (SLAVE_STDERR, "a") as stderr_fd:
+                        stderr_fd.write(stderr_msg)
+                else:
+                    with open (SLAVE_STDERR, "w") as stderr_fd:
+                        stderr_fd.write(stderr_msg)
+
+                message = update.message
+                logger.info("Receive message {0}".format(update.message))
+                message_list = message.split()
+
+                if message_list[0].strip(' \t\n\r') == "[EXECUTOR_OUTPUT]":
+
+                    if os.path.isfile(FILE_TASK_STATE): 
+                        oup_fn = open(FILE_TASK_STATE, "a", 0)
+                    else:
+                        logger.error("{0} is not created in advanced".format(FILE_TASK_STATE))
+                        exit(1)
+
+                    output_file_dir = message_list[1].strip(' \t\n\r')
+                    curr_task_id = message_list[3].strip(' \t\n\r')
+
+                    output_fns = mms.tasks_info_dict[curr_task_id].oup_fns
+
+                    for output_fn in output_fns:
+                        output_file_addr = "{0}/{1}".format(output_file_dir, output_fn)
+                        logger.info("The output file address is: {0}".format(\
+                                output_file_addr))
+                        urlretrieve_start = time.time()
+                        urllib.urlretrieve(output_file_addr, output_fn)
+                        urlretrieve_end = time.time()
+                         
+
+                        if os.path.exists(output_fn):
+                            output_fn_size = os.stat(output_fn).st_size 
+                            transfer_rate = ((output_fn_size/(urlretrieve_end - urlretrieve_start))/(1024*1024))
+                            logger.info("Task {0} get output file {1} with transfer rate {2} MB/s".format(curr_task_id, \
+                                output_fn, transfer_rate))
+                        else:
+                            logger.error("Task {0} is failed because it cannot get \
+                            output file {1}".format(curr_task_id, output_fn))
+                            oup_fn.write("{0},failed\n".format(curr_task_id))  
+                            mms.tasks_info_dict[update.task_id.value].action = "failed"
+                            self.clean_mesos_file(update.task_id.value)  
+                            return 
+                
+                    logger.info("{0} is done".format(update.task_id.value))
+                    oup_fn.write("{0},finished\n".format(curr_task_id))
+                    mms.tasks_info_dict[curr_task_id].action = "finished"
+                    self.clean_mesos_file(curr_task_id)
+
+                    oup_fn.close()
+
+                self.finished_tasks += 1
+
+            if update.state == mesos_pb2.TASK_FAILED:
+                failed_task_id = update.task_id.value
+                logger.info("Task {0} failed with reason code {1}.".format(failed_task_id, update.reason))
+                self.print_mesos_info(update.task_id.value)
+
+                if failed_task_id in mms.tasks_failed_time:
+                    if mms.tasks_failed_time[failed_task_id] <= MAX_FAILED:
+                        mms.tasks_failed_time[failed_task_id] += 1
+                        mms.tasks_info_dict[failed_task_id].action = "resubmitted"
+                        if update.message == "run out of resource":
+                            logger.info("Task {0} has been failed {1} times because running out memory". format(failed_task_id, mms.tasks_failed_time[failed_task_id])) 
+                            mms.tasks_info_dict[failed_task_id].cores = 4 
+                            mms.tasks_info_dict[failed_task_id].mem = 5120 
+                            mms.tasks_info_dict[failed_task_id].disk = 5120 
+                        else:
+                            logger.info("Task {0} has been failed {1} times". format(failed_task_id, mms.tasks_failed_time[failed_task_id])) 
+                        logger.info("Try to resubmit failed task {0}".format(failed_task_id))
+                    else:
+                        oup_fn.write("{0},failed\n".format(failed_task_id))
+                        mms.tasks_info_dict[failed_task_id].action = "failed"
+                        self.clean_mesos_file(failed_task_id)
+                else:  
+                    mms.tasks_failed_time[failed_task_id] = 1
+                    mms.tasks_info_dict[failed_task_id].action = "resubmitted"
+                    logger.info("Task {0} has been failed 1 time". format(failed_task_id)) 
+                    if update.message == "run out of resource":
+                        logger.info("Task {0} has been failed {1} times because running out memory". format(failed_task_id, mms.tasks_failed_time[failed_task_id])) 
+                        mms.tasks_info_dict[failed_task_id].cores = 4
+                        mms.tasks_info_dict[failed_task_id].mem = 5120
+                        mms.tasks_info_dict[failed_task_id].disk = 5120 
+                    logger.info("Try to resubmit failed task {0}".format(failed_task_id))
+
+            if update.state == mesos_pb2.TASK_KILLED:
+                oup_fn.write("{0},killed\n".format(update.task_id.value))
+                mms.tasks_info_dict[update.task_id.value].action = "killed"
+                logger.info("{0}".format(update.message))
+                self.clean_mesos_file(update.task_id.value)
+                self.print_mesos_info(update.task_id.value)
+
+            if update.state == mesos_pb2.TASK_LOST:
+                lost_task_id = update.task_id.value
+                logger.error("Task {0} lost with error message: {1}".format(update.task_id.value,\
+                    update.message))
+                self.print_mesos_info(update.task_id.value)
+                if lost_task_id in mms.tasks_lost_time:
+                    if mms.tasks_lost_time[lost_task_id] <= MAX_LOST:
+                        mms.tasks_lost_time[lost_task_id] += 1
+                        mms.tasks_info_dict[lost_task_id].action = "resubmitted"
+                        logger.info("Task {0} has been lost {1} time".format(lost_task_id, mms.tasks_lost_time[lost_task_id]))
+                        logger.info("Try to resubmit lost task {0}".format(lost_task_id))
+                    else:
+                        oup_fn.write("{0},lost\n".format(update.task_id.value))
+                        mms.tasks_info_dict[update.task_id.value].action = "lost"
+                        self.clean_mesos_file(update.task_id.value)
+                else:
+                    mms.tasks_lost_time[lost_task_id] = 1
+                    mms.tasks_info_dict[lost_task_id].action = "resubmitted"
+                    logger.info("Task {0} has been lost 1 time". format(lost_task_id))
+                    logger.info("Try to resubmit lost task {0}".format(lost_task_id))
+                
+
+            if update.state == mesos_pb2.TASK_ERROR:
+                mms.tasks_info_dict[update.task_id.value].action = "resubmitted"
+                logger.info("{0} try to resubmit task {1}".format(update.message,\
+                update.task_id.value))
+                self.print_mesos_info(update.task_id.value)
+                logger.error("Task {0} fail with error message: {1}".format(update.task_id.value,\
+                update.message))
+        
+        oup_fn.close()
+
+    # TODO deprecate the using of this method, since the message transmission is not reliable
+    def frameworkMessage(self, driver, executorId, slaveId, message):
+        logger.info("Receive message {0}".format(message))
+        message_list = message.split()
+        if message_list[0].strip(' \t\n\r') == "[EXECUTOR_STATE]":
+            curr_executor_id = message_list[1].strip(' \t\n\r')
+            curr_executor_state = message_list[2].strip(' \t\n\r')
+             
+            with mms.lock:
+                mms.executors_info_dict[curr_executor_id].state = \
+                        curr_executor_state
+
+                # if a executor is aborted, the corresponding task is aborted
+                if curr_executor_state == "aborted":
+                    curr_task_id = message_list[3].strip(' \t\n\r')
+                    file_task_state = open(FILE_TASK_STATE, "a+")
+                    file_task_state.write("{0},{1}\n".format(curr_task_id,\
+                            curr_executor_state))
+                    file_task_state.close()
+                    os.remove("task_{0}_cmd".format(curr_task_id))
+
+
+class MakefowMonitor(threading.Thread):
+  
+    def __init__(self, driver):
+        threading.Thread.__init__(self)
+        self.driver = driver
+
+    # Check if all tasks done
+    def is_all_executor_stopped(self):
+        
+        with mms.lock:
+            for executor_info in mms.executors_info_dict.itervalues():
+                if executor_info.state == "registered":
+                    return False
+    
+            return True
+
+    # stop all running executors
+    def stop_executors(self):
+        task_action_fn = open(FILE_TASK_INFO, "r")
+        lines = task_action_fn.readlines()
+    
+        with mms.lock:
+            for line in lines:
+                task_info_list = re.split(''',(?=(?:[^'"]|'[^']*'|"[^"]*")*$)''', line)
+                task_id = task_info_list[0]
+                task_action = task_info_list[4]
+                if task_action == "aborting":
+                    mf_task = mms.tasks_info_dict[task_id]
+
+                    self.driver.sendFrameworkMessage(self, \
+                            mf_task.executor_id, \
+                            mms.executors_info_dict[mf_task.executor_id].slave_id, \
+                            "[SCHEDULER_REQUEST] abort")
+    
+        task_action_fn.close()
+
+    def stop_mesos_scheduler(self):
+
+        # If makeflow creat "makeflow_done" file, stop the scheduler
+        mf_done_fn_path = os.path.join(mms.mf_wk_dir, MESOS_DONE_FILE)
+
+        if os.path.isfile(mf_done_fn_path):
+            mf_done_fn = open(mf_done_fn_path, "r")
+            mf_state = mf_done_fn.readline().strip(' \t\n\r')
+            mf_done_fn.close()
+
+            logger.info("Makeflow workflow is {0}".format(mf_state))
+
+            if mf_state == "aborted":
+                logger.info("Workflow aborted, stopping executors...")
+                self.stop_executors()
+        else: 
+            
+            logger.info("batch job system exited unexpectedly")
+
+        fn_run_tks_path = os.path.join(mms.mf_wk_dir, FILE_TASK_INFO)
+        fn_finish_tks_path = os.path.join(mms.mf_wk_dir, FILE_TASK_STATE)
+
+        #if os.path.isfile(mf_done_fn_path):
+        #    os.remove(mf_done_fn_path)
+        #if os.path.isfile(fn_run_tks_path):
+        #    os.remove(fn_run_tks_path)
+        #if os.path.isfile(fn_finish_tks_path):
+        #    os.remove(fn_finish_tks_path)
+        
+        while(not self.is_all_executor_stopped()):
+            pass
+
+        self.driver.stop()  
+    
+    
+    def abort_mesos_task(self, task_id):
+        logger.info("Makeflow is trying to abort task {0}.".format(task_id))
+       
+        if mms.tasks_info_dict[task_id].action == "finished" or \
+                mms.tasks_info_dict[task_id].action == "failed" or \
+                mms.tasks_info_dict[task_id].action == "aborted":
+                return
+
+        with mms.lock:
+            if mms.tasks_info_dict[task_id].action == "submitted":
+                mms.tasks_info_dict[task_id].action = "aborted"
+            if mms.tasks_info_dict[task_id].action == "running":
+                py_task_id = mesos_pb2.TaskID()
+                py_task_id.value = task_id 
+                self.driver.killTask(py_task_id)
+                mms.tasks_info_dict[task_id].action = "aborted"
+
+        if os.path.isfile(FILE_TASK_STATE): 
+            oup_fn = open(FILE_TASK_STATE, "a", 0)
+        else:
+            logger.error("{0} is not created in advanced".format(FILE_TASK_STATE))
+            exit(1)
+        
+        oup_fn.write("{0},aborted\n".format(task_id))
+        oup_fn.close()
+
+    def run(self):
+
+        while(not os.path.isfile(MESOS_DONE_FILE)):
+
+            # The parent process (i.e. batch_job_mesos) has 
+            # been killed. Stop the scheduler
+
+            task_info_fp = open(FILE_TASK_INFO, "r")
+            lines = task_info_fp.readlines()
+
+            for line in lines:
+                task_info_list = re.split(''',(?=(?:[^'"]|'[^']*'|"[^"]*")*$)''', line)
+                task_id = task_info_list[0].strip(" \t\n\r")
+                task_cmd = task_info_list[1].strip(" \t\n\r")
+                task_inp_fns = task_info_list[2].split()
+                task_oup_fns = task_info_list[3].split()
+                task_cores = int(task_info_list[4].strip(" \t\n\r"))
+                task_mem = int(task_info_list[5].strip(" \t\n\r"))
+                task_disk = int(task_info_list[6].strip(" \t\n\r"))
+                task_action = task_info_list[7].strip(" \t\n\r")
+             
+                with mms.lock:
+                    # find new tasks
+                    if (task_id not in mms.tasks_info_dict):
+                        logger.info("Put task {0} into queue".format(task_id))
+                        mf_mesos_task_info = mms.MfMesosTaskInfo(\
+                                task_id, task_cmd, task_inp_fns, task_oup_fns, \
+                                task_cores, task_mem, task_disk, \
+                                task_action)
+
+                        mms.tasks_info_dict[task_id] \
+                                = mf_mesos_task_info
+                    else:
+                        
+                        if task_action == "aborting":
+                            self.abort_mesos_task(task_id) 
+
+            task_info_fp.close()
+            time.sleep(2)
+       
+        self.stop_mesos_scheduler() 
+
+
+if __name__ == '__main__':
+
+    class ThreadedServer(ThreadPoolMixIn, SocketServer.TCPServer):
+        pass
+
+    # Start the httpserver in the working directory
+    port = get_open_port()
+    Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
+    httpd = ThreadedServer(("", port), Handler)
+    threading.Thread(target=start_httpserver, args=(httpd,port)).start()
+
+    # make us a framework
+    mms.mf_wk_dir = sys.argv[1]
+    mesos_master_addr = sys.argv[2]
+
+    # create the "task_state" and "task_info" file
+    if not os.path.isfile(FILE_TASK_STATE):
+        open(FILE_TASK_STATE, 'w').close()
+    if not os.path.isfile(FILE_TASK_INFO):
+        open(FILE_TASK_INFO, 'w').close()
+
+    # initialize a framework instance
+    framework = mesos_pb2.FrameworkInfo()
+    framework.user = ""  # Have Mesos fill in the current user.
+    framework.name = "Makeflow"
+    mf_hostname = socket.getfqdn()
+
+    driver = MesosSchedulerDriver(
+        MakeflowScheduler(mms.mf_wk_dir, mesos_master_addr, mf_hostname, port),
+        framework,
+        mesos_master_addr  # assumes running on the master
+    )
+
+    # Start the monitor thread 
+    mf_monitor = MakefowMonitor(driver)
+    mf_monitor.start()
+
+    status = 0 if driver.run() == mesos_pb2.DRIVER_STOPPED else 1
+
+    httpd.shutdown()
+    sys.exit(status)

--- a/makeflow/src/mf_mesos_scheduler
+++ b/makeflow/src/mf_mesos_scheduler
@@ -38,7 +38,7 @@ import SocketServer
 import socket
 from Queue import Queue
 
-setting_module_path = os.path.join(os.getenv('CCTOOLS'), "bin", "mf_mesos_setting")
+setting_module_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "mf_mesos_setting")
 mms = imp.load_source("mf_mesos_setting", setting_module_path)
 
 sys.path.insert(0,sys.argv[3])
@@ -159,9 +159,9 @@ class MakeflowScheduler(Scheduler):
         executor = mesos_pb2.ExecutorInfo()
         executor.framework_id.value = framework_id
         executor.executor_id.value = str(uuid.uuid4())
-        cctools_path = os.getenv('CCTOOLS')
+        cctools_bin_path = os.path.dirname(os.path.realpath(__file__))
         ld_preload = os.getenv('LD_PRELOAD')
-        sh_path = os.path.join(cctools_path, 'bin', 'mf-mesos-executor')
+        sh_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mf-mesos-executor')
         task_cmd_sh = "task_{0}_cmd".format(mf_task.task_id)
         task_cmd_f = open(task_cmd_sh, "w+")
         task_cmd_f.write(mf_task.cmd)
@@ -180,8 +180,8 @@ class MakeflowScheduler(Scheduler):
         
         # add $CCTOOLS as the env variables for executor command
         cctools_env = executor.command.environment.variables.add()
-        cctools_env.name = "CCTOOLS"
-        cctools_env.value = cctools_path
+        cctools_env.name = "CCTOOLS_BIN"
+        cctools_env.value = os.path.dirname(os.path.realpath(__file__))
 
         # add $LD_PRELOAD as the env variables for executor command
         ld_preload_env = executor.command.environment.variables.add()
@@ -263,7 +263,7 @@ class MakeflowScheduler(Scheduler):
         mf_mesos_executor_info = \
                 mms.MfMesosExecutorInfo(\
                 executor.executor_id, \
-                offer.slave_id.value, offer.hostname)
+                offer.slave_id, offer.hostname)
 
         mf_mesos_executor_info.tasks.append(task_id)
 
@@ -424,7 +424,11 @@ class MakeflowScheduler(Scheduler):
                             mms.tasks_info_dict[update.task_id.value].action = "failed"
                             self.clean_mesos_file(update.task_id.value)  
                             return 
-                
+               
+			  		# send message to executor to deleting the sandbox directory 
+                    logger.info("sending {0} to {1} at {2}".format("[SCHEDULER_STATE] retrieve done",update.executor_id.value, mms.executors_info_dict[update.executor_id.value].slave_id.value ))
+                    driver.sendFrameworkMessage(update.executor_id, mms.executors_info_dict[update.executor_id.value].slave_id, "[SCHEDULER_STATE] retrieve done")	
+			    
                     logger.info("{0} is done".format(update.task_id.value))
                     oup_fn.write("{0},finished\n".format(curr_task_id))
                     mms.tasks_info_dict[curr_task_id].action = "finished"
@@ -556,10 +560,7 @@ class MakefowMonitor(threading.Thread):
                 if task_action == "aborting":
                     mf_task = mms.tasks_info_dict[task_id]
 
-                    self.driver.sendFrameworkMessage(self, \
-                            mf_task.executor_id, \
-                            mms.executors_info_dict[mf_task.executor_id].slave_id, \
-                            "[SCHEDULER_REQUEST] abort")
+                    self.driver.sendFrameworkMessage( mf_task.executor_id, mms.executors_info_dict[mf_task.executor_id].slave_id, "[SCHEDULER_REQUEST] abort")
     
         task_action_fn.close()
 

--- a/makeflow/src/mf_mesos_scheduler
+++ b/makeflow/src/mf_mesos_scheduler
@@ -328,7 +328,12 @@ class MakeflowScheduler(Scheduler):
                             
                                 task_id = task_info.task_id
                                 mms.tasks_info_dict[task_id].action = "running"
-
+                               
+                                if task_info.cores == -1 and task_info.mem == -1 and task_info.disk == -1:
+                                    task_info.cores = offer_cpus
+                                    task_info.mem = offer_mem
+                                    task_info.disk = offer_disk 
+                                    logger.info("User did not specify resource requirement, Task {0} will use all available resources".format(task_id))
                                 logger.info("Task {0} will use {1} cores {2} mem {3} disk".format(task_id, task_info.cores, task_info.mem, task_info.disk))
                                 
                                 self.launch_mesos_task(driver, offer, task_id, task_info.cores, task_info.mem, task_info.disk)
@@ -410,7 +415,6 @@ class MakeflowScheduler(Scheduler):
                         urlretrieve_start = time.time()
                         urllib.urlretrieve(output_file_addr, output_fn)
                         urlretrieve_end = time.time()
-                         
 
                         if os.path.exists(output_fn):
                             output_fn_size = os.stat(output_fn).st_size 
@@ -420,7 +424,7 @@ class MakeflowScheduler(Scheduler):
                         else:
                             logger.error("Task {0} is failed because it cannot get \
                             output file {1}".format(curr_task_id, output_fn))
-                            oup_fn.write("{0},failed\n".format(curr_task_id))  
+                            oup_fn.write("{0},failed,444\n".format(curr_task_id))  
                             mms.tasks_info_dict[update.task_id.value].action = "failed"
                             self.clean_mesos_file(update.task_id.value)  
                             return 
@@ -440,35 +444,10 @@ class MakeflowScheduler(Scheduler):
 
             if update.state == mesos_pb2.TASK_FAILED:
                 failed_task_id = update.task_id.value
-                logger.info("Task {0} failed with reason code {1}.".format(failed_task_id, update.reason))
+                logger.info("Task {0} failed with reason code {1} and exit code {2}.".format(failed_task_id, update.reason, update.message))
                 self.print_mesos_info(update.task_id.value)
-
-                if failed_task_id in mms.tasks_failed_time:
-                    if mms.tasks_failed_time[failed_task_id] <= MAX_FAILED:
-                        mms.tasks_failed_time[failed_task_id] += 1
-                        mms.tasks_info_dict[failed_task_id].action = "resubmitted"
-                        if update.message == "run out of resource":
-                            logger.info("Task {0} has been failed {1} times because running out memory". format(failed_task_id, mms.tasks_failed_time[failed_task_id])) 
-                            mms.tasks_info_dict[failed_task_id].cores = 4 
-                            mms.tasks_info_dict[failed_task_id].mem = 5120 
-                            mms.tasks_info_dict[failed_task_id].disk = 5120 
-                        else:
-                            logger.info("Task {0} has been failed {1} times". format(failed_task_id, mms.tasks_failed_time[failed_task_id])) 
-                        logger.info("Try to resubmit failed task {0}".format(failed_task_id))
-                    else:
-                        oup_fn.write("{0},failed\n".format(failed_task_id))
-                        mms.tasks_info_dict[failed_task_id].action = "failed"
-                        self.clean_mesos_file(failed_task_id)
-                else:  
-                    mms.tasks_failed_time[failed_task_id] = 1
-                    mms.tasks_info_dict[failed_task_id].action = "resubmitted"
-                    logger.info("Task {0} has been failed 1 time". format(failed_task_id)) 
-                    if update.message == "run out of resource":
-                        logger.info("Task {0} has been failed {1} times because running out memory". format(failed_task_id, mms.tasks_failed_time[failed_task_id])) 
-                        mms.tasks_info_dict[failed_task_id].cores = 4
-                        mms.tasks_info_dict[failed_task_id].mem = 5120
-                        mms.tasks_info_dict[failed_task_id].disk = 5120 
-                    logger.info("Try to resubmit failed task {0}".format(failed_task_id))
+                mms.tasks_info_dict[failed_task_id].action = "failed"
+                oup_fn.write("{0},failed,{1}\n".format(failed_task_id, update.message))
 
             if update.state == mesos_pb2.TASK_KILLED:
                 oup_fn.write("{0},killed\n".format(update.task_id.value))

--- a/makeflow/src/mf_mesos_setting
+++ b/makeflow/src/mf_mesos_setting
@@ -1,5 +1,12 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2016- The University of Notre Dame.
+# This software is distributed under the GNU General Public License.
+# See the file COPYING for details. 
+
 # This module defined global variables and classes 
-# used by mf_mesos_scheduler.py
+# shared by httpserver, MakeflowMonitor MesosScheduler, which 
+# defined in mf_mesos_scheduler
 
 import os
 import Queue
@@ -57,3 +64,5 @@ class MfMesosExecutorInfo:
         self.hostname = hostname
         self.state = "init"
         self.tasks = []
+
+# vim: set noexpandtab tabstop=4:

--- a/makeflow/src/mf_mesos_setting
+++ b/makeflow/src/mf_mesos_setting
@@ -1,0 +1,59 @@
+# This module defined global variables and classes 
+# used by mf_mesos_scheduler.py
+
+import os
+import Queue
+import threading
+
+# variables need to be synchronized between threads
+tasks_info_dict = {}
+executors_info_dict = {}
+tasks_failed_time = {}
+tasks_lost_time = {}
+lock = threading.RLock()
+offers_queue = Queue.Queue()
+# default makeflow working directory
+mf_wk_dir = "."
+DEBUG_FILE = "debug_mesos"
+SLEEP = 0
+
+def print_task_id_state():
+    if os.path.isfile(DEBUG_FILE):
+        debug_fn = open(DEBUG_FILE, "a+")
+    else:
+        debug_fn = open(DEBUG_FILE, "w+")
+
+    if len(tasks_info_dict) > 0:
+
+        for value in tasks_info_dict.itervalues():
+            debug_fn.write("{}:{},".format(value.task_id, value.action))
+
+        debug_fn.write("================\n")
+
+    debug_fn.close()
+    
+
+# Makeflow Mesos task info class
+class MfMesosTaskInfo:
+
+    def __init__(self, task_id, cmd, inp_fns, oup_fns, cores, mem, disk, action):
+        self.task_id = task_id
+        self.cmd = cmd
+        self.inp_fns = inp_fns
+        self.oup_fns = oup_fns
+        self.cores = cores
+        self.mem = mem
+        self.disk = disk
+        self.action = action
+        self.num_exe = 0
+        self.executor_id = None
+
+# Makeflow Mesos executor info class
+class MfMesosExecutorInfo:
+
+    def __init__(self, executor_id, slave_id, hostname):
+        self.executor_id = executor_id
+        self.slave_id = slave_id
+        self.hostname = hostname
+        self.state = "init"
+        self.tasks = []

--- a/makeflow/src/mf_mesos_setting
+++ b/makeflow/src/mf_mesos_setting
@@ -15,7 +15,6 @@ import threading
 # variables need to be synchronized between threads
 tasks_info_dict = {}
 executors_info_dict = {}
-tasks_failed_time = {}
 tasks_lost_time = {}
 lock = threading.RLock()
 offers_queue = Queue.Queue()

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -362,7 +362,7 @@ void write_variables_gnuplot(struct field_stats *h, struct field_stats *all)
 	fprintf(f, "%s = %lf\n", "current_first_allocation_min_waste", rmsummary_to_external_unit(h->field, h->fa_min_waste_time_dependence.first));
 
 	fprintf(f, "%s = %lf\n", "current_bin_size",   rmsummary_to_external_unit(h->field, histogram_bucket_size(h->histogram)));
-
+	
 	if(all) {
 
 		fprintf(f, "%s = %lf\n", "all_minimum",    floor(rmsummary_to_external_unit(h->field, histogram_min_value(all->histogram))));


### PR DESCRIPTION
This is the initial version of makeflow mesos mode. By enabling this mesos mode, makeflow can run on top of mesos clusters. 
1. Procedures is as follows
   - makeflow process the dags and write task detail to text file "task_info"
   - makeflow start the makeflow mesos scheduler (source can be found in `$CCTOOLS/bin/mf_mesos_scheduler`)
   - mesos scheduler read the task information and submit each task to mesos master
   - mesos master receive resource offer from mesos slaves
   - mesos master bundle resource offer with makeflow tasks
   - mesos master create makeflow mesos executor(source can be found in `$CCTOOLS/bin/mf_mesos_executor`) 
   - mesos master launch each task with a executor on mesos slaves
   - when tasks are complete, mesos executor inform mesos master and master write the status of finished tasks to text file "task_state" 
   - At the mean time, makeflow is keep pooling the "task_state" and wait for all tasks complete
2. Problem of current version
   - Each executor can only launch one task, may be we can reserve the executor on the slaves for launching multiple tasks to avoid the overhead?