### PR TITLE
update proxy of failing parrot tests

### DIFF
--- a/parrot/test/TR_parrot_cvmfs_access.sh
+++ b/parrot/test/TR_parrot_cvmfs_access.sh
@@ -4,7 +4,7 @@
 . ./parrot-test.sh
 
 export PARROT_ALLOW_SWITCHING_CVMFS_REPOSITORIES="yes"
-export HTTP_PROXY=http://eddie.crc.nd.edu:3128
+export HTTP_PROXY=http://cache01.hep.wisc.edu:3128
 export PARROT_CVMFS_REPO='*.cern.ch:pubkey=<BUILTIN-cern.ch.pub>,url=http://cvmfs-stratum-one.cern.ch/cvmfs/*.cern.ch'
 
 tmp_dir=${PWD}/parrot_temp_dir

--- a/parrot/test/TR_parrot_cvmfs_alien_cache.sh
+++ b/parrot/test/TR_parrot_cvmfs_alien_cache.sh
@@ -4,7 +4,7 @@
 . ./parrot-test.sh
 
 export PARROT_ALLOW_SWITCHING_CVMFS_REPOSITORIES="yes"
-export HTTP_PROXY=http://eddie.crc.nd.edu:3128
+export HTTP_PROXY=http://cache01.hep.wisc.edu:3128
 export PARROT_CVMFS_REPO='*.cern.ch:pubkey=<BUILTIN-cern.ch.pub>,url=http://cvmfs-stratum-one.cern.ch/cvmfs/*.cern.ch'
 
 tmp_dir_master=${PWD}/parrot_temp_dir


### PR DESCRIPTION
Simply change the proxy used for parrot tests.