### PR TITLE
Add local mode to GROW-FS

### DIFF
--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -95,6 +95,7 @@ SOURCES = \
 	sigdef.c \
 	sleeptools.c \
 	sort_dir.c \
+	stats.c \
 	string_array.c \
 	stringtools.c \
 	text_array.c \

--- a/dttools/src/stats.c
+++ b/dttools/src/stats.c
@@ -1,0 +1,127 @@
+/*
+Copyright (C) 2017- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include <assert.h>
+#include <inttypes.h>
+#include "stats.h"
+#include "hash_table.h"
+#include "xxmalloc.h"
+
+static struct hash_table *stats = NULL;
+static int stats_enabled = 0;
+
+typedef enum {
+	STATS_INT,
+	STATS_LOG,
+} stats_type_t;
+
+typedef struct {
+	stats_type_t type;
+	union {
+		int64_t value;
+		unsigned buckets[64];
+	} v;
+} stats_t;
+
+static void stats_init () {
+	if (!stats) {
+		stats = hash_table_create(0, 0);
+	}
+}
+
+static stats_t *stats_touch (const char *name, stats_type_t type) {
+	assert(name);
+	stats_init();
+	stats_t *s = hash_table_lookup(stats, name);
+	if (s) {
+		assert(s->type == type);
+	} else {
+		s = xxcalloc(1, sizeof(*s));
+		s->type = type;
+		int rc = hash_table_insert(stats, name, s);
+		assert(rc);
+	}
+	return s;
+}
+
+static size_t log2b(uint64_t n) {
+	size_t i = 0;
+	while (n >>= 1) ++i;
+	return i;
+}
+
+void stats_enable () {
+	stats_enabled = 1;
+}
+
+void stats_unset (const char *name) {
+	if (!stats_enabled) return;
+	assert(name);
+	stats_init();
+	free(hash_table_remove(stats, name));
+}
+
+void stats_set (const char *name, int64_t value) {
+	if (!stats_enabled) return;
+	stats_t *s = stats_touch(name, STATS_INT);
+	s->v.value = value;
+}
+
+void stats_inc (const char *name, int64_t offset) {
+	if (!stats_enabled) return;
+	stats_t *s = stats_touch(name, STATS_INT);
+	s->v.value += offset;
+}
+
+void stats_log (const char *name, uint64_t value) {
+	if (!stats_enabled) return;
+	stats_t *s = stats_touch(name, STATS_LOG);
+	++s->v.buckets[log2b(value)];
+}
+
+void stats_print_buffer (buffer_t *b) {
+	if (!stats_enabled) return;
+	assert(b);
+	char *k;
+	stats_t *s;
+	stats_init();
+	hash_table_firstkey(stats);
+	while (hash_table_nextkey(stats, &k, (void **) &s)) {
+		switch (s->type) {
+		case STATS_INT:
+			buffer_printf(b, "%s\t%" PRIi64 "\n", k, s->v.value);
+			break;
+		case STATS_LOG:
+			buffer_putstring(b, k);
+			for (size_t i = 0; i < 64; i++) {
+				buffer_printf(b, "\t%u", s->v.buckets[i]);
+			}
+			buffer_putstring(b, "\n");
+			break;
+		}
+	}
+}
+
+void stats_print_stream (FILE *file) {
+	assert(file);
+	buffer_t buffer;
+	buffer_init(&buffer);
+	stats_print_buffer(&buffer);
+	fprintf(file, "%s", buffer_tostring(&buffer));
+	buffer_free(&buffer);
+}
+
+char *stats_print_string () {
+	buffer_t buffer;
+	char *str;
+	buffer_init(&buffer);
+	stats_print_buffer(&buffer);
+	buffer_dup(&buffer,&str);
+	buffer_free(&buffer);
+	return str;
+}
+
+/* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/stats.c
+++ b/dttools/src/stats.c
@@ -15,7 +15,7 @@ static int stats_enabled = 0;
 
 typedef enum {
 	STATS_INT,
-	STATS_LOG,
+	STATS_BIN,
 } stats_type_t;
 
 typedef struct {
@@ -76,9 +76,9 @@ void stats_inc (const char *name, int64_t offset) {
 	s->v.value += offset;
 }
 
-void stats_log (const char *name, uint64_t value) {
+void stats_bin (const char *name, uint64_t value) {
 	if (!stats_enabled) return;
-	stats_t *s = stats_touch(name, STATS_LOG);
+	stats_t *s = stats_touch(name, STATS_BIN);
 	++s->v.buckets[log2b(value)];
 }
 
@@ -95,7 +95,7 @@ struct jx *stats_get () {
 		case STATS_INT:
 			jx_insert_integer(out, k, s->v.value);
 			break;
-		case STATS_LOG:
+		case STATS_BIN:
 			log = jx_array(NULL);
 			for (size_t i = 0; i < 64; i++) {
 				jx_array_append(log, jx_integer(s->v.buckets[i]));

--- a/dttools/src/stats.c
+++ b/dttools/src/stats.c
@@ -26,7 +26,7 @@ typedef struct {
 	} v;
 } stats_t;
 
-static void stats_init () {
+static void stats_init (void) {
 	if (!stats) {
 		stats = hash_table_create(0, 0);
 	}
@@ -82,7 +82,7 @@ void stats_bin (const char *name, uint64_t value) {
 	++s->v.buckets[log2b(value)];
 }
 
-struct jx *stats_get () {
+struct jx *stats_get (void) {
 	if (!stats_enabled) return jx_null();
 	char *k;
 	stats_t *s;

--- a/dttools/src/stats.h
+++ b/dttools/src/stats.h
@@ -1,0 +1,62 @@
+/*
+Copyright (C) 2017- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#ifndef STATS_H
+#define STATS_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include "buffer.h"
+
+/** Collect statistics for the current program.
+ */
+void stats_enable ();
+
+/** Clear a statistic.
+ * @param name The key to clear.
+ */
+void stats_unset (const char *name);
+
+/** Set an integer statistic.
+ * Any previous value will be cleared.
+ * @param name The key to set.
+ * @param value The value to set.
+ */
+void stats_set (const char *name, int64_t value);
+
+/** Increment an integer statistic.
+ * Adding a negative number is fine.
+ * If the given key does not exist, it will be initialized to zero.
+ * @param name The key to set.
+ * @param offset The signed quantity to add.
+ */
+void stats_inc (const char *name, int64_t offset);
+
+/** Record an event by value
+ * For frequent events like read()s, it would be expensive to record the size
+ * of each and every one. Instead, this function records a histogram with
+ * logarithmic bins, to give an idea of the distribution of event values.
+ * @param name The key to log.
+ * @param value The value log.
+ */
+void stats_log (const char *name, uint64_t value);
+
+/** Write a human-readable representation of the program statistics to a buffer.
+ * @param buf The initialized buffer to use.
+ */
+void stats_print_buffer (buffer_t *b);
+
+/** Write a human-readable representation of the program statistics to a stream.
+ * @param file The stdio stream to write to.
+ */
+void stats_print_stream (FILE *file);
+
+/** Write a human-readable representation of the program statistics to a string.
+ * The caller is responsible for freeing the returned string.
+ */
+char *stats_print_string ();
+
+#endif

