### PR TITLE
Revert --ld-path handling

### DIFF
--- a/parrot/src/parrot_client.c
+++ b/parrot/src/parrot_client.c
@@ -260,12 +260,12 @@ ssize_t parrot_version ( char *buf, size_t len )
 #endif
 }
 
-int parrot_fork_namespace ( const char *ldso )
+int parrot_fork_namespace ( void )
 {
 #ifdef CCTOOLS_CPU_I386
-	return syscall(SYSCALL32_parrot_fork_namespace, ldso);
+	return syscall(SYSCALL32_parrot_fork_namespace);
 #else
-	return syscall(SYSCALL64_parrot_fork_namespace, ldso);
+	return syscall(SYSCALL64_parrot_fork_namespace);
 #endif
 }
 

--- a/parrot/src/parrot_client.h
+++ b/parrot/src/parrot_client.h
@@ -28,6 +28,6 @@ int parrot_debug( const char *flags, const char *path, off_t size );
 int parrot_mount( const char *path, const char *destination, const char *mode );
 int parrot_unmount( const char *path );
 ssize_t parrot_version ( char *buf, size_t len );
-int parrot_fork_namespace ( const char *ldso );
+int parrot_fork_namespace ( void );
 
 #endif

--- a/parrot/src/parrot_namespace.c
+++ b/parrot/src/parrot_namespace.c
@@ -58,10 +58,8 @@ int main( int argc, char *argv[] )
 	struct list *mountstrings = list_create();
 
 	char *parrot_path = "parrot_run";
-	char *ldso_path = "";
 
 	if (getenv("PARROT_PATH")) parrot_path = getenv("PARROT_PATH");
-	if (getenv("PARROT_LDSO_PATH")) ldso_path = getenv("PARROT_LDSO_PATH");
 
 	if (getenv("PARROT_MOUNT_FILE")) list_push_head(mountfiles, getenv("PARROT_MOUNT_FILE"));
 	if (getenv("PARROT_MOUNT_STRING")) list_push_head(mountstrings, getenv("PARROT_MOUNT_STRING"));
@@ -82,7 +80,7 @@ int main( int argc, char *argv[] )
 			cctools_version_print(stdout,"parrot_mount");
 			return 0;
 		case 'l':
-			ldso_path = xxstrdup(optarg);
+			// compatibility option
 			break;
 		case LONG_OPT_PARROT_PATH:
 			parrot_path = xxstrdup(optarg);
