### PR TITLE
Make existing channel anonymous on rename

### DIFF
--- a/parrot/src/pfs_channel.c
+++ b/parrot/src/pfs_channel.c
@@ -235,6 +235,20 @@ int pfs_channel_update_name( const char *oldname, const char *newname )
 {
 	struct entry *e = head;
 	debug(D_CHANNEL,"updating channel for file '%s' to '%s'",oldname,newname);
+	/* If the channel already has an entry with the new name, make it
+	 * anonymous so we don't see stale entries later.
+	 */
+	if (newname) {
+		do {
+			if(e->name && !strcmp(e->name, newname)) {
+				debug(D_CHANNEL, "invalidating existing channel name");
+				free(e->name);
+				e->name = NULL;
+			}
+			e = e->next;
+		} while(e != head);
+	}
+
 	do {
 		if(e->name && !strcmp(e->name,oldname)) {
 			free(e->name);

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -815,6 +815,12 @@ or the file itself might be in use by several opens.
 
 int pfs_table::close( int fd )
 {
+	/* FIXME: if a previously mmaped file is written to, we ought to clean up
+	 * the channel cache on close. Otherwise, subsequent mmaps might return
+	 * stale data. Related:
+	 * https://github.com/cooperative-computing-lab/cctools/issues/1584
+	 */
+
 	if (isnative(fd)) {
 		debug(D_DEBUG, "marking closed native fd %d", fd);
 		pointers[fd] = NULL;


### PR DESCRIPTION
This is a minimal fix for #1584. Currently Parrot incorrectly handles channels during a rename. If there's an existing mapped entry under the new name, then a rename will result in multiple entries with the same name, only one of which is current. This patch makes any files being renamed over anonymous, that way they won't be returned from the cache. Once the last existing mapping is removed, they can be cleaned up as usual.