--- a/dttools/src/stats.h
+++ b/dttools/src/stats.h
@@ -13,7 +13,7 @@ See the file COPYING for details.
 
 /** Collect statistics for the current program.
  */
-void stats_enable ();
+void stats_enable (void);
 
 /** Clear a statistic.
  * @param name The key to clear.
@@ -49,6 +49,6 @@ void stats_bin (const char *name, uint64_t value);
  * counters, the value is a number. A histogram is represented as an
  * array of counts.
  */
-struct jx *stats_get ();
+struct jx *stats_get (void);
 
 #endif

--- a/dttools/src/stats.h
+++ b/dttools/src/stats.h
@@ -9,7 +9,7 @@ See the file COPYING for details.
 
 #include <stdio.h>
 #include <stdint.h>
-#include "buffer.h"
+#include "jx.h"
 
 /** Collect statistics for the current program.
  */
@@ -44,19 +44,10 @@ void stats_inc (const char *name, int64_t offset);
  */
 void stats_log (const char *name, uint64_t value);
 
-/** Write a human-readable representation of the program statistics to a buffer.
- * @param buf The initialized buffer to use.
+/** Get the current statistics in JSON format.
+ * The returned object is a mapping of key names to values. For simple
+ * counters, the value is a number. A histogram is represented as an
+ * array of counts.
  */
-void stats_print_buffer (buffer_t *b);
-
-/** Write a human-readable representation of the program statistics to a stream.
- * @param file The stdio stream to write to.
- */
-void stats_print_stream (FILE *file);
-
-/** Write a human-readable representation of the program statistics to a string.
- * The caller is responsible for freeing the returned string.
- */
-char *stats_print_string ();
-
+struct jx *stats_get ();
 #endif

