### PR TITLE
Check CCTOOLS_IP_MODE when handling addresses

### DIFF
--- a/dttools/src/address.h
+++ b/dttools/src/address.h
@@ -3,6 +3,8 @@
 
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <sys/types.h>
+#include <netdb.h>
 
 #ifndef SOCKLEN_T
 #if defined(__GLIBC__) || defined(CCTOOLS_OPSYS_DARWIN) || defined(CCTOOLS_OPSYS_AIX) || defined(__MUSL__)
@@ -17,5 +19,6 @@
 int address_to_sockaddr( const char *addr, int port, struct sockaddr_storage *s, SOCKLEN_T *length );
 int address_from_sockaddr( char *str, struct sockaddr *saddr );
 int address_parse_hostport( const char *hostport, char *host, int *port, int default_port );
+int address_check_mode( struct addrinfo *info );
 
 #endif

--- a/dttools/src/domain_name.c
+++ b/dttools/src/domain_name.c
@@ -63,20 +63,7 @@ int domain_name_lookup(const char *name, char *addr)
 
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_socktype = SOCK_STREAM;
-
-	const char *mode_str = getenv("CCTOOLS_IP_MODE");
-	if(!mode_str) mode_str = "IPV4";
-
-	if(!strcmp(mode_str,"AUTO")) {
-		hints.ai_family = AF_UNSPEC;
-	} else if(!strcmp(mode_str,"IPV4")) {
-		hints.ai_family = AF_INET;
-	} else if(!strcmp(mode_str,"IPV6")) {
-		hints.ai_family = AF_INET6;
-	} else {
-		debug(D_NOTICE,"CCTOOLS_IP_MODE has invalid value (%s).  Choices are IPV4, IPV6, or AUTO",mode_str);
-		hints.ai_family = AF_UNSPEC;
-	}
+	address_check_mode(&hints);
 
 	if ((err = getaddrinfo(name, NULL, &hints, &result)) != 0) {
 		debug(D_DNS, "couldn't look up %s: %s", name, gai_strerror(err));


### PR DESCRIPTION
This is for #1601. With no address specified, the default behaviour is IPv4 only, which can be overridden with an environment variable. @dthain this fixes the issue I was having on the CRC machines