### PR TITLE
Adds --snapshot-file=<file> to resource_monitor

### DIFF
--- a/doc/man/resource_monitor.m4
+++ b/doc/man/resource_monitor.m4
@@ -2,7 +2,7 @@ include(manual.h)dnl
 HEADER(resource_monitor)
 
 SECTION(NAME)
-BOLD(resource_monitor, resource_monitorv) - monitors the cpu, memory, io, and disk usage of a tree of processes.
+BOLD(resource_monitor) - monitors the cpu, memory, io, and disk usage of a tree of processes.
 
 SECTION(SYNOPSIS)
 CODE(BOLD(resource_monitor [options] -- command [command-options]))
@@ -29,9 +29,6 @@ respective limits.
 
 In systems that support it, BOLD(resource_monitor) wraps some
 libc functions to obtain a better estimate of the resources used.
-In contrast, BOLD(resource_monitorv) disables this wrapping,
-which means, among others, that it can only monitor the root
-process, but not its descendants.
 
 Currently, the monitor does not support interactive applications. That
 is, if a process issues a read call from standard input, and standard
@@ -179,7 +176,6 @@ SECTION(BUGS)
 
 LIST_BEGIN
 LIST_ITEM(The monitor cannot track the children of statically linked executables.)
-LIST_ITEM(One would expect to be able to generate the information of the summary from the time-series, however they use different mechanisms, and the summary tends to be more accurate.)
 LIST_END
 
 SECTION(COPYRIGHT)

--- a/doc/man/resource_monitor.m4
+++ b/doc/man/resource_monitor.m4
@@ -104,6 +104,7 @@ OPTION_ITEM(--measure-dir=<dir>)Follow the size of <dir>. If not specified, foll
 OPTION_ITEM(--without-time-series)Do not write the time-series log file.
 OPTION_ITEM(--without-opened-files)Do not write the list of opened files.
 OPTION_ITEM(--without-disk-footprint)Do not measure working directory footprint (default).