--- a/dttools/src/stats.h
+++ b/dttools/src/stats.h
@@ -35,14 +35,14 @@ void stats_set (const char *name, int64_t value);
  */
 void stats_inc (const char *name, int64_t offset);
 
-/** Record an event by value
+/** Record an event, binned by value
  * For frequent events like read()s, it would be expensive to record the size
  * of each and every one. Instead, this function records a histogram with
  * logarithmic bins, to give an idea of the distribution of event values.
  * @param name The key to log.
  * @param value The value log.
  */
-void stats_log (const char *name, uint64_t value);
+void stats_bin (const char *name, uint64_t value);
 
 /** Get the current statistics in JSON format.
  * The returned object is a mapping of key names to values. For simple
@@ -50,4 +50,5 @@ void stats_log (const char *name, uint64_t value);
  * array of counts.
  */
 struct jx *stats_get ();
+
 #endif

--- a/dttools/src/xxmalloc.c
+++ b/dttools/src/xxmalloc.c
@@ -47,4 +47,14 @@ void *xxrealloc(void *ptr, size_t nsize)
 	return result;
 }
 
+void *xxcalloc(size_t nmemb, size_t size) {
+	void *result = calloc(nmemb, size);
+	if (result) {
+		return result;
+	} else {
+		fatal("out of memory");
+		return NULL;
+	}
+}
+
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/xxmalloc.h
+++ b/dttools/src/xxmalloc.h
@@ -23,7 +23,7 @@ caller of these routines need not continually check for a null pointer return.
 @return On success, returns a valid pointer.  On failure, aborts by calling @ref fatal.
 */
 void *xxmalloc(size_t nbytes);
