### PR TITLE
Enhance parrot_packaging_run

### DIFF
--- a/doc/man/chroot_package_run.m4
+++ b/doc/man/chroot_package_run.m4
@@ -13,7 +13,7 @@ If CODE(chroot) is used to help repeat one experiment, common directories like B
 SECTION(OPTIONS)
 OPTIONS_BEGIN
 OPTION_ITEM(`-p, --package-path')The path of the package.
-OPTION_ITEM(`-e, --env-list')The path of the environment file. (Default: package-path/env_list)
+OPTION_ITEM(`-e, --env-list')The path of the environment file, each line is in the format of <key>=<value>. (Default: package-path/env_list)
 OPTION_ITEM(`-h, --help')Show this help message.
 OPTIONS_END
 

--- a/doc/man/parrot_package_run.m4
+++ b/doc/man/parrot_package_run.m4
@@ -13,7 +13,7 @@ If CODE(parrot_run) is used to repeat one experiment, one mountlist must be crea
 SECTION(OPTIONS)
 OPTIONS_BEGIN
 OPTION_ITEM(`-p, --package-path')The path of the package.
-OPTION_ITEM(`-e, --env-list')The path of the environment file. (Default: package-path/env_list)
+OPTION_ITEM(`-e, --env-list')The path of the environment file, each line is in the format of <key>=<value>. (Default: package-path/env_list)
 OPTION_ITEM(`-h, --help')Show this help message.
 OPTIONS_END
 

--- a/parrot/src/chroot_package_run
+++ b/parrot/src/chroot_package_run
@@ -12,7 +12,7 @@ show_help()
 	echo ''
 	echo "Options:"
 	echo "-p, --package-path         The path of the package."
-	echo "-e, --env-list             The path of the environment file. (Default: package-path/env_list)"
+	echo "-e, --env-list             The path of the environment file, each line is in the format of <key>=<value>. (Default: package-path/env_list)"
 	echo "-h, --help                 Show this help message."
 	exit 1
 }
@@ -48,9 +48,19 @@ do
 	shift
 done
 
+if [ -n "${env_path}" ] && [ ! -f "${env_path}" ]; then
+	echo "The --env-list option specified (${env_path}) is not a file!"
+	exit 1
+fi
+
 if [ -z "${env_path}" ]; then
 	env_path="${package_path}/env_list"
+	if [ ! -f "${env_path}" ]; then
+		echo "Warning: you are going to use the environment variable settings from your current shell to run your package."
+		echo "         You can specify an environment variable list file with the --env-list option."
+	fi
 fi
+
 
 if [ -z "${package_path}" ]; then
 	echo "Please specify package-path!"
@@ -124,8 +134,13 @@ remove_special_files() {
 	done < "${package_path}/special_files"
 }
 
-unmount_virtual_fs
-remove_special_files
+if [ -f "${common_mountlist}" ]; then
+	unmount_virtual_fs
+fi
+
+if [ -f "${package_path}/special_files" ]; then
+	remove_special_files
+fi
 
 # This allows DNS lookups via your system's networking
 if [ ! -e etc ]; then
@@ -133,32 +148,36 @@ if [ ! -e etc ]; then
 fi
 cp -L /etc/resolv.conf etc/
 
-while read item
-do
-	tmp_fs=$(echo "${item}"|cut -d' ' -f1)
-	virtual_fs="./${tmp_fs}"
-	mkdir -p "${virtual_fs}" 1>/dev/null 2>/dev/null
-	mount --bind "${tmp_fs}" "${virtual_fs}" 1>/dev/null 2>/dev/null
-done <"${common_mountlist}"
+if [ -f "${common_mountlist}" ]; then
+	while read item
+	do
+		tmp_fs=$(echo "${item}"|cut -d' ' -f1)
+		virtual_fs="./${tmp_fs}"
+		mkdir -p "${virtual_fs}" 1>/dev/null 2>/dev/null
+		mount --bind "${tmp_fs}" "${virtual_fs}" 1>/dev/null 2>/dev/null
+	done <"${common_mountlist}"
+fi
 
 #create hardlink to special files
-while read line
-do
-	item=$(echo "${line}"|cut -d' ' -f1)
-	if [ -e "${package_path}/${item}" -o ! -e "${item}" ]; then
-		continue
-	fi
-	filename=$(basename "${item}")
-	filepath="${item%filename}"
-	if [ ! -e "${package_path}/${filepath}" ]; then
-		mkdir -p "${package_path}/${filepath}"
-	fi
-	cd "${ackage_path}/${filepath}"
-	ln "${item}" "${filename}"
-	if [ ! "$?" -eq 0 ]; then
-		echo "Creating hardlink to special file (${item}) failed."
-	fi
-done < "${package_path}/special_files"
+if [ -f "${package_path}/special_files" ]; then
+	while read line
+	do
+		item=$(echo "${line}"|cut -d' ' -f1)
+		if [ -e "${package_path}/${item}" -o ! -e "${item}" ]; then
+			continue
+		fi
+		filename=$(basename "${item}")
+		filepath="${item%filename}"
+		if [ ! -e "${package_path}/${filepath}" ]; then
+			mkdir -p "${package_path}/${filepath}"
+		fi
+		cd "${ackage_path}/${filepath}"
+		ln "${item}" "${filename}"
+		if [ ! "$?" -eq 0 ]; then
+			echo "Creating hardlink to special file (${item}) failed."
+		fi
+	done < "${package_path}/special_files"
+fi
 
 cd "${package_path}"
 
@@ -176,7 +195,10 @@ export_env() {
 		IFS=" "
 	done < "${env_path}"
 }
-export_env
+
+if [ -f "${env_path}" ]; then
+	export_env
+fi
 
 export PACKAGE_CHROOT_PWD="${PWD}"
 if [ -z "$1" ]; then
@@ -186,5 +208,10 @@ else
 fi
 
 #post cleaning process
-unmount_virtual_fs
-remove_special_files
+if [ -f "${common_mountlist}" ]; then
+	unmount_virtual_fs
+fi
+
+if [ -f "${package_path}/special_files" ]; then
+	remove_special_files
+fi

--- a/parrot/src/parrot_package_run
+++ b/parrot/src/parrot_package_run
@@ -12,7 +12,7 @@ show_help()
 	echo ''
 	echo "Options:"
 	echo "-p, --package-path         The path of the package."
-	echo "-e, --env-list             The path of the environment file. (Default: package-path/env_list)"
+	echo "-e, --env-list             The path of the environment file, each line is in the format of <key>=<value>. (Default: package-path/env_list)"
 	echo "-h, --help                 Show this help message."
 	exit 1
 }
@@ -48,8 +48,17 @@ do
 	shift
 done
 
+if [ -n "${env_path}" ] && [ ! -f "${env_path}" ]; then
+	echo "The --env-list option specified (${env_path}) is not a file!"
+	exit 1
+fi
+
 if [ -z "${env_path}" ]; then
 	env_path="${package_path}/env_list"
+	if [ ! -f "${env_path}" ]; then
+		echo "Warning: you are going to use the environment variable settings from your current shell to run your package."
+		echo "         You can specify an environment variable list file with the --env-list option."
+	fi
 fi
 
 if [ -z "${package_path}" ]; then
@@ -73,9 +82,17 @@ fi
 
 echo "/ ${package_path}" >> "${mountlist}"
 echo "${package_path} ${package_path}" >> "${mountlist}"
-cat "${package_path}/common-mountlist" >> "${mountlist}"
 
-cat "${package_path}/special_files" >> "${mountlist}"
+if [ -f "${package_path}/common-mountlist" ]; then
+	cat "${package_path}/common-mountlist" >> "${mountlist}"
+else
+	echo "/proc /proc" >> "${mountlist}"
+	echo "/dev /dev" >> "${mountlist}"
+fi
+
+if [ -f "${package_path}/common-mountlist" ]; then
+	cat "${package_path}/special_files" >> "${mountlist}"
+fi
 
 cmd_parrot_run=$(which parrot_run)
 
@@ -84,14 +101,17 @@ if [ -z "${cmd_parrot_run}" ]; then
 	exit 1
 fi
 
-#import environment varibales
+#import environment variables
 export_env() {
 	while read -r -d '' line
 	do
 		export "${line}"
 	done < "${env_path}"
 }
-export_env
+
+if [ -f "${env_path}" ]; then
+	export_env
+fi
 
 ldso_file="$(echo "$(pwd)/$(ldd ${cmd_parrot_run} | grep ld-linux | cut -d' ' -f1)" | sed -e 's/[ \t]//g')"
 


### PR DESCRIPTION
Currently, `parrot_package_run` does not work well on packages created by tools
other than `parrot_package_create` due to lacking of `common_mountlist` and
`env_list` files inside the packages.

This commit fixes this.