### PR TITLE
Add parrot feature: fixed PID and warped PID

### DIFF
--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -1260,8 +1260,6 @@ static void decode_syscall( struct pfs_process *p, int entering )
 		case SYSCALL32_getitimer:
 		case SYSCALL32_getpgid:
 		case SYSCALL32_getpgrp:
-		case SYSCALL32_getpid:
-		case SYSCALL32_getppid:
 		case SYSCALL32_getpriority:
 		case SYSCALL32_getrandom:
 		case SYSCALL32_getrlimit:
@@ -1445,6 +1443,16 @@ static void decode_syscall( struct pfs_process *p, int entering )
 			/* We need to track the umask ourselves and use it in open. */
 			if(entering)
 				pfs_current->umask = args[0] & 0777;
+			break;
+
+		case SYSCALL32_getpid:
+			if(entering) {
+				p->syscall_result = pfs_process_getpid();
+				divert_to_dummy(p,p->syscall_result);
+			}
+			break;
+
+		case SYSCALL32_getppid:
 			break;
 
 		case SYSCALL32_getuid32:

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -1041,8 +1041,6 @@ static void decode_syscall( struct pfs_process *p, int entering )
 		case SYSCALL64_getitimer:
 		case SYSCALL64_getpgid:
 		case SYSCALL64_getpgrp:
-		case SYSCALL64_getpid:
-		case SYSCALL64_getppid:
 		case SYSCALL64_getpriority:
 		case SYSCALL64_getrandom:
 		case SYSCALL64_getrlimit:
@@ -1215,6 +1213,16 @@ static void decode_syscall( struct pfs_process *p, int entering )
 			/* We need to track the umask ourselves and use it in open. */
 			if(entering)
 				pfs_current->umask = args[0] & 0777;
+			break;
+
+		case SYSCALL64_getpid:
+			if(entering) {
+				p->syscall_result = pfs_process_getpid();
+				divert_to_dummy(p,p->syscall_result);
+			}
+			break;
+
+		case SYSCALL64_getppid:
 			break;
 
 		case SYSCALL64_getuid:

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -162,6 +162,8 @@ enum {
 	LONG_OPT_TIME_STOP,
 	LONG_OPT_TIME_WARP,
 	LONG_OPT_PARROT_PATH,
+	LONG_OPT_PID_WARP,
+	LONG_OPT_PID_FIXED
 };
 
 static void get_linux_version(const char *cmd)
@@ -846,6 +848,8 @@ int main( int argc, char *argv[] )
 		{"work-dir", required_argument, 0, 'w'},
 		{"time-stop", no_argument, 0, LONG_OPT_TIME_STOP},
 		{"time-warp", no_argument, 0, LONG_OPT_TIME_WARP},
+		{"pid-fixed", no_argument, 0, LONG_OPT_PID_FIXED},
+		{"pid-warp", no_argument, 0, LONG_OPT_PID_WARP},
 		{0,0,0,0}
 	};
 
@@ -1079,6 +1083,14 @@ int main( int argc, char *argv[] )
 			break;
 		case LONG_OPT_PARROT_PATH:
 			// compatibility option for parrot_namespace
+			break;
+		case LONG_OPT_PID_FIXED:
+			pfs_pid_mode = PFS_PID_MODE_FIXED;
+			pfs_use_helper = 1;
+			break;
+		case LONG_OPT_PID_WARP:
+			pfs_pid_mode = PFS_PID_MODE_WARP;
+			pfs_use_helper = 1;
 			break;
 		default:
 			show_help(argv[0]);

--- a/parrot/src/pfs_process.cc
+++ b/parrot/src/pfs_process.cc
@@ -31,6 +31,10 @@ extern "C" {
 #include <stdlib.h>
 #include <string.h>
 
+pfs_pid_mode_t pfs_pid_mode = PFS_PID_MODE_NORMAL;
+
+int emulated_pid = 12345;
+
 struct pfs_process *pfs_current=0;
 int parrot_dir_fd = -1;
 
@@ -39,6 +43,7 @@ static int nprocs = 0;
 
 extern uid_t pfs_uid;
 extern gid_t pfs_gid;
+
 
 struct pfs_process * pfs_process_lookup( pid_t pid )
 {
@@ -343,11 +348,25 @@ int pfs_process_count()
 
 extern "C" int pfs_process_getpid()
 {
-	if(pfs_current) {
-		return pfs_current->pid;
-	} else {
-		return getpid();
+	switch(pfs_pid_mode) {
+		case PFS_PID_MODE_NORMAL:
+			if(pfs_current) {
+				return pfs_current->pid;
+			} else {
+				return getpid();
+			}
+			break;
+		case PFS_PID_MODE_FIXED:
+			return emulated_pid;
+			break;
+		case PFS_PID_MODE_WARP:
+			emulated_pid += 1;
+			return emulated_pid;
+			break;
 	}
+
+	errno = ENOSYS;
+	return -1;
 }
 
 extern "C" char * pfs_process_name()

--- a/parrot/src/pfs_process.h
+++ b/parrot/src/pfs_process.h
@@ -26,6 +26,14 @@ extern "C" {
 
 #define PFS_NGROUPS_MAX 128
 
+typedef enum {
+	PFS_PID_MODE_NORMAL,
+	PFS_PID_MODE_FIXED,
+	PFS_PID_MODE_WARP
+} pfs_pid_mode_t;
+
+extern pfs_pid_mode_t pfs_pid_mode;
+
 enum {
 	PFS_PROCESS_FLAGS_STARTUP = (1<<0),
 	PFS_PROCESS_FLAGS_ASYNC   = (1<<1)


### PR DESCRIPTION
Fixed PID was used to help bring a HEP application closer to being deterministic.

These features could be dangerous options if there are any incidental PID conflicts (ie. important processes could get killed). Use at your own risk.