### PR TITLE
Add parrot features: fixed PID and warped PID

### DIFF
--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -1258,8 +1258,6 @@ static void decode_syscall( struct pfs_process *p, int entering )
 		case SYSCALL32_getitimer:
 		case SYSCALL32_getpgid:
 		case SYSCALL32_getpgrp:
-		case SYSCALL32_getpid:
-		case SYSCALL32_getppid:
 		case SYSCALL32_getpriority:
 		case SYSCALL32_getrandom:
 		case SYSCALL32_getrlimit:
@@ -1443,6 +1441,16 @@ static void decode_syscall( struct pfs_process *p, int entering )
 			/* We need to track the umask ourselves and use it in open. */
 			if(entering)
 				pfs_current->umask = args[0] & 0777;
+			break;
+
+		case SYSCALL32_getpid:
+			if(entering) {
+				p->syscall_result = pfs_process_getpid();
+				divert_to_dummy(p,p->syscall_result);
+			}
+			break;
+
+		case SYSCALL32_getppid:
 			break;
 
 		case SYSCALL32_getuid32:

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -1039,8 +1039,6 @@ static void decode_syscall( struct pfs_process *p, int entering )
 		case SYSCALL64_getitimer:
 		case SYSCALL64_getpgid:
 		case SYSCALL64_getpgrp:
-		case SYSCALL64_getpid:
-		case SYSCALL64_getppid:
 		case SYSCALL64_getpriority:
 		case SYSCALL64_getrandom:
 		case SYSCALL64_getrlimit:
@@ -1213,6 +1211,16 @@ static void decode_syscall( struct pfs_process *p, int entering )
 			/* We need to track the umask ourselves and use it in open. */
 			if(entering)
 				pfs_current->umask = args[0] & 0777;
+			break;
+
+		case SYSCALL64_getpid:
+			if(entering) {
+				p->syscall_result = pfs_process_getpid();
+				divert_to_dummy(p,p->syscall_result);
+			}
+			break;
+
+		case SYSCALL64_getppid:
 			break;
 
 		case SYSCALL64_getuid:

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -160,7 +160,9 @@ enum {
 	LONG_OPT_DYNAMIC_MOUNTS,
 	LONG_OPT_IS_RUNNING,
 	LONG_OPT_TIME_STOP,
-	LONG_OPT_TIME_WARP
+	LONG_OPT_TIME_WARP,
+	LONG_OPT_PID_WARP,
+	LONG_OPT_PID_FIXED
 };
 
 static void get_linux_version(const char *cmd)
@@ -843,6 +845,8 @@ int main( int argc, char *argv[] )
 		{"work-dir", required_argument, 0, 'w'},
 		{"time-stop", no_argument, 0, LONG_OPT_TIME_STOP},
 		{"time-warp", no_argument, 0, LONG_OPT_TIME_WARP},
+		{"pid-fixed", no_argument, 0, LONG_OPT_PID_FIXED},
+		{"pid-warp", no_argument, 0, LONG_OPT_PID_WARP},
 		{0,0,0,0}
 	};
 
@@ -1072,6 +1076,14 @@ int main( int argc, char *argv[] )
 			break;
 		case LONG_OPT_TIME_WARP:
 			pfs_time_mode = PFS_TIME_MODE_WARP;
+			pfs_use_helper = 1;
+			break;
+		case LONG_OPT_PID_FIXED:
+			pfs_pid_mode = PFS_PID_MODE_FIXED;
+			pfs_use_helper = 1;
+			break;
+		case LONG_OPT_PID_WARP:
+			pfs_pid_mode = PFS_PID_MODE_WARP;
 			pfs_use_helper = 1;
 			break;
 		default:

--- a/parrot/src/pfs_process.cc
+++ b/parrot/src/pfs_process.cc
@@ -30,6 +30,10 @@ extern "C" {
 #include <stdlib.h>
 #include <string.h>
 
+pfs_pid_mode_t pfs_pid_mode = PFS_PID_MODE_NORMAL;
+
+int emulated_pid = 12345;
+
 struct pfs_process *pfs_current=0;
 int parrot_dir_fd = -1;
 
@@ -38,6 +42,7 @@ static int nprocs = 0;
 
 extern uid_t pfs_uid;
 extern gid_t pfs_gid;
+
 
 struct pfs_process * pfs_process_lookup( pid_t pid )
 {
@@ -339,11 +344,25 @@ int pfs_process_count()
 
 extern "C" int pfs_process_getpid()
 {
-	if(pfs_current) {
-		return pfs_current->pid;
-	} else {
-		return getpid();
+	switch(pfs_pid_mode) {
+		case PFS_PID_MODE_NORMAL:
+			if(pfs_current) {
+				return pfs_current->pid;
+			} else {
+				return getpid();
+			}
+			break;
+		case PFS_PID_MODE_FIXED:
+			return emulated_pid;
+			break;
+		case PFS_PID_MODE_WARP:
+			emulated_pid += 1;
+			return emulated_pid;
+			break;
 	}
+
+	errno = ENOSYS;
+	return -1;
 }
 
 extern "C" char * pfs_process_name()

--- a/parrot/src/pfs_process.h
+++ b/parrot/src/pfs_process.h
@@ -25,6 +25,14 @@ extern "C" {
 
 #define PFS_NGROUPS_MAX 128
 
+typedef enum {
+	PFS_PID_MODE_NORMAL,
+	PFS_PID_MODE_FIXED,
+	PFS_PID_MODE_WARP
+} pfs_pid_mode_t;
+
+extern pfs_pid_mode_t pfs_pid_mode;
+
 enum {
 	PFS_PROCESS_FLAGS_STARTUP = (1<<0),
 	PFS_PROCESS_FLAGS_ASYNC   = (1<<1)


### PR DESCRIPTION
Fixed PID was used to help bring at least one application closer to being deterministic.

These could be dangerous options if there are any incidental PID conflicts and important processes could get killed. Use at your own risk.