### PR TITLE
Lobster fixes halt on recv

### DIFF
--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -681,8 +681,6 @@ int rmonitor_handle_inotify(void)
 {
 	int urgent = 0;
 
-	debug(D_RMON, "uno");
-
 #if defined(RESOURCE_MONITOR_USE_INOTIFY)
 	struct inotify_event *evdata;
 	struct rmonitor_file_info *finfo;
@@ -864,7 +862,7 @@ struct peak_cores_sample {
 int64_t peak_cores(int64_t wall_time, int64_t cpu_time) {
 	static struct list *samples = NULL;
 
-	int64_t max_separation = 60 + 2*interval; /* at least one minute and a complete */
+	int64_t max_separation = 60 + 2*interval; /* at least one minute and a complete interval */
 
 	if(!samples) {
 		samples = list_create();

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -1594,7 +1594,12 @@ int rmonitor_dispatch_msg(void)
 	struct rmonitor_msg msg;
 	struct rmonitor_process_info *p;
 
-	recv_monitor_msg(rmonitor_queue_fd, &msg);
+	int recv_status = recv_monitor_msg(rmonitor_queue_fd, &msg);
+
+	if(recv_status < 0 || ((unsigned int) recv_status) < sizeof(msg)) {
+		debug(D_RMON, "Malformed message from monitored processes. Ignoring.");
+		return 1;
+	}
 
 	//Next line commented: Useful for detailed debugging, but too spammy for regular operations.
 	//debug(D_RMON,"message '%s' (%d) from %d with status '%s' (%d)\n", str_msgtype(msg.type), msg.type, msg.origin, strerror(msg.error), msg.error);

--- a/resource_monitor/src/rmonitor_helper_comm.c
+++ b/resource_monitor/src/rmonitor_helper_comm.c
@@ -105,7 +105,9 @@ char *rmonitor_helper_locate(char *default_path)
 
 int recv_monitor_msg(int fd, struct rmonitor_msg *msg)
 {
-	return recv(fd, msg, sizeof(struct rmonitor_msg), 0);
+	int status = recv(fd, msg, sizeof(struct rmonitor_msg), 0);
+
+	return status;
 }
 
 int find_localhost_addr(int port, struct addrinfo **addr)
@@ -208,6 +210,9 @@ int rmonitor_client_open_socket(int *fd, struct addrinfo **addr) {
 		freeaddrinfo(res);
 		return -1;
 	}
+
+	struct timeval read_timeout = { .tv_sec = 10, .tv_usec = 0 };
+	setsockopt(*fd, SOL_SOCKET, SO_RCVTIMEO, (const void *) &read_timeout, sizeof(read_timeout));
 
 	*addr = res;
 

--- a/resource_monitor/src/rmonitor_helper_comm.c
+++ b/resource_monitor/src/rmonitor_helper_comm.c
@@ -105,8 +105,7 @@ char *rmonitor_helper_locate(char *default_path)
 
 int recv_monitor_msg(int fd, struct rmonitor_msg *msg)
 {
-	int status = recv(fd, msg, sizeof(struct rmonitor_msg), 0);
-
+	int status = recv(fd, msg, sizeof(struct rmonitor_msg), MSG_DONTWAIT);
 	return status;
 }
 


### PR DESCRIPTION
Using a combination of  singularity and the resource_monitor,  some tasks are getting stuck waiting on a recv forever. This is even after select indicates that the corresponding fd is ready for reading. 

The current pr puts a maximum recv wait time, and ignores malformed messages. 