### PR TITLE
add preferred connection to bindings

### DIFF
--- a/work_queue/src/perl/Work_Queue.pm
+++ b/work_queue/src/perl/Work_Queue.pm
@@ -156,6 +156,11 @@ sub specify_name {
 	return work_queue_specify_name($self->{_work_queue}, $name);
 }
 
+sub specify_master_preferred_connection {
+	my ($self, $mode) = @_;
+	return work_queue_master_preferred_connection($self->{_work_queue}, $mode);
+}
+
 sub specify_min_taskid {
 	my ($self, $minid) = @_;
 	return work_queue_specify_min_taskid($self->{_work_queue}, $minid);

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -958,6 +958,16 @@ class WorkQueue(_object):
         return work_queue_specify_name(self._work_queue, name)
 
     ##
+    # Set the preference for using hostname over IP address to connect.
+    # 'by_ip' uses IP address (standard behavior), or 'by_hostname' to use the
+    # hostname at the master.
+    #
+    # @param self   Reference to the current work queue object.
+    # @param preferred_connection An string to indicate using 'by_ip' or a 'by_hostname'.
+    def specify_master_preferred_connection(self, mode):
+        return work_queue_master_preferred_connection(self._work_queue, mode)
+
+    ##
     # Set the minimum taskid of future submitted tasks.
     #
     # Further submitted tasks are guaranteed to have a taskid larger or equal

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -867,9 +867,9 @@ void work_queue_specify_keepalive_interval(struct work_queue *q, int interval);
 void work_queue_specify_keepalive_timeout(struct work_queue *q, int timeout);
 
 /** Set the preference for using hostname over IP address to connect.
-IP uses IP address (standard behavior), HOSTNAME uses hostname provided by master
+'by_ip' uses IP address (standard behavior), or 'by_hostname' to use the hostname at the master.
 @param q A work queue object.
-@param preferred_connection An string to indicate using IP or HOSTNAME.
+@param preferred_connection An string to indicate using 'by_ip' or a 'by_hostname'.
 */
 void work_queue_master_preferred_connection(struct work_queue *q, const char *preferred_connection);
 


### PR DESCRIPTION
Adds the binding to specify 'by_ip' or 'by_hostname'.