### PR TITLE
Add line numbers in makeflow error messages

### DIFF
--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -935,11 +935,11 @@ static int makeflow_check_batch_consistency(struct dag *d)
 
 		if(itable_size(n->remote_names) > 0 || (wrapper && wrapper->uses_remote_rename)){
 			if(n->local_job) {
-				debug(D_ERROR, "Remote renaming is not supported with -Tlocal or LOCAL execution. Rule %d.\n", n->nodeid);
+				debug(D_ERROR, "Remote renaming is not supported with -Tlocal or LOCAL execution. Rule %d (line %d).\n", n->nodeid, n->linenum);
 				error = 1;
 				break;
 			} else if (!batch_queue_supports_feature(remote_queue, "remote_rename")) {
-				debug(D_ERROR, "Remote renaming is not supported on selected batch system. Rule %d.\n", n->nodeid);
+				debug(D_ERROR, "Remote renaming is not supported on selected batch system. Rule %d (line %d).\n", n->nodeid, n->linenum);
 				error = 1;
 				break;
 			}
@@ -951,7 +951,7 @@ static int makeflow_check_batch_consistency(struct dag *d)
 				if(makeflow_file_on_sharedfs(f->filename)) continue;
 				const char *remotename = dag_node_get_remote_name(n, f->filename);
 				if((remotename && *remotename == '/') || (*f->filename == '/' && !remotename)) {
-					debug(D_ERROR, "Absolute paths are not supported on selected batch system. Rule %d.\n", n->nodeid);
+					debug(D_ERROR, "Absolute paths are not supported on selected batch system. Rule %d (line %d).\n", n->nodeid, n->linenum);
 					error = 1;
 					break;
 				}
@@ -962,7 +962,7 @@ static int makeflow_check_batch_consistency(struct dag *d)
 				if(makeflow_file_on_sharedfs(f->filename)) continue;
 				const char *remotename = dag_node_get_remote_name(n, f->filename);
 				if((remotename && *remotename == '/') || (*f->filename == '/' && !remotename)) {
-					debug(D_ERROR, "Absolute paths are not supported on selected batch system. Rule %d.\n", n->nodeid);
+					debug(D_ERROR, "Absolute paths are not supported on selected batch system. Rule %d (line %d).\n", n->nodeid, n->linenum);
 					error = 1;
 					break;
 				}


### PR DESCRIPTION
For debugging errors in makeflow scripts, associating a problematic rule with its line number might not be straightforward in some cases (like long makeflow scripts with comments). This PR adds the line number to the error message.

before:
```2017/05/26 14:24:41.09 makeflow[45593] error: Absolute paths are not supported on selected batch system. Rule 244.```

after:
```2017/05/26 14:26:03.26 makeflow[46565] error: Absolute paths are not supported on selected batch system. Rule 244 (line 740).```