### PR TITLE
Add --disable-service to parrot

### DIFF
--- a/doc/man/parrot_run.m4
+++ b/doc/man/parrot_run.m4
@@ -65,6 +65,7 @@ OPTION_TRIPLET(-w, work-dir, dir)Initial working directory.
 OPTION_ITEM(-W, --syscall-table)Display table of system calls trapped.
 OPTION_ITEM(-Y, --sync-write)Force synchronous disk writes.
 OPTION_ITEM(-Z, --auto-decompress)Enable automatic decompression on .gz files.
+OPTION_PAIR(--disable-service,service) Disable a compiled-in service (e.g. http, cvmfs, etc.)
 OPTIONS_END
 
 SECTION(ENVIRONMENT VARIABLES)

--- a/doc/parrot.html
+++ b/doc/parrot.html
@@ -144,6 +144,16 @@ The following protocols have been supported in the past, but are not currently i
 </table>
 <hr>
 <p>
+
+If a remote service is interfering with your system,
+e.g. you already have CVMFS mounted at /cvmfs,
+you can run Parrot as
+<code>% parrot_run --disable-service cvmfs sh</code>
+to disable Parrot's handling.
+This option can be specified multiple times.
+</p>
+
+<p>
 You will notice quite quickly that not all remote I/O systems
 provide all of the functionality common to an ordinary file system.
 For example, HTTP is incapable of listing files.

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -168,6 +168,7 @@ enum {
 	LONG_OPT_PID_WARP,
 	LONG_OPT_PID_FIXED,
 	LONG_OPT_STATS_FILE,
+	LONG_OPT_DISABLE_SERVICE,
 };
 
 static void get_linux_version(const char *cmd)
@@ -275,6 +276,7 @@ static void show_help( const char *cmd )
 	printf( " %-30s Enable whole session caching for all protocols.\n", "-S,--session-caching");
 	printf( " %-30s Force synchronous disk writes.            (PARROT_FORCE_SYNC)\n", "-Y,--sync-write");
 	printf( " %-30s Enable automatic decompression on .gz files.\n", "-Z,--auto-decompress");
+	printf( " %-30s Disable the given service.\n", "--disable-service");
 	printf("\n");
 	printf("FTP / GridFTP options:\n");
 	printf( " %-30s Enable data channel authentication in GridFTP.\n", "-C,--channel-auth");
@@ -856,6 +858,7 @@ int main( int argc, char *argv[] )
 		{"time-warp", no_argument, 0, LONG_OPT_TIME_WARP},
 		{"pid-fixed", no_argument, 0, LONG_OPT_PID_FIXED},
 		{"pid-warp", no_argument, 0, LONG_OPT_PID_WARP},
+		{"disable-service", required_argument, 0, LONG_OPT_DISABLE_SERVICE},
 		{0,0,0,0}
 	};
 
@@ -1101,6 +1104,11 @@ int main( int argc, char *argv[] )
 		case LONG_OPT_STATS_FILE:
 			free(stats_file);
 			stats_file = xxstrdup(optarg);
+			break;
+		case LONG_OPT_DISABLE_SERVICE:
+			if (!hash_table_remove(available_services, optarg)) {
+				fprintf(stderr, "warning: unknown service %s\n", optarg);
+			}
 			break;
 		default:
 			show_help(argv[0]);


### PR DESCRIPTION
Add an option to Parrot to disable a compiled-in service at runtime. This addresses #1629, so that it's possible to tell Parrot not to intercept `/cvmfs` and instead let things fall through to the FUSE module. @hmeng-19 let me know if this works for you