### PR TITLE
Match /proc/self more carefully

### DIFF
--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -548,27 +548,27 @@ int pfs_table::resolve_name(int is_special_syscall, const char *cname, struct pf
 			follow_symlink(pname, mode, depth + 1);
 		}
 
-	if(pattern_match(pname->path, "^/proc/self/?()", &n) >= 0) {
-		strncpy(full_logical_name, pname->path, sizeof(full_logical_name));
-		snprintf(pname->path, sizeof(pname->path), "/proc/%d/%s", pfs_process_getpid(), &full_logical_name[n]);
-		strcpy(pname->logical_name, pname->path);
-		strcpy(pname->rest, pname->path);
-		pname->service = pfs_service_lookup_default();
-		strcpy(pname->service_name,"local");
-		strcpy(pname->host,"localhost");
-		strcpy(pname->hostport,"localhost");
-		pname->is_local = 1;
-	} else if (pattern_match(pname->path, "^/dev/fd/?()", &n) >= 0) {
-		strncpy(full_logical_name, pname->path, sizeof(full_logical_name));
-		snprintf(pname->path, sizeof(pname->path), "/proc/%d/fd/%s", pfs_process_getpid(), &full_logical_name[n]);
-		strcpy(pname->logical_name, pname->path);
-		strcpy(pname->rest, pname->path);
-		pname->service = pfs_service_lookup_default();
-		strcpy(pname->service_name,"local");
-		strcpy(pname->host,"localhost");
-		strcpy(pname->hostport,"localhost");
-		pname->is_local = 1;
-	}
+		if(pattern_match(pname->path, "^/proc/self/?()", &n) >= 0) {
+			strncpy(full_logical_name, pname->path, sizeof(full_logical_name));
+			snprintf(pname->path, sizeof(pname->path), "/proc/%d/%s", pfs_process_getpid(), &full_logical_name[n]);
+			strcpy(pname->logical_name, pname->path);
+			strcpy(pname->rest, pname->path);
+			pname->service = pfs_service_lookup_default();
+			strcpy(pname->service_name,"local");
+			strcpy(pname->host,"localhost");
+			strcpy(pname->hostport,"localhost");
+			pname->is_local = 1;
+		} else if (pattern_match(pname->path, "^/dev/fd/?()", &n) >= 0) {
+			strncpy(full_logical_name, pname->path, sizeof(full_logical_name));
+			snprintf(pname->path, sizeof(pname->path), "/proc/%d/fd/%s", pfs_process_getpid(), &full_logical_name[n]);
+			strcpy(pname->logical_name, pname->path);
+			strcpy(pname->rest, pname->path);
+			pname->service = pfs_service_lookup_default();
+			strcpy(pname->service_name,"local");
+			strcpy(pname->host,"localhost");
+			strcpy(pname->hostport,"localhost");
+			pname->is_local = 1;
+		}
 
 		return 1;
 	}

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -396,9 +396,9 @@ void pfs_table::follow_symlink( struct pfs_name *pname, mode_t mode, int depth )
 	char link_parent[PFS_PATH_MAX];
 	struct pfs_name new_pname = *pname;
 
-	if (string_prefix_is(pname->path, "/proc/self/") || string_match_regex(pname->path, "^/proc/[0-9]+/ns/")) {
+	if (string_match_regex(pname->path, "^/proc/self(/|$)|^/proc/[0-9]+/ns/")) {
 		/*
-		 * We need to handle /proc/self/ in resolve_name, and eagerly following it here would
+		 * We need to handle /proc/self in resolve_name, and eagerly following it here would
 		 * give Parrot's PID. Return for now, and let resolve name call us again after it
 		 * rewrites the path to /proc/[pid]/.
 		 *


### PR DESCRIPTION
Old versions of `find` read links in an odd way. In the case of `/proc/self/exe`, `find` first opens `/proc/self`, then reads the link `exe`. Parrot's symlink following has been short circuiting on any resolved path with prefix `/proc/self/` (note the trailing slash), so opening `/proc/self` falls through to Parrot.

I wrote a more careful regex, and adjusted the footwork for dealing with symlinks and `/proc`, which I think is *more correct*. Testing on RHEL5-7, the failing test from #1610 passes with these changes.