@@ -96,7 +94,7 @@ int main( int argc, char *argv[] )
 	char buf[4096];
 	if (parrot_version(buf, sizeof(buf)) >= 0) {
 		debug(D_DEBUG, "running under parrot %s\n", buf);
-		if (parrot_fork_namespace(ldso_path) < 0) {
+		if (parrot_fork_namespace() < 0) {
 			fatal("cannot dissociate from parent namespace");
 		}
 	} else {

--- a/parrot/src/parrot_namespace.c
+++ b/parrot/src/parrot_namespace.c
@@ -31,7 +31,6 @@ static void show_help()
 	printf("Where options are:\n");
 	printf(optfmt, "-M", "--mount /foo=/bar", "Mount (redirect) /foo to /bar", " (PARROT_MOUNT_STRING)");
 	printf(optfmt, "-m", "--ftab-file <file>", "Use <file> as a mountlist", " (PARROT_MOUNT_FILE)");
-	printf(optfmt, "-l", "--ld-path=<path>", "Path to ld.so to use", " (PARROT_LDSO_PATH)");
 	printf(optfmt, "", "--parrot-path <path>", "Path to parrot_run", " (PARROT_PATH)");
 	printf(optfmt, "-v", "--version", "Show version number", "");
 	printf(optfmt, "-h", "--help", "Help: Show these options", "");
@@ -47,7 +46,6 @@ static const struct option long_options[] = {
 	{"version", no_argument, 0, 'v'},
 	{"mount", required_argument, 0, 'M'},
 	{"tab-file", required_argument, 0, 'm'},
-	{"ld-path", required_argument, 0, 'l'},
 	{"parrot-path", required_argument, 0, LONG_OPT_PARROT_PATH},
 	{0,0,0,0}
 };
@@ -79,9 +77,6 @@ int main( int argc, char *argv[] )
 		case 'v':
 			cctools_version_print(stdout,"parrot_mount");
 			return 0;
-		case 'l':
-			// compatibility option
-			break;
 		case LONG_OPT_PARROT_PATH:
 			parrot_path = xxstrdup(optarg);
 			break;

--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -1172,7 +1172,6 @@ static void decode_syscall( struct pfs_process *p, int entering )
 
 	char path[PFS_PATH_MAX];
 	char path2[PFS_PATH_MAX];
-	char ldso[PFS_PATH_MAX];
 	void *value = NULL;
 
 	/* SYSCALL_execve has a different value in 32 and 64 bit modes. When an
@@ -3469,8 +3468,7 @@ static void decode_syscall( struct pfs_process *p, int entering )
 
 		case SYSCALL32_parrot_fork_namespace:
 			if (entering) {
-				TRACER_MEM_OP(tracer_copy_in_string(p->tracer,ldso,POINTER(args[0]),sizeof(ldso),0));
-				p->ns = pfs_resolve_fork_ns(p->ns, strlen(ldso) == 0 ? NULL : ldso);
+				p->ns = pfs_resolve_fork_ns(p->ns);
 				divert_to_dummy(p,0);
 			}
 			break;
@@ -3665,11 +3663,12 @@ void pfs_dispatch( struct pfs_process *p )
 
 int pfs_dispatch_prepexe (struct pfs_process *p, char exe[PATH_MAX], const char *physical_name)
 {
+	extern char pfs_ldso_path[PFS_PATH_MAX];
+
 	int rc;
 	int phyfd = -1;
 	int exefd = -1;
 	int tmpfd = -1;
-	const char *ldso = pfs_resolve_get_ldso();
 	char ldso_physical_name[PATH_MAX] = "";
 
 	strcpy(exe, "");
@@ -3678,9 +3677,9 @@ int pfs_dispatch_prepexe (struct pfs_process *p, char exe[PATH_MAX], const char 
 
 	CATCHUNIX(phyfd = open(physical_name, O_RDONLY));
 
-	if (ldso) {
-		debug(D_PROCESS, "%s: forcing use of loader %s", __func__, ldso);
-		CATCHUNIX(pfs_get_local_name(ldso, ldso_physical_name, 0, 0));
+	if (pfs_ldso_path[0]) {
+		debug(D_PROCESS, "%s: forcing use of loader %s", __func__, pfs_ldso_path);
+		CATCHUNIX(pfs_get_local_name(pfs_ldso_path, ldso_physical_name, 0, 0));
 	} else {
 		char path[PATH_MAX] = "";
 		rc = elf_get_interp(phyfd, path);

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -952,7 +952,6 @@ static void decode_syscall( struct pfs_process *p, int entering )
 
 	char path[PFS_PATH_MAX];
 	char path2[PFS_PATH_MAX];
-	char ldso[PFS_PATH_MAX];
 	void *value = NULL;
 
 	/* SYSCALL_execve has a different value in 32 and 64 bit modes. When an
@@ -3150,8 +3149,7 @@ static void decode_syscall( struct pfs_process *p, int entering )
 
 		case SYSCALL64_parrot_fork_namespace:
 			if (entering) {
-				TRACER_MEM_OP(tracer_copy_in_string(p->tracer,ldso,POINTER(args[0]),sizeof(ldso),0));
-				p->ns = pfs_resolve_fork_ns(p->ns, strlen(ldso) == 0 ? NULL : ldso);
+				p->ns = pfs_resolve_fork_ns(p->ns);
 				divert_to_dummy(p,0);
 			}
 			break;

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -112,6 +112,7 @@ const char *pfs_root_checksum=0;
 const char *pfs_initial_working_directory=0;
 
 char *pfs_false_uname = 0;
+char pfs_ldso_path[PATH_MAX];
 uid_t pfs_uid = 0;
 gid_t pfs_gid = 0;
 const char * pfs_username = 0;
@@ -728,7 +729,7 @@ int main( int argc, char *argv[] )
 	if(s) pfs_force_sync = 1;
 
 	s = getenv("PARROT_LDSO_PATH");
-	if(s) pfs_resolve_set_ldso(s);
+	if(s) snprintf(pfs_ldso_path, sizeof(pfs_ldso_path), "%s", s);
 
 	s = getenv("PARROT_DEBUG_FLAGS");
 	if(s) {
@@ -926,7 +927,7 @@ int main( int argc, char *argv[] )
 			pfs_checksum_files = 1;
 			break;
 		case 'l':
-			pfs_resolve_set_ldso(optarg);
+			snprintf(pfs_ldso_path, sizeof(pfs_ldso_path), "%s", optarg);
 			break;
 		case 'm':
 			pfs_mountfile_parse_file(optarg);

--- a/parrot/src/pfs_resolve.c
+++ b/parrot/src/pfs_resolve.c
@@ -72,31 +72,6 @@ static struct pfs_mount_entry *find_parent_ns(struct pfs_mount_entry *ns) {
 	return ns;
 }
 
-const char *pfs_resolve_get_ldso(void) {
-	struct pfs_mount_entry *ns = pfs_process_current_ns();
-	if (!ns) ns = mount_list;
-	assert(ns);
-	while (ns->next) {
-		assert(!ns->parent);
-		ns = ns->next;
-	}
-
-	return ns->ldso;
-}
-
-void pfs_resolve_set_ldso(const char *ldso) {
-	struct pfs_mount_entry *ns = pfs_process_current_ns();
-	if (!ns) ns = mount_list;
-	assert(ns);
-	while (ns->next) {
-		assert(!ns->parent);
-		ns = ns->next;
-	}
-
-	free(ns->ldso);
-	ns->ldso = strndup(ldso, PATH_MAX);
-}
-
 void pfs_resolve_add_entry( const char *prefix, const char *redirect, mode_t mode )
 {
 	assert(prefix);
@@ -410,11 +385,10 @@ static pfs_resolve_t pfs_resolve_ns( struct pfs_mount_entry *ns, const char *log
 	return result;
 }
 
-struct pfs_mount_entry *pfs_resolve_fork_ns(struct pfs_mount_entry *ns, const char *ldso) {
+struct pfs_mount_entry *pfs_resolve_fork_ns(struct pfs_mount_entry *ns) {
 	struct pfs_mount_entry *result = (struct pfs_mount_entry *) xxmalloc(sizeof(*result));
 	memset(result, 0, sizeof(*result));
 	result->refcount = 1;
-	if (ldso) result->ldso = strndup(ldso, PATH_MAX);
 	if (ns) {
 		assert(!(ns->next && ns->parent));
 		result->parent = pfs_resolve_share_ns(ns);
@@ -442,7 +416,6 @@ void pfs_resolve_drop_ns(struct pfs_mount_entry *ns) {
 	if (ns->refcount == 0) {
 		pfs_resolve_drop_ns(ns->next);
 		pfs_resolve_drop_ns(ns->parent);
-		free(ns->ldso);
 		free(ns);
 	}
 }
@@ -455,7 +428,6 @@ void pfs_resolve_seal_ns(void) {
 	struct pfs_mount_entry *m = (struct pfs_mount_entry *) xxmalloc(sizeof(*m));
 	memcpy(m, ns, sizeof(*m));
 	memset(ns, 0, sizeof(*ns));
-	if (m->ldso) ns->ldso = strndup(m->ldso, PATH_MAX);
 	ns->parent = m;
 	ns->refcount = m->refcount;
 	m->refcount = 1;

--- a/parrot/src/pfs_resolve.h
+++ b/parrot/src/pfs_resolve.h
@@ -23,16 +23,12 @@ struct pfs_mount_entry {
 	unsigned refcount;
 	char prefix[PFS_PATH_MAX];
 	char redirect[PFS_PATH_MAX];
-	char *ldso;
 	mode_t mode;
 	struct pfs_mount_entry *next;
 	struct pfs_mount_entry *parent;
 };
 
 void pfs_resolve_init(void);
-
-const char *pfs_resolve_get_ldso(void);
-void pfs_resolve_set_ldso(const char *ldso);
 
 void pfs_resolve_add_entry( const char *path, const char *device, mode_t mode );
 int pfs_resolve_remove_entry( const char *path );
@@ -41,7 +37,7 @@ int pfs_resolve_mount ( const char *path, const char *destination, const char *m
 
 pfs_resolve_t pfs_resolve( const char *logical_name, char *physical_name, mode_t mode, time_t stoptime );
 
-struct pfs_mount_entry *pfs_resolve_fork_ns( struct pfs_mount_entry *ns, const char *ldso);
+struct pfs_mount_entry *pfs_resolve_fork_ns(struct pfs_mount_entry *ns);
 struct pfs_mount_entry *pfs_resolve_share_ns(struct pfs_mount_entry *ns);
 void pfs_resolve_drop_ns(struct pfs_mount_entry *ns);
 void pfs_resolve_seal_ns(void);


### PR DESCRIPTION
This rolls back the handling of Parrot's `--ld-path` option to pre-#1492. I cut out some awkward namespace code, so that flag should work as before. I also adjusted interpreter search to work better with mounts. This should resolve #1634