### PR TITLE
Do not interpret more than one pair of ':'

### DIFF
--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -2023,8 +2023,11 @@ struct list *parse_master_addresses(const char *specs, int default_port) {
 
 		char *port_str = strchr(next_master, ':');
 		if(port_str) {
-			*port_str = '\0';
-			port = atoi(port_str+1);
+			int no_ipv4 = strchr(port_str+1, ':'); /* if another ':', then this is not ipv4. */
+			if(!no_ipv4) {
+				*port_str = '\0';
+				port = atoi(port_str+1);
+			}
 		}
 
 		if(port < 1) {


### PR DESCRIPTION
Fix for #1619 