-
+void *xxcalloc(size_t nmemb, size_t size);
 void *xxrealloc(void *ptr, size_t nbytes);
 
 /** Duplicate string, or abort on failure.

--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -2099,8 +2099,10 @@ static void decode_syscall( struct pfs_process *p, int entering )
 					} else {
 						divert_to_dummy(p,-ENOTTY);
 					}
-				} else if (!p->table->isnative(fd)) {
+				} else if (!p->table->isvalid(fd)) {
 					divert_to_dummy(p,-EBADF);
+				} else if (!p->table->isnative(fd)) {
+					divert_to_dummy(p,-ENOTTY);
 				}
 			}
 			break;

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -1829,8 +1829,10 @@ static void decode_syscall( struct pfs_process *p, int entering )
 					} else {
 						divert_to_dummy(p,-ENOTTY);
 					}
-				} else if (!p->table->isnative(fd)) {
+				} else if (!p->table->isvalid(fd)) {
 					divert_to_dummy(p,-EBADF);
+				} else if (!p->table->isnative(fd)) {
+					divert_to_dummy(p,-ENOTTY);
 				}
 			}
 			break;

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -49,6 +49,7 @@ extern "C" {
 #include "xxmalloc.h"
 #include "hash_table.h"
 #include "jx.h"
+#include "stats.h"
 }
 
 #include <fcntl.h>
@@ -130,6 +131,7 @@ char pfs_cvmfs_option_file[PATH_MAX];
 struct jx *pfs_cvmfs_options = NULL;
 
 int pfs_irods_debug_level = 0;
+char *stats_file = NULL;
 
 int parrot_fd_max = -1;
 int parrot_fd_start = -1;
@@ -163,7 +165,8 @@ enum {
 	LONG_OPT_TIME_WARP,
 	LONG_OPT_PARROT_PATH,
 	LONG_OPT_PID_WARP,
-	LONG_OPT_PID_FIXED
+	LONG_OPT_PID_FIXED,
+	LONG_OPT_STATS_FILE,
 };
 
 static void get_linux_version(const char *cmd)
@@ -238,6 +241,7 @@ static void show_help( const char *cmd )
 	printf( " %-30s     (default 10M, 0 disables)\n","");
 	printf( " %-30s Display version number.\n", "-v,--version");
 	printf( " %-30s Test if Parrot is already running.\n", "   --is-running");
+	printf( " %-30s Save runtime statistics to a file.\n", "   --stats-file");
 	printf( " %-30s Show most commonly used options.\n", "-h,--help");
 	printf("\n");
 	printf("Virtualization options:\n");
@@ -829,6 +833,7 @@ int main( int argc, char *argv[] )
 		{"proxy", required_argument, 0, 'p'},
 		{"root-checksum", required_argument, 0, 'R'},
 		{"session-caching", no_argument, 0, 'S'},
+		{"stats-file", required_argument, 0, LONG_OPT_STATS_FILE},
 		{"status-file", required_argument, 0, 'c'},
 		{"stream-no-cache", no_argument, 0, 's'},
 		{"sync-write", no_argument, 0, 'Y'},
@@ -1092,6 +1097,10 @@ int main( int argc, char *argv[] )
 			pfs_pid_mode = PFS_PID_MODE_WARP;
 			pfs_use_helper = 1;
 			break;
+		case LONG_OPT_STATS_FILE:
+			free(stats_file);
+			stats_file = xxstrdup(optarg);
+			break;
 		default:
 			show_help(argv[0]);
 			break;
@@ -1099,6 +1108,14 @@ int main( int argc, char *argv[] )
 	}
 
 	if(optind>=argc) show_help(argv[0]);
+
+	FILE *stats_out;
+	if (stats_file) {
+		stats_enable();
+		stats_out = fopen(stats_file, "w");
+		if (!stats_out)
+			fatal("could not open stats file %s: %s", stats_file, strerror(errno));
+	}
 
 	{
 		char buf[4096];
@@ -1387,6 +1404,11 @@ int main( int argc, char *argv[] )
 		}
 		hash_table_delete(namelist_table);
 		fclose(namelist_file);
+	}
+
+	if (stats_file) {
+		stats_print_stream(stats_out);
+		fclose(stats_out);
 	}
 
 	if(WIFEXITED(root_exitstatus)) {

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -49,6 +49,7 @@ extern "C" {
 #include "xxmalloc.h"
 #include "hash_table.h"
 #include "jx.h"
+#include "jx_pretty_print.h"
 #include "stats.h"
 }
 
@@ -1407,7 +1408,8 @@ int main( int argc, char *argv[] )
 	}
 
 	if (stats_file) {
-		stats_print_stream(stats_out);
+		jx_pretty_print_stream(stats_get(), stats_out);
+		fprintf(stats_out, "\n");
 		fclose(stats_out);
 	}
 

--- a/parrot/src/pfs_service_grow.cc
+++ b/parrot/src/pfs_service_grow.cc
@@ -63,6 +63,7 @@ extern "C" {
 #include "sleeptools.h"
 }
 
+#include <assert.h>
 #include <unistd.h>
 #include <string.h>
 #include <stdio.h>
@@ -379,62 +380,81 @@ struct grow_filesystem * grow_filesystem_create( const char *hostport, const cha
 	struct link *link;
 	int sleep_time = 1;
 	time_t stoptime = time(0)+pfs_master_timeout;
+	int local_index = !strcmp(hostport, "local");
 
 	retry:
 
-	sprintf(url,"http://%s%s/.growfschecksum",hostport,path);
+	if (local_index) {
+		snprintf(filename, sizeof(filename), "%s/.growfschecksum", path);
+		debug(D_GROW, "opening checksum: %s", filename);
 
-	debug(D_GROW,"searching for filesystem at %s",url);
+		file = fopen(filename, "r");
+		if (!file) {
+			debug(D_GROW, "couldn't get checksum at %s: %s", filename, strerror(errno));
+			return NULL;
+		}
+		if (!fscanf(file, "%s", checksum)) {
+			debug(D_GROW, "checksum is malformed");
+			fclose(file);
+			return NULL;
+		}
+		fclose(file);
+	} else {
+		sprintf(url, "http://%s%s/.growfschecksum", hostport, path);
+		debug(D_GROW, "fetching checksum: %s", url);
 
-	debug(D_GROW,"fetching checksum: %s",url);
-
-	link = http_query_no_cache(url,"GET",stoptime);
-	if(link) {
-		if(link_readline(link,line,sizeof(line),stoptime)) {
-			if(sscanf(line,"%s",checksum)) {
-				/* ok to continue */
+		link = http_query_no_cache(url, "GET", stoptime);
+		if (link) {
+			if(link_readline(link, line, sizeof(line), stoptime)) {
+				if (sscanf(line,"%s", checksum)) {
+					/* ok to continue */
+				} else {
+					debug(D_GROW, "checksum is malformed!");
+					goto sleep_retry;
+				}
 			} else {
-				debug(D_GROW,"checksum is malformed!");
+				debug(D_GROW, "lost connection while fetching checksum!");
 				goto sleep_retry;
 			}
 		} else {
-			debug(D_GROW,"lost connection while fetching checksum!");
+			return 0;
+		}
+	}
+
+	debug(D_GROW,"checksum is %s",checksum);
+
+	if (local_index) {
+		snprintf(filename, sizeof(filename), "%s/.growfsdir", path);
+	} else {
+		sprintf(url, "http://%s%s/.growfsdir", hostport, path);
+
+		if (file_cache_contains(pfs_file_cache, url, filename) != 0) {
+
+			debug(D_GROW, "fetching directory: %s", url);
+
+			int fd = file_cache_begin(pfs_file_cache, url, txn);
+			if (fd >= 0) {
+				INT64_T size;
+				struct link *link = http_query_size(url, "GET", &size, stoptime, 1);
+				if (link) {
+					if (link_stream_to_fd(link, fd, size, stoptime) >= 0) {
+						file_cache_commit(pfs_file_cache, url, txn);
+					} else {
+						file_cache_abort(pfs_file_cache, url, txn);
+					}
+					link_close(link);
+				} else {
+					file_cache_abort(pfs_file_cache, url, txn);
+				}
+				close(fd);
+			}
+		} else {
+			debug(D_GROW, "directory is already cached");
+		}
+
+		if (file_cache_contains(pfs_file_cache, url, filename) != 0) {
 			goto sleep_retry;
 		}
-	} else {
-		return 0;
-	}
-
-	debug(D_GROW,"remote checksum is %s",checksum);
-
-	sprintf(url,"http://%s%s/.growfsdir",hostport,path);
-
-	if(file_cache_contains(pfs_file_cache,url,filename)!=0) {
-
-		debug(D_GROW,"fetching directory: %s",url);
-
-		int fd = file_cache_begin(pfs_file_cache,url,txn);
-		if(fd>=0) {
-			INT64_T size;
-			struct link *link = http_query_size(url,"GET",&size,stoptime,1);
-			if(link) {
-				if(link_stream_to_fd(link,fd,size,stoptime)>=0) {
-					file_cache_commit(pfs_file_cache,url,txn);
-				} else {
-					file_cache_abort(pfs_file_cache,url,txn);
-				}
-				link_close(link);
-			} else {
-				file_cache_abort(pfs_file_cache,url,txn);
-			}
-			close(fd);
-		}
-	} else {
-		debug(D_GROW,"directory is already cached");
-	}
-
-	if(file_cache_contains(pfs_file_cache,url,filename)!=0) {
-		goto sleep_retry;
 	}
 
 	debug(D_GROW,"checksumming %s",filename);
