### PR TITLE
Allow users to use cvmfs on the host machine in umbrella

### DIFF
--- a/doc/umbrella.html
+++ b/doc/umbrella.html
@@ -287,7 +287,17 @@ cmsDriver.py Hadronizer_MgmMatchTuneZ2star_8TeV_madgraph_cff.py -s GEN \
 
 			The analysis code will create a directory called <tt>sim_job</tt> and put the CMSSW software dependencies under it.
 
-			<p><b>The umbrella command for Parrot execution engine:</b></p>
+			<p><b>The umbrella command for Parrot execution engine when the local machine has cvmfs installed:</b></p>
+			<code>umbrella \
+	--sandbox_mode parrot \
+	--log umbrella.log \
+	--spec cms_complex.umbrella \
+	--localdir /tmp/umbrella_test/ \
+	--output "/tmp/sim_job=/tmp/umbrella_test/parrot_cms_complex_output" \
+	--use_local_cvmfs \
+	run</code>
+
+			<p><b>The umbrella command for Parrot execution engine when the local machine does not have cvmfs installed:</b></p>
 			<code>umbrella \
 	--sandbox_mode parrot \
 	--log umbrella.log \

--- a/umbrella/example/cms_complex/README
+++ b/umbrella/example/cms_complex/README
@@ -1,6 +1,12 @@
 The documentation illustrates how to use different execution engines of Umbrella to execute
 a complex CMS application.
 
+When the parrot sandbox mode is used, there exists two options to deliver
+cvmfs. First, if the local machine has cvmfs intalled by FUSE, the
+--use_local_cvmfs option can be used. Second, if the local machine does not
+have cvmfs installed, the --cvmfs_http_proxy option can be used to specified a
+http proxy, and parrot will be used to deliver cvmfs.
+
 #parrot execution engine test command.
 umbrella \
 --spec cms_complex.umbrella \

--- a/umbrella/example/cms_opendata/README
+++ b/umbrella/example/cms_opendata/README
@@ -1,6 +1,12 @@
 The documentation illustrates how to use different execution engines of Umbrella to execute
 a complex CMS application.
 
+When the parrot sandbox mode is used, there exists two options to deliver
+cvmfs. First, if the local machine has cvmfs intalled by FUSE, the
+--use_local_cvmfs option can be used. Second, if the local machine does not
+have cvmfs installed, the --cvmfs_http_proxy option can be used to specified a
+http proxy, and parrot will be used to deliver cvmfs.
+
 #parrot execution engine test command - Metadata database is specified through --meta option.
 umbrella \
 --spec cms_opendata.umbrella \

--- a/umbrella/example/cms_opendata_git/README
+++ b/umbrella/example/cms_opendata_git/README
@@ -1,6 +1,12 @@
 The documentation illustrates how to use different execution engines of Umbrella to execute
 a complex CMS application.
 
+When the parrot sandbox mode is used, there exists two options to deliver
+cvmfs. First, if the local machine has cvmfs intalled by FUSE, the
+--use_local_cvmfs option can be used. Second, if the local machine does not
+have cvmfs installed, the --cvmfs_http_proxy option can be used to specified a
+http proxy, and parrot will be used to deliver cvmfs.
+
 #parrot execution engine test command.
 umbrella \
 --spec cms_opendata_git.umbrella \

--- a/umbrella/example/cms_simple/README
+++ b/umbrella/example/cms_simple/README
@@ -1,6 +1,12 @@
 The documentation illustrates how to use different execution engines of Umbrella to execute
 a complex CMS application.
 
+When the parrot sandbox mode is used, there exists two options to deliver
+cvmfs. First, if the local machine has cvmfs intalled by FUSE, the
+--use_local_cvmfs option can be used. Second, if the local machine does not
+have cvmfs installed, the --cvmfs_http_proxy option can be used to specified a
+http proxy, and parrot will be used to deliver cvmfs.
+
 #parrot execution engine test command.
 umbrella \
 --spec cms_simple.umbrella \

--- a/umbrella/example/git_protocol/README
+++ b/umbrella/example/git_protocol/README
@@ -1,6 +1,12 @@
 The documentation illustrates how to use different execution engines of Umbrella to execute
 a complex CMS application.
 
