### PR TITLE
Pass the right argv[0]

### DIFF
--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -770,29 +770,29 @@ static void decode_execve( struct pfs_process *p, int entering, INT64_T syscall,
 		p->set_gid = p->egid;
 
 		tracer_copy_in_string(p->tracer,logical_name,POINTER(args[0]),sizeof(logical_name),0);
+		strncpy(p->new_logical_name, logical_name, sizeof(p->new_logical_name)-1);
 
 		{
 			char buf[PATH_MAX] = "";
 			if(pfs_readlink(logical_name, buf, sizeof buf - 1) > 0) {
 				if (buf[0] == '/') {
-					snprintf(logical_name, sizeof logical_name, "%s", buf);
+					snprintf(p->new_logical_name, sizeof p->new_logical_name, "%s", buf);
 				} else {
-					char *sep = strrchr(logical_name, '/');
+					char *sep = strrchr(p->new_logical_name, '/');
 					if (!sep) {
-						sep = logical_name;
+						sep = p->new_logical_name;
 					}
-					snprintf(sep, sizeof logical_name - (size_t)(sep-logical_name), "/%s", buf);
+					snprintf(sep, sizeof p->new_logical_name - (size_t)(sep - p->new_logical_name), "/%s", buf);
 				}
 			}
 		}
 
-		strncpy(p->new_logical_name, logical_name, sizeof(p->new_logical_name)-1);
 		p->exefd = -1;
 
-		if(!pfs_dispatch_isexe(logical_name, &p->set_uid, &p->set_gid))
+		if(!pfs_dispatch_isexe(p->new_logical_name, &p->set_uid, &p->set_gid))
 			goto failure;
 
-		if (pfs_get_local_name(logical_name,physical_name,firstline,sizeof(firstline))<0)
+		if (pfs_get_local_name(p->new_logical_name, physical_name, firstline, sizeof(firstline)) < 0)
 			goto failure;
 
 		/* force to single line: */

--- a/parrot/test/TR_parrot_argv0.sh
+++ b/parrot/test/TR_parrot_argv0.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -ex
+
+. ../../dttools/test/test_runner_common.sh
+. ./parrot-test.sh
+
+prepare()
+{
+	echo '#!/bin/sh' > target.sh
+	echo 'echo $0' >> target.sh
+	chmod +x target.sh
+	ln -sf target.sh source.sh
+}
+
+run()
+{
+	[ "$(parrot ./target.sh)" =  "$(./target.sh)" ]
+	[ "$(parrot ./source.sh)" =  "$(./source.sh)" ]
+}
+
+clean()
+{
+	rm -f target.sh source.sh
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:


### PR DESCRIPTION
It looks like some previous fixes lined up to cause an issue for the specific case of `exec()`ing a symlink to an interpreted script. `decode_execve` was overwriting the passed-in path with the value of the symlink. This should leave `argv[0]` as passed in while still setting `/proc/self/exe` to the canonical path to the executable.

This seems to resolve the issue in #1612