@@ -448,7 +468,7 @@ struct grow_filesystem * grow_filesystem_create( const char *hostport, const cha
 
 	if(strcmp((char*)checksum,sha1_string(digest))) {
 		debug(D_GROW,"checksum does not match, reloading...");
-		file_cache_delete(pfs_file_cache,url);
+		if (!local_index) file_cache_delete(pfs_file_cache, url);
 		goto sleep_retry;
 	}
 
@@ -462,7 +482,7 @@ struct grow_filesystem * grow_filesystem_create( const char *hostport, const cha
 	if(!d) {
 		debug(D_GROW,"%s is corrupted",filename);
 		fclose(file);
-		file_cache_delete(pfs_file_cache,url);
+		if (!local_index) file_cache_delete(pfs_file_cache, url);
 		goto sleep_retry;
 	}
 
@@ -569,12 +589,15 @@ class pfs_file_grow : public pfs_file
 {
 private:
 	struct link *link;
+	int local_fd;
 	pfs_stat info;
 	sha1_context_t context;
 
 public:
-	pfs_file_grow( pfs_name *n, struct link *l, struct grow_dirent *d ) : pfs_file(n) {
+	pfs_file_grow( pfs_name *n, struct link *l, int fd, struct grow_dirent *d ) : pfs_file(n) {
+		assert(!(l && (fd < 0)));
 		link = l;
+		local_fd = fd;
 		grow_dirent_to_stat(d,&info);
 		if(pfs_checksum_files) {
 			sha1_init(&context);
@@ -582,7 +605,10 @@ public:
 	}
 
 	virtual int close() {
-		link_close(link);
+		if (link)
+			link_close(link);
+		else
+			::close(local_fd);
 
 		struct grow_dirent *d;
 		d = grow_dirent_lookup(&name,1);
@@ -612,7 +638,10 @@ public:
 
 	virtual pfs_ssize_t read( void *d, pfs_size_t length, pfs_off_t offset ) {
 		pfs_ssize_t actual;
-		actual = link_read(link,(char*)d,length,LINK_FOREVER);
+		if (link)
+			actual = link_read(link,(char*)d,length,LINK_FOREVER);
+		else
+			actual = ::read(local_fd, d, length);
 		if(pfs_checksum_files && actual>0) sha1_update(&context,(unsigned char *)d,actual);
 		return actual;
 	}
@@ -646,6 +675,7 @@ public:
 	virtual pfs_file * open( pfs_name *name, int flags, mode_t mode ) {
 		struct grow_dirent *d;
 		char url[PFS_PATH_MAX];
+		int local_index = !strcmp(name->hostport, "local");
 
 		d = grow_dirent_lookup(name,1);
 		if(!d) return 0;
@@ -655,15 +685,24 @@ public:
 			return 0;
 		}
 
-		sprintf(url,"http://%s%s",name->hostport,name->rest);
-
-		struct link *link = http_query_no_cache(url,"GET",time(0)+pfs_master_timeout);
-		if(link) {
-			debug(D_GROW,"open %s",url);
-			return new pfs_file_grow(name,link,d);
+		if (local_index) {
+			int fd = ::open(name->rest, O_RDONLY);
+			if (fd < 0) {
+				debug(D_GROW, "failed to open %s: %s", name->rest, strerror(errno));
+				return NULL;
+			}
+			return new pfs_file_grow(name, NULL, fd, d);
 		} else {
-			debug(D_GROW,"failed to open %s",url);
-			return 0;
+			sprintf(url, "http://%s%s", name->hostport, name->rest);
+
+			struct link *link = http_query_no_cache(url, "GET", time(0) + pfs_master_timeout);
+			if(link) {
+				debug(D_GROW, "open %s", url);
+				return new pfs_file_grow(name, link, -1, d);
+			} else {
+				debug(D_GROW, "failed to open %s", url);
+				return 0;
+			}
 		}
 	}
 
@@ -673,7 +712,7 @@ public:
 		generate it interally using the list of known filesystems.
 		*/
 
-		if(!name->host[0]) {
+		if(!name->rest[0]) {
 			pfs_dir *dir = new pfs_dir(name);
 			dir->append(".");
 			dir->append("..");
@@ -711,7 +750,7 @@ public:
 	virtual int lstat( pfs_name *name, struct pfs_stat *info ) {
 		/* If we get stat("/grow") then construct a dummy entry. */
 
-		if(!name->host[0]) {
+		if(!name->rest[0]) {
 						pfs_service_emulate_stat(name,info);
 						info->st_mode = S_IFDIR | 0555;
 			return 0;
@@ -730,7 +769,7 @@ public:
 	virtual int stat( pfs_name *name, struct pfs_stat *info ) {
 		/* If we get stat("/grow") then construct a dummy entry. */
 
-		if(!name->host[0]) {
+		if(!name->rest[0]) {
 						pfs_service_emulate_stat(name,info);
 						info->st_mode = S_IFDIR | 0555;
 			return 0;

--- a/parrot/src/pfs_service_grow.cc
+++ b/parrot/src/pfs_service_grow.cc
@@ -607,10 +607,13 @@ public:
 
 	virtual int close() {
 		stats_inc("parrot.grow.close", 1);
-		if (link)
+		if (link) {
+			debug(D_GROW, "close %p", link);
 			link_close(link);
-		else
+		} else {
+			debug(D_GROW, "close %d", local_fd);
 			::close(local_fd);
+		}
 
 		struct grow_dirent *d;
 		d = grow_dirent_lookup(&name,1);
@@ -643,10 +646,13 @@ public:
 		stats_bin("parrot.grow.read.requested", length);
 
 		pfs_ssize_t actual;
-		if (link)
+		if (link) {
+			debug(D_GROW, "read %p %p %lld %lld", link, d, (long long) length, (long long) offset);
 			actual = link_read(link,(char*)d,length,LINK_FOREVER);
-		else
+		} else {
+			debug(D_GROW, "read %d %p %lld %lld", local_fd, d, (long long) length, (long long) offset);
 			actual = ::read(local_fd, d, length);
+		}
 		if(pfs_checksum_files && actual>0) sha1_update(&context,(unsigned char *)d,actual);
 		if (actual >= 0) stats_bin("parrot.grow.read.actual", actual);
 		return actual;
@@ -654,6 +660,11 @@ public:
 
 	virtual int fstat( struct pfs_stat *i ) {
 		stats_inc("parrot.grow.fstat", 1);
+		if (link) {
+			debug(D_GROW, "fstat %p %p", link, i);
+		} else {
+			debug(D_GROW, "flock %d %p", local_fd, i);
+		}
 		*i = info;
 		return 0;
 	}
@@ -665,6 +676,11 @@ public:
 	*/
 	virtual int flock( int op ) {
 		stats_inc("parrot.grow.flock", 1);
+		if (link) {
+			debug(D_GROW, "flock %p %d", link, op);
+		} else {
+			debug(D_GROW, "flock %d %d", local_fd, op);
+		}
 		return 0;
 	}
 
@@ -682,6 +698,7 @@ public:
 
 	virtual pfs_file * open( pfs_name *name, int flags, mode_t mode ) {
 		stats_inc("parrot.grow.open", 1);
+		debug(D_GROW, "open %s %d %d", name->rest, flags, (flags&O_CREAT) ? mode : 0);
 
 		struct grow_dirent *d;
 		char url[PFS_PATH_MAX];
@@ -701,13 +718,14 @@ public:
 				debug(D_GROW, "failed to open %s: %s", name->rest, strerror(errno));
 				return NULL;
 			}
+			debug(D_GROW, "open local %s=%d", name->rest, fd);
 			return new pfs_file_grow(name, NULL, fd, d);
 		} else {
 			sprintf(url, "http://%s%s", name->hostport, name->rest);
 
 			struct link *link = http_query_no_cache(url, "GET", time(0) + pfs_master_timeout);
 			if(link) {
-				debug(D_GROW, "open %s", url);
+				debug(D_GROW, "open remote %s=%p", url, link);
 				return new pfs_file_grow(name, link, -1, d);
 			} else {
 				debug(D_GROW, "failed to open %s", url);
@@ -718,6 +736,7 @@ public:
 
 	pfs_dir * getdir( pfs_name *name ) {
 		stats_inc("parrot.grow.getdir", 1);
+		debug(D_GROW, "getdir %s", name->rest);
 
 		/*
 		If the root of the GROW filesystem is requested,
@@ -771,6 +790,7 @@ public:
 
 	virtual int lstat( pfs_name *name, struct pfs_stat *info ) {
 		stats_inc("parrot.grow.lstat", 1);
+		debug(D_GROW, "lstat %s %p", name->rest, info);
 
 		/* If we get stat("/grow") then construct a dummy entry. */
 
@@ -792,6 +812,7 @@ public:
 
 	virtual int stat( pfs_name *name, struct pfs_stat *info ) {
 		stats_inc("parrot.grow.stat", 1);
+		debug(D_GROW, "stat %s %p", name->rest, info);
 
 		/* If we get stat("/grow") then construct a dummy entry. */
 
@@ -813,12 +834,14 @@ public:
 
 	virtual int unlink( pfs_name *name ) {
 		stats_inc("parrot.grow.unlink", 1);
+		debug(D_GROW, "unlink %s", name->rest);
 		errno = EROFS;
 		return -1;
 	}
 
 	virtual int access( pfs_name *name, mode_t mode ) {
 		stats_inc("parrot.grow.access", 1);
+		debug(D_GROW, "access %s %d", name->rest, mode);
 
 		struct pfs_stat info;
 		if(this->stat(name,&info)==0) {
@@ -835,42 +858,49 @@ public:
 
 	virtual int chmod( pfs_name *name, mode_t mode ) {
 		stats_inc("parrot.grow.chmod", 1);
+		debug(D_GROW, "chmod %s %d", name->rest, mode);
 		errno = EROFS;
 		return -1;
 	}
 
 	virtual int chown( pfs_name *name, uid_t uid, gid_t gid ) {
 		stats_inc("parrot.grow.chown", 1);
+		debug(D_GROW, "chown %s %d %d", name->rest, uid, gid);
 		errno = EROFS;
 		return -1;
 	}
 
 	virtual int lchown( pfs_name *name, uid_t uid, gid_t gid ) {
 		stats_inc("parrot.grow.lchown", 1);
+		debug(D_GROW, "lchown %s %d %d", name->rest, uid, gid);
 		errno = EROFS;
 		return -1;
 	}
 
 	virtual int truncate( pfs_name *name, pfs_off_t length ) {
 		stats_inc("parrot.grow.truncate", 1);
+		debug(D_GROW, "truncate %s %lld", name->rest, (long long)length);
 		errno = EROFS;
 		return -1;
 	}
 
 	virtual int utime( pfs_name *name, struct utimbuf *buf ) {
 		stats_inc("parrot.grow.utime", 1);
+		debug(D_GROW, "utime %s %p", name->rest, buf);
 		errno = EROFS;
 		return -1;
 	}
 
 	virtual int rename( pfs_name *oldname, pfs_name *newname ) {
 		stats_inc("parrot.grow.rename", 1);
+		debug(D_GROW, "! rename %s %s", oldname->rest, newname->rest);
 		errno = EROFS;
 		return -1;
 	}
 
 	virtual int chdir( pfs_name *name, char *newpath ) {
 		stats_inc("parrot.grow.chdir", 1);
+		debug(D_GROW, "chdir %s", name->rest);
 
 		struct pfs_stat info;
 		if(this->stat(name,&info)==0) {
@@ -887,18 +917,21 @@ public:
 
 	virtual int link( pfs_name *oldname, pfs_name *newname ) {
 		stats_inc("parrot.grow.link", 1);
+		debug(D_GROW, "! link %s %s", oldname->rest, newname->rest);
 		errno = EROFS;
 		return -1;
 	}
 
 	virtual int symlink( const char *linkname, pfs_name *newname ) {
 		stats_inc("parrot.grow.symlink", 1);
+		debug(D_GROW, "! symlink %s %s", linkname, newname->rest);
 		errno = EROFS;
 		return -1;
 	}
 
 	virtual int readlink( pfs_name *name, char *buf, pfs_size_t bufsiz ) {
 		stats_inc("parrot.grow.readlink", 1);
+		debug(D_GROW, "readlink %s %p %d", name->rest, buf, (int) bufsiz);
 
 		struct grow_dirent *d;
 
@@ -920,12 +953,14 @@ public:
 
 	virtual int mkdir( pfs_name *name, mode_t mode ) {
 		stats_inc("parrot.grow.mkdir", 1);
+		debug(D_GROW, "! mkdir %s %d", name->rest, mode);
 		errno = EROFS;
 		return -1;
 	}
 
 	virtual int rmdir( pfs_name *name ) {
 		stats_inc("parrot.grow.rmdir", 1);
+		debug(D_GROW, "! rmdir %s", name->rest);
 		errno = EROFS;
 		return -1;
 	}

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -528,14 +528,21 @@ int pfs_table::resolve_name(int is_special_syscall, const char *cname, struct pf
 				pname->rest[0] = 0;
 				return 1;
 			}
-			char *c = strrchr(pname->host,':');
-			if(c) {
-				*c = 0;
-				pname->port = atoi(c+1);
+
+			if (!strcmp(pname->service_name, "grow") && !strcmp(pname->host, "local")) {
+				pname->host[0] = 0;
+				pname->port = 0;
+				strcpy(pname->hostport, "local");
 			} else {
-				pname->port = pname->service->get_default_port();
+				char *c = strrchr(pname->host, ':');
+				if(c) {
+					*c = 0;
+					pname->port = atoi(c+1);
+				} else {
+					pname->port = pname->service->get_default_port();
+				}
+				sprintf(pname->hostport,"%s:%d",pname->host,pname->port);
 			}
-			sprintf(pname->hostport,"%s:%d",pname->host,pname->port);
 
 			if(!strcmp(pname->service_name,"multi")) {
 				strcpy(tmp,pname->rest);


### PR DESCRIPTION
This is a first draft of local mode for GROW-FS. The idea is to index a directory on the local system, and let Parrot handle metadata without touching the filesystem. To access the directory `/home/john` with this, first generate the index.

    $ make_growfs /home/john
    $ touch /home/john/foo

Note that we added a file after generating the index. Next, run your program under Parrot. `/grow/` should still work as before, except for the path `/grow/local`. Parrot will search the local filesystem rather than connect to a web server. Now you can look at metadata under `/home/john` without touching the disk.

    $ ls /grow/local/home/john
    $ cat /grow/local/john/foo          # ENOENT: the file is not in the index

Any reads are passed down to the local filesystem.

I haven't done extensive testing, but it seems to work as expected. Some limitations:
- This mode could shadow a GROW server. If someone actually needs to connect to a GROW server named `local`, it's easy to add a command line flag for this feature.
- Only one repo is supported. The first access to a local repo binds that path. For example, if you access `/grow/local/home/john/repoA`, you can no longer access `/grow/local/home/john/repoB`. The GROW service does this for a given host:port as well.

@dthain thoughts?