### PR TITLE
create output directory when using bundler

### DIFF
--- a/makeflow/src/makeflow_analyze.c
+++ b/makeflow/src/makeflow_analyze.c
@@ -290,8 +290,13 @@ int main(int argc, char *argv[])
 
 		char output_makeflow[PATH_MAX];
 		sprintf(output_makeflow, "%s/%s", expanded_path, path_basename(dagfile));
-		if(strcmp(bundle_directory, "*"))
-			dag_to_file(d, output_makeflow, bundler_rename);
+		if(strcmp(bundle_directory, "*")) {
+			if(create_dir(expanded_path, 0755)) {
+				dag_to_file(d, output_makeflow, bundler_rename);
+			} else {
+				fatal("Could not create directory '%s'.", bundler_rename);
+			}
+		}
 		free(bundle_directory);
 		exit(0);
 	}


### PR DESCRIPTION
makeflow_analyze -b DIR would only succeed if DIR already existed.

(Found this bug while fixing a bug related to incorrect assignment of categories, which fix is still to come.)