### PR TITLE
DON'T do remote renaming on shared fs

### DIFF
--- a/doc/makeflow.html
+++ b/doc/makeflow.html
@@ -679,7 +679,7 @@ filesystem like NFS or HDFS, and so, to be safe, it copies all necessary depende
 be used to efficiently access files without making remote copies.
 Makeflow must be told where the shared filesystem is located, so that it
 can take advantage of it.  To enable this, invoke Makeflow with the 
-<code>--shared-fs</code> option, indicating the path where the shared
+<tt>--shared-fs</tt> option, indicating the path where the shared
 filesystem is mounted.  (This option can be given multiple times.)
 Makeflow will then verify the existence of input and output files in these
 locations, but will not cause them to be transferred.
@@ -690,9 +690,15 @@ For example, if you use NFS to access the <code>/home</code> and
 <code>/software</code> directories on your cluster, then invoke makeflow like this:
 </p>
 
-<code>
-makeflow --shared-fs /home --shared-fs /software example.makeflow ...
+<code>makeflow --shared-fs /home --shared-fs /software example.makeflow
 </code>
+
+<p>
+On files that are remotely renamed,
+<tt>--shared-fs</tt> has no effect.
+If it is important to avoid transfers of large files,
+do not use remote renaming.
+</p>
 
 <a name=consistency><h3>NFS Consistency Delay</h3></a>
 

--- a/doc/makeflow.html
+++ b/doc/makeflow.html
@@ -679,7 +679,7 @@ filesystem like NFS or HDFS, and so, to be safe, it copies all necessary depende
 be used to efficiently access files without making remote copies.
 Makeflow must be told where the shared filesystem is located, so that it
 can take advantage of it.  To enable this, invoke Makeflow with the 
-<tt>--shared-fs</tt> option, indicating the path where the shared
+<code>--shared-fs</code> option, indicating the path where the shared
 filesystem is mounted.  (This option can be given multiple times.)
 Makeflow will then verify the existence of input and output files in these
 locations, but will not cause them to be transferred.
@@ -690,15 +690,9 @@ For example, if you use NFS to access the <code>/home</code> and
 <code>/software</code> directories on your cluster, then invoke makeflow like this:
 </p>
 
-<code>makeflow --shared-fs /home --shared-fs /software example.makeflow
+<code>
+makeflow --shared-fs /home --shared-fs /software example.makeflow ...
 </code>
-
-<p>
-On files that are remotely renamed,
-<tt>--shared-fs</tt> has no effect.
-If it is important to avoid transfers of large files,
-do not use remote renaming.
-</p>
 
 <a name=consistency><h3>NFS Consistency Delay</h3></a>
 

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -454,9 +454,6 @@ static char * makeflow_file_list_format( struct dag_node *node, char *file_str, 
 	list_first_item(file_list);
 	while((file=list_next_item(file_list))) {
 		if (makeflow_file_on_sharedfs(file->filename)) {
-			if (dag_node_get_remote_name(node, file->filename))
-				fatal("Remote renaming for %s is not supported on a shared filesystem",
-					file->filename);
 			debug(D_MAKEFLOW_RUN, "Skipping file %s on shared fs\n",
 				file->filename);
 			continue;
@@ -949,8 +946,13 @@ static int makeflow_check_batch_consistency(struct dag *d)
 		if(!batch_queue_supports_feature(remote_queue, "absolute_path") && !n->local_job){
 			list_first_item(n->source_files);
 			while((f = list_next_item(n->source_files)) && !error) {
-				if(makeflow_file_on_sharedfs(f->filename)) continue;
 				const char *remotename = dag_node_get_remote_name(n, f->filename);
+				if (makeflow_file_on_sharedfs(f->filename)) {
+					if (remotename)
+						fatal("Remote renaming for %s is not supported on a shared filesystem",
+							f->filename);
+					continue;
+				}
 				if((remotename && *remotename == '/') || (*f->filename == '/' && !remotename)) {
 					debug(D_ERROR, "Absolute paths are not supported on selected batch system. Rule %d (line %d).\n", n->nodeid, n->linenum);
 					error = 1;
@@ -960,8 +962,13 @@ static int makeflow_check_batch_consistency(struct dag *d)
 
 			list_first_item(n->target_files);
 			while((f = list_next_item(n->target_files)) && !error) {
-				if(makeflow_file_on_sharedfs(f->filename)) continue;
 				const char *remotename = dag_node_get_remote_name(n, f->filename);
+				if (makeflow_file_on_sharedfs(f->filename)) {
+					if (remotename)
+						fatal("Remote renaming for %s is not supported on a shared filesystem",
+							f->filename);
+					continue;
+				}
 				if((remotename && *remotename == '/') || (*f->filename == '/' && !remotename)) {
 					debug(D_ERROR, "Absolute paths are not supported on selected batch system. Rule %d (line %d).\n", n->nodeid, n->linenum);
 					error = 1;

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -453,8 +453,12 @@ static char * makeflow_file_list_format( struct dag_node *node, char *file_str, 
 
 	list_first_item(file_list);
 	while((file=list_next_item(file_list))) {
-		if (!dag_node_get_remote_name(node, file->filename) && makeflow_file_on_sharedfs(file->filename)) {
-			debug(D_MAKEFLOW_RUN, "Skipping file %s on shared fs\n", file->filename);
+		if (makeflow_file_on_sharedfs(file->filename)) {
+			if (dag_node_get_remote_name(node, file->filename))
+				fatal("Remote renaming for %s is not supported on a shared filesystem",
+					file->filename);
+			debug(D_MAKEFLOW_RUN, "Skipping file %s on shared fs\n",
+				file->filename);
 			continue;
 		}
 		char *f = makeflow_file_format(node,file,queue);

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -453,7 +453,7 @@ static char * makeflow_file_list_format( struct dag_node *node, char *file_str, 
 
 	list_first_item(file_list);
 	while((file=list_next_item(file_list))) {
-		if (makeflow_file_on_sharedfs(file->filename)) {
+		if (!dag_node_get_remote_name(node, file->filename) && makeflow_file_on_sharedfs(file->filename)) {
 			debug(D_MAKEFLOW_RUN, "Skipping file %s on shared fs\n", file->filename);
 			continue;
 		}


### PR DESCRIPTION
When using Makeflow with `--shared-fs`, also check if the file is remotely renamed. If so, pass it to the batch system anyway. This could lead to poor performance if used on large files.

resolves #1680 