+OPTION_ITEM(--snapshot-file=<file>) If <file> exists at the end of a measurement interval, take a snapshot of current resources, and delete <file>. If <file> has a non-empty first line, it is used as a label for the snapshot.
 OPTION_ITEM(`-v,--version')Show version string.
 OPTION_ITEM(`-h,--help')Show help text.
 OPTIONS_END

--- a/dttools/src/rmsummary.c
+++ b/dttools/src/rmsummary.c
@@ -1230,6 +1230,14 @@ int64_t rmsummary_get_int_field_by_offset(const struct rmsummary *s, size_t offs
 	return (*((int64_t *) ((char *) s + offset)));
 }
 
+struct rmsummary *rmsummary_get_snapshot(const struct rmsummary *s, int i) {
+	if(!s || i < 0 || i > s->snapshots_count) {
+		return NULL;
+	}
+
+	return s->snapshots[i];
+}
+
 
 
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/rmsummary.c
+++ b/dttools/src/rmsummary.c
@@ -162,40 +162,40 @@ int rmsummary_field_is_float(const char *key) {
 
 int rmsummary_assign_char_field(struct rmsummary *s, const char *key, char *value) {
 	if(strcmp(key, "category") == 0) {
-		if(s->category)
-			free(s->category);
+		free(s->category);
 		s->category = xxstrdup(value);
 		return 1;
 	}
 
 	if(strcmp(key, "command") == 0) {
-		if(s->command)
-			free(s->command);
+		free(s->command);
 		s->command = xxstrdup(value);
 		return 1;
 	}
 
 	if(strcmp(key, "exit_type") == 0) {
-		if(s->exit_type)
-			free(s->exit_type);
+		free(s->exit_type);
 		s->exit_type = xxstrdup(value);
 		return 1;
 	}
 
 	if(strcmp(key, "taskid") == 0) {
-		if(s->taskid)
-			free(s->taskid);
+		free(s->taskid);
 		s->taskid = xxstrdup(value);
 		return 1;
 	}
 
 	if(strcmp(key, "task_id") == 0) {
-		if(s->taskid)
-			free(s->taskid);
+		free(s->taskid);
 		s->taskid = xxstrdup(value);
 		return 1;
 	}
 
+	if(strcmp(key, "snapshot_name") == 0) {
+		free(s->snapshot_name);
+		s->snapshot_name = xxstrdup(value);
+		return 1;
+	}
 
 	return 0;
 }
@@ -289,6 +289,10 @@ int64_t rmsummary_get_int_field(struct rmsummary *s, const char *key) {
 		return s->gpus;
 	}
 
+	if(strcmp(key, "snapshots_count") == 0) {
+		return s->snapshots_count;
+	}
+
 	fatal("resource summary does not have a '%s' key. This is most likely a CCTools bug.", key);
 
 
@@ -309,6 +313,10 @@ const char *rmsummary_get_char_field(struct rmsummary *s, const char *key) {
 	}
 
 	if(strcmp(key, "taskid") == 0) {
+		return s->taskid;
+	}
+
+	if(strcmp(key, "snapshot_name") == 0) {
 		return s->taskid;
 	}
 
@@ -425,6 +433,11 @@ int rmsummary_assign_int_field(struct rmsummary *s, const char *key, int64_t val
 
 	if(strcmp(key, "gpus") == 0) {
 		s->gpus = value;
+		return 1;
+	}
+
+	if(strcmp(key, "snapshots_count") == 0) {
+		s->snapshots_count = value;
 		return 1;
 	}
 
@@ -826,6 +839,7 @@ struct rmsummary *rmsummary_create(signed char default_value)
 	s->exit_status = 0;
 	s->signal = 0;
 
+	s->snapshot_name   = NULL;
 	s->snapshots_count = 0;
 	s->snapshots       = NULL;
 

--- a/dttools/src/rmsummary.c
+++ b/dttools/src/rmsummary.c
@@ -826,6 +826,9 @@ struct rmsummary *rmsummary_create(signed char default_value)
 	s->exit_status = 0;
 	s->signal = 0;
 
+	s->snapshots_count = 0;
+	s->snapshots       = NULL;
+
 	return s;
 }
 

--- a/dttools/src/rmsummary.h
+++ b/dttools/src/rmsummary.h
@@ -55,12 +55,15 @@ struct rmsummary
 	int64_t  total_files;
 	int64_t  disk;                           /* MB */
 
-	int64_t  cores;                      /* peak usage in a small time window */
+	int64_t  cores;                          /* peak usage in a small time window */
 	int64_t  cores_avg;
 	int64_t  gpus;
 
 	struct rmsummary *limits_exceeded;
-	struct rmsummary *peak_times;        /* from start, in usecs */
+	struct rmsummary *peak_times;           /* from start, in usecs */
+
+	int    snapshots_count;                 /* number of intermediate measurements, if any. */
+	struct rmsummary **snapshots;           /* snapshots_count sized array of snapshots. */
 
 	/* these fields are not used when reading/printing summaries */
 	int64_t  fs_nodes;

--- a/dttools/src/rmsummary.h
+++ b/dttools/src/rmsummary.h
@@ -62,6 +62,7 @@ struct rmsummary
 	struct rmsummary *limits_exceeded;
 	struct rmsummary *peak_times;           /* from start, in usecs */
 
+	char  *snapshot_name;                   /* NULL for main summary, otherwise label of the snapshot. */
 	int    snapshots_count;                 /* number of intermediate measurements, if any. */
 	struct rmsummary **snapshots;           /* snapshots_count sized array of snapshots. */
 

--- a/dttools/src/rmsummary.h
+++ b/dttools/src/rmsummary.h
@@ -129,4 +129,6 @@ int64_t rmsummary_get_int_field_by_offset(const struct rmsummary *s, size_t offs
 void rmsummary_add_conversion_field(const char *name, const char *internal, const char *external, double multiplier, int float_flag);
 int rmsummary_field_is_float(const char *key);
 
+struct rmsummary *rmsummary_get_snapshot(const struct rmsummary *s, int i);
+
 #endif

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -1037,7 +1037,7 @@ int record_snapshot(struct rmsummary *tr) {
 
 	struct jx *j = rmsummary_to_json(tr, /* only resources */ 1);
 
-	jx_insert_string(j, "taskid", label);
+	jx_insert_string(j, "snapshot_name", label);
 
 	if(!j) {
 		return 0;

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -648,7 +648,7 @@ void rmonitor_add_file_watch(const char *filename, int is_output, int override_f
 			inotify_flags = override_flags;
 		}
 
-		if ((iwd = inotify_add_watch(rmonitor_inotify_fd, filename, override_flags)) < 0)
+		if ((iwd = inotify_add_watch(rmonitor_inotify_fd, filename, inotify_flags)) < 0)
 		{
 			debug(D_RMON, "inotify_add_watch for file %s fails: %s", filename, strerror(errno));
 		} else {

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -742,9 +742,6 @@ int rmonitor_handle_inotify(void)
 					if(snapshot_signal_file && strcmp(fname, snapshot_signal_file) == 0) {
 						urgent = 1;
 					}
-
-					warn(D_DEBUG, "close: %s", evdata[i].name);
-
 				}
 			}
 		}
@@ -1051,7 +1048,8 @@ int record_snapshot(struct rmsummary *tr) {
 	jx_print_stream(j, snap_f);
 	fclose(snap_f);
 
-	list_push_tail(snapshots, j);
+	/* push to the front, since snapshots are writen in reverse order. */
+	list_push_head(snapshots, j);
 
 	return 1;
 }

--- a/work_queue/src/perl/Work_Queue.pm
+++ b/work_queue/src/perl/Work_Queue.pm
@@ -121,6 +121,12 @@ sub enable_monitoring_full {
 	return work_queue_enable_monitoring_full($self->{_work_queue}, $dir_name);
 }
 
+
+sub enable_monitoring_snapshots {
+	my ($self, $filename) = @_;
+	return work_queue_enable_monitoring_snapshots($self->{_work_queue}, $filename);
+}
+
 sub activate_fast_abort {
 	my ($self, $multiplier) = @_;
 	return work_queue_activate_fast_abort($self->{_work_queue}, $multiplier);
@@ -500,6 +506,24 @@ Returns 1 on success, 0 on failure (i.e., monitoring was not enabled).
 =item dirname    Directory name for the monitor output.
 
 =back
+
+=head3 C<enable_monitoring_snapshots($filename)>
+
+When monitoring, indicates a file that when present, directs the resource
+monitor to take a snapshot of the resources. Snapshots appear in the JSON
+summary file of the task, under the key "snapshots". The file is removed after
+the snapshot, so that a new snapshot can be taken when it is recreated by a
+task. Optionaly, the first line of the file can be used to give an identifying
+label to the snapshot.
+
+=over 12
+
+=item self 	Reference to the current work queue object.
+
+item signal_file Name of the file which presence directs the resource monitor to take a snapshot. After the snapshot, THIS FILE IS REMOVED.
+
+=back
+
 
 =head3 C<activate_fast_abort>
 

--- a/work_queue/src/perl/Work_Queue/Task.pm
+++ b/work_queue/src/perl/Work_Queue/Task.pm
@@ -386,6 +386,24 @@ sub resources_allocated {
 
 1;
 
+package work_queue::rmsummary;
+
+sub rmsummary_snapshots_get {
+	my $self = shift;
+
+	my $snapshots = [];
+
+	my $n = work_queuec::rmsummary_snapshots_count_get($self);
+
+	for my $i (0..($n-1)) {
+		push @{$snapshots}, work_queuec::rmsummary_get_snapshot($self, $i);
+	}
+
+	return $snapshots;
+}
+
+*swig_snapshots_get = *rmsummary_snapshots_get;
+
 __END__
 
 =head1 NAME

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -891,6 +891,20 @@ class WorkQueue(_object):
     def enable_monitoring_full(self, dirname):
         return work_queue_enable_monitoring_full(self._work_queue, dirname)
 
+    ## When monitoring, indicates a file that when present, directs the resource
+    # monitor to take a snapshot of the resources. Snapshots appear in the JSON
+    # summary file of the task, under the key "snapshots". The file
+    # is removed after the snapshot, so that a new snapshot can be taken when it is
+    # recreated by a task. Optionaly, the first line of the file can be used to give
+    # an identifying label to the snapshot.
+
+    # @param self 	Reference to the current work queue object.
+    # @param signal_file Name of the file which presence directs the resource
+    # monitor to take a snapshot. After the snapshot, THIS FILE IS REMOVED.
+    def enable_monitoring_snapshots(self, filename):
+        return work_queue_enable_monitoring_snapshots(self._work_queue, filename)
+
+
     ##
     # Turn on or off fast abort functionality for a given queue for tasks in
     # the "default" category, and for task which category does not set an

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -1260,7 +1260,7 @@ def rmsummary_snapshots(self):
 
     snapshots = []
     for i in range(0, self.snapshots_count):
-        snapshot = self.get_snapshot(i)
+        snapshot = rmsummary_get_snapshot(self, i);
         snapshots.append(snapshot)
     return snapshots
 

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -1256,7 +1256,7 @@ class WorkQueue(_object):
 
 def rmsummary_snapshots(self):
     if self.snapshots_count < 1:
-        return NULL
+        return None
 
     snapshots = []
     for i in range(0, self.snapshots_count):

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -1253,3 +1253,15 @@ class WorkQueue(_object):
             del(self._task_table[task_pointer.taskid])
             return task
         return None
+
+def rmsummary_snapshots(self):
+    if self.snapshots_count < 1:
+        return NULL
+
+    snapshots = []
+    for i in range(0, self.snapshots_count):
+        snapshot = self.get_snapshot(i)
+        snapshots.append(snapshot)
+    return snapshots
+
+rmsummary.snapshots = property(rmsummary_snapshots)

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -545,6 +545,19 @@ queue object.
 */
 int work_queue_enable_monitoring_full(struct work_queue *q, char *monitor_output_directory);
 
+
+/** When monitoring, indicates a file that when present, directs the resource
+monitor to take a snapshot of the resources. Snapshots appear in the JSON
+summary file of the task, under the key "snapshots". The file
+is removed after the snapshot, so that a new snapshot can be taken when it is
+recreated by a task. Optionaly, the first line of the file can be used to give
+an identifying label to the snapshot.
+@param q A work queue object.
+@param monitor_snapshot_file A filename.
+*/
+
+void work_queue_enable_monitoring_snapshots(struct work_queue *q, const char *monitor_snapshot_file);
+
 /** Submit a task to a queue.
 Once a task is submitted to a queue, it is not longer under the user's
 control and should not be inspected until returned via @ref work_queue_wait.

--- a/work_queue/src/work_queue.i
+++ b/work_queue/src/work_queue.i
@@ -28,3 +28,19 @@
 %include "work_queue.h"
 %include "rmsummary.h"
 %include "category.h"
+
+
+%extend rmsummary {
+	struct rmsummary *get_snapshot(int i) {
+		if(i < 0 || i > $self->snapshots_count) {
+			return NULL;
+		}
+
+		return $self->snapshots[i];
+	}
+
+	/* rename, so that we can use 'snapshots' inside python and perl. */
+	struct rmsummary **_snapshots() {
+		return $self->snapshots;
+	}
+};

--- a/work_queue/src/work_queue.i
+++ b/work_queue/src/work_queue.i
@@ -30,17 +30,3 @@
 %include "category.h"
 
 
-%extend rmsummary {
-	struct rmsummary *get_snapshot(int i) {
-		if(i < 0 || i > $self->snapshots_count) {
-			return NULL;
-		}
-
-		return $self->snapshots[i];
-	}
-
-	/* rename, so that we can use 'snapshots' inside python and perl. */
-	struct rmsummary **_snapshots() {
-		return $self->snapshots;
-	}
-};


### PR DESCRIPTION
When <file> exists, the resource_monitor takes a snapshot of the
resources and removes <file>. The snapshot is written to
PREFIX.snapshot.NN, where PREFIX is the prefix used for the summary
file. The snapshots are also included in the final summary file, under
the key "snapshots".

Example:
myscript.sh
init()
echo "after_init" > signal.file
analysis()
echo "after_analysys" > signal.file

$ resource_monitor --snapshot-file=signal.file -Omysummary -- ./myscript.sh
$ ls
mysummary.snapshot.01
mysummary.snapshot.02
mysummary.summary

(as requested by @klannon, and @matz-e)