+When the parrot sandbox mode is used, there exists two options to deliver
+cvmfs. First, if the local machine has cvmfs intalled by FUSE, the
+--use_local_cvmfs option can be used. Second, if the local machine does not
+have cvmfs installed, the --cvmfs_http_proxy option can be used to specified a
+http proxy, and parrot will be used to deliver cvmfs.
+
 #parrot execution engine test command.
 umbrella \
 --spec git_protocol.umbrella \

--- a/umbrella/src/umbrella.py
+++ b/umbrella/src/umbrella.py
@@ -110,8 +110,9 @@ import urlparse
 import json
 
 #Replace the version of cctools inside umbrella is easy: set cctools_binary_version.
+# cctools binary is hosted at: /afs/crc.nd.edu/group/ccl/web/hep-case-study/parrot
 cctools_binary_source = "http://ccl.cse.nd.edu/research/data/hep-case-study/parrot"
-cctools_binary_version = "6.0.10"
+cctools_binary_version = "14fb31b2"
 cctools_dest = ""
 
 #set cms_siteconf_url to be the url for the siteconf your application depends

--- a/umbrella/src/umbrella.py
+++ b/umbrella/src/umbrella.py
@@ -3736,6 +3736,21 @@ def spec_build(spec_json):
 				count += dep_build(sec[item], item)
 	return count
 
+def trim_list(origin, s):
+	"""Trim the strings in the set s from the origin list.
+
+	Args:
+		origin: a list of string
+		s: a set of string
+
+	Returns:
+		final: a new list of string
+	"""
+	final = []
+	for a in origin:
+		if a not in s:
+			final.append(a)
+	return final
 
 help_info = {
 "build": '''Build up the metadata info of dependencies inside an umbrella spec, and write the built-up version into a new file.
@@ -4110,6 +4125,8 @@ To check the help doc for a specific behavoir, use: %prog <behavior> help""",
 			json2file(args[1], spec_json)
 		sys.exit(0)
 
+	output_fileset = set()
+	output_dirset = set()
 	if behavior in ["run"]:
 		if not meta_path:
 			print "Trying to build the metadata info for local dependencies ..."
@@ -4223,6 +4240,7 @@ To check the help doc for a specific behavoir, use: %prog <behavior> help""",
 				if not os.path.exists(d):
 					os.makedirs(d)
 					tempdir_list.append(d)
+					output_dirset.add(d)
 				elif not os.path.isdir(d):
 					cleanup(tempfile_list, tempdir_list)
 					logging.critical("the parent path of the output file (%s) is not a directory!", f)
@@ -4232,6 +4250,7 @@ To check the help doc for a specific behavoir, use: %prog <behavior> help""",
 				new_file = open(f, 'a')
 				new_file.close()
 				tempfile_list.append(f)
+				output_fileset.add(f)
 			elif len(f) != 0:
 				cleanup(tempfile_list, tempdir_list)
 				logging.critical("the output file (%s) already exists!", f)
@@ -4244,6 +4263,7 @@ To check the help doc for a specific behavoir, use: %prog <behavior> help""",
 				logging.debug("create the output dir: %s", d)
 				os.makedirs(d)
 				tempdir_list.append(d)
+				output_dirset.add(d)
 			elif len(d) != 0:
 				cleanup(tempfile_list, tempdir_list)
 				logging.critical("the output dir (%s) already exists!", d)
@@ -4490,7 +4510,7 @@ To check the help doc for a specific behavoir, use: %prog <behavior> help""",
 				logging.debug("All the dependencies has been already inside S3!")
 				print "All the dependencies has been already inside S3!"
 
-	cleanup(tempfile_list, tempdir_list)
+	cleanup(trim_list(tempfile_list, output_fileset), trim_list(tempdir_list, output_dirset))
 	end = datetime.datetime.now()
 	diff = end - start
 	logging.debug("End time: %s", end)


### PR DESCRIPTION
Change parrot version used in umbrella, the parrot used in umbrella moves to the commit id [14fb31b](https://github.com/cooperative-computing-lab/cctools/commit/14fb31b22c2b263e4b0764754b7aefd22b7d90ea).
Allow `--use_local_cvmfs` to use cvmfs on the host machine in umbrella
Add `--parrot_log` option to allow generate parrot debugging log
Remove outputs from cleanup list if job succeeds
