### PR TITLE
fix mis-assignment of categories

### DIFF
--- a/makeflow/src/dag_visitors.c
+++ b/makeflow/src/dag_visitors.c
@@ -74,7 +74,7 @@ int dag_to_file_exports(const struct dag *d, FILE * dag_stream, const char *pref
 	set_first_element(vars);
 	for(name = set_next_element(vars); name; name = set_next_element(vars))
 	{
-		v = hash_table_lookup(d->default_category->mf_variables, name);
+		v = dag_variable_get_value(name, d->default_category->mf_variables, 0);
 		if(v)
 		{
 			fprintf(dag_stream, "%s%s=", prefix, name);

--- a/makeflow/src/lexer.c
+++ b/makeflow/src/lexer.c
@@ -97,6 +97,9 @@ char *lexer_print_token(struct token *t)
 	case TOKEN_IO_REDIRECT:
 		snprintf(str, n, "IO_REDIRECT: %s\n", t->lexeme);
 		break;
+	case TOKEN_DIRECTIVE:
+		snprintf(str, n, "DIRECTIVE\n");
+		break;
 	default:
 		snprintf(str, n, "unknown: %s\n", t->lexeme);
 		break;

--- a/makeflow/src/parser.c
+++ b/makeflow/src/parser.c
@@ -388,11 +388,11 @@ static int dag_parse_variable_wmode(struct lexer *bk, struct dag_node *n, char m
 	{
 	case '=':
 		dag_variable_add_value(name, current_table, nodeid, value);
-		debug(D_MAKEFLOW_PARSER, "%s appending to variable name=%s, value=%s", (n ? "node" : "dag"), name, value);
+		debug(D_MAKEFLOW_PARSER, "%s variable name=%s, value=%s", (n ? "node" : "dag"), name, value);
 		break;
 	case '+':
 		dag_parse_append_variable(bk, nodeid, n, name, value);
-		debug(D_MAKEFLOW_PARSER, "%s variable name=%s, value=%s", (n ? "node" : "dag"), name, value);
+		debug(D_MAKEFLOW_PARSER, "%s appending to variable name=%s, value=%s", (n ? "node" : "dag"), name, value);
 		break;
 	default:
 		lexer_report_error(bk, "Unknown variable operator.");

--- a/makeflow/src/parser.c
+++ b/makeflow/src/parser.c
@@ -276,7 +276,6 @@ static void dag_parse_process_category(struct lexer *bk, struct dag_node *n, int
 	else {
 		/* set value of current category */
 		bk->category = category;
-		dag_variable_add_value("CATEGORY", bk->category->mf_variables, nodeid, value);
 	}
 }
 


### PR DESCRIPTION
When switching to .MAKEFLOW directives, all the related variables were being assigned at the node level, rather than the dag. This meant that all nodes were assigned to the first category that was defined.

Since we do not use directives inside a node anyway, I simply deleted that from the code.

Also, we were assigning two times the values to a variable when it was both a directive and a special variable. The result was not an error, but it was inefficient.