### PR TITLE
Inform catalog about multiple interfaces

### DIFF
--- a/configure
+++ b/configure
@@ -1288,14 +1288,15 @@ optional_function utime /usr/include/utime.h HAS_UTIME HAVE_UTIME
 optional_function utimensat /usr/include/sys/stat.h HAS_UTIMENSAT
 
 # sqlite3 uses define "HAVE_*"
-optional_include attr/xattr.h HAS_ATTR_XATTR_H
-optional_include fts.h HAS_FTS_H
-optional_include inttypes.h HAS_INTTYPES_H HAVE_INTTYPES_H
-optional_include stdint.h HAS_STDINT_H HAVE_STDINT_H
-optional_include sys/statfs.h HAS_SYS_STATFS_H
+optional_include attr/xattr.h  HAS_ATTR_XATTR_H
+optional_include fts.h         HAS_FTS_H
+optional_include ifaddrs.h     HAS_IFADDRS
+optional_include inttypes.h    HAS_INTTYPES_H   HAVE_INTTYPES_H
+optional_include stdint.h      HAS_STDINT_H     HAVE_STDINT_H
+optional_include sys/statfs.h  HAS_SYS_STATFS_H
 optional_include sys/statvfs.h HAS_SYS_STATVFS_H
-optional_include sys/xattr.h HAS_SYS_XATTR_H
-optional_include syslog.h HAS_SYSLOG_H
+optional_include sys/xattr.h   HAS_SYS_XATTR_H
+optional_include syslog.h      HAS_SYSLOG_H
 
 #if optional_library_function systemd/sd-journal.h sd_journal_print systemd HAS_SYSTEMD_JOURNAL_H; then
 #	external_libraries="${external_libraries} -lsystemd"

--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -55,6 +55,7 @@ SOURCES = \
 	host_disk_info.c \
 	host_memory_info.c \
 	http_query.c \
+	interfaces_address.c \
 	itable.c \
 	json.c \
 	json_aux.c \

--- a/dttools/src/interfaces_address.c
+++ b/dttools/src/interfaces_address.c
@@ -1,0 +1,87 @@
+
+#include  "jx.h"
+
+#ifndef HAS_IFADDRS
+
+struct jx *interfaces_of_host() {
+	return NULL;
+}
+
+#else
+
+#include <errno.h>
+#include <ifaddrs.h>
+#include <netdb.h>
+#include <string.h>
+
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include "debug.h"
+#include "link.h"
+#include "stringtools.h"
+
+struct jx *interfaces_of_host() {
+	struct ifaddrs *ifa, *head_if;
+
+	char host[NI_MAXHOST];
+
+	if(getifaddrs(&head_if) == -1 ) {
+		warn(D_NOTICE, "Could not get network interfaces information: %s", strerror(errno));
+		return NULL;
+	}
+
+	struct jx *interfaces = NULL;
+
+	for(ifa = head_if; ifa != NULL; ifa = ifa->ifa_next) {
+		if(ifa->ifa_addr == NULL) {
+			continue;
+		}
+
+		int family = ifa->ifa_addr->sa_family;
+
+		if(family != AF_INET && family != AF_INET6) {
+			continue;
+		}
+
+		if(string_prefix_is(ifa->ifa_name, "lo") == 0) {
+			continue;
+		}
+
+		int size   = (family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
+		int result = getnameinfo(ifa->ifa_addr, size, host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
+
+		if(!result) {
+			warn(D_NOTICE, "Could not determine address of interface '%s': %s", ifa->ifa_name, gai_strerror(errno));
+			continue;
+		}
+
+		if(!interfaces) {
+			interfaces = jx_array(0);
+		}
+
+		struct jx *jf = jx_object(0);
+
+		jx_insert_string(jf, "interface", ifa->ifa_name);
+		jx_insert_string(jf, "host",      host);
+
+		switch(family) {
+			case AF_INET:
+				jx_insert_string(jf, "family", "AF_INET");
+				break;
+			case AF_INET6:
+				jx_insert_string(jf, "family", "AF_INET6");
+				break;
+			default:
+				break;
+		}
+
+		jx_array_append(interfaces, jf);
+	}
+
+	freeifaddrs(head_if);
+
+	return interfaces;
+}
+
+#endif

--- a/dttools/src/interfaces_address.c
+++ b/dttools/src/interfaces_address.c
@@ -1,5 +1,10 @@
+/*
+Copyright (C) 2017- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
 
-#include  "jx.h"
+#include "interfaces_address.h"
 
 #ifndef HAS_IFADDRS
 
@@ -44,15 +49,15 @@ struct jx *interfaces_of_host() {
 			continue;
 		}
 
-		if(string_prefix_is(ifa->ifa_name, "lo") == 0) {
+		if(string_prefix_is(ifa->ifa_name, "lo")) {
 			continue;
 		}
 
 		int size   = (family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
 		int result = getnameinfo(ifa->ifa_addr, size, host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
 
-		if(!result) {
-			warn(D_NOTICE, "Could not determine address of interface '%s': %s", ifa->ifa_name, gai_strerror(errno));
+		if(result) {
+			warn(D_NOTICE, "Could not determine address of interface '%s': %s", ifa->ifa_name, gai_strerror(result));
 			continue;
 		}
 

--- a/dttools/src/interfaces_address.h
+++ b/dttools/src/interfaces_address.h
@@ -1,0 +1,14 @@
+/*
+Copyright (C) 2017- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#ifndef INTERFACES_ADDRESS_H
+#define INTERFACES_ADDRESS_H
+
+#include  "jx.h"
+
+struct jx *interfaces_of_host();
+
+#endif

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -25,6 +25,7 @@ The following major problems must be fixed:
 #include "datagram.h"
 #include "domain_name_cache.h"
 #include "hash_table.h"
+#include "interfaces_address.h"
 #include "itable.h"
 #include "list.h"
 #include "macros.h"
@@ -2254,6 +2255,11 @@ static struct jx * queue_to_jx( struct work_queue *q, struct link *foreman_uplin
 	jx_insert_string(j,"working_dir",q->workingdir);
 	jx_insert_string(j,"owner",owner);
 	jx_insert_string(j,"version",CCTOOLS_VERSION);
+
+	struct jx *interfaces = interfaces_of_host();
+	if(interfaces) {
+		jx_insert(j,jx_string("network_interfaces"),interfaces);
+	}
 
 	// If this is a foreman, add the master address and the disk resources
 	if(foreman_uplink) {


### PR DESCRIPTION
Second part to fix #1615.

The master informs the catalog about multiple interfaces with a json field that looks like:

"network_interfaces":[{"family":"AF_INET","host":"129.74.153.171","interface":"eth0"},{"family":"AF_INET","host":"172.17.42.1","interface":"docker0"},{"family":"AF_INET6","host":"fe80::b6b5:2fff:fecf:a0d4%eth0","interface":"eth0"},{"family":"AF_INET6","host":"fe80::c025:bff:feaa:31f2%docker0","interface":"docker0"}]

Only works on linux, as it needs getifaddrs, which is not POSIX.  If the master runs on a non-linux machine, the field is not included.

