### PR TITLE
configure: replace expr substr with native bash

### DIFF
--- a/configure
+++ b/configure
@@ -36,7 +36,7 @@ fi
 
 # `git archive` (man gitattributes(5)) fills this in, otherwise we do it manually...
 COMMIT='$Format:%H$'
-if [ "$(expr substr "$COMMIT" 1 1)" = '$' ]; then
+if [ "${COMMIT:0:1}" = '$' ]; then
 	if [ "$GIT" = y ]; then
 		COMMIT="$(git rev-parse HEAD)"
 	else
@@ -54,7 +54,7 @@ fi
 
 # The date is the commit date of the commit, or now if the working tree is dirty.
 DATE='$Format:%ci$'
-if [ "$(expr substr "$DATE" 1 1)" = '$' ]; then
+if [ "${DATE:0:1}" = '$' ]; then
 	if [ "$GIT" = y ]; then
 		DATE="$(git log -1 --pretty=format:%ci HEAD)"
 	else
@@ -72,7 +72,7 @@ elif [ -n "$CCTOOLS_BRANCH" ]; then
 	BRANCH="$CCTOOLS_BRANCH"
 else
 	BRANCH='$Format:%d$'
-	if [ "$(expr substr "$BRANCH" 1 1)" = '$' ]; then
+	if [ "${BRANCH:0:1}" = '$' ]; then
 		if [ "$GIT" = y ]; then
 			BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 		else
@@ -95,7 +95,7 @@ else
 	fi
 fi
 
-SOURCE="${BRANCH}:$(expr substr "$COMMIT" 1 8)${DIRTY}"
+SOURCE="${BRANCH}:${COMMIT:0:8}${DIRTY}"
 VERSION="$MAJOR.$MINOR.$MICRO [${SOURCE}]"
 
 # Bourne shell is tricky when you use backtick command substitution backslash


### PR DESCRIPTION
According to POSIX, `substr` in `expr` produces undefined results. In
some versions of `expr`, it has no special meaning. This causes
configure to fail on these expressions and assign the literal string
"$Format:%.*$" to config commit values, which causes the build to fail
because the closing quote is interpreted as a variable.

Change instances of `expr substr $VAR $index $len` to ${VAR:$index:$len},
which should be supported by all instances of bash.