### PR TITLE
JX syntax

### DIFF
--- a/doc/jx.html
+++ b/doc/jx.html
@@ -214,10 +214,8 @@ Division by zero is an error.</p>
 <h3 id="conjunction">Conjunction<a class="sectionlink" href="#conjunction" title="Link to this section.">&#x21d7;</a></h3>
 
 <blockquote>
-<pre><code>A and A -&gt; A
+<pre><code>Boolean and Boolean -&gt; Boolean
 </code></pre>
-
-<p>where A = Boolean|Integer</p>
 </blockquote>
 
 <p>Computes the logical conjunction of its operands.</p>
@@ -227,8 +225,6 @@ Division by zero is an error.</p>
 <blockquote>
 <pre><code>Boolean or Boolean -&gt; Boolean
 </code></pre>
-
-<p>where A = Boolean|Integer</p>
 </blockquote>
 
 <p>Computes the logical disjunction of its operands.</p>

--- a/doc/jx.html
+++ b/doc/jx.html
@@ -19,11 +19,25 @@
 <div id="manual">
 <h1 id="jx">JX (JSON + Expressions)<a class="sectionlink" href="#jx" title="Link to this section.">&#x21d7;</a></h1>
 
-<p style="text-align: right;"><b>Last edited: 14 June 2016</b></p>
+<p style="text-align: right;"><b>Last edited: 5 July 2017</b></p>
 
-<p>JX is a superset of JSON with additional syntax for dynamically generating data. The use case in mind when designing JX was writing job descriptions for a workflow manager accepting JSON input. For workflows with a large number of rules with similar structure, it is sometimes necessary to write a script in another language like Python to generate the JSON output. It would be desirable to have a special-purpose language that can dynamically generate rules while still bearing a resemblance to JSON, and more importantly, still being readable. JX is much lighter than a full-featured language like Python or JavaScript, and is suited to embedding in other systems like a workflow manager.</p>
+<p>
+JX is a superset of JSON with additional syntax for dynamically generating data.
+The use case in mind when designing JX was writing job descriptions for a workflow manager accepting JSON input.
+For workflows with a large number of rules with similar structure,
+it is sometimes necessary to write a script in another language like Python to generate the JSON output.
+It would be desirable to have a special-purpose language that can dynamically generate rules while still bearing a resemblance to JSON,
+and more importantly, still being readable.
+JX is much lighter than a full-featured language like Python or JavaScript,
+and is suited to embedding in other systems like a workflow manager.
+</p>
 
-<p>Standard JSON syntax is supported, with two important additions: operators and functions. Operators include the usual arithmetic, comparison, and logical operators (e.g. +, &lt;=, &amp;&amp;) and are useful for simple computations. Note that JX is less forgiving than JavaScript with respect to type; values will <em>not</em> be coerced. JX syntax is styled after JavaScript, but does not strictly adhere to JS. While JX can often be interpreted as valid JS, the result is not necessarily the same between the two. This is especially apparent with the type coercions that JS performs. For all operators and functions, invalid invocation (wrong number of arguments, wrong arguments types, etc.) will return an error. The main exception is that integers will be promoted to doubles as needed. Thus JX is a superset of JSON, and (with care) mostly a subset of JS.</p>
+<p>
+Standard JSON syntax is supported, with some additions from Python.
+JX allows for expressions using Python's basic operators.
+These include the usual arithmetic, comparison, and logical operators (e.g. <tt>+</tt>, <tt>&lt;=</tt>, <tt>and</tt>, etc.).
+JX also includes Python's <tt>range()</tt> function for generating sequences of numbers.
+</p>
 
 <pre><code>"123" + 4
 =&gt; Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","operator":"123"+4,"code":2}
@@ -35,45 +49,18 @@
 =&gt; 127
 </code></pre>
 
-<p>JX supports the same basic types as JSON</p>
-
-<ul>
-<li>Null</li>
-<li>Boolean</li>
-<li>Integer</li>
-<li>Double</li>
-<li>String</li>
-<li>Object</li>
-<li>Array</li>
-</ul>
-
-<p>Note that unlike JSON, JX makes a distinction between integer and floating point values. Unevaluated JX may also contain</p>
-
-<ul>
-<li>Symbol</li>
-<li>Function</li>
-<li>Operator</li>
-<li>Error</li>
-</ul>
-
-<p>but evaluation will produce the plain JSON types above, assuming the evaluation succeeded. If an error occurs, evaluation stops and an error is returned to the caller. Error objects can include additional information indicating where the failure occurred and what the cause was. Details on the syntax and usage of Errors is given in a following section. If a non-error type is returned, then evaluation succeeded and the result contains only plain JSON types. JX expressions are evaluated in a <em>context</em>, which is an object mapping names to arbitrary JX values. On evaluating a symbol, the symbol's name is looked up in the current context. If found, the value from the context is substituted in place of the symbol. If the symbol is not found in the context, an error is returned.</p>
-
-<p>Functions allow for more advanced manipulations on the data. The details of required arguments, return type, side effects, etc. vary, but in general,</p>
-
-<ul>
-<li>functions are designed for generating/expanding data. This means no I/O access on the host, and (mostly) no side effects.</li>
-<li>the set of built in functions is fairly minimal.</li>
-<li>functions are strict about the types of their arguments, as are operators.</li>
-<li>evaluating a JX expression must have a finite time bound. This means no while loops and no lambda.</li>
-</ul>
-
-<p>In this example, foreach, range, and str are used to generate a list of filenames.</p>
-
-<pre><code>foreach(x, range(4), "input" + str(x) + ".dat")
-=&gt; ["input0.dat", "input1.dat", "input2.dat", "input3.dat"]
-</code></pre>
-
-<p>Functions may be nested or composed as needed, and will produce plain JSON when evaluated. Functions do not need to be given at the top level, and may be used to generate object keys, array elements, operands to JX operators, etc. The following sections give detailed descriptions of the currently supported operators and functions. </p>
+Evaluation will produce plain JSON types from JX,
+assuming the evaluation succeeded.
+If an error occurs, evaluation stops and an error is returned to the caller.
+Error objects can include additional information indicating where the failure occurred and what the cause was.
+Details on the syntax and usage of Errors is given in a following section.
+If a non-error type is returned, then evaluation succeeded and the result contains only plain JSON types.
+JX expressions are evaluated in a <em>context</em>,
+which is an object mapping names to arbitrary JX values.
+On evaluating a variable, the variable's name is looked up in the current context.
+If found, the value from the context is substituted in place of the variable.
+If the variable is not found in the context, an error is returned.
+</p>
 
 <p>JX supports comments, introduced by the <tt>&#35;</tt> character and continuing for the rest of the line.</p>
 
@@ -82,7 +69,7 @@
 <h3 id="complement">Logical Complement<a class="sectionlink" href="#complement" title="Link to this section.">&#x21d7;</a></h3>
 
 <blockquote>
-<pre><code>!Boolean -&gt; Boolean
+<pre><code>not Boolean -&gt; Boolean
 </code></pre>
 </blockquote>
 
@@ -112,15 +99,20 @@
 
 <h2 id="binary">Binary Operators<a class="sectionlink" href="#binary" title="Link to this section.">&#x21d7;</a></h2>
 
-<p>For complicated expressions, parentheses may be used as grouping symbols. In the absence of parentheses, operators are evaluated left to right in order of precedence. From highest to lowest precedence,</p>
+<p>
+For complicated expressions, parentheses may be used as grouping symbols.
+JX does not allow tuples.
+In the absence of parentheses,
+operators are evaluated left to right in order of precedence. From highest to lowest precedence,</p>
 
 <ul>
-<li>lookup</li>
-<li>*, %, /</li>
-<li>+, -</li>
-<li>==, !=, &lt;, &lt;=, &gt;, &gt;=</li>
-<li>||</li>
-<li>&amp;&amp;</li>
+<li>lookup, function call</li>
+<li><tt>*</tt>, <tt>%</tt>, <tt>/</tt></li>
+<li><tt>+</tt>, <tt>-</tt></li>
+<li><tt>==</tt>, <tt>!=</tt>, <tt>&lt;</tt>, <tt>&lt;=</tt>, <tt>&gt;</tt>, <tt>&gt;=</tt></li>
+<li><tt>not</tt></li>
+<li><tt>and</tt></li>
+<li><tt>or</tt></li>
 </ul>
 
 <h3 id="lookup">Lookup<a class="sectionlink" href="#lookup" title="Link to this section.">&#x21d7;</a></h3>
@@ -132,7 +124,30 @@
 <p>where A,B = Array,Integer or A,B = Object,String</p>
 </blockquote>
 
-<p>Gets the item at the given index/key in a collection type. If the key/index is not present, returns null.</p>
+<p>
+Gets the item at the given index/key in a collection type.
+A negative index into an array is taken as the offset from the tail end.
+</p>
+
+<p>
+Arrays also support slicing, with the index is given as <tt>N:M</tt>
+where <tt>N</tt> and <tt>M</tt> are optional values that evaluate to integers.
+If either is absent, the beginning/end of the array is used.
+This slice syntax is based on Python's.
+
+<pre><code>range(10)
+= [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+range(10)[:3]
+= [0, 1, 2]
+
+range(10)[4:]
+= [4, 5, 6, 7, 8, 9]
+
+range(10)[3:7]
+= [3, 4, 5, 6]
+</code></pre>
+</p>
 
 <h3 id="addition">Addition<a class="sectionlink" href="#addition" title="Link to this section.">&#x21d7;</a></h3>
 
@@ -199,34 +214,24 @@ Division by zero is an error.</p>
 <h3 id="conjunction">Conjunction<a class="sectionlink" href="#conjunction" title="Link to this section.">&#x21d7;</a></h3>
 
 <blockquote>
-<pre><code>A &amp;&amp; A -&gt; A
+<pre><code>A and A -&gt; A
 </code></pre>
 
 <p>where A = Boolean|Integer</p>
 </blockquote>
 
-<p>The behaviour of the conjunction operator depends on the type of its operands.</p>
-
-<ul>
-<li>Boolean: logical AND</li>
-<li>Integer: bitwise AND</li>
-</ul>
+<p>Computes the logical conjunction of its operands.</p>
 
 <h3 id="disjunction">Disjunction<a class="sectionlink" href="#disjunction" title="Link to this section.">&#x21d7;</a></h3>
 
 <blockquote>
-<pre><code>Boolean || Boolean -&gt; Boolean
+<pre><code>Boolean or Boolean -&gt; Boolean
 </code></pre>
 
 <p>where A = Boolean|Integer</p>
 </blockquote>
 
-<p>The behaviour of the disjunction operator depends on the type of its operands.</p>
-
-<ul>
-<li>Boolean: logical OR</li>
-<li>Integer: bitwise OR</li>
-</ul>
+<p>Computes the logical disjunction of its operands.</p>
 
 <h3 id="equality">Equality<a class="sectionlink" href="#equality" title="Link to this section.">&#x21d7;</a></h3>
 
@@ -316,17 +321,6 @@ Division by zero is an error.</p>
 
 <h2 id="functions">Functions<a class="sectionlink" href="#functions" title="Link to this section.">&#x21d7;</a></h2>
 
-<h3>str</h3>
-
-<blockquote>
-<pre><code>str(A) -&gt; String
-</code></pre>
-</blockquote>
-
-<p>Returns a string representation of the given value.</p>
-
-<h3 id="range">range<a class="sectionlink" href="#range" title="Link to this section.">&#x21d7;</a></h3>
-
 <blockquote>
 <pre><code>range(A) -&gt; Array
 range(A, A[, A]) -&gt; Array
@@ -367,100 +361,92 @@ range(5,0,-1)
 
 <p>Calling with step = 0 is an error.</p>
 
-<h3 id="foreach">foreach<a class="sectionlink" href="#foreach" title="Link to this section.">&#x21d7;</a></h3>
-
 <blockquote>
-<pre><code>foreach(Symbol, A, B) -&gt; C
+<pre><code>format(A, ...) -&gt; String
 </code></pre>
 
-<p>where and A = [_] and C = [B]</p>
+<p>where A = String</p>
 </blockquote>
 
-<p>foreach provides similar functionality to the map function in other languages, but has reduced semantics to limit recursion. foreach requires three arguments.</p>
-
-<pre><code>foreach(var, items, body)
-</code></pre>
-
+<p>
+Replaces format specifiers in the given string.
+This function is based on C's <tt>printf</tt> function and provides the following format specifiers.
 <ul>
-<li>var: a Symbol to be used as the iteration variable</li>
-<li>items: an Array</li>
-<li>body: an arbitrary expression, probably containing var</li>
+	<li><tt>&#37;d</tt></li>
+	<li><tt>&#37;i</tt></li>
+	<li><tt>&#37;e</tt></li>
+	<li><tt>&#37;E</tt></li>
+	<li><tt>&#37;f</tt></li>
+	<li><tt>&#37;F</tt></li>
+	<li><tt>&#37;g</tt></li>
+	<li><tt>&#37;G</tt></li>
+	<li><tt>&#37;s</tt></li>
+	<li><tt>&#37;&#37;</tt></li>
 </ul>
+</p>
 
-<p>Evaluating foreach results in an Array of the same length as items, or null on invalid arguments. We bind var to each value in items in turn, and evaluate body with this extra binding.</p>
+<pre><code>format("file%d.txt", 10)
+= "file10.txt"
 
-<pre><code>foreach(x, range(4), x * 2)
-=&gt; [0, 2, 4, 6]
-
-foreach(x, [-1, 2.2, "foo"], str(x))
-=&gt; ["-1", "2.2", "foo"]
+format("SM%s_%d.sam", "10001", 23)
+= "SM10001_23.sam"
 </code></pre>
 
-<h3 id="join">join<a class="sectionlink" href="#join" title="Link to this section.">&#x21d7;</a></h3>
+<p>
+This function serves the same purpose as Python's format operator (&#37;).
+Since JX does not include tuples,
+it provides a function to allow formatting with multiple fields.
+JX's format function could be written in Python as follows.
 
-<blockquote>
-<pre><code>join(A[, B]) -&gt; String
+<pre><code>def format(spec, *args):
+    return spec % tuple(args)
+</code></pre>
+</p>
+
+<h2 id="comprehensions">Comprehensions<a class="sectionlink" href="#comprehensions" title="Link to this section.">&#x21d7;</a></h2>
+
+<p>
+JX supports list comprehensions for expressing repeated structure.
+An entry in a list can be postfixed with one or more <tt>for</tt> clauses to evaluate the list item once for each entry in the specified list.
+A <tt>for</tt> clause consists of a variable and a list, along with an optional condition.
+
+<pre><code>[x + x for x in ["a", "b", "c"]]
+= ["aa", "bb", "cc"]
+
+[3 * i for i in range(4)]
+= [0, 3, 6, 9]
+
+[i for i in range(10) if i%2 == 0]
+= [0, 2, 4, 6, 8]
 </code></pre>
 
-<p>where A = [String] and B = String</p>
-</blockquote>
+If multiple clauses are specified,
+they are evaluated from left to right.
 
-<p>Takes an array of strings, and concatenates them into a single string. If the optional second argument is given, it is used as the separator, or " " otherwise.</p>
-
-<pre><code>join(["1", "2", "3"])
-=&gt; "1 2 3"
-
-join(["a", "b", "c"], ", ")
-=&gt; "a, b, c"
+<pre><code>[[i, j] for i in range(5) for j in range(4) if (i + j)%2 == 0]
+= [[0, 0], [0, 2], [1, 1], [2, 0], [2, 2], [3, 1]]
 </code></pre>
-
-<h3 id="let">let<a class="sectionlink" href="#let" title="Link to this section.">&#x21d7;</a></h3>
-
-<blockquote>
-<pre><code>let(A, B) -&gt; C
-</code></pre>
-
-<p>where A = Object</p>
-</blockquote>
-
-<p>Evaluates an expression with local name bindings. The first argument is an object whose keys will be bound variable names when evaluating the second argument.
-Names specified in a local scope may shadow names in the enclosing scope.</p>
-
-<pre><code>let({"x": 10}, 1 + x)
-=&gt; 11
-
-let({"x": 10, "y": 20}, let({"x": 1}, x + y))
-=&gt; 21
-</code></pre>
-
-<h3 id="dbg">dbg<a class="sectionlink" href="#dbg" title="Link to this section.">&#x21d7;</a></h3>
-
-<blockquote>
-<pre><code>dbg(A) -&gt; A
-</code></pre>
-</blockquote>
-
-<p>This function simply returns its argument. As a side effect, it prints its argument before and after evaluation to stderr. This function might be useful to debug evaluation issues, as it lets you see the evaluation of arbitrary parts of an expression.</p>
-
-<pre><code>join(foreach(x, range(5), x))
-=&gt; Error{"source":"jx_eval","name":"invalid arguments","message":"joined items must be strings","func":join(foreach(x,range(5),x)),"code":6}
-
-join(dbg(foreach(x, range(5), x)))
-+ dbg  in: foreach(x,range(5),x)
-+ dbg out: [0,1,2,3,4]
-</code></pre>
-
-<p>Recalling that join takes an array of Strings, not Integers, we should use</p>
-
-<pre><code>join(dbg(foreach(x, range(5), str(x))))
-+ dbg  in: foreach(x,range(5),str(x))
-+ dbg out: ["0","1","2","3","4"]
-=&gt; "0 1 2 3 4"
-</code></pre>
+</p>
 
 <h2 id="errors">Errors<a class="sectionlink" href="#errors" title="Link to this section.">&#x21d7;</a></h2>
 
-<p>JX has a special type, Error, to indicate some kind of failure or exceptional condition. If a function or operator is misapplied, jx_eval will return an error indicating the cause of the failure. While errors are valid JX, they are special in that they have no JSON equivalent. Furthermore, errors do not evaluate in the same way as other types. The additional information in an error is protected from evaluation, so calling jx_eval on an Error simply returns a copy. It is therefore safe to directly include the invalid function/operator in the body of an error. If a function or operator encounters an error as an argument, evaluation is aborted and the Error is returned as the result of evaluation. Thus if an error occurs deeply nested within a structure, the error will be passed up as the result of the entire evaluation. Errors are defined using the keyword Error followed by a body enclosed in curly braces.</p>
+<p>
+JX has a special type, Error, to indicate some kind of failure or exceptional condition.
+If a function or operator is misapplied,
+jx_eval will return an error indicating the cause of the failure.
+Errors are akin to Python's exceptions,
+but JX does not allow Errors to be caught;
+they simply terminate evaluation and report what happened.
+Errors do not evaluate in the same way as other types.
+The additional information in an error is protected from evaluation,
+so calling jx_eval on an Error simply returns a copy.
+It is therefore safe to directly include the invalid function/operator in the body of an error.
+If a function or operator encounters an error as an argument,
+evaluation is aborted and the Error is returned as the result of evaluation.
+Thus if an error occurs deeply nested within a structure,
+the error will be passed up as the result of the entire evaluation.
+Errors are defined using the keyword Error followed by a body enclosed in curly braces.
+</p>
 
 <pre><code>Error{"source":"jx_eval","name":"undefined symbol","message":"undefined symbol","context":{"outfile":"results","infile":"mydata","a":true,"b":false,"f":0.5,"g":3.14159,"x":10,"y":20,"list":[100,200,300],"object":{"house":"home"}},"symbol":c,"code":0}
 </code></pre>

--- a/dttools/src/.gitignore
+++ b/dttools/src/.gitignore
@@ -3,6 +3,7 @@ batch_submit_workers
 catalog_query
 catalog_server
 catalog_update
+category_test
 chunk_test
 disk_alloc_test
 disk_allocator

--- a/dttools/src/.gitignore
+++ b/dttools/src/.gitignore
@@ -11,6 +11,7 @@ hmac_test
 histogram_test
 int_sizes.h
 jx_test
+jx2json
 libdttools.a
 make_int_sizes
 microbench

--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -68,6 +68,7 @@ SOURCES = \
 	jx_table.c \
 	jx_export.c \
 	jx_eval.c \
+	jx_function.c \
 	link.c \
 	link_auth.c \
 	list.c \

--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -59,6 +59,7 @@ SOURCES = \
 	itable.c \
 	json.c \
 	json_aux.c \
+	jx2json.c \
 	jx.c \
 	jx_database.c \
 	jx_match.c \
@@ -140,7 +141,7 @@ PRELOAD_LIBRARIES = libforce_halt_enospc.so
 OBJECTS = $(SOURCES:%.c=%.o)
 
 #separate, because catalog_query has a slightly different order of linking.
-MOST_PROGRAMS = catalog_update catalog_server watchdog disk_allocator
+MOST_PROGRAMS = catalog_update catalog_server watchdog disk_allocator jx2json
 PROGRAMS = $(MOST_PROGRAMS) catalog_query
 
 SCRIPTS = cctools_gpu_autodetect cctools_python

--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -61,7 +61,6 @@ SOURCES = \
 	json_aux.c \
 	jx.c \
 	jx_database.c \
-	jx_function.c \
 	jx_match.c \
 	jx_parse.c \
 	jx_print.c \

--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -529,6 +529,7 @@ struct jx  *jx_copy( struct jx *j )
 			c = jx_function(j->u.func.name,
 				jx_item_copy(j->u.func.params),
 				jx_copy(j->u.func.body));
+			c->u.func.builtin = j->u.func.builtin;
 			break;
 		case JX_ERROR:
 			c = jx_error(jx_copy(j->u.err));

--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -130,13 +130,14 @@ struct jx * jx_error( struct jx *err )
 	return j;
 }
 
-struct jx *jx_function(
-	const char *name, struct jx_item *params, struct jx *body) {
+struct jx *jx_function(const char *name, jx_builtin_t op,
+	struct jx_item *params, struct jx *body) {
 	assert(name);
 	struct jx *j = jx_create(JX_FUNCTION);
 	j->u.func.name = strdup(name);
 	j->u.func.params = params;
 	j->u.func.body = body;
+	j->u.func.builtin = op;
 	return j;
 }
 
@@ -526,10 +527,9 @@ struct jx  *jx_copy( struct jx *j )
 			c = jx_operator(j->u.oper.type, jx_copy(j->u.oper.left), jx_copy(j->u.oper.right));
 			break;
 		case JX_FUNCTION:
-			c = jx_function(j->u.func.name,
+			c = jx_function(j->u.func.name, j->u.func.builtin,
 				jx_item_copy(j->u.func.params),
 				jx_copy(j->u.func.body));
-			c->u.func.builtin = j->u.func.builtin;
 			break;
 		case JX_ERROR:
 			c = jx_error(jx_copy(j->u.err));

--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -121,13 +121,6 @@ struct jx * jx_operator( jx_operator_t type, struct jx *left, struct jx *right )
 	return j;
 }
 
-struct jx *jx_function( jx_function_t func, struct jx *args ) {
-	struct jx * j = jx_create(JX_FUNCTION);
-	j->u.func.function = func;
-	j->u.func.arguments = args;
-	return j;
-}
-
 struct jx * jx_error( struct jx *err )
 {
 	if(!jx_error_valid(err)) return NULL;
@@ -378,9 +371,6 @@ void jx_delete( struct jx *j )
 			jx_delete(j->u.oper.left);
 			jx_delete(j->u.oper.right);
 			break;
-		case JX_FUNCTION:
-			jx_delete(j->u.func.arguments);
-			break;
 		case JX_ERROR:
 			jx_delete(j->u.err);
 			break;
@@ -439,9 +429,6 @@ int jx_equals( struct jx *j, struct jx *k )
 			return j->u.oper.type == k->u.oper.type
 				&& jx_equals(j->u.oper.left,k->u.oper.right)
 				&& jx_equals(j->u.oper.right,j->u.oper.right);
-		case JX_FUNCTION:
-			return j->u.func.function == k->u.func.function
-				&& jx_equals(j->u.func.arguments, k->u.func.arguments);
 		case JX_ERROR:
 			return jx_equals(j->u.err, k->u.err);
 	}
@@ -504,9 +491,6 @@ struct jx  *jx_copy( struct jx *j )
 		case JX_OPERATOR:
 			c = jx_operator(j->u.oper.type, jx_copy(j->u.oper.left), jx_copy(j->u.oper.right));
 			break;
-		case JX_FUNCTION:
-			c = jx_function(j->u.func.function, jx_copy(j->u.func.arguments));
-			break;
 		case JX_ERROR:
 			c = jx_error(jx_copy(j->u.err));
 			break;
@@ -560,7 +544,6 @@ int jx_is_constant( struct jx *j )
 			return jx_item_is_constant(j->u.items);
 		case JX_OBJECT:
 			return jx_pair_is_constant(j->u.pairs);
-		case JX_FUNCTION:
 		case JX_ERROR:
 		case JX_OPERATOR:
 			return 0;

--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -133,8 +133,6 @@ struct jx * jx_error( struct jx *err )
 struct jx *jx_function(
 	const char *name, struct jx_item *params, struct jx *body) {
 	assert(name);
-	assert(params);
-	assert(body);
 	struct jx *j = jx_create(JX_FUNCTION);
 	j->u.func.name = strdup(name);
 	j->u.func.params = params;

--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -317,6 +317,7 @@ void jx_array_append( struct jx *array, struct jx *value )
 struct jx * jx_array_index( struct jx *j, int nth )
 {
 	if (!jx_istype(j, JX_ARRAY)) return NULL;
+	if (nth < 0) return NULL;
 	struct jx_item *item = j->u.items;
 
 	for(int i = 0; i < nth; i++) {

--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -339,6 +339,19 @@ struct jx *jx_array_concat( struct jx *array, ...) {
 	return result;
 }
 
+struct jx *jx_array_shift(struct jx *array) {
+	if (!jx_istype(array, JX_ARRAY)) return NULL;
+	struct jx_item *i = array->u.items;
+	struct jx *result = NULL;
+	if (i) {
+		result = i->value;
+		array->u.items = i->next;
+		free(i);
+	}
+	return result;
+
+}
+
 void jx_pair_delete( struct jx_pair *pair )
 {
 	if(!pair) return;

--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -368,6 +368,7 @@ void jx_item_delete( struct jx_item *item )
 	jx_delete(item->value);
 	free(item->variable);
 	jx_delete(item->list);
+	jx_delete(item->condition);
 	jx_item_delete(item->next);
 	free(item);
 }
@@ -433,10 +434,11 @@ int jx_item_equals( struct jx_item *j, struct jx_item *k )
 	if(!j || !k) return 0;
 	if (j->variable && !k->variable) return 0;
 	if (!j->variable && k->variable) return 0;
-	if (j->variable && strcmp(j->variable, k->variable)) return 0;
-	if (!jx_equals(j->list, k->list)) return 0;
-	if (!jx_equals(j->value, k->value)) return 0;
-	return jx_item_equals(j->next, k->next);
+	return !(j->variable && strcmp(j->variable, k->variable))
+		&& jx_equals(j->list, k->list)
+		&& jx_equals(j->condition, k->condition)
+		&& jx_equals(j->value, k->value)
+		&& jx_item_equals(j->next, k->next);
 }
 
 int jx_equals( struct jx *j, struct jx *k )
@@ -497,6 +499,7 @@ struct jx_item * jx_item_copy( struct jx_item *i )
 	item->value = jx_copy(i->value);
 	if (i->variable) item->variable = strdup(i->variable);
 	item->list = jx_copy(i->list);
+	item->condition = jx_copy(i->condition);
 	item->next = jx_item_copy(i->next);
 	item->line = i->line;
 	return item;
@@ -574,7 +577,7 @@ int jx_pair_is_constant( struct jx_pair *p )
 int jx_item_is_constant( struct jx_item *i )
 {
 	if(!i) return 1;
-	if (i->variable || i->list) return 0;
+	if (i->variable || i->list || i->condition) return 0;
 	return jx_is_constant(i->value) && jx_item_is_constant(i->next);
 }
 

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -100,11 +100,16 @@ struct jx_operator {
 	struct jx *right;
 };
 
+typedef enum {
+	JX_BUILTIN_RANGE,
+} jx_builtin_t;
+
 struct jx_function {
 	char *name;
 	unsigned line;
 	struct jx_item *params;
 	struct jx *body;
+	jx_builtin_t builtin;
 };
 
 /** JX value representing any expression type. */

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -41,16 +41,17 @@ Will create the following output:
 
 /** JX atomic type.  */
 typedef enum {
-	JX_NULL = 0,	/**< null value */
-	JX_BOOLEAN,	/**< true or false */
-	JX_INTEGER,	/**< integer value */
-	JX_DOUBLE,	/**< floating point value */
-	JX_STRING,	/**< string value */
-	JX_SYMBOL,	/**< variable identifier */
-	JX_ARRAY,	/**< array containing values */
-	JX_OBJECT,	/**< object containing key-value pairs */
-	JX_OPERATOR,	/**< operator on multiple values. */
-	JX_ERROR,	/**< indicates failed evaluation */
+	JX_NULL = 0, /**< null value */
+	JX_BOOLEAN,  /**< true or false */
+	JX_INTEGER,  /**< integer value */
+	JX_DOUBLE,   /**< floating point value */
+	JX_STRING,   /**< string value */
+	JX_SYMBOL,   /**< variable identifier */
+	JX_ARRAY,    /**< array containing values */
+	JX_OBJECT,   /**< object containing key-value pairs */
+	JX_OPERATOR, /**< operator on multiple values. */
+	JX_FUNCTION, /**< function definition */
+	JX_ERROR,    /**< indicates failed evaluation */
 } jx_type_t;
 
 typedef int64_t jx_int_t;
@@ -99,6 +100,13 @@ struct jx_operator {
 	struct jx *right;
 };
 
+struct jx_function {
+	char *name;
+	unsigned line;
+	struct jx_item *params;
+	struct jx *body;
+};
+
 /** JX value representing any expression type. */
 
 struct jx {
@@ -113,6 +121,7 @@ struct jx {
 		struct jx_item *items;  /**< value of @ref JX_ARRAY */
 		struct jx_pair *pairs;  /**< value of @ref JX_OBJECT */
 		struct jx_operator oper; /**< value of @ref JX_OPERATOR */
+		struct jx_function func; /**< value of @ref JX_FUNCTION */
 		struct jx *err;  /**< error value of @ref JX_ERROR */
 	} u;
 };
@@ -141,6 +150,12 @@ struct jx * jx_symbol( const char *symbol_name );
 
 /** Create a JX_ERROR. @param err The associated data for the error. This object MUST have a string at the "source" key. @return A JX error value, or NULL if "source" is missing. */
 struct jx * jx_error( struct jx *err );
+
+/** Create a JX_FUNCTION. @param params The list of JX_STRING parameter names.
+ * @param body The function body to evaluate. @returns A JX function definition.
+ */
+struct jx *jx_function(
+	const char *name, struct jx_item *params, struct jx *body);
 
 /** Create a JX array.  @param items A linked list of @ref jx_item values.  @return A JX array. */
 struct jx * jx_array( struct jx_item *items );

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -58,8 +58,10 @@ typedef int64_t jx_int_t;
 /** JX item linked-list used by @ref JX_ARRAY and @ref jx.items */
 
 struct jx_item {
-	struct jx      *value;	/**< value of this item */
 	unsigned line;
+	struct jx *value;       /**< value of this item */
+	char *variable;		/**< variable for list comprehension */
+	struct jx *list;	/**< items for list comprehension */
 	struct jx_item *next;	/**< pointer to next item */
 };
 

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -98,6 +98,7 @@ typedef enum {
 	JX_OP_NOT,
 	JX_OP_LOOKUP,
 	JX_OP_CALL,
+	JX_OP_SLICE,
 	JX_OP_INVALID,
 } jx_operator_t;
 

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -50,7 +50,6 @@ typedef enum {
 	JX_ARRAY,	/**< array containing values */
 	JX_OBJECT,	/**< object containing key-value pairs */
 	JX_OPERATOR,	/**< operator on multiple values. */
-	JX_FUNCTION,	/**< function to be applied to some values */
 	JX_ERROR,	/**< indicates failed evaluation */
 } jx_type_t;
 
@@ -89,6 +88,7 @@ typedef enum {
 	JX_OP_OR,
 	JX_OP_NOT,
 	JX_OP_LOOKUP,
+	JX_OP_CALL,
 	JX_OP_INVALID,
 } jx_operator_t;
 
@@ -97,22 +97,6 @@ struct jx_operator {
 	unsigned line;
 	struct jx *left;
 	struct jx *right;
-};
-
-typedef enum {
-	JX_FUNCTION_INVALID = 0,
-	JX_FUNCTION_DBG,
-	JX_FUNCTION_RANGE,
-	JX_FUNCTION_STR,
-	JX_FUNCTION_FOREACH,
-	JX_FUNCTION_JOIN,
-	JX_FUNCTION_LET,
-} jx_function_t;
-
-struct jx_function {
-	jx_function_t function;
-	unsigned line;
-	struct jx *arguments;
 };
 
 /** JX value representing any expression type. */
@@ -129,7 +113,6 @@ struct jx {
 		struct jx_item *items;  /**< value of @ref JX_ARRAY */
 		struct jx_pair *pairs;  /**< value of @ref JX_OBJECT */
 		struct jx_operator oper; /**< value of @ref JX_OPERATOR */
-		struct jx_function func; /**< function of @ref JX_FUNCTION */
 		struct jx *err;  /**< error value of @ref JX_ERROR */
 	} u;
 };
@@ -151,9 +134,6 @@ struct jx * jx_string( const char *string_value );
 
 /** Create a JX string value using prinf style formatting.  @param fmt A printf-style format string, followed by matching arguments.  @return A JX string value. */
 struct jx * jx_format( const char *fmt, ... );
-
-/** Create a JX function on the given arguments. @param func The function to be applied. @param args The function arguments. */
-struct jx *jx_function( jx_function_t func, struct jx *args );
 
 /** Create a JX symbol. Note that symbols are an extension to the JSON standard. A symbol is a reference to an external variable, which can be resolved by using @ref jx_eval. @param symbol_name A C string. @return A JX expression.
 */

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -62,6 +62,7 @@ struct jx_item {
 	struct jx *value;       /**< value of this item */
 	char *variable;		/**< variable for list comprehension */
 	struct jx *list;	/**< items for list comprehension */
+	struct jx *condition;   /**< condition for filtering list comprehension */
 	struct jx_item *next;	/**< pointer to next item */
 };
 

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -101,6 +101,7 @@ struct jx_operator {
 
 typedef enum {
 	JX_BUILTIN_RANGE,
+	JX_BUILTIN_FORMAT,
 } jx_builtin_t;
 
 struct jx_function {

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -55,14 +55,20 @@ typedef enum {
 
 typedef int64_t jx_int_t;
 
+struct jx_comprehension {
+	unsigned line;
+	char *variable; /**< variable for comprehension */
+	struct jx *elements; /**< items for list comprehension */
+	struct jx *condition; /**< condition for filtering list comprehension */
+	struct jx_comprehension *next;
+};
+
 /** JX item linked-list used by @ref JX_ARRAY and @ref jx.items */
 
 struct jx_item {
 	unsigned line;
 	struct jx *value;       /**< value of this item */
-	char *variable;		/**< variable for list comprehension */
-	struct jx *list;	/**< items for list comprehension */
-	struct jx *condition;   /**< condition for filtering list comprehension */
+	struct jx_comprehension *comp;
 	struct jx_item *next;	/**< pointer to next item */
 };
 
@@ -184,11 +190,24 @@ struct jx_pair * jx_pair( struct jx *key, struct jx *value, struct jx_pair *next
 /** Create a JX array item.  @param value The value of this item.  @param next The next item in the linked list.  @return An array item. */
 struct jx_item * jx_item( struct jx *value, struct jx_item *next );
 
+/** Create a JX comprehension.
+ * @param variable The variable name to bind.
+ * @param elements The elements to bind.
+ * @param condition The boolean filter to evaluate.
+ * @param next Nested comprehension(s).
+ * @returns A JX comprehension.
+ */
+struct jx_comprehension *jx_comprehension(const char *variable, struct jx *elements, struct jx *condition, struct jx_comprehension *next);
+
 /** Test an expression's type.  @param j An expression. @param type The desired type. @return True if the expression type matches, false otherwise. */
 int jx_istype( struct jx *j, jx_type_t type );
 
 /** Test an expression for the boolean value TRUE.  @param j An expression to test.  @return True if the expression is boolean and true. */
 int jx_istrue( struct jx *j );
+
+int jx_comprehension_equals(struct jx_comprehension *j, struct jx_comprehension *k);
+int jx_item_equals(struct jx_item *j, struct jx_item *k);
+int jx_pair_equals(struct jx_pair *j, struct jx_pair *k);
 
 /** Test two expressions for equality. @param j A constant expression. @param k A constant expression. @return True if equal, false if not.
 */
@@ -196,6 +215,10 @@ int jx_equals( struct jx *j, struct jx *k );
 
 /** Get the length of an array. Returns -1 if array is null or not an array. @param array The array to check. */
 int jx_array_length( struct jx *array );
+
+struct jx_comprehension *jx_comprehension_copy(struct jx_comprehension *c);
+struct jx_item *jx_item_copy(struct jx_item *i);
+struct jx_pair *jx_pair_copy(struct jx_pair *p);
 
 /** Duplicate an expression. @param j An expression. @return A copy of the expression, which must be deleted by @ref jx_delete
 */
@@ -209,6 +232,9 @@ void jx_pair_delete( struct jx_pair *p );
 
 /** Delete an array item.  @param i The array item to delete. */
 void jx_item_delete( struct jx_item *i );
+
+/** Delete a comprehension. @param c The comprehension to delete. */
+void jx_comprehension_delete(struct jx_comprehension *comp);
 
 /** Remove a key-value pair from an object.  @param object The object.  @param key The key. @return The corresponding value, or null if it is not present. */
 struct jx * jx_remove( struct jx *object, struct jx *key );

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -100,6 +100,7 @@ struct jx_operator {
 };
 
 typedef enum {
+	JX_BUILTIN_LAMBDA,
 	JX_BUILTIN_RANGE,
 	JX_BUILTIN_FORMAT,
 } jx_builtin_t;
@@ -159,8 +160,8 @@ struct jx * jx_error( struct jx *err );
 /** Create a JX_FUNCTION. @param params The list of JX_STRING parameter names.
  * @param body The function body to evaluate. @returns A JX function definition.
  */
-struct jx *jx_function(
-	const char *name, struct jx_item *params, struct jx *body);
+struct jx *jx_function(const char *name, jx_builtin_t op,
+	struct jx_item *params, struct jx *body);
 
 /** Create a JX array.  @param items A linked list of @ref jx_item values.  @return A JX array. */
 struct jx * jx_array( struct jx_item *items );

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -37,7 +37,6 @@ Will create the following output:
 */
 
 #include <stdint.h>
-#include <assert.h>
 
 /** JX atomic type.  */
 typedef enum {
@@ -253,6 +252,11 @@ struct jx * jx_array_index( struct jx *j, int nth );
 
 /** Concatenate the given arrays into a single array. The passed arrays are consumed. @param array An array to concatenate. The list of arrays must be terminated by NULL. */
 struct jx *jx_array_concat( struct jx *array, ...);
+
+/** Remove and return the first element in the array.
+ * @param array The JX_ARRAY to update.
+ * @returns The first value in array, or NULL if array is empty or not a JX_ARRAY. */
+struct jx *jx_array_shift(struct jx *array);
 
 /** Determine if an expression is constant.  Traverses the expression recursively, and returns true if it consists only of constant values, arrays, and objects. @param j The expression to evaluate.  @return True if constant. */
 int jx_is_constant( struct jx *j );

--- a/dttools/src/jx2json.c
+++ b/dttools/src/jx2json.c
@@ -1,0 +1,115 @@
+/*
+Copyright (C) 2017- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "cctools.h"
+#include "getopt.h"
+#include "jx.h"
+#include "jx_eval.h"
+#include "jx_parse.h"
+#include "jx_pretty_print.h"
+#include "jx_print.h"
+
+static void show_help() {
+	const char *optfmt = "%2s %-20s %s\n";
+	printf("usage: jx2json [OPTIONS] [INPUT]\n");
+	printf("\n");
+	printf("If INPUT is not specified, stdin is used.");
+	printf("OPTIONS are:\n");
+	printf(optfmt, "-c", "--context <FILE>", "Evaluate FILE and use it as the context");
+	printf(optfmt, "-p", "--pretty", "Print more readable JSON");
+	printf(optfmt, "-v", "--version", "Show version number");
+	printf(optfmt, "-h", "--help", "Help: Show these options");
+}
+
+static const struct option long_options[] = {
+	{"help", no_argument, 0, 'h'},
+	{"version", no_argument, 0, 'v'},
+	{"pretty", no_argument, 0, 'p'},
+	{"context", required_argument, 0, 'c'},
+	{0, 0, 0, 0}};
+
+int main(int argc, char *argv[]) {
+	char *context = NULL;
+	char *input = NULL;
+	FILE *stream = stdin;
+	struct jx *ctx = NULL;
+	struct jx *body = NULL;
+	void (*print_stream)(struct jx *, FILE *) = jx_print_stream;
+
+	int c;
+	while ((c = getopt_long(argc, argv, "vhc:p", long_options, NULL)) > -1) {
+		switch (c) {
+			case 'c':
+				context = strdup(optarg);
+				break;
+			case 'p':
+				print_stream = jx_pretty_print_stream;
+				break;
+			case 'h':
+				show_help();
+				return 0;
+			case 'v':
+				cctools_version_print(stdout, "jx2json");
+				return 0;
+			default:
+				show_help();
+				return 1;
+		}
+	}
+
+	if (argc - optind == 1) {
+		input = strdup(argv[optind]);
+	} else if (argc - optind > 1) {
+		show_help();
+		return 1;
+	}
+
+	if (context) {
+		FILE *f = fopen(context, "r");
+		if (!f) {
+			fprintf(stderr, "failed to open context file %s: %s\n",
+				context, strerror(errno));
+			return 1;
+		}
+		ctx = jx_parse_stream(f);
+		fclose(f);
+		if (!ctx) return 1;
+	}
+
+	ctx = jx_eval(ctx, NULL);
+	if (jx_istype(ctx, JX_ERROR)) {
+		printf("invalid context\n");
+		print_stream(ctx, stdout);
+		printf("\n");
+		return 1;
+	}
+
+	if (input) {
+		stream = fopen(input, "r");
+		if (!stream) {
+			fprintf(stderr, "failed to open input file %s: %s\n",
+				input, strerror(errno));
+			return 1;
+		}
+	}
+
+	body = jx_parse_stream(stream);
+	fclose(stream);
+	if (!body) return 1;
+
+	body = jx_eval(body, ctx);
+	print_stream(body, stdout);
+	printf("\n");
+	return 0;
+}
+
+/* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/jx_eval.c
+++ b/dttools/src/jx_eval.c
@@ -6,7 +6,6 @@ See the file COPYING for details.
 
 #include "jx_eval.h"
 #include "jx_print.h"
-#include "jx_function.h"
 #include "debug.h"
 
 #include <assert.h>
@@ -370,28 +369,6 @@ static struct jx * jx_eval_lookup( struct jx *left, struct jx *right )
 	}
 }
 
-static struct jx *jx_eval_function( struct jx_function *f, struct jx *context )
-{
-	if(!f) return NULL;
-	switch(f->function) {
-		case JX_FUNCTION_DBG:
-			return jx_function_dbg(f, context);
-		case JX_FUNCTION_RANGE:
-			return jx_function_range(f, context);
-		case JX_FUNCTION_FOREACH:
-			return jx_function_foreach(f, context);
-		case JX_FUNCTION_STR:
-			return jx_function_str(f, context);
-		case JX_FUNCTION_JOIN:
-			return jx_function_join(f, context);
-		case JX_FUNCTION_LET:
-			return jx_function_let(f, context);
-		case JX_FUNCTION_INVALID:
-			return NULL;
-	}
-	return NULL;
-}
-
 /*
 Type conversion rules:
 Generally, operators are not meant to be applied to unequal types.
@@ -593,8 +570,6 @@ struct jx * jx_eval( struct jx *j, struct jx *context )
 			return jx_check_errors(jx_object(jx_eval_pair(j->u.pairs,context)));
 		case JX_OPERATOR:
 			return jx_eval_operator(&j->u.oper,context);
-		case JX_FUNCTION:
-			return jx_eval_function(&j->u.func,context);
 	}
 	/* not reachable, but some compilers complain. */
 	return 0;

--- a/dttools/src/jx_eval.c
+++ b/dttools/src/jx_eval.c
@@ -285,8 +285,10 @@ static struct jx *jx_eval_call(
 	struct jx *func, struct jx *args, struct jx *ctx) {
 	assert(func);
 	assert(func->type == JX_FUNCTION);
+	assert(func->u.func.params);
 	assert(args);
 	assert(args->type == JX_ARRAY);
+	assert(args->u.items);
 
 	ctx = jx_copy(ctx);
 	if (!ctx) ctx = jx_object(NULL);
@@ -294,8 +296,7 @@ static struct jx *jx_eval_call(
 
 	struct jx_item *p = func->u.func.params;
 	struct jx_item *a = args->u.items;
-	while (p) {
-		assert(p->value);
+	while (p->value) {
 		assert(p->value->type == JX_STRING);
 		if (a) {
 			jx_insert(ctx, jx_string(p->value->u.string_value),

--- a/dttools/src/jx_eval.c
+++ b/dttools/src/jx_eval.c
@@ -11,35 +11,61 @@ See the file COPYING for details.
 
 #include <assert.h>
 #include <string.h>
+#include <stdbool.h>
+
+// FAILOP(int code, jx_operator *op, struct jx *left, struct jx *right, const char *message)
+// left, right, and message are evaluated exactly once
+#define FAILOP(code, op, left, right, message) do { \
+	struct jx *ebidfgds = jx_object(NULL); \
+	jx_insert_integer(ebidfgds, "code", code); \
+	jx_insert(ebidfgds, jx_string("operator"), jx_operator(op->type, left, right)); \
+	if (op->line) jx_insert_integer(ebidfgds, "line", op->line); \
+	jx_insert_string(ebidfgds, "message", message); \
+	jx_insert_string(ebidfgds, "name", jx_error_name(code)); \
+	jx_insert_string(ebidfgds, "source", "jx_eval"); \
+	return jx_error(ebidfgds); \
+} while (false)
+
+// FAILARR(struct jx *array, struct jx *index, const char *message)
+#define FAILARR(array, index, message) do { \
+	struct jx *ekjhgsae = jx_object(NULL); \
+	jx_insert_integer(ekjhgsae, "code", 4); \
+	jx_insert(ekjhgsae, jx_string("array"), jx_copy(array)); \
+	jx_insert(ekjhgsae, jx_string("index"), jx_copy(index)); \
+	if (index && index->line) jx_insert_integer(ekjhgsae, "line", index->line); \
+	jx_insert_string(ekjhgsae, "message", message); \
+	jx_insert_string(ekjhgsae, "name", jx_error_name(4)); \
+	jx_insert_string(ekjhgsae, "source", "jx_eval"); \
+	return jx_error(ekjhgsae); \
+} while (false)
+
+// FAILOBJ(struct jx *obj, struct jx *key, const char *message)
+#define FAILOBJ(obj, key, message) do { \
+	struct jx *edgibijs = jx_object(NULL); \
+	jx_insert_integer(edgibijs, "code", 3); \
+	jx_insert(edgibijs, jx_string("object"), jx_copy(obj)); \
+	jx_insert(edgibijs, jx_string("key"), jx_copy(key)); \
+	if (key && key->line) jx_insert_integer(edgibijs, "line", key->line); \
+	jx_insert_string(edgibijs, "message", message); \
+	jx_insert_string(edgibijs, "name", jx_error_name(3)); \
+	jx_insert_string(edgibijs, "source", "jx_eval"); \
+	return jx_error(edgibijs); \
+} while (false)
 
 static struct jx *jx_check_errors(struct jx *j);
 
 static struct jx *jx_eval_null(struct jx_operator *op, struct jx *left, struct jx *right) {
-	struct jx *err;
-	int code;
-
 	assert(op);
 	switch(op->type) {
 		case JX_OP_EQ:
 			return jx_boolean(1);
 		case JX_OP_NE:
 			return jx_boolean(0);
-		default:
-			code = 1;
-			err = jx_object(NULL);
-			jx_insert_integer(err, "code", code);
-			jx_insert(err, jx_string("operator"), jx_operator(op->type, jx_null(), jx_null()));
-			if (op->line) jx_insert_integer(err, "line", op->line);
-			jx_insert_string(err, "message", "unsupported operator on null");
-			jx_insert_string(err, "name", jx_error_name(code));
-			jx_insert_string(err, "source", "jx_eval");
-			return jx_error(err);
+		default: FAILOP(1, op, jx_null(), jx_null(), "unsupported operator on null");
 	}
 }
 
 static struct jx *jx_eval_boolean(struct jx_operator *op, struct jx *left, struct jx *right) {
-	struct jx *err;
-	int code;
 	int a = left ? left->u.boolean_value : 0;
 	int b = right ? right->u.boolean_value : 0;
 
@@ -55,22 +81,11 @@ static struct jx *jx_eval_boolean(struct jx_operator *op, struct jx *left, struc
 			return jx_boolean(a||b);
 		case JX_OP_NOT:
 			return jx_boolean(!b);
-		default:
-			code = 1;
-			err = jx_object(NULL);
-			jx_insert_integer(err, "code", code);
-			jx_insert(err, jx_string("operator"), jx_operator(op->type, jx_copy(left), jx_copy(right)));
-			if (op->line) jx_insert_integer(err, "line", op->line);
-			jx_insert_string(err, "message", "unsupported operator on boolean");
-			jx_insert_string(err, "name", jx_error_name(code));
-			jx_insert_string(err, "source", "jx_eval");
-			return jx_error(err);
+		default: FAILOP(1, op, jx_copy(left), jx_copy(right), "unsupported operator on boolean");
 	}
 }
 
 static struct jx *jx_eval_integer(struct jx_operator *op, struct jx *left, struct jx *right) {
-	struct jx *err;
-	int code;
 	jx_int_t a = left ? left->u.integer_value : 0;
 	jx_int_t b = right ? right->u.integer_value : 0;
 
@@ -99,47 +114,16 @@ static struct jx *jx_eval_integer(struct jx_operator *op, struct jx *left, struc
 		case JX_OP_MUL:
 			return jx_integer(a*b);
 		case JX_OP_DIV:
-			if(b==0) {
-				code = 5;
-				err = jx_object(NULL);
-				jx_insert_integer(err, "code", code);
-				jx_insert(err, jx_string("operator"), jx_operator(op->type, jx_copy(left), jx_copy(right)));
-				if (op->line) jx_insert_integer(err, "line", op->line);
-				jx_insert_string(err, "message", "division by zero");
-				jx_insert_string(err, "name", jx_error_name(code));
-				jx_insert_string(err, "source", "jx_eval");
-				return jx_error(err);
-			}
+			if(b==0) FAILOP(5, op, jx_copy(left), jx_copy(right), "division by zero");
 			return jx_integer(a/b);
 		case JX_OP_MOD:
-			if(b==0) {
-				code = 5;
-				err = jx_object(NULL);
-				jx_insert_integer(err, "code", code);
-				jx_insert(err, jx_string("operator"), jx_operator(op->type, jx_copy(left), jx_copy(right)));
-				if (op->line) jx_insert_integer(err, "line", op->line);
-				jx_insert_string(err, "message", "division by zero");
-				jx_insert_string(err, "name", jx_error_name(code));
-				jx_insert_string(err, "source", "jx_eval");
-				return jx_error(err);
-			}
+			if(b==0) FAILOP(5, op, jx_copy(left), jx_copy(right), "division by zero");
 			return jx_integer(a%b);
-		default:
-			code = 1;
-			err = jx_object(NULL);
-			jx_insert_integer(err, "code", code);
-			jx_insert(err, jx_string("operator"), jx_operator(op->type, jx_copy(left), jx_copy(right)));
-			if (op->line) jx_insert_integer(err, "line", op->line);
-			jx_insert_string(err, "message", "unsupported operator on integer");
-			jx_insert_string(err, "name", jx_error_name(code));
-			jx_insert_string(err, "source", "jx_eval");
-			return jx_error(err);
+		default: FAILOP(1, op, jx_copy(left), jx_copy(right), "unsupported operator on integer");
 	}
 }
 
 static struct jx *jx_eval_double(struct jx_operator *op, struct jx *left, struct jx *right) {
-	struct jx *err;
-	int code;
 	double a = left ? left->u.double_value : 0;
 	double b = right ? right->u.double_value : 0;
 
@@ -173,47 +157,16 @@ static struct jx *jx_eval_double(struct jx_operator *op, struct jx *left, struct
 			return jx_double(a*b);
 			break;
 		case JX_OP_DIV:
-			if(b==0) {
-				code = 5;
-				err = jx_object(NULL);
-				jx_insert_integer(err, "code", code);
-				jx_insert(err, jx_string("operator"), jx_operator(op->type, jx_copy(left), jx_copy(right)));
-				if (op->line) jx_insert_integer(err, "line", op->line);
-				jx_insert_string(err, "message", "division by zero");
-				jx_insert_string(err, "name", jx_error_name(code));
-				jx_insert_string(err, "source", "jx_eval");
-				return jx_error(err);
-			}
+			if(b==0) FAILOP(5, op, jx_copy(left), jx_copy(right), "division by zero");
 			return jx_double(a/b);
 		case JX_OP_MOD:
-			if(b==0) {
-				code = 5;
-				err = jx_object(NULL);
-				jx_insert_integer(err, "code", code);
-				jx_insert(err, jx_string("operator"), jx_operator(op->type, jx_copy(left), jx_copy(right)));
-				if (op->line) jx_insert_integer(err, "line", op->line);
-				jx_insert_string(err, "message", "division by zero");
-				jx_insert_string(err, "name", jx_error_name(code));
-				jx_insert_string(err, "source", "jx_eval");
-				return jx_error(err);
-			}
+			if(b==0) FAILOP(5, op, jx_copy(left), jx_copy(right), "division by zero");
 			return jx_double((jx_int_t)a%(jx_int_t)b);
-		default:
-			code = 1;
-			err = jx_object(NULL);
-			jx_insert_integer(err, "code", code);
-			jx_insert(err, jx_string("operator"), jx_operator(op->type, jx_copy(left), jx_copy(right)));
-			if (op->line) jx_insert_integer(err, "line", op->line);
-			jx_insert_string(err, "message", "unsupported operator on double");
-			jx_insert_string(err, "name", jx_error_name(code));
-			jx_insert_string(err, "source", "jx_eval");
-			return jx_error(err);
+		default: FAILOP(1, op, jx_copy(left), jx_copy(right), "unsupported operator on double");
 	}
 }
 
 static struct jx *jx_eval_string(struct jx_operator *op, struct jx *left, struct jx *right) {
-	struct jx *err;
-	int code;
 	const char *a = left ? left->u.string_value : "";
 	const char *b = right ? right->u.string_value : "";
 
@@ -233,34 +186,13 @@ static struct jx *jx_eval_string(struct jx_operator *op, struct jx *left, struct
 			return jx_boolean(strcmp(a,b)>=0);
 		case JX_OP_ADD:
 			return jx_format("%s%s",a,b);
-		default:
-			code = 1;
-			err = jx_object(NULL);
-			jx_insert_integer(err, "code", code);
-			jx_insert(err, jx_string("operator"), jx_operator(op->type, jx_copy(left), jx_copy(right)));
-			if (op->line) jx_insert_integer(err, "line", op->line);
-			jx_insert_string(err, "message", "unsupported operator on string");
-			jx_insert_string(err, "name", jx_error_name(code));
-			jx_insert_string(err, "source", "jx_eval");
-			return jx_error(err);
+		default: FAILOP(1, op, jx_copy(left), jx_copy(right), "unsupported operator on string");
 	}
 }
 
 static struct jx *jx_eval_array(struct jx_operator *op, struct jx *left, struct jx *right) {
-	struct jx *err;
-	int code;
 	assert(op);
-	if (!(left && right)) {
-		err = jx_object(NULL);
-		code = 1;
-		jx_insert_integer(err, "code", code);
-		jx_insert(err, jx_string("operator"), jx_operator(op->type, jx_copy(left), jx_copy(right)));
-		if (op->line) jx_insert_integer(err, "line", op->line);
-		jx_insert_string(err, "message", "missing arguments to array operator");
-		jx_insert_string(err, "name", jx_error_name(code));
-		jx_insert_string(err, "source", "jx_eval");
-		return jx_error(err);
-	}
+	if (!(left && right)) FAILOP(1, op, jx_copy(left), jx_copy(right), "missing arguments to array operator");
 
 	switch(op->type) {
 		case JX_OP_EQ:
@@ -269,16 +201,7 @@ static struct jx *jx_eval_array(struct jx_operator *op, struct jx *left, struct 
 			return jx_boolean(!jx_equals(left, right));
 		case JX_OP_ADD:
 			return jx_check_errors(jx_array_concat(jx_copy(left), jx_copy(right), NULL));
-		default:
-			code = 1;
-			err = jx_object(NULL);
-			jx_insert_integer(err, "code", code);
-			jx_insert(err, jx_string("operator"), jx_operator(op->type, jx_copy(left), jx_copy(right)));
-			if (op->line) jx_insert_integer(err, "line", op->line);
-			jx_insert_string(err, "message", "unsupported operator on array");
-			jx_insert_string(err, "name", jx_error_name(code));
-			jx_insert_string(err, "source", "jx_eval");
-			return jx_error(err);
+		default: FAILOP(1, op, jx_copy(left), jx_copy(right), "unsupported operator on array");
 	}
 }
 
@@ -342,47 +265,16 @@ static struct jx * jx_eval_lookup( struct jx *left, struct jx *right )
 		if(r) {
 			return jx_copy(r);
 		} else {
-			code = 3;
-			err = jx_object(NULL);
-			jx_insert_integer(err, "code", code);
-			jx_insert(err, jx_string("object"), jx_copy(left));
-			jx_insert(err, jx_string("key"), jx_copy(right));
-			if (right && right->line) jx_insert_integer(err, "line", right->line);
-			jx_insert_string(err, "message", "key not found");
-			jx_insert_string(err, "name", jx_error_name(code));
-			jx_insert_string(err, "source", "jx_eval");
-			return jx_error(err);
+			FAILOBJ(left, right, "key not found");
 		}
 	} else if(left->type==JX_ARRAY && right->type==JX_INTEGER) {
 		struct jx_item *item = left->u.items;
 		int count = right->u.integer_value;
 
-		if(count<0) {
-			code = 4;
-			err = jx_object(NULL);
-			jx_insert_integer(err, "code", code);
-			jx_insert(err, jx_string("array"), jx_copy(left));
-			jx_insert(err, jx_string("index"), jx_copy(right));
-			if (right && right->line) jx_insert_integer(err, "line", right->line);
-			jx_insert_string(err, "message", "index must be positive");
-			jx_insert_string(err, "name", jx_error_name(code));
-			jx_insert_string(err, "source", "jx_eval");
-			return jx_error(err);
-		}
+		if(count<0) FAILARR(left, right, "index must be positive");
 
 		while(count>0) {
-			if(!item) {
-				code = 4;
-				err = jx_object(NULL);
-				jx_insert_integer(err, "code", code);
-				jx_insert(err, jx_string("array"), jx_copy(left));
-				jx_insert(err, jx_string("index"), jx_copy(right));
-				if (right && right->line) jx_insert_integer(err, "line", right->line);
-				jx_insert_string(err, "message", "index out of range");
-				jx_insert_string(err, "name", jx_error_name(code));
-				jx_insert_string(err, "source", "jx_eval");
-				return jx_error(err);
-			}
+			if(!item) FAILARR(left, right, "index out of range");
 			item = item->next;
 			count--;
 		}
@@ -390,16 +282,7 @@ static struct jx * jx_eval_lookup( struct jx *left, struct jx *right )
 		if(item) {
 			return jx_copy(item->value);
 		} else {
-			code = 4;
-			err = jx_object(NULL);
-			jx_insert_integer(err, "code", code);
-			jx_insert(err, jx_string("array"), jx_copy(left));
-			jx_insert(err, jx_string("index"), jx_copy(right));
-			if (right && right->line) jx_insert_integer(err, "line", right->line);
-			jx_insert_string(err, "message", "index out of range");
-			jx_insert_string(err, "name", jx_error_name(code));
-			jx_insert_string(err, "source", "jx_eval");
-			return jx_error(err);
+			FAILARR(left, right, "index out of range");
 		}
 	} else {
 		code = 1;
@@ -430,9 +313,7 @@ static struct jx * jx_eval_operator( struct jx_operator *o, struct jx *context )
 
 	struct jx *left = jx_eval(o->left,context);
 	struct jx *right = jx_eval(o->right,context);
-	struct jx *err;
 	struct jx *result;
-	int code;
 
 	if (jx_istype(left, JX_ERROR)) {
 		result = left;
@@ -473,15 +354,7 @@ static struct jx * jx_eval_operator( struct jx_operator *o, struct jx *context )
 			jx_delete(right);
 			return r;
 		} else {
-			code = 2;
-			err = jx_object(NULL);
-			jx_insert_integer(err, "code", code);
-			jx_insert(err, jx_string("operator"), jx_operator(o->type, left, right));
-			if (o->line) jx_insert_integer(err, "line", o->line);
-			jx_insert_string(err, "message", "mismatched types for operator");
-			jx_insert_string(err, "name", jx_error_name(code));
-			jx_insert_string(err, "source", "jx_eval");
-			return jx_error(err);
+			FAILOP(2, o, left, right, "mismatched types for operator");
 		}
 	}
 
@@ -504,17 +377,7 @@ static struct jx * jx_eval_operator( struct jx_operator *o, struct jx *context )
 		case JX_ARRAY:
 			result = jx_eval_array(o, left, right);
 			break;
-		default:
-			code = 1;
-			err = jx_object(NULL);
-			jx_insert_integer(err, "code", code);
-			jx_insert(err, jx_string("operator"), jx_operator(o->type, jx_copy(left), jx_copy(right)));
-			if (o->line) jx_insert_integer(err, "line", o->line);
-			jx_insert_string(err, "message", "rvalue does not support operators");
-			jx_insert_string(err, "name", jx_error_name(code));
-			jx_insert_string(err, "source", "jx_eval");
-			result = jx_error(err);
-			break;
+		default: FAILOP(1, o, left, right, "rvalue does not support operators");
 	}
 
 DONE:

--- a/dttools/src/jx_eval.c
+++ b/dttools/src/jx_eval.c
@@ -103,10 +103,6 @@ static struct jx *jx_eval_integer(struct jx_operator *op, struct jx *left, struc
 			return jx_boolean(a>b);
 		case JX_OP_GE:
 			return jx_boolean(a>=b);
-		case JX_OP_OR:
-			return jx_integer(a|b);
-		case JX_OP_AND:
-			return jx_integer(a&b);
 		case JX_OP_ADD:
 			return jx_integer(a+b);
 		case JX_OP_SUB:
@@ -131,31 +127,22 @@ static struct jx *jx_eval_double(struct jx_operator *op, struct jx *left, struct
 	switch(op->type) {
 		case JX_OP_EQ:
 			return jx_boolean(a==b);
-			break;
 		case JX_OP_NE:
 			return jx_boolean(a!=b);
-			break;
 		case JX_OP_LT:
 			return jx_boolean(a<b);
-			break;
 		case JX_OP_LE:
 			return jx_boolean(a<=b);
-			break;
 		case JX_OP_GT:
 			return jx_boolean(a>b);
-			break;
 		case JX_OP_GE:
 			return jx_boolean(a>=b);
-			break;
 		case JX_OP_ADD:
 			return jx_double(a+b);
-			break;
 		case JX_OP_SUB:
 			return jx_double(a-b);
-			break;
 		case JX_OP_MUL:
 			return jx_double(a*b);
-			break;
 		case JX_OP_DIV:
 			if(b==0) FAILOP(5, op, jx_copy(left), jx_copy(right), "division by zero");
 			return jx_double(a/b);

--- a/dttools/src/jx_eval.c
+++ b/dttools/src/jx_eval.c
@@ -5,8 +5,9 @@ See the file COPYING for details.
 */
 
 #include "jx_eval.h"
-#include "jx_print.h"
 #include "debug.h"
+#include "jx_function.h"
+#include "jx_print.h"
 
 #include <assert.h>
 #include <string.h>
@@ -285,10 +286,18 @@ static struct jx *jx_eval_call(
 	struct jx *func, struct jx *args, struct jx *ctx) {
 	assert(func);
 	assert(func->type == JX_FUNCTION);
-	assert(func->u.func.params);
 	assert(args);
 	assert(args->type == JX_ARRAY);
-	assert(args->u.items);
+
+	if (!func->u.func.body) {
+		switch (func->u.func.builtin) {
+			case JX_BUILTIN_RANGE: return jx_function_range(args);
+		}
+		// invalid function, so bail out
+		abort();
+	}
+
+	assert(func->u.func.params);
 
 	ctx = jx_copy(ctx);
 	if (!ctx) ctx = jx_object(NULL);

--- a/dttools/src/jx_export.c
+++ b/dttools/src/jx_export.c
@@ -110,6 +110,21 @@ void jx_export_xml( struct jx *j, FILE *stream )
 		jx_print_stream(j,stream);
 		fprintf(stream,"</expr>\n");
 		break;
+	case JX_FUNCTION:
+		fprintf(stream, "<func>");
+		fprintf(stream, "<name>");
+		fprintf(stream, j->u.func.name);
+		fprintf(stream, "</name>");
+		for (struct jx_item *i = j->u.func.params; i; i = i->next) {
+			fprintf(stream, "<param>");
+			jx_export_xml(i->value, stream);
+			fprintf(stream, "</param>");
+		}
+		fprintf(stream, "<body>");
+		jx_export_xml(j->u.func.body, stream);
+		fprintf(stream, "</body>");
+		fprintf(stream, "</func>");
+		break;
 	case JX_ERROR:
 		fprintf(stream,"<error>\n");
 		jx_print_stream(j,stream);

--- a/dttools/src/jx_export.c
+++ b/dttools/src/jx_export.c
@@ -98,6 +98,16 @@ void jx_export_xml( struct jx *j, FILE *stream )
 		break;
 	case JX_ARRAY:
 		fprintf(stream,"<array>\n");
+		if (j->u.items && j->u.items->variable) {
+			fprintf(stream, "<var>");
+			fprintf(stream, j->u.items->variable);
+			fprintf(stream, "</var>");
+		}
+		if (j->u.items && j->u.items->list) {
+			fprintf(stream, "<list>");
+			jx_export_xml(j->u.items->list, stream);
+			fprintf(stream, "</list>");
+		}
 		for(i=j->u.items;i;i=i->next) {
 			fprintf(stream,"<item>");
 			jx_export_xml(i->value,stream);

--- a/dttools/src/jx_export.c
+++ b/dttools/src/jx_export.c
@@ -110,11 +110,6 @@ void jx_export_xml( struct jx *j, FILE *stream )
 		jx_print_stream(j,stream);
 		fprintf(stream,"</expr>\n");
 		break;
-	case JX_FUNCTION:
-		fprintf(stream,"<func>\n");
-		jx_print_stream(j,stream);
-		fprintf(stream,"</func>\n");
-		break;
 	case JX_ERROR:
 		fprintf(stream,"<error>\n");
 		jx_print_stream(j,stream);

--- a/dttools/src/jx_export.c
+++ b/dttools/src/jx_export.c
@@ -98,19 +98,24 @@ void jx_export_xml( struct jx *j, FILE *stream )
 		break;
 	case JX_ARRAY:
 		fprintf(stream,"<array>\n");
-		if (j->u.items && j->u.items->variable) {
-			fprintf(stream, "<var>");
-			fprintf(stream, j->u.items->variable);
-			fprintf(stream, "</var>");
-		}
-		if (j->u.items && j->u.items->list) {
-			fprintf(stream, "<list>");
-			jx_export_xml(j->u.items->list, stream);
-			fprintf(stream, "</list>");
-		}
-		for(i=j->u.items;i;i=i->next) {
-			fprintf(stream,"<item>");
-			jx_export_xml(i->value,stream);
+		for (i = j->u.items; i; i = i->next) {
+			fprintf(stream, "<item>");
+			jx_export_xml(i->value, stream);
+			if (i->variable) {
+				fprintf(stream, "<var>");
+				fprintf(stream, i->variable);
+				fprintf(stream, "</var>");
+			}
+			if (i->condition) {
+				fprintf(stream, "<cond>");
+				jx_export_xml(i->condition, stream);
+				fprintf(stream, "</cond>");
+			}
+			if (i->list) {
+				fprintf(stream, "<list>");
+				jx_export_xml(i->list, stream);
+				fprintf(stream, "</list>");
+			}
 			fprintf(stream,"</item>");
 		}
 		fprintf(stream,"</array>\n");

--- a/dttools/src/jx_export.c
+++ b/dttools/src/jx_export.c
@@ -101,21 +101,6 @@ void jx_export_xml( struct jx *j, FILE *stream )
 		for (i = j->u.items; i; i = i->next) {
 			fprintf(stream, "<item>");
 			jx_export_xml(i->value, stream);
-			if (i->variable) {
-				fprintf(stream, "<var>");
-				fprintf(stream, "%s", i->variable);
-				fprintf(stream, "</var>");
-			}
-			if (i->condition) {
-				fprintf(stream, "<cond>");
-				jx_export_xml(i->condition, stream);
-				fprintf(stream, "</cond>");
-			}
-			if (i->list) {
-				fprintf(stream, "<list>");
-				jx_export_xml(i->list, stream);
-				fprintf(stream, "</list>");
-			}
 			fprintf(stream,"</item>");
 		}
 		fprintf(stream,"</array>\n");

--- a/dttools/src/jx_export.c
+++ b/dttools/src/jx_export.c
@@ -103,7 +103,7 @@ void jx_export_xml( struct jx *j, FILE *stream )
 			jx_export_xml(i->value, stream);
 			if (i->variable) {
 				fprintf(stream, "<var>");
-				fprintf(stream, i->variable);
+				fprintf(stream, "%s", i->variable);
 				fprintf(stream, "</var>");
 			}
 			if (i->condition) {
@@ -128,7 +128,7 @@ void jx_export_xml( struct jx *j, FILE *stream )
 	case JX_FUNCTION:
 		fprintf(stream, "<func>");
 		fprintf(stream, "<name>");
-		fprintf(stream, j->u.func.name);
+		fprintf(stream, "%s", j->u.func.name);
 		fprintf(stream, "</name>");
 		for (struct jx_item *i = j->u.func.params; i; i = i->next) {
 			fprintf(stream, "<param>");

--- a/dttools/src/jx_function.c
+++ b/dttools/src/jx_function.c
@@ -17,14 +17,15 @@ See the file COPYING for details.
 #include "stringtools.h"
 #include "xxmalloc.h"
 
-// FAIL(const char *name, struct jx *args, const char *message) -> !
-#define FAIL(name, args, message)                                              \
+// FAIL(const char *name, jx_builtin_t b struct jx *args, const char *message)
+#define FAIL(name, b, args, message)                                           \
 	do {                                                                   \
 		int ciuygssd = 6;                                              \
 		struct jx *ebijuaef = jx_object(NULL);                         \
 		jx_insert_integer(ebijuaef, "code", ciuygssd);                 \
 		jx_insert(ebijuaef, jx_string("function"),                     \
-			jx_operator(JX_OP_CALL, jx_function(name, NULL, NULL), \
+			jx_operator(JX_OP_CALL,                                \
+				jx_function(name, b, NULL, NULL),              \
 				jx_copy(args)));                               \
 		if (args->line)                                                \
 			jx_insert_integer(ebijuaef, "line", args->line);       \
@@ -131,7 +132,7 @@ FAILURE:
 	jx_delete(args);
 	free(result);
 	free(format);
-	FAIL(funcname, orig_args, err);
+	FAIL(funcname, JX_BUILTIN_FORMAT, orig_args, err);
 }
 
 // see https://docs.python.org/2/library/functions.html#range
@@ -148,10 +149,13 @@ struct jx *jx_function_range(struct jx *args) {
 			break;
 		case 2: step = 1; break;
 		case 3: break;
-		default: FAIL(funcname, args, "invalid arguments");
+		default:
+			FAIL(funcname, JX_BUILTIN_RANGE, args,
+				"invalid arguments");
 	}
 
-	if (step == 0) FAIL(funcname, args, "step must be nonzero");
+	if (step == 0)
+		FAIL(funcname, JX_BUILTIN_RANGE, args, "step must be nonzero");
 
 	struct jx *result = jx_array(NULL);
 

--- a/dttools/src/jx_function.c
+++ b/dttools/src/jx_function.c
@@ -119,6 +119,10 @@ struct jx *jx_function_format(struct jx *orig_args) {
 		err = "truncated format specifier";
 		goto FAILURE;
 	}
+	if (jx_array_length(args) > 0) {
+		err = "too many arguments for format specifier";
+		goto FAILURE;
+	}
 	jx_delete(args);
 	free(format);
 	j = jx_string(result);

--- a/dttools/src/jx_function.c
+++ b/dttools/src/jx_function.c
@@ -8,192 +8,49 @@ See the file COPYING for details.
 #include <string.h>
 #include <stdarg.h>
 #include "jx.h"
-#include "jx_eval.h"
-#include "jx_print.h"
-#include "jx_function.h"
 #include "jx_match.h"
 #include "xxmalloc.h"
 #include "stringtools.h"
 
-#define DBG "dbg"
-#define STR "str"
-#define RANGE "range"
-#define FOREACH "foreach"
-#define JOIN "join"
-#define LET "let"
-
-const char *jx_function_name_to_string(jx_function_t func) {
-	switch (func) {
-	case JX_FUNCTION_DBG: return DBG;
-	case JX_FUNCTION_STR: return STR;
-	case JX_FUNCTION_RANGE: return RANGE;
-	case JX_FUNCTION_FOREACH: return FOREACH;
-	case JX_FUNCTION_JOIN: return JOIN;
-	case JX_FUNCTION_LET: return LET;
-	default: return "???";
-	}
-}
-
-jx_function_t jx_function_name_from_string(const char *name) {
-	if (!strcmp(name, DBG)) return JX_FUNCTION_DBG;
-	else if (!strcmp(name, STR)) return JX_FUNCTION_STR;
-	else if (!strcmp(name, RANGE)) return JX_FUNCTION_RANGE;
-	else if (!strcmp(name, FOREACH)) return JX_FUNCTION_FOREACH;
-	else if (!strcmp(name, JOIN)) return JX_FUNCTION_JOIN;
-	else if (!strcmp(name, LET)) return JX_FUNCTION_LET;
-	else return JX_FUNCTION_INVALID;
-}
-
-struct jx *jx_function_dbg(struct jx_function *f, struct jx *context) {
-	struct jx *result;
-	// we want to detect more than one arg, so try to match twice
-	if (jx_match_array(f->arguments, &result, JX_ANY, &result, JX_ANY, NULL) != 1) {
-		struct jx *err = jx_object(NULL);
-		int code = 6;
-		jx_insert_integer(err, "code", code);
-		jx_insert(err, jx_string("function"), jx_function(f->function, jx_copy(f->arguments)));
-		jx_insert_string(err, "message", "only one argument is allowed");
-		jx_insert_string(err, "name", jx_error_name(code));
-		jx_insert_string(err, "source", "jx_eval");
-		return jx_error(err);
-	}
-	fprintf(stderr, "dbg  in: ");
-	jx_print_stream(result, stderr);
-	fprintf(stderr, "\n");
-	result = jx_eval(result, context);
-	fprintf(stderr, "dbg out: ");
-	jx_print_stream(result, stderr);
-	fprintf(stderr, "\n");
-	return result;
-}
-
-struct jx *jx_function_str( struct jx_function *f, struct jx *context ) {
-	struct jx *args;
-	struct jx *err;
-	struct jx *result;
-	int code;
-
-	switch (jx_array_length(f->arguments)) {
-	case 0:
-		return jx_string("");
-	case 1:
-		args = jx_eval(f->arguments->u.items->value, context);
-		break;
-	default:
-		code = 6;
-		err = jx_object(NULL);
-		jx_insert_integer(err, "code", code);
-		jx_insert(err, jx_string("function"), jx_function(f->function, jx_copy(f->arguments)));
-		jx_insert_string(err, "message", "at most one argument is allowed");
-		jx_insert_string(err, "name", jx_error_name(code));
-		jx_insert_string(err, "source", "jx_eval");
-		return jx_error(err);
-
-	}
-	if (!args) return jx_null();
-	switch (args->type) {
-	case JX_ERROR:
-	case JX_STRING:
-		return args;
-	default:
-		result = jx_string(jx_print_string(args));
-		jx_delete(args);
-		return result;
-	}
-}
-
-struct jx *jx_function_foreach( struct jx_function *f, struct jx *context ) {
-	char *symbol = NULL;
-	struct jx *array = NULL;
-	struct jx *body = NULL;
-	struct jx *result = NULL;
-	struct jx *err;
-	int code;
-
-	if ((jx_match_array(f->arguments, &symbol, JX_SYMBOL, &array, JX_ANY, &body, JX_ANY, NULL) != 3)) {
-		code = 6;
-		err = jx_object(NULL);
-		jx_insert_integer(err, "code", code);
-		jx_insert(err, jx_string("function"), jx_function(f->function, jx_copy(f->arguments)));
-		jx_insert_string(err, "message", "invalid arguments");
-		jx_insert_string(err, "name", jx_error_name(code));
-		jx_insert_string(err, "source", "jx_eval");
-		result =  jx_error(err);
-		goto DONE;
-	}
-	// shuffle around to avoid leaking memory
-	result = array;
-	array = jx_eval(array, context);
-	jx_delete(result);
-	result = NULL;
-	if (!jx_istype(array, JX_ARRAY)) {
-		code = 6;
-		err = jx_object(NULL);
-		jx_insert_integer(err, "code", code);
-		jx_insert(err, jx_string("function"), jx_function(f->function, jx_copy(f->arguments)));
-		jx_insert_string(err, "message", "second argument must evaluate to an array");
-		jx_insert_string(err, "name", jx_error_name(code));
-		jx_insert_string(err, "source", "jx_eval");
-		result =  jx_error(err);
-		goto DONE;
-	}
-
-	result = jx_array(NULL);
-	void *i = NULL;
-	struct jx *item;
-	while ((item = jx_iterate_array(array, &i))) {
-		struct jx *local_context = jx_copy(context);
-		if (!local_context) local_context = jx_object(NULL);
-		jx_insert(local_context, jx_string(symbol), jx_copy(item));
-		struct jx *local_result = jx_eval(body, local_context);
-		jx_array_append(result, local_result);
-		jx_delete(local_context);
-	}
-
-DONE:
-	if (symbol) free(symbol);
-	jx_delete(array);
-	jx_delete(body);
-	return result;
-}
-
 // see https://docs.python.org/2/library/functions.html#range
-struct jx *jx_function_range( struct jx_function *f, struct jx *context ) {
+struct jx *jx_function_range(struct jx *args) {
 	jx_int_t start, stop, step;
-	int code;
-	struct jx *err;
-	struct jx *args = jx_eval(f->arguments, context);
-	if (jx_istype(args, JX_ERROR)) {
-		return args;
-	}
+
+	assert(args);
 	switch (jx_match_array(args, &start, JX_INTEGER, &stop, JX_INTEGER, &step, JX_INTEGER, NULL)) {
-	case 1:
-		stop = start;
-		start = 0;
-		step = 1;
-		break;
-	case 2:
-		step = 1;
-		break;
-	case 3:
-		break;
-	default:
-		code = 6;
-		err = jx_object(NULL);
-		jx_insert_integer(err, "code", code);
-		jx_insert(err, jx_string("function"), jx_function(f->function, jx_copy(f->arguments)));
-		jx_insert_string(err, "message", "invalid arguments");
-		jx_insert_string(err, "name", jx_error_name(code));
-		jx_insert_string(err, "source", "jx_eval");
-		return jx_error(err);
+		case 1:
+			stop = start;
+			start = 0;
+			step = 1;
+			break;
+		case 2: step = 1; break;
+		case 3: break;
+		default: {
+			int code = 6;
+			struct jx *err = jx_object(NULL);
+			jx_insert_integer(err, "code", code);
+			jx_insert(err, jx_string("function"),
+				jx_operator(JX_OP_CALL,
+					jx_function("range", NULL, NULL),
+					jx_copy(args)));
+			if (args->line)
+				jx_insert_integer(err, "line", args->line);
+			jx_insert_string(err, "message", "invalid arguments");
+			jx_insert_string(err, "name", jx_error_name(code));
+			jx_insert_string(err, "source", "jx_eval");
+			return jx_error(err);
+		}
 	}
-	jx_delete(args);
 
 	if (step == 0) {
-		code = 6;
-		err = jx_object(NULL);
+		int code = 6;
+		struct jx *err = jx_object(NULL);
 		jx_insert_integer(err, "code", code);
-		jx_insert(err, jx_string("function"), jx_function(f->function, jx_copy(f->arguments)));
+		jx_insert(err, jx_string("function"),
+			jx_operator(JX_OP_CALL,
+				jx_function("range", NULL, NULL),
+				jx_copy(args)));
+		if (args->line) jx_insert_integer(err, "line", args->line);
 		jx_insert_string(err, "message", "step must be nonzero");
 		jx_insert_string(err, "name", jx_error_name(code));
 		jx_insert_string(err, "source", "jx_eval");
@@ -212,111 +69,4 @@ struct jx *jx_function_range( struct jx_function *f, struct jx *context ) {
 	}
 
 	return result;
-}
-
-struct jx *jx_function_join(struct jx_function *f, struct jx *context) {
-	char *sep = NULL;
-	struct jx *result;
-	struct jx *array = NULL;
-	struct jx *args = jx_eval(f->arguments, context);
-	struct jx *err;
-	int code;
-	if (jx_istype(args, JX_ERROR)) {
-		return args;
-	}
-	switch (jx_match_array(args, &array, JX_ARRAY, &sep, JX_STRING, NULL)) {
-	case 1:
-	case 2:
-		break;
-	default:
-		code = 6;
-		err = jx_object(NULL);
-		jx_insert_integer(err, "code", code);
-		jx_insert(err, jx_string("function"), jx_function(f->function, jx_copy(f->arguments)));
-		jx_insert_string(err, "message", "invalid arguments");
-		jx_insert_string(err, "name", jx_error_name(code));
-		jx_insert_string(err, "source", "jx_eval");
-		result = jx_error(err);
-		goto DONE;
-	}
-	if (!sep) sep = xxstrdup(" ");
-
-	result = jx_string("");
-	void *i = NULL;
-	struct jx *item;
-	while ((item = jx_iterate_array(array, &i))) {
-		if (!jx_istype(item, JX_STRING)) {
-			jx_delete(result);
-			code = 6;
-			err = jx_object(NULL);
-			jx_insert_integer(err, "code", code);
-			jx_insert(err, jx_string("function"), jx_function(f->function, jx_copy(f->arguments)));
-			jx_insert_string(err, "message", "joined items must be strings");
-			jx_insert_string(err, "name", jx_error_name(code));
-			jx_insert_string(err, "source", "jx_eval");
-			result = jx_error(err);
-			goto DONE;
-		}
-		result->u.string_value = string_combine(result->u.string_value, item->u.string_value);
-		void *peek = i;
-		if (jx_iterate_array(NULL, &peek)) {
-			result->u.string_value = string_combine(result->u.string_value, sep);
-		}
-	}
-
-DONE:
-	free(sep);
-	jx_delete(array);
-	jx_delete(args);
-	return result;
-}
-
-struct jx *jx_function_let(struct jx_function *f, struct jx *context) {
-	int code;
-	struct jx *bindings = NULL;
-	struct jx *body = NULL;
-	struct jx *scratch = NULL;
-	struct jx *err = NULL;
-
-	if (jx_match_array(f->arguments, &bindings, JX_ANY, &body, JX_ANY, &scratch, JX_ANY, NULL) != 2) {
-		jx_delete(bindings);
-		jx_delete(body);
-		jx_delete(scratch);
-		code = 6;
-		err = jx_object(NULL);
-		jx_insert_integer(err, "code", code);
-		jx_insert(err, jx_string("function"), jx_function(f->function, jx_copy(f->arguments)));
-		jx_insert_string(err, "message", "let requires exactly two arguments");
-		jx_insert_string(err, "name", jx_error_name(code));
-		jx_insert_string(err, "source", "jx_eval");
-		return jx_error(err);
-	}
-
-	scratch = jx_eval(bindings, context);
-	jx_delete(bindings);
-	bindings = scratch;
-	scratch = NULL;
-	if (!jx_istype(bindings, JX_OBJECT)) {
-		jx_delete(bindings);
-		jx_delete(body);
-		code = 6;
-		err = jx_object(NULL);
-		jx_insert_integer(err, "code", code);
-		jx_insert(err, jx_string("function"), jx_function(f->function, jx_copy(f->arguments)));
-		jx_insert_string(err, "message", "bindings must be passed in an object");
-		jx_insert_string(err, "name", jx_error_name(code));
-		jx_insert_string(err, "source", "jx_eval");
-		return jx_error(err);
-	}
-
-	if (context) {
-		context = jx_merge(context, bindings, NULL);
-		jx_delete(bindings);
-	} else {
-		context = bindings;
-	}
-	scratch = jx_eval(body, context);
-	jx_delete(context);
-	jx_delete(body);
-	return scratch;
 }

--- a/dttools/src/jx_function.c
+++ b/dttools/src/jx_function.c
@@ -74,10 +74,6 @@ static char *jx_function_format_value(char spec, struct jx *args) {
 			if (jx_istype(j, JX_STRING))
 				result = xxstrdup(j->u.string_value);
 			break;
-		case 'b':
-			if (jx_istype(j, JX_BOOLEAN))
-				result = j->u.boolean_value ? xxstrdup("true") : xxstrdup("false");
-			break;
 		default: break;
 	}
 	jx_delete(j);

--- a/dttools/src/jx_function.h
+++ b/dttools/src/jx_function.h
@@ -10,5 +10,6 @@ See the file COPYING for details.
 #include "jx.h"
 
 struct jx *jx_function_range(struct jx *args);
+struct jx *jx_function_format(struct jx *args);
 
 #endif

--- a/dttools/src/jx_function.h
+++ b/dttools/src/jx_function.h
@@ -9,13 +9,6 @@ See the file COPYING for details.
 
 #include "jx.h"
 
-const char *jx_function_name_to_string(jx_function_t func);
-jx_function_t jx_function_name_from_string(const char *name);
-struct jx *jx_function_range(struct jx_function *f, struct jx *context);
-struct jx *jx_function_foreach(struct jx_function *f, struct jx *context);
-struct jx *jx_function_str(struct jx_function *f, struct jx *context);
-struct jx *jx_function_join(struct jx_function *f, struct jx *context);
-struct jx *jx_function_let(struct jx_function *f, struct jx *context);
-struct jx *jx_function_dbg(struct jx_function *f, struct jx *context);
+struct jx *jx_function_range(struct jx *args);
 
 #endif

--- a/dttools/src/jx_match.h
+++ b/dttools/src/jx_match.h
@@ -88,6 +88,8 @@ See the file COPYING for details.
 #ifndef JX_MATCH_H
 #define JX_MATCH_H
 
+#include <jx.h>
+
 #ifndef JX_ANY
 #define JX_ANY -1
 #endif

--- a/dttools/src/jx_parse.c
+++ b/dttools/src/jx_parse.c
@@ -49,6 +49,7 @@ typedef enum {
 	JX_TOKEN_RPAREN,
 	JX_TOKEN_FOR,
 	JX_TOKEN_IN,
+	JX_TOKEN_IF,
 	JX_TOKEN_PARSE_ERROR,
 	JX_TOKEN_EOF,
 } jx_token_t;
@@ -372,6 +373,8 @@ static jx_token_t jx_scan( struct jx_parser *s )
 					return JX_TOKEN_FOR;
 				} else if (!strcmp(s->token, "in")) {
 					return JX_TOKEN_IN;
+				} else if (!strcmp(s->token, "if")) {
+					return JX_TOKEN_IF;
 				} else if(!strcmp(s->token, "Error")) {
 					return JX_TOKEN_ERROR;
 				} else {
@@ -438,6 +441,17 @@ static struct jx_item *jx_parse_item_list(struct jx_parser *s, bool arglist) {
 		}
 
 		t = jx_scan(s);
+		if (t == JX_TOKEN_IF) {
+			i->condition = jx_parse(s);
+			if (!i->condition) {
+				jx_item_delete(i);
+				if (jx_parser_errors(s)) return NULL;
+				jx_parse_error(s,
+					"EOF while parsing list comprehension");
+				return NULL;
+			}
+			t = jx_scan(s);
+		}
 	}
 
 	if(t==JX_TOKEN_COMMA) {

--- a/dttools/src/jx_parse.c
+++ b/dttools/src/jx_parse.c
@@ -64,17 +64,16 @@ struct jx_parser {
 	time_t stoptime;
 	char *error_string;
 	int errors;
-	int strict_mode;
-	int putback_char_valid;
+	bool strict_mode;
+	bool putback_char_valid;
 	int putback_char;
-	int putback_token_valid;
+	bool putback_token_valid;
 	jx_token_t putback_token;
 	jx_int_t integer_value;
 	double double_value;
 };
 
-struct jx_parser * jx_parser_create( int strict_mode )
-{
+struct jx_parser *jx_parser_create(bool strict_mode) {
 	struct jx_parser *p = malloc(sizeof(*p));
 	memset(p,0,sizeof(*p));
 	p->strict_mode = strict_mode;
@@ -110,7 +109,7 @@ const char * jx_parser_error_string( struct jx_parser *p )
 
 void jx_parser_delete( struct jx_parser *p )
 {
-	if(p->error_string) free(p->error_string);
+	free(p->error_string);
 	free(p);
 }
 
@@ -133,7 +132,7 @@ static int jx_getchar( struct jx_parser *p )
 	int c=0;
 
 	if(p->putback_char_valid) {
-		p->putback_char_valid = 0;
+		p->putback_char_valid = false;
 		if (p->putback_char == '\n') ++p->line;
 		return p->putback_char;
 	}
@@ -165,7 +164,7 @@ static void jx_ungetchar( struct jx_parser *p, int c )
 {
 	if (c == '\n') --p->line;
 	p->putback_char = c;
-	p->putback_char_valid = 1;
+	p->putback_char_valid = true;
 }
 
 static int jx_scan_unicode( struct jx_parser *s )
@@ -219,7 +218,7 @@ static int jx_scan_string_char( struct jx_parser *s )
 static void jx_unscan( struct jx_parser *s, jx_token_t t )
 {
 	s->putback_token = t;
-	s->putback_token_valid = 1;
+	s->putback_token_valid = true;
 }
 
 static jx_token_t jx_scan( struct jx_parser *s )
@@ -227,7 +226,7 @@ static jx_token_t jx_scan( struct jx_parser *s )
 	int c;
 
 	if(s->putback_token_valid) {
-		s->putback_token_valid = 0;
+		s->putback_token_valid = false;
 		return s->putback_token;
 	}
 
@@ -388,25 +387,24 @@ static jx_token_t jx_scan( struct jx_parser *s )
 	}
 }
 
-static struct jx_item * jx_parse_item_list( struct jx_parser *s, int arglist )
-{
+static struct jx_item *jx_parse_item_list(struct jx_parser *s, bool arglist) {
 	jx_token_t rdelim = arglist ? JX_TOKEN_RPAREN : JX_TOKEN_RBRACKET;
 	jx_token_t t = jx_scan(s);
 	if(t==rdelim) {
 		// empty list
-		return 0;
+		return NULL;
 	}
 
 	jx_unscan(s,t);
 
-	struct jx_item *i = jx_item(0,0);
+	struct jx_item *i = jx_item(NULL, NULL);
 	i->line = s->line;
 
 	i->value = jx_parse(s);
 	if(!i->value) {
 		// error set by deeper layer
 		jx_item_delete(i);
-		return 0;
+		return NULL;
 	}
 
 	t = jx_scan(s);
@@ -415,14 +413,14 @@ static struct jx_item * jx_parse_item_list( struct jx_parser *s, int arglist )
 		if (jx_parser_errors(s)) {
 			// error set by deeper layer
 			jx_item_delete(i);
-			return 0;
+			return NULL;
 		}
 	} else if(t==rdelim) {
-		i->next = 0;
+		i->next = NULL;
 	} else {
 		jx_parse_error(s,"list of items missing a comma or closing delimiter");
 		jx_item_delete(i);
-		return 0;
+		return NULL;
 	}
 
 	return i;
@@ -433,25 +431,25 @@ static struct jx_pair * jx_parse_pair_list( struct jx_parser *s )
 	jx_token_t t = jx_scan(s);
 	if(t==JX_TOKEN_RBRACE) {
 		// empty list
-		return 0;
+		return NULL;
 	}
 
 	jx_unscan(s,t);
 
-	struct jx_pair *p = jx_pair(0,0,0);
+	struct jx_pair *p = jx_pair(NULL, NULL, NULL);
 
 	p->key = jx_parse(s);
 	if(!p->key) {
 		// error set by deeper layer
 		jx_pair_delete(p);
-		return 0;
+		return NULL;
 	}
 
 	if(s->strict_mode) {
 		if(p->key->type!=JX_STRING) {
 			jx_parse_error(s,"key-value pair must have a string as the key");
 			jx_pair_delete(p);
-			return 0;
+			return NULL;
 		}
 	}
 
@@ -459,7 +457,7 @@ static struct jx_pair * jx_parse_pair_list( struct jx_parser *s )
 	if(t!=JX_TOKEN_COLON) {
 		jx_parse_error(s,"key-value pair must be separated by a colon");
 		jx_pair_delete(p);
-		return 0;
+		return NULL;
 	}
 
 	p->line = s->line;
@@ -467,7 +465,7 @@ static struct jx_pair * jx_parse_pair_list( struct jx_parser *s )
 	if(!p->value) {
 		// error set by deeper layer
 		jx_pair_delete(p);
-		return 0;
+		return NULL;
 	}
 
 	t = jx_scan(s);
@@ -476,21 +474,20 @@ static struct jx_pair * jx_parse_pair_list( struct jx_parser *s )
 		if (jx_parser_errors(s)) {
 			// error set by deeper layer
 			jx_pair_delete(p);
-			return 0;
+			return NULL;
 		}
 	} else if(t==JX_TOKEN_RBRACE) {
-		p->next = 0;
+		p->next = NULL;
 	} else {
 		jx_parse_error(s,"key-value pairs missing a comma or closing brace");
 		jx_pair_delete(p);
-		return 0;
+		return NULL;
 	}
 
 	return p;
 }
 
-static struct jx * jx_parse_atomic( struct jx_parser *s, int arglist )
-{
+static struct jx *jx_parse_atomic(struct jx_parser *s, bool arglist) {
 	jx_token_t t = jx_scan(s);
 
 	if (arglist) {
@@ -536,10 +533,8 @@ static struct jx * jx_parse_atomic( struct jx_parser *s, int arglist )
 			return jx_add_lineno(s, jx_integer(s->integer_value));
 		case JX_TOKEN_DOUBLE:
 			return jx_add_lineno(s, jx_double(s->double_value));
-		case JX_TOKEN_TRUE:
-			return jx_add_lineno(s, jx_boolean(1));
-		case JX_TOKEN_FALSE:
-			return jx_add_lineno(s, jx_boolean(0));
+		case JX_TOKEN_TRUE: return jx_add_lineno(s, jx_boolean(true));
+		case JX_TOKEN_FALSE: return jx_add_lineno(s, jx_boolean(false));
 		case JX_TOKEN_NULL:
 			return jx_add_lineno(s, jx_null());
 		case JX_TOKEN_SYMBOL: {
@@ -573,7 +568,7 @@ static struct jx * jx_parse_atomic( struct jx_parser *s, int arglist )
 	*/
 
 	jx_parse_error(s,"parse error");
-	return 0;
+	return NULL;
 }
 
 #define JX_PRECEDENCE_MAX 5
@@ -621,20 +616,18 @@ static jx_operator_t jx_token_to_operator( jx_token_t t )
 	}
 }
 
-static int jx_operator_is_unary( jx_operator_t op )
-{
+static bool jx_operator_is_unary(jx_operator_t op) {
 	switch(op) {
-		case JX_OP_NOT:
-			return 1;
-		default:
-			return 0;
+		case JX_OP_NOT: return true;
+		default: return false;
 	}
 }
 
 static struct jx * jx_parse_postfix( struct jx_parser *s, int arglist )
 {
 	struct jx *a = jx_parse_atomic(s, arglist);
-	if(!a) return 0;
+	if (!a)
+		return NULL;
 
 	jx_token_t t = jx_scan(s);
 	if(t==JX_TOKEN_LBRACKET) {
@@ -643,7 +636,7 @@ static struct jx * jx_parse_postfix( struct jx_parser *s, int arglist )
 		if(!b) {
 			jx_delete(a);
 			// parse error already set
-			return 0;
+			return NULL;
 		}
 
 		t = jx_scan(s);
@@ -651,7 +644,7 @@ static struct jx * jx_parse_postfix( struct jx_parser *s, int arglist )
 			jx_parse_error(s,"missing closing bracket");
 			jx_delete(a);
 			jx_delete(b);
-			return 0;
+			return NULL;
 		} else {
 			struct jx *j = jx_operator(JX_OP_LOOKUP, a, b);
 			j->line = line;
@@ -672,7 +665,7 @@ static struct jx * jx_parse_unary( struct jx_parser *s )
 		case JX_TOKEN_ADD:
 		case JX_TOKEN_NOT: {
 			unsigned line = s->line;
-			struct jx *j = jx_parse_postfix(s, 0);
+			struct jx *j = jx_parse_postfix(s, false);
 			if (!j) {
 				// error set by deeper level
 				return NULL;
@@ -689,7 +682,7 @@ static struct jx * jx_parse_unary( struct jx_parser *s )
 				return NULL;
 			}
 			unsigned line = s->line;
-			struct jx *j = jx_parse_postfix(s, 1);
+			struct jx *j = jx_parse_postfix(s, true);
 			if (!j) {
 				// error set by deeper level
 				return NULL;
@@ -705,7 +698,7 @@ static struct jx * jx_parse_unary( struct jx_parser *s )
 		}
 		case JX_TOKEN_ERROR: {
 			unsigned line = s->line;
-			struct jx *j = jx_parse_postfix(s, 0);
+			struct jx *j = jx_parse_postfix(s, false);
 			if (!j) {
 				jx_parse_error(s, "error is missing a required field");
 				return NULL;
@@ -722,7 +715,7 @@ static struct jx * jx_parse_unary( struct jx_parser *s )
 		}
 		default: {
 			jx_unscan(s,t);
-			return jx_parse_postfix(s, 0);
+			return jx_parse_postfix(s, false);
 		}
 	}
 }
@@ -737,7 +730,8 @@ static struct jx * jx_parse_binary( struct jx_parser *s, int precedence )
 		a = jx_parse_binary(s,precedence-1);
 	}
 
-	if(!a) return 0;
+	if (!a)
+		return NULL;
 
 	jx_token_t t = jx_scan(s);
 	jx_operator_t op = jx_token_to_operator(t);
@@ -763,7 +757,8 @@ static struct jx * jx_parse_binary( struct jx_parser *s, int precedence )
 struct jx * jx_parse( struct jx_parser *s )
 {
 	struct jx *j = jx_parse_binary(s,JX_PRECEDENCE_MAX);
-	if(!j) return 0;
+	if (!j)
+		return NULL;
 
 	jx_token_t t = jx_scan(s);
 	if(t!=JX_TOKEN_SEMI) jx_unscan(s,t);
@@ -778,7 +773,7 @@ static struct jx * jx_parse_finish( struct jx_parser *p )
 		debug(D_JX|D_NOTICE, "parse error: %s", jx_parser_error_string(p));
 		jx_parser_delete(p);
 		jx_delete(j);
-		return 0;
+		return NULL;
 	}
 	jx_parser_delete(p);
 	return j;
@@ -790,28 +785,28 @@ struct jx * jx_parser_yield( struct jx_parser *p )
 	if(jx_parser_errors(p)) {
 		debug(D_JX|D_NOTICE, "parse error: %s", jx_parser_error_string(p));
 		jx_delete(j);
-		return 0;
+		return NULL;
 	}
 	return j;
 }
 
 struct jx * jx_parse_string( const char *str )
 {
-	struct jx_parser *p = jx_parser_create(0);
+	struct jx_parser *p = jx_parser_create(false);
 	jx_parser_read_string(p,str);
 	return jx_parse_finish(p);
 }
 
 struct jx * jx_parse_link( struct link *l, time_t stoptime )
 {
-	struct jx_parser *p = jx_parser_create(0);
+	struct jx_parser *p = jx_parser_create(false);
 	jx_parser_read_link(p,l,stoptime);
 	return jx_parse_finish(p);
 }
 
 struct jx * jx_parse_stream( FILE *file )
 {
-	struct jx_parser *p = jx_parser_create(0);
+	struct jx_parser *p = jx_parser_create(false);
 	jx_parser_read_stream(p,file);
 	return jx_parse_finish(p);
 }
@@ -819,7 +814,8 @@ struct jx * jx_parse_stream( FILE *file )
 struct jx * jx_parse_file( const char *name )
 {
 	FILE *file = fopen(name,"r");
-	if(!file) return 0;
+	if (!file)
+		return NULL;
 	struct jx *j = jx_parse_stream(file);
 	fclose(file);
 	return j;

--- a/dttools/src/jx_parse.c
+++ b/dttools/src/jx_parse.c
@@ -262,11 +262,6 @@ static jx_token_t jx_scan( struct jx_parser *s )
 		return JX_TOKEN_DIV;
 	} else if(c=='%') {
 		return JX_TOKEN_MOD;
-	} else if(c=='&') {
-		char d = jx_getchar(s);
-		if(d=='&') return JX_TOKEN_AND;
-		jx_parse_error(s,"invalid character: &");
-		return JX_TOKEN_PARSE_ERROR;
 	} else if(c=='|') {
 		char d = jx_getchar(s);
 		if(d=='|') return JX_TOKEN_OR;
@@ -276,7 +271,8 @@ static jx_token_t jx_scan( struct jx_parser *s )
 		char d = jx_getchar(s);
 		if(d=='=') return JX_TOKEN_NE;
 		jx_ungetchar(s,d);
-		return JX_TOKEN_NOT;
+		jx_parse_error(s,"invalid character: !");
+		return JX_TOKEN_PARSE_ERROR;
 	} else if(c=='=') {
 		char d = jx_getchar(s);
 		if(d=='=') return JX_TOKEN_EQ;
@@ -363,12 +359,18 @@ static jx_token_t jx_scan( struct jx_parser *s )
 			} else {
 				jx_ungetchar(s,c);
 				s->token[i] = 0;
-				if(!strcmp(s->token,"true")) {
+				if(!strcmp(s->token,"null")) {
+					return JX_TOKEN_NULL;
+				} else if(!strcmp(s->token,"true")) {
 					return JX_TOKEN_TRUE;
 				} else if(!strcmp(s->token,"false")) {
 					return JX_TOKEN_FALSE;
-				} else if(!strcmp(s->token,"null")) {
-					return JX_TOKEN_NULL;
+				} else if(!strcmp(s->token,"or")) {
+					return JX_TOKEN_OR;
+				} else if(!strcmp(s->token,"and")) {
+					return JX_TOKEN_AND;
+				} else if(!strcmp(s->token,"not")) {
+					return JX_TOKEN_NOT;
 				} else if (!strcmp(s->token, "for")) {
 					return JX_TOKEN_FOR;
 				} else if (!strcmp(s->token, "in")) {

--- a/dttools/src/jx_parse.c
+++ b/dttools/src/jx_parse.c
@@ -820,3 +820,5 @@ struct jx * jx_parse_file( const char *name )
 	fclose(file);
 	return j;
 }
+
+/* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/jx_parse.c
+++ b/dttools/src/jx_parse.c
@@ -394,11 +394,11 @@ static jx_token_t jx_scan( struct jx_parser *s )
 	}
 }
 
-static struct jx_comprehension *jx_parse_comprehension(struct jx_parser *s, struct jx_comprehension *next) {
+static struct jx_comprehension *jx_parse_comprehension(struct jx_parser *s) {
 	jx_token_t t = jx_scan(s);
 	if (t != JX_TOKEN_FOR) {
 		jx_unscan(s, t);
-		return next;
+		return NULL;
 	}
 
 	unsigned line = s->line;
@@ -441,11 +441,10 @@ static struct jx_comprehension *jx_parse_comprehension(struct jx_parser *s, stru
 		variable,
 		elements,
 		condition,
-		next);
+		jx_parse_comprehension(s));
 	result->line = line;
 	free(variable);
-
-	return jx_parse_comprehension(s, result);
+	return result;
 
 FAILURE:
 	free(variable);
@@ -474,7 +473,7 @@ static struct jx_item *jx_parse_item_list(struct jx_parser *s, bool arglist) {
 		jx_item_delete(i);
 		return NULL;
 	}
-	i->comp = jx_parse_comprehension(s, NULL);
+	i->comp = jx_parse_comprehension(s);
 	if (jx_parser_errors(s)) {
 		// error set by deeper layer
 		jx_item_delete(i);

--- a/dttools/src/jx_parse.h
+++ b/dttools/src/jx_parse.h
@@ -20,6 +20,7 @@ with the following exceptions:
 #include "jx.h"
 #include "link.h"
 
+#include <stdbool.h>
 #include <stdio.h>
 
 struct jx_parser;
@@ -37,7 +38,7 @@ struct jx * jx_parse_file( const char *name );
 struct jx * jx_parse_link( struct link *l, time_t stoptime );
 
 /** Create a JX parser object.  @return A parser object. */
-struct jx_parser * jx_parser_create();
+struct jx_parser *jx_parser_create(bool strict_mode);
 
 /** Attach parser to a file.  @param p A parser object.  @param file A standard IO stream. */
 void jx_parser_read_stream( struct jx_parser *p, FILE *file );

--- a/dttools/src/jx_pretty_print.c
+++ b/dttools/src/jx_pretty_print.c
@@ -38,6 +38,7 @@ static void jx_pretty_print_item( struct jx_item *item, buffer_t *b, int level)
 	buffer_printf(b,"%*s", level*SPACES, "");
 
 	jx_pretty_print_buffer(item->value, b, level );
+	jx_comprehension_print(item->comp, b);
 
 	if(item->next) {
 		buffer_putstring(b,",\n");

--- a/dttools/src/jx_print.c
+++ b/dttools/src/jx_print.c
@@ -6,7 +6,6 @@ See the file COPYING for details.
 
 #include "jx_print.h"
 #include "jx_parse.h"
-#include "jx_function.h"
 
 #include <ctype.h>
 
@@ -51,8 +50,9 @@ const char * jx_operator_string( jx_operator_t type )
 		case JX_OP_AND:	return "&&";
 		case JX_OP_OR:	return "||";
 		case JX_OP_NOT:	return "!";
-		// note that the closing bracket is in jx_print_subexpr
+		// note that the closing bracket/paren is in jx_print_subexpr
 		case JX_OP_LOOKUP: return "[";
+		case JX_OP_CALL: return "(";
 		default:        return "???";
 	}
 }
@@ -161,14 +161,14 @@ void jx_print_buffer( struct jx *j, buffer_t *b )
 		case JX_OPERATOR:
 			jx_print_subexpr(j->u.oper.left,j->u.oper.type,b);
 			buffer_putstring(b,jx_operator_string(j->u.oper.type));
-			jx_print_subexpr(j->u.oper.right,j->u.oper.type,b);
+			if (j->u.oper.type == JX_OP_CALL) {
+				jx_item_print(j->u.oper.right->u.items, b);
+				buffer_putstring(b, ")");
+			} else {
+				jx_print_subexpr(
+					j->u.oper.right, j->u.oper.type, b);
+			}
 			if(j->u.oper.type==JX_OP_LOOKUP) buffer_putstring(b,"]");
-			break;
-		case JX_FUNCTION:
-			buffer_putstring(b, jx_function_name_to_string(j->u.func.function));
-			buffer_putstring(b, "(");
-			jx_print_args(j->u.func.arguments, b);
-			buffer_putstring(b, ")");
 			break;
 		case JX_ERROR:
 			buffer_putstring(b,"Error");

--- a/dttools/src/jx_print.c
+++ b/dttools/src/jx_print.c
@@ -64,9 +64,9 @@ const char * jx_operator_string( jx_operator_t type )
 		case JX_OP_MUL: return "*";
 		case JX_OP_DIV: return "/";
 		case JX_OP_MOD: return "%";
-		case JX_OP_AND:	return "&&";
-		case JX_OP_OR:	return "||";
-		case JX_OP_NOT:	return "!";
+		case JX_OP_AND:	return " and ";
+		case JX_OP_OR:	return " or ";
+		case JX_OP_NOT:	return " not ";
 		// note that the closing bracket/paren is in jx_print_subexpr
 		case JX_OP_LOOKUP: return "[";
 		case JX_OP_CALL: return "(";

--- a/dttools/src/jx_print.c
+++ b/dttools/src/jx_print.c
@@ -10,7 +10,7 @@ See the file COPYING for details.
 #include <assert.h>
 #include <ctype.h>
 
-static void jx_comprehension_print(struct jx_comprehension *comp, buffer_t *b) {
+void jx_comprehension_print(struct jx_comprehension *comp, buffer_t *b) {
 	if (!comp) return;
 	jx_comprehension_print(comp->next, b);
 

--- a/dttools/src/jx_print.c
+++ b/dttools/src/jx_print.c
@@ -12,7 +12,6 @@ See the file COPYING for details.
 
 void jx_comprehension_print(struct jx_comprehension *comp, buffer_t *b) {
 	if (!comp) return;
-	jx_comprehension_print(comp->next, b);
 
 	buffer_putstring(b, " for ");
 	buffer_putstring(b, comp->variable);
@@ -22,6 +21,8 @@ void jx_comprehension_print(struct jx_comprehension *comp, buffer_t *b) {
 		buffer_putstring(b, " if ");
 		jx_print_buffer(comp->condition, b);
 	}
+
+	jx_comprehension_print(comp->next, b);
 }
 
 static void jx_pair_print( struct jx_pair *pair, buffer_t *b )

--- a/dttools/src/jx_print.c
+++ b/dttools/src/jx_print.c
@@ -10,6 +10,20 @@ See the file COPYING for details.
 #include <assert.h>
 #include <ctype.h>
 
+static void jx_comprehension_print(struct jx_comprehension *comp, buffer_t *b) {
+	if (!comp) return;
+	jx_comprehension_print(comp->next, b);
+
+	buffer_putstring(b, " for ");
+	buffer_putstring(b, comp->variable);
+	buffer_putstring(b, " in ");
+	jx_print_buffer(comp->elements, b);
+	if (comp->condition) {
+		buffer_putstring(b, " if ");
+		jx_print_buffer(comp->condition, b);
+	}
+}
+
 static void jx_pair_print( struct jx_pair *pair, buffer_t *b )
 {
 	if(!pair) return;
@@ -27,18 +41,9 @@ static void jx_item_print( struct jx_item *item, buffer_t *b )
 {
 	if(!item) return;
 
-	jx_print_buffer(item->value,b);
-	if (item->variable) {
-		assert(item->list);
-		buffer_putstring(b, " for ");
-		buffer_putstring(b, item->variable);
-		buffer_putstring(b, " in ");
-		jx_print_buffer(item->list, b);
-		if (item->condition) {
-			buffer_putstring(b, " if ");
-			jx_print_buffer(item->condition, b);
-		}
-	}
+	jx_print_buffer(item->value, b);
+	jx_comprehension_print(item->comp, b);
+
 	if(item->next) {
 		buffer_putstring(b,",");
 		jx_item_print(item->next,b);

--- a/dttools/src/jx_print.c
+++ b/dttools/src/jx_print.c
@@ -7,6 +7,7 @@ See the file COPYING for details.
 #include "jx_print.h"
 #include "jx_parse.h"
 
+#include <assert.h>
 #include <ctype.h>
 
 static void jx_pair_print( struct jx_pair *pair, buffer_t *b )
@@ -27,6 +28,13 @@ static void jx_item_print( struct jx_item *item, buffer_t *b )
 	if(!item) return;
 
 	jx_print_buffer(item->value,b);
+	if (item->variable) {
+		assert(item->list);
+		buffer_putstring(b, " for ");
+		buffer_putstring(b, item->variable);
+		buffer_putstring(b, " in ");
+		jx_print_buffer(item->list, b);
+	}
 	if(item->next) {
 		buffer_putstring(b,",");
 		jx_item_print(item->next,b);

--- a/dttools/src/jx_print.c
+++ b/dttools/src/jx_print.c
@@ -34,6 +34,10 @@ static void jx_item_print( struct jx_item *item, buffer_t *b )
 		buffer_putstring(b, item->variable);
 		buffer_putstring(b, " in ");
 		jx_print_buffer(item->list, b);
+		if (item->condition) {
+			buffer_putstring(b, " if ");
+			jx_print_buffer(item->condition, b);
+		}
 	}
 	if(item->next) {
 		buffer_putstring(b,",");

--- a/dttools/src/jx_print.c
+++ b/dttools/src/jx_print.c
@@ -70,6 +70,7 @@ const char * jx_operator_string( jx_operator_t type )
 		// note that the closing bracket/paren is in jx_print_subexpr
 		case JX_OP_LOOKUP: return "[";
 		case JX_OP_CALL: return "(";
+		case JX_OP_SLICE: return ":";
 		default:        return "???";
 	}
 }

--- a/dttools/src/jx_print.c
+++ b/dttools/src/jx_print.c
@@ -170,6 +170,7 @@ void jx_print_buffer( struct jx *j, buffer_t *b )
 			}
 			if(j->u.oper.type==JX_OP_LOOKUP) buffer_putstring(b,"]");
 			break;
+		case JX_FUNCTION: buffer_putstring(b, j->u.func.name); break;
 		case JX_ERROR:
 			buffer_putstring(b,"Error");
 			jx_print_buffer(j->u.err, b);

--- a/dttools/src/jx_print.h
+++ b/dttools/src/jx_print.h
@@ -38,4 +38,7 @@ void jx_print_args( struct jx *j, buffer_t *b );
 
 /** Get a string representation of an operator. @param type The operator to get. */
 const char * jx_operator_string( jx_operator_t type );
+
+// internal function for printing list comprehension expressions
+void jx_comprehension_print(struct jx_comprehension *comp, buffer_t *b);
 #endif

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -297,62 +297,53 @@ value:      []
 expression: range(5,0,-1)
 value:      [5,4,3,2,1]
 
-expression: str()
-value:      ""
+expression: format()
+value:      Error{"source":"jx_eval","name":"invalid arguments","message":"invalid/missing format string","function":format(),"code":6}
 
-expression: str(2)
-value:      "2"
+expression: format("%%")
+value:      "%"
 
-expression: str(x+y)
-value:      "30"
+expression: format("value: %i!!",x+y)
+value:      "value: 30!!"
 
-expression: str(x,y)
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"at most one argument is allowed","function":str(x,y),"code":6}
+expression: format("%i",x,y)
+value:      "10"
 
-expression: str(range(10))
-value:      "[0,1,2,3,4,5,6,7,8,9]"
+expression: format("(%d, %i)",x,y)
+value:      "(10, 20)"
 
-expression: str("a")
-value:      "a"
+expression: format("%i")
+value:      Error{"source":"jx_eval","name":"invalid arguments","message":"mismatched format specifier","function":format("%i"),"code":6}
 
-expression: foreach("too","few")
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"invalid arguments","function":foreach("too","few"),"code":6}
+expression: format("%e",1.2e-22)
+value:      "1.200000e-22"
 
-expression: foreach(x,"nope",str(x))
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"second argument must evaluate to an array","function":foreach(x,"nope",str(x)),"code":6}
+expression: format("%E",6.02e+23)
+value:      "6.020000E+23"
 
-expression: foreach(x,range(5),"item"+str(x))
-value:      ["item0","item1","item2","item3","item4"]
+expression: format("%f",2.5)
+value:      "2.500000"
 
-expression: join(["a","b",c])
-value:      Error{"source":"jx_eval","name":"undefined symbol","message":"undefined symbol","line":152,"context":{"outfile":"results","infile":"mydata","a":true,"b":false,"f":0.5,"g":3.14159,"x":10,"y":20,"list":[100,200,300],"object":{"house":"home"}},"symbol":c,"code":0}
+expression: format("%F",3.14)
+value:      "3.140000"
 
-expression: join([1,2])
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"joined items must be strings","function":join([1,2]),"code":6}
+expression: format("%g",9.9e+09)
+value:      "9.9e+09"
 
-expression: join(["a",2])
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"joined items must be strings","function":join(["a",2]),"code":6}
+expression: format("%G",2.11111e-12)
+value:      "2.11111E-12"
 
-expression: join([])
-value:      ""
+expression: format("%b",false)
+value:      "false"
 
-expression: join(["a"])
-value:      "a"
-
-expression: join(["a","b","c"])
-value:      "a b c"
-
-expression: join(["a","b","c"],", ")
-value:      "a, b, c"
-
-expression: dbg(join(dbg(foreach(x,dbg(range(dbg(3))),dbg(dbg(str(dbg(x)))+dbg(".")+dbg(str(dbg(dbg(x)+dbg(1)))))))))
-value:      "0.1 1.2 2.3"
+expression: format("%s","foo")
+value:      "foo"
 
 expression: 10+[1]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":162,"operator":10+[1],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":156,"operator":10+[1],"code":2}
 
 expression: "abc"+[2]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":163,"operator":"abc"+[2],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":157,"operator":"abc"+[2],"code":2}
 
 expression: []+[]
 value:      []
@@ -383,7 +374,4 @@ value:      true
 
 expression: Error{"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"}
 value:      Error{"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"}
-
-expression: let({"f":2.2,"g":4.5},f+y)
-value:      22.2
 

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -396,9 +396,6 @@ value:      "9.9e+09"
 expression: format("%G",2.11111e-12)
 value:      "2.11111E-12"
 
-expression: format("%b",false)
-value:      "false"
-
 expression: format("%s","foo")
 value:      "foo"
 

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -261,8 +261,20 @@ value:      500
 expression: a==b||(f>g&&x<y)
 value:      false
 
-expression: [10,-90.5,true,false,null,[-1,-2,-3]]
-value:      [10,-90.5,true,false,null,[-1,-2,-3]]
+expression: [[0,i] for i in [1,2,x],10,-90.5,true for i in range(5),false,null,[-1,-2,-3]]
+value:      [[0,1],[0,2],[0,10],10,-90.5,true,true,true,true,true,false,null,[-1,-2,-3]]
+
+expression: [format(":%d",2*i) for i in range(10)]
+value:      [":0",":2",":4",":6",":8",":10",":12",":14",":16",":18"]
+
+expression: [i+1 for i in [10-i for i in range(10)]]
+value:      [11,10,9,8,7,6,5,4,3,2]
+
+expression: [[[i,j] for j in range(3)] for i in [10-i for i in range(4)]]
+value:      [[[10,0],[10,1],[10,2]],[[9,0],[9,1],[9,2]],[[8,0],[8,1],[8,2]],[[7,0],[7,1],[7,2]]]
+
+expression: [null for i in 7]
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"list comprehension takes an array","line":121,"list":7,"code":2}
 
 expression: list[2]
 value:      300
@@ -340,10 +352,10 @@ expression: format("%s","foo")
 value:      "foo"
 
 expression: 10+[1]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":156,"operator":10+[1],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":160,"operator":10+[1],"code":2}
 
 expression: "abc"+[2]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":157,"operator":"abc"+[2],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":161,"operator":"abc"+[2],"code":2}
 
 expression: []+[]
 value:      []

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -244,10 +244,10 @@ expression: x%y
 value:      10
 
 expression: x and y
-value:      0
+value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on integer","line":109,"operator":10 and 20,"code":1}
 
 expression: x or y
-value:      30
+value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on integer","line":110,"operator":10 or 20,"code":1}
 
 expression: (x+y)*(f+g)
 value:      109.248

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -300,6 +300,36 @@ value:      [[0,0,0,true],[1,0,0,true],[2,0,0,true],[3,0,0,true],[0,1,0,true],[1
 expression: list[2]
 value:      300
 
+expression: list[1:]
+value:      [200,300]
+
+expression: list[:2]
+value:      [100,200]
+
+expression: list[1:2]
+value:      [200]
+
+expression: list[:]
+value:      [100,200,300]
+
+expression: list[3:2]
+value:      []
+
+expression: list[(-11):3]
+value:      [100,200,300]
+
+expression: list[0:100]
+value:      [100,200,300]
+
+expression: list[true:4]
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"slice indices must be integers","operator":true:4,"code":2}
+
+expression: list[4:null]
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"slice indices must be integers","operator":4:null,"code":2}
+
+expression: list[true:false]
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"slice indices must be integers","operator":true:false,"code":2}
+
 expression: object["house"]
 value:      "home"
 
@@ -373,10 +403,10 @@ expression: format("%s","foo")
 value:      "foo"
 
 expression: 10+[1]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":167,"operator":10+[1],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":177,"operator":10+[1],"code":2}
 
 expression: "abc"+[2]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":168,"operator":"abc"+[2],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":178,"operator":"abc"+[2],"code":2}
 
 expression: []+[]
 value:      []

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -42,34 +42,34 @@ value:      false
 expression: null
 value:      null
 
-expression: true&&true
+expression: true and true
 value:      true
 
-expression: true&&false
+expression: true and false
 value:      false
 
-expression: false&&true
+expression: false and true
 value:      false
 
-expression: false&&false
+expression: false and false
 value:      false
 
-expression: true||true
+expression: true or true
 value:      true
 
-expression: true||false
+expression: true or false
 value:      true
 
-expression: false||true
+expression: false or true
 value:      true
 
-expression: false||false
+expression: false or false
 value:      false
 
-expression: !true
+expression:  not true
 value:      false
 
-expression: !false
+expression:  not false
 value:      true
 
 expression: 10==20
@@ -151,16 +151,16 @@ expression: a!=b
 value:      true
 
 expression: a<b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":72,"operator":true<false,"code":1}
+value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":73,"operator":true<false,"code":1}
 
 expression: a>b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":73,"operator":true>false,"code":1}
+value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":74,"operator":true>false,"code":1}
 
 expression: a<=b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":74,"operator":true<=false,"code":1}
+value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":75,"operator":true<=false,"code":1}
 
 expression: a>=b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":75,"operator":true>=false,"code":1}
+value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":76,"operator":true>=false,"code":1}
 
 expression: f==g
 value:      false
@@ -199,19 +199,19 @@ expression: x>=y
 value:      false
 
 expression: a+b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":91,"operator":true+false,"code":1}
+value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":92,"operator":true+false,"code":1}
 
 expression: a-b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":92,"operator":true-false,"code":1}
+value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":93,"operator":true-false,"code":1}
 
 expression: a*b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":93,"operator":true*false,"code":1}
+value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":94,"operator":true*false,"code":1}
 
 expression: a/b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":94,"operator":true/false,"code":1}
+value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":95,"operator":true/false,"code":1}
 
 expression: a%b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":95,"operator":true%false,"code":1}
+value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":96,"operator":true%false,"code":1}
 
 expression: f+g
 value:      3.64159
@@ -243,10 +243,10 @@ value:      0
 expression: x%y
 value:      10
 
-expression: x&&y
+expression: x and y
 value:      0
 
-expression: x||y
+expression: x or y
 value:      30
 
 expression: (x+y)*(f+g)
@@ -258,7 +258,7 @@ value:      610
 expression: 10*(20+30)
 value:      500
 
-expression: a==b||(f>g&&x<y)
+expression: a==b or (f>g and x<y)
 value:      false
 
 expression: [[0,i] for i in [1,2,x],10,-90.5,true for i in range(5),false,null,[-1,-2,-3]]
@@ -274,7 +274,7 @@ expression: [[[i,j] for j in range(3)] for i in [10-i for i in range(4)]]
 value:      [[[10,0],[10,1],[10,2]],[[9,0],[9,1],[9,2]],[[8,0],[8,1],[8,2]],[[7,0],[7,1],[7,2]]]
 
 expression: [null for i in 7]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"list comprehension takes an array","line":121,"list":7,"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"list comprehension takes an array","line":122,"list":7,"code":2}
 
 expression: [i for i in range(10) if i%3==0]
 value:      [0,3,6,9]
@@ -292,7 +292,7 @@ expression: [[i,j] for i in range(5) if i%2==0 for j in range(4) if j%2==1]
 value:      [[0,1],[2,1],[4,1],[0,3],[2,3],[4,3]]
 
 expression: [[i,j] for i in range(5) if j%2==0 for j in range(4) if i%2==1]
-value:      Error{"source":"jx_eval","name":"undefined symbol","message":"undefined symbol","line":127,"context":{"j":0,"format":format,"range":range,"outfile":"results","infile":"mydata","a":true,"b":false,"f":0.5,"g":3.14159,"x":10,"y":20,"list":[100,200,300],"object":{"house":"home"}},"symbol":i,"code":0}
+value:      Error{"source":"jx_eval","name":"undefined symbol","message":"undefined symbol","line":128,"context":{"j":0,"format":format,"range":range,"outfile":"results","infile":"mydata","a":true,"b":false,"f":0.5,"g":3.14159,"x":10,"y":20,"list":[100,200,300],"object":{"house":"home"}},"symbol":i,"code":0}
 
 expression: [[i,j,k,l] for i in range(4) for j in range(3) for k in range(3) for l in [true,false]]
 value:      [[0,0,0,true],[1,0,0,true],[2,0,0,true],[3,0,0,true],[0,1,0,true],[1,1,0,true],[2,1,0,true],[3,1,0,true],[0,2,0,true],[1,2,0,true],[2,2,0,true],[3,2,0,true],[0,0,1,true],[1,0,1,true],[2,0,1,true],[3,0,1,true],[0,1,1,true],[1,1,1,true],[2,1,1,true],[3,1,1,true],[0,2,1,true],[1,2,1,true],[2,2,1,true],[3,2,1,true],[0,0,2,true],[1,0,2,true],[2,0,2,true],[3,0,2,true],[0,1,2,true],[1,1,2,true],[2,1,2,true],[3,1,2,true],[0,2,2,true],[1,2,2,true],[2,2,2,true],[3,2,2,true],[0,0,0,false],[1,0,0,false],[2,0,0,false],[3,0,0,false],[0,1,0,false],[1,1,0,false],[2,1,0,false],[3,1,0,false],[0,2,0,false],[1,2,0,false],[2,2,0,false],[3,2,0,false],[0,0,1,false],[1,0,1,false],[2,0,1,false],[3,0,1,false],[0,1,1,false],[1,1,1,false],[2,1,1,false],[3,1,1,false],[0,2,1,false],[1,2,1,false],[2,2,1,false],[3,2,1,false],[0,0,2,false],[1,0,2,false],[2,0,2,false],[3,0,2,false],[0,1,2,false],[1,1,2,false],[2,1,2,false],[3,1,2,false],[0,2,2,false],[1,2,2,false],[2,2,2,false],[3,2,2,false]]
@@ -403,10 +403,10 @@ expression: format("%s","foo")
 value:      "foo"
 
 expression: 10+[1]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":177,"operator":10+[1],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":178,"operator":10+[1],"code":2}
 
 expression: "abc"+[2]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":178,"operator":"abc"+[2],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":179,"operator":"abc"+[2],"code":2}
 
 expression: []+[]
 value:      []

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -276,6 +276,9 @@ value:      [[[10,0],[10,1],[10,2]],[[9,0],[9,1],[9,2]],[[8,0],[8,1],[8,2]],[[7,
 expression: [null for i in 7]
 value:      Error{"source":"jx_eval","name":"mismatched types","message":"list comprehension takes an array","line":121,"list":7,"code":2}
 
+expression: [i for i in range(10) if i%3==0]
+value:      [0,3,6,9]
+
 expression: list[2]
 value:      300
 
@@ -352,10 +355,10 @@ expression: format("%s","foo")
 value:      "foo"
 
 expression: 10+[1]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":160,"operator":10+[1],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":161,"operator":10+[1],"code":2}
 
 expression: "abc"+[2]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":161,"operator":"abc"+[2],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":162,"operator":"abc"+[2],"code":2}
 
 expression: []+[]
 value:      []

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -370,7 +370,7 @@ expression: format("value: %i!!",x+y)
 value:      "value: 30!!"
 
 expression: format("%i",x,y)
-value:      "10"
+value:      Error{"source":"jx_eval","name":"invalid arguments","message":"too many arguments for format specifier","function":format("%i",10,20),"code":6}
 
 expression: format("(%d, %i)",x,y)
 value:      "(10, 20)"
@@ -400,10 +400,10 @@ expression: format("%s","foo")
 value:      "foo"
 
 expression: 10+[1]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":178,"operator":10+[1],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":177,"operator":10+[1],"code":2}
 
 expression: "abc"+[2]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":179,"operator":"abc"+[2],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":178,"operator":"abc"+[2],"code":2}
 
 expression: []+[]
 value:      []

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -280,22 +280,22 @@ expression: [i for i in range(10) if i%3==0]
 value:      [0,3,6,9]
 
 expression: [[i,j] for i in range(4) for j in range(3)]
-value:      [[0,0],[1,0],[2,0],[3,0],[0,1],[1,1],[2,1],[3,1],[0,2],[1,2],[2,2],[3,2]]
+value:      [[0,0],[0,1],[0,2],[1,0],[1,1],[1,2],[2,0],[2,1],[2,2],[3,0],[3,1],[3,2]]
 
-expression: [[i,j] for i in range(5) if (i+j)%2==0 for j in range(4)]
-value:      [[0,0],[2,0],[4,0],[1,1],[3,1],[0,2],[2,2],[4,2],[1,3],[3,3]]
+expression: [[i,j] for i in range(5) for j in range(4) if (i+j)%2==0]
+value:      [[0,0],[0,2],[1,1],[1,3],[2,0],[2,2],[3,1],[3,3],[4,0],[4,2]]
 
 expression: [[i,j] for i in range(5) for j in range(4) if j%2==1]
-value:      [[0,1],[1,1],[2,1],[3,1],[4,1],[0,3],[1,3],[2,3],[3,3],[4,3]]
+value:      [[0,1],[0,3],[1,1],[1,3],[2,1],[2,3],[3,1],[3,3],[4,1],[4,3]]
 
 expression: [[i,j] for i in range(5) if i%2==0 for j in range(4) if j%2==1]
-value:      [[0,1],[2,1],[4,1],[0,3],[2,3],[4,3]]
+value:      [[0,1],[0,3],[2,1],[2,3],[4,1],[4,3]]
 
 expression: [[i,j] for i in range(5) if j%2==0 for j in range(4) if i%2==1]
-value:      Error{"source":"jx_eval","name":"undefined symbol","message":"undefined symbol","line":128,"context":{"j":0,"format":format,"range":range,"outfile":"results","infile":"mydata","a":true,"b":false,"f":0.5,"g":3.14159,"x":10,"y":20,"list":[100,200,300],"object":{"house":"home"}},"symbol":i,"code":0}
+value:      Error{"source":"jx_eval","name":"undefined symbol","message":"undefined symbol","line":128,"context":{"i":0,"format":format,"range":range,"outfile":"results","infile":"mydata","a":true,"b":false,"f":0.5,"g":3.14159,"x":10,"y":20,"list":[100,200,300],"object":{"house":"home"}},"symbol":j,"code":0}
 
 expression: [[i,j,k,l] for i in range(4) for j in range(3) for k in range(3) for l in [true,false]]
-value:      [[0,0,0,true],[1,0,0,true],[2,0,0,true],[3,0,0,true],[0,1,0,true],[1,1,0,true],[2,1,0,true],[3,1,0,true],[0,2,0,true],[1,2,0,true],[2,2,0,true],[3,2,0,true],[0,0,1,true],[1,0,1,true],[2,0,1,true],[3,0,1,true],[0,1,1,true],[1,1,1,true],[2,1,1,true],[3,1,1,true],[0,2,1,true],[1,2,1,true],[2,2,1,true],[3,2,1,true],[0,0,2,true],[1,0,2,true],[2,0,2,true],[3,0,2,true],[0,1,2,true],[1,1,2,true],[2,1,2,true],[3,1,2,true],[0,2,2,true],[1,2,2,true],[2,2,2,true],[3,2,2,true],[0,0,0,false],[1,0,0,false],[2,0,0,false],[3,0,0,false],[0,1,0,false],[1,1,0,false],[2,1,0,false],[3,1,0,false],[0,2,0,false],[1,2,0,false],[2,2,0,false],[3,2,0,false],[0,0,1,false],[1,0,1,false],[2,0,1,false],[3,0,1,false],[0,1,1,false],[1,1,1,false],[2,1,1,false],[3,1,1,false],[0,2,1,false],[1,2,1,false],[2,2,1,false],[3,2,1,false],[0,0,2,false],[1,0,2,false],[2,0,2,false],[3,0,2,false],[0,1,2,false],[1,1,2,false],[2,1,2,false],[3,1,2,false],[0,2,2,false],[1,2,2,false],[2,2,2,false],[3,2,2,false]]
+value:      [[0,0,0,true],[0,0,0,false],[0,0,1,true],[0,0,1,false],[0,0,2,true],[0,0,2,false],[0,1,0,true],[0,1,0,false],[0,1,1,true],[0,1,1,false],[0,1,2,true],[0,1,2,false],[0,2,0,true],[0,2,0,false],[0,2,1,true],[0,2,1,false],[0,2,2,true],[0,2,2,false],[1,0,0,true],[1,0,0,false],[1,0,1,true],[1,0,1,false],[1,0,2,true],[1,0,2,false],[1,1,0,true],[1,1,0,false],[1,1,1,true],[1,1,1,false],[1,1,2,true],[1,1,2,false],[1,2,0,true],[1,2,0,false],[1,2,1,true],[1,2,1,false],[1,2,2,true],[1,2,2,false],[2,0,0,true],[2,0,0,false],[2,0,1,true],[2,0,1,false],[2,0,2,true],[2,0,2,false],[2,1,0,true],[2,1,0,false],[2,1,1,true],[2,1,1,false],[2,1,2,true],[2,1,2,false],[2,2,0,true],[2,2,0,false],[2,2,1,true],[2,2,1,false],[2,2,2,true],[2,2,2,false],[3,0,0,true],[3,0,0,false],[3,0,1,true],[3,0,1,false],[3,0,2,true],[3,0,2,false],[3,1,0,true],[3,1,0,false],[3,1,1,true],[3,1,1,false],[3,1,2,true],[3,1,2,false],[3,2,0,true],[3,2,0,false],[3,2,1,true],[3,2,1,false],[3,2,2,true],[3,2,2,false]]
 
 expression: list[2]
 value:      300

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -300,6 +300,15 @@ value:      [[0,0,0,true],[1,0,0,true],[2,0,0,true],[3,0,0,true],[0,1,0,true],[1
 expression: list[2]
 value:      300
 
+expression: list[(-1)]
+value:      300
+
+expression: list[(-3)]
+value:      100
+
+expression: list[(-10)]
+value:      Error{"source":"jx_eval","name":"range error","message":"index out of range","index":-10,"array":[100,200,300],"code":4}
+
 expression: list[1:]
 value:      [200,300]
 
@@ -317,6 +326,15 @@ value:      []
 
 expression: list[(-11):3]
 value:      [100,200,300]
+
+expression: list[3:(-11)]
+value:      []
+
+expression: list[1:(-1)]
+value:      [200]
+
+expression: list[(-1):1]
+value:      []
 
 expression: list[0:100]
 value:      [100,200,300]
@@ -400,10 +418,10 @@ expression: format("%s","foo")
 value:      "foo"
 
 expression: 10+[1]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":177,"operator":10+[1],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":183,"operator":10+[1],"code":2}
 
 expression: "abc"+[2]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":178,"operator":"abc"+[2],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":184,"operator":"abc"+[2],"code":2}
 
 expression: []+[]
 value:      []

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -279,6 +279,24 @@ value:      Error{"source":"jx_eval","name":"mismatched types","message":"list c
 expression: [i for i in range(10) if i%3==0]
 value:      [0,3,6,9]
 
+expression: [[i,j] for i in range(4) for j in range(3)]
+value:      [[0,0],[1,0],[2,0],[3,0],[0,1],[1,1],[2,1],[3,1],[0,2],[1,2],[2,2],[3,2]]
+
+expression: [[i,j] for i in range(5) if (i+j)%2==0 for j in range(4)]
+value:      [[0,0],[2,0],[4,0],[1,1],[3,1],[0,2],[2,2],[4,2],[1,3],[3,3]]
+
+expression: [[i,j] for i in range(5) for j in range(4) if j%2==1]
+value:      [[0,1],[1,1],[2,1],[3,1],[4,1],[0,3],[1,3],[2,3],[3,3],[4,3]]
+
+expression: [[i,j] for i in range(5) if i%2==0 for j in range(4) if j%2==1]
+value:      [[0,1],[2,1],[4,1],[0,3],[2,3],[4,3]]
+
+expression: [[i,j] for i in range(5) if j%2==0 for j in range(4) if i%2==1]
+value:      Error{"source":"jx_eval","name":"undefined symbol","message":"undefined symbol","line":127,"context":{"j":0,"format":format,"range":range,"outfile":"results","infile":"mydata","a":true,"b":false,"f":0.5,"g":3.14159,"x":10,"y":20,"list":[100,200,300],"object":{"house":"home"}},"symbol":i,"code":0}
+
+expression: [[i,j,k,l] for i in range(4) for j in range(3) for k in range(3) for l in [true,false]]
+value:      [[0,0,0,true],[1,0,0,true],[2,0,0,true],[3,0,0,true],[0,1,0,true],[1,1,0,true],[2,1,0,true],[3,1,0,true],[0,2,0,true],[1,2,0,true],[2,2,0,true],[3,2,0,true],[0,0,1,true],[1,0,1,true],[2,0,1,true],[3,0,1,true],[0,1,1,true],[1,1,1,true],[2,1,1,true],[3,1,1,true],[0,2,1,true],[1,2,1,true],[2,2,1,true],[3,2,1,true],[0,0,2,true],[1,0,2,true],[2,0,2,true],[3,0,2,true],[0,1,2,true],[1,1,2,true],[2,1,2,true],[3,1,2,true],[0,2,2,true],[1,2,2,true],[2,2,2,true],[3,2,2,true],[0,0,0,false],[1,0,0,false],[2,0,0,false],[3,0,0,false],[0,1,0,false],[1,1,0,false],[2,1,0,false],[3,1,0,false],[0,2,0,false],[1,2,0,false],[2,2,0,false],[3,2,0,false],[0,0,1,false],[1,0,1,false],[2,0,1,false],[3,0,1,false],[0,1,1,false],[1,1,1,false],[2,1,1,false],[3,1,1,false],[0,2,1,false],[1,2,1,false],[2,2,1,false],[3,2,1,false],[0,0,2,false],[1,0,2,false],[2,0,2,false],[3,0,2,false],[0,1,2,false],[1,1,2,false],[2,1,2,false],[3,1,2,false],[0,2,2,false],[1,2,2,false],[2,2,2,false],[3,2,2,false]]
+
 expression: list[2]
 value:      300
 
@@ -355,10 +373,10 @@ expression: format("%s","foo")
 value:      "foo"
 
 expression: 10+[1]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":161,"operator":10+[1],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":167,"operator":10+[1],"code":2}
 
 expression: "abc"+[2]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":162,"operator":"abc"+[2],"code":2}
+value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":168,"operator":"abc"+[2],"code":2}
 
 expression: []+[]
 value:      []

--- a/dttools/test/jx.input
+++ b/dttools/test/jx.input
@@ -138,26 +138,20 @@ range(0, 5, -1);
 range(5, 0, 1);
 range(5, 0, -1);
 
-str();
-str(2);
-str(x + y);
-str(x, y);
-str(range(10));
-str("a");
-
-foreach("too", "few");
-foreach(x, "nope", str(x));
-foreach(x, range(5), "item" + str(x));
-
-join(["a", "b", c]);
-join([1, 2]);
-join(["a", 2]);
-join([]);
-join(["a"]);
-join(["a", "b", "c"]);
-join(["a", "b", "c"], ", ");
-
-dbg(join(dbg(foreach(x, dbg(range(dbg(3))), dbg(dbg(str(dbg(x))) + dbg(".") + dbg(str(dbg(dbg(x) + dbg(1)))) )))));
+format();
+format("%%");
+format("value: %i!!", x + y);
+format("%i", x, y);
+format("(%d, %i)", x, y);
+format("%i");
+format("%e", 1.2e-22);
+format("%E", 6.02e23);
+format("%f", 2.5);
+format("%F", 3.14);
+format("%g", 9.9e9);
+format("%G", 2.11111e-12);
+format("%b", false);
+format("%s", "foo");
 
 10 + [1];
 "abc" + [2];
@@ -173,5 +167,4 @@ dbg(join(dbg(foreach(x, dbg(range(dbg(3))), dbg(dbg(str(dbg(x))) + dbg(".") + db
 
 Error{"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"};
 
-let({"f": 2.2, "g": 4.5}, f + y);
 #end

--- a/dttools/test/jx.input
+++ b/dttools/test/jx.input
@@ -129,12 +129,18 @@ x or y;
 [[i, j, k, l] for i in range(4) for j in range(3) for k in range(3) for l in [true, false]];
 
 list[2];
+list[-1];
+list[-3];
+list[-10];
 list[1:];
 list[:2];
 list[1:2];
 list[:];
 list[3:2];
 list[-11:3];
+list[3:-11];
+list[1:-1];
+list[-1:1];
 list[0:100];
 list[true:4];
 list[4:null];

--- a/dttools/test/jx.input
+++ b/dttools/test/jx.input
@@ -1,3 +1,4 @@
+#!/bin/false
 {
 "outfile":"results",
 "infile":"mydata",
@@ -28,16 +29,16 @@
 true;
 false;
 null;
-true && true;
-true && false;
-false && true;
-false && false;
-true || true;
-true || false;
-false || true;
-false || false;
-!true;
-!false;
+true and true;
+true and false;
+false and true;
+false and false;
+true or true;
+true or false;
+false or true;
+false or false;
+not true;
+not false;
 
 10 == 20;
 10 != 20;
@@ -105,13 +106,13 @@ x-y;
 x*y;
 x/y;
 x%y;
-x&&y;
-x||y;
+x and y;
+x or y;
 
 (x+y)*(f+g);
 (10 + (20 * 30));
 (10*(20+30));
-(a==b) || ((f>g) && x<y);
+(a==b) or ((f>g) and x<y);
 
 #[10,-90.5,true,false,null,[-1,-2,-3]];
 [[0, i] for i in [1,2,x], 10,-90.5,true for i in range(5),false,null,[-1,-2,-3]];

--- a/dttools/test/jx.input
+++ b/dttools/test/jx.input
@@ -114,7 +114,11 @@ x||y;
 (a==b) || ((f>g) && x<y);
 
 #[10,-90.5,true,false,null,[-1,-2,-3]];
-[10,-90.5,true,false,null,[-1,-2,-3]];
+[[0, i] for i in [1,2,x], 10,-90.5,true for i in range(5),false,null,[-1,-2,-3]];
+[format(":%d", 2*i) for i in range(10)];
+[i + 1 for i in [10 - i for i in range(10)]];
+[[[i, j] for j in range(3)] for i in [10 - i for i in range(4)]];
+[null for i in 7]
 
 list[2];
 object["house"];

--- a/dttools/test/jx.input
+++ b/dttools/test/jx.input
@@ -12,112 +12,112 @@
 }
 
 #comment
-10
-3847.576
-.5
-10.
-987
-12347812309487
+10;
+3847.576;
+.5;
+10.;
+987;
+12347812309487;
 
-"hello"
-"goodbye\n"
-"\"quotes\""
-"tab\ttab\ttab\rreturn\nnewline\n"
-"\\\\\\\\"
+"hello";
+"goodbye\n";
+"\"quotes\"";
+"tab\ttab\ttab\rreturn\nnewline\n";
+"\\\\\\\\";
 
-true
-false
-null
-true && true
-true && false
-false && true
-false && false
-true || true
-true || false
-false || true
-false || false
-!true
-!false
+true;
+false;
+null;
+true && true;
+true && false;
+false && true;
+false && false;
+true || true;
+true || false;
+false || true;
+false || false;
+!true;
+!false;
 
-10 == 20
-10 != 20
-10 < 20
-10 <= 20
-10 > 20
-10 >= 20
+10 == 20;
+10 != 20;
+10 < 20;
+10 <= 20;
+10 > 20;
+10 >= 20;
 
-10.5 == 20.5
-10.5 != 20.5
-10.5 < 20.5
-10.5 <= 20.5
-10.5 > 20.5
-10.5 >= 20.5
+10.5 == 20.5;
+10.5 != 20.5;
+10.5 < 20.5;
+10.5 <= 20.5;
+10.5 > 20.5;
+10.5 >= 20.5;
 
-"hello" == "goodbye"
-"hello" != "goodbye"
-"hello" <= "goodbye"
-"hello" < "goodbye"
-"hello" > "goodbye"
-"hello" >= "goodbye"
+"hello" == "goodbye";
+"hello" != "goodbye";
+"hello" <= "goodbye";
+"hello" < "goodbye";
+"hello" > "goodbye";
+"hello" >= "goodbye";
 
-"hello" == "hello"
-"hello" != "hello"
-"hello" <= "hello"
-"hello" < "hello"
-"hello" > "hello"
-"hello" >= "hello"
+"hello" == "hello";
+"hello" != "hello";
+"hello" <= "hello";
+"hello" < "hello";
+"hello" > "hello";
+"hello" >= "hello";
 
-a==b
-a!=b
-a<b
-a>b
-a<=b
-a>=b
+a==b;
+a!=b;
+a<b;
+a>b;
+a<=b;
+a>=b;
 
-f==g
-f!=g
-f<g
-f>g
-f<=g
-f>=g
+f==g;
+f!=g;
+f<g;
+f>g;
+f<=g;
+f>=g;
 
-x==y
-x!=y
-x<y
-x>y
-x<=y
-x>=y
+x==y;
+x!=y;
+x<y;
+x>y;
+x<=y;
+x>=y;
 
-a+b
-a-b
-a*b
-a/b
-a%b
+a+b;
+a-b;
+a*b;
+a/b;
+a%b;
 
-f+g
-f-g
-f*g
-f/g
-f%g
+f+g;
+f-g;
+f*g;
+f/g;
+f%g;
 
-x+y
-x-y
-x*y
-x/y
-x%y
-x&&y
-x||y
+x+y;
+x-y;
+x*y;
+x/y;
+x%y;
+x&&y;
+x||y;
 
-(x+y)*(f+g)
-(10 + (20 * 30))
-(10*(20+30))
+(x+y)*(f+g);
+(10 + (20 * 30));
+(10*(20+30));
 (a==b) || ((f>g) && x<y);
 
 #[10,-90.5,true,false,null,[-1,-2,-3]];
 [10,-90.5,true,false,null,[-1,-2,-3]];
 
-list[2]
-object["house"]
+list[2];
+object["house"];
 
 {
 "command":"grep English "+infile+" > "+outfile,
@@ -126,52 +126,52 @@ object["house"]
 "environment":{"PATH":"/usr/bin"},
 "cores":1,
 "memory":16,
-"disk":1
-}
+"disk":1,
+};
 
-range(5)
-range(3, 7)
-range (7, 3)
-range(-1, 10, 2)
-range(1, 10, 0)
-range(0, 5, -1)
-range(5, 0, 1)
-range(5, 0, -1)
+range(5);
+range(3, 7);
+range (7, 3);
+range(-1, 10, 2);
+range(1, 10, 0);
+range(0, 5, -1);
+range(5, 0, 1);
+range(5, 0, -1);
 
-str()
-str(2)
-str(x + y)
-str(x, y)
-str(range(10))
-str("a")
+str();
+str(2);
+str(x + y);
+str(x, y);
+str(range(10));
+str("a");
 
-foreach("too", "few")
-foreach(x, "nope", str(x))
-foreach(x, range(5), "item" + str(x))
+foreach("too", "few");
+foreach(x, "nope", str(x));
+foreach(x, range(5), "item" + str(x));
 
-join(["a", "b", c])
-join([1, 2])
-join(["a", 2])
-join([])
-join(["a"])
-join(["a", "b", "c"])
-join(["a", "b", "c"], ", ")
+join(["a", "b", c]);
+join([1, 2]);
+join(["a", 2]);
+join([]);
+join(["a"]);
+join(["a", "b", "c"]);
+join(["a", "b", "c"], ", ");
 
-dbg(join(dbg(foreach(x, dbg(range(dbg(3))), dbg(dbg(str(dbg(x))) + dbg(".") + dbg(str(dbg(dbg(x) + dbg(1)))) )))))
+dbg(join(dbg(foreach(x, dbg(range(dbg(3))), dbg(dbg(str(dbg(x))) + dbg(".") + dbg(str(dbg(dbg(x) + dbg(1)))) )))));
 
-;10 + [1]
-;"abc" + [2]
-;[] + []
-;[] + [1]
-;[1] + []
-;[1, 2] + [3]
-;[1, 2] + [] + [4, [5, 6]]
-;[10] == [10]
-;[10] != [10]
-;[1,2, 3] == [1,3,2]
-;[1,2,[3,4]] == [1,2,[3,4]]
+10 + [1];
+"abc" + [2];
+[] + [];
+[] + [1];
+[1] + [];
+[1, 2] + [3];
+[1, 2] + [] + [4, [5, 6]];
+[10] == [10];
+[10] != [10];
+[1,2, 3] == [1,3,2];
+[1,2,[3,4]] == [1,2,[3,4]];
 
-Error{"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"}
+Error{"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"};
 
-let({"f": 2.2, "g": 4.5}, f + y)
+let({"f": 2.2, "g": 4.5}, f + y);
 #end

--- a/dttools/test/jx.input
+++ b/dttools/test/jx.input
@@ -122,7 +122,7 @@ x or y;
 [null for i in 7];
 [i for i in range(10) if i % 3 == 0];
 [[i, j] for i in range(4) for j in range(3)];
-[[i, j] for i in range(5) if (i + j) % 2 == 0 for j in range(4)];
+[[i, j] for i in range(5) for j in range(4) if (i + j) % 2 == 0];
 [[i, j] for i in range(5) for j in range(4) if j % 2 == 1];
 [[i, j] for i in range(5) if i % 2 == 0 for j in range(4) if j % 2 == 1];
 [[i, j] for i in range(5) if j % 2 == 0 for j in range(4) if i % 2 == 1];

--- a/dttools/test/jx.input
+++ b/dttools/test/jx.input
@@ -120,6 +120,12 @@ x||y;
 [[[i, j] for j in range(3)] for i in [10 - i for i in range(4)]];
 [null for i in 7];
 [i for i in range(10) if i % 3 == 0];
+[[i, j] for i in range(4) for j in range(3)];
+[[i, j] for i in range(5) if (i + j) % 2 == 0 for j in range(4)];
+[[i, j] for i in range(5) for j in range(4) if j % 2 == 1];
+[[i, j] for i in range(5) if i % 2 == 0 for j in range(4) if j % 2 == 1];
+[[i, j] for i in range(5) if j % 2 == 0 for j in range(4) if i % 2 == 1];
+[[i, j, k, l] for i in range(4) for j in range(3) for k in range(3) for l in [true, false]];
 
 list[2];
 object["house"];

--- a/dttools/test/jx.input
+++ b/dttools/test/jx.input
@@ -172,7 +172,6 @@ format("%f", 2.5);
 format("%F", 3.14);
 format("%g", 9.9e9);
 format("%G", 2.11111e-12);
-format("%b", false);
 format("%s", "foo");
 
 10 + [1];

--- a/dttools/test/jx.input
+++ b/dttools/test/jx.input
@@ -118,7 +118,8 @@ x||y;
 [format(":%d", 2*i) for i in range(10)];
 [i + 1 for i in [10 - i for i in range(10)]];
 [[[i, j] for j in range(3)] for i in [10 - i for i in range(4)]];
-[null for i in 7]
+[null for i in 7];
+[i for i in range(10) if i % 3 == 0];
 
 list[2];
 object["house"];

--- a/dttools/test/jx.input
+++ b/dttools/test/jx.input
@@ -128,6 +128,16 @@ x||y;
 [[i, j, k, l] for i in range(4) for j in range(3) for k in range(3) for l in [true, false]];
 
 list[2];
+list[1:];
+list[:2];
+list[1:2];
+list[:];
+list[3:2];
+list[-11:3];
+list[0:100];
+list[true:4];
+list[4:null];
+list[true:false];
 object["house"];
 
 {

--- a/grow/src/grow_fuse.c
+++ b/grow/src/grow_fuse.c
@@ -6,17 +6,18 @@
 
 #define FUSE_USE_VERSION 26
 
-#include <fuse.h>
-#include <stdio.h>
-#include <stddef.h>
-#include <string.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <limits.h>
-#include <sys/stat.h>
+#include <assert.h>
 #include <dirent.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <fuse.h>
+#include <limits.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 #include "grow.h"
 #include "debug.h"

--- a/makeflow/example/context.jx
+++ b/makeflow/example/context.jx
@@ -1,0 +1,6 @@
+{
+  "CURL": "/usr/bin/curl",
+  "CONVERT": "/usr/bin/convert",
+
+  "ANGLES": range(90, 361, 90),
+}

--- a/makeflow/example/example.jx
+++ b/makeflow/example/example.jx
@@ -1,16 +1,7 @@
 # This is a sample Makeflow script that retrieves an image from the web,
 # creates four variations of it, and then combines them into an animation
 
-
-# The `let` here introduces new variable bindings,
-# so we don't have to repeat the strings in the inputs and commands.
-# Since this `let` is at the top-level, we could get the same effect by
-# running Makeflow with a JX context.
-let({
-  "CURL": "/usr/bin/curl",
-  "CONVERT": "/usr/bin/convert"
-}, {
-
+{
   # Makeflow will set $CONVERT and $CURL in the environment when executing the tasks.
   # We repeat the variables here so there's only one place to change the paths.
   # In the rules, we can run $CONVERT rather than hardcoding paths.
@@ -25,12 +16,11 @@ let({
     {
       "command": "$CONVERT -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.montage.gif",
       "outputs": ["capitol.montage.gif"],
-      "inputs": [CONVERT,
-                 "capitol.jpg",
-                 "capitol.90.jpg",
-                 "capitol.180.jpg",
-                 "capitol.270.jpg",
-                 "capitol.360.jpg"]
+      "inputs": [
+        CONVERT,
+        "capitol.jpg",
+        format("capitol.%d.jpg", i) for i in ANGLES,
+      ],
     },
     # This rule downloads the input data.
     {
@@ -47,13 +37,13 @@ let({
       },
       # If a rule is specified with local_job, it executes at the local site
       "local_job": true
-    }] + foreach(i, ["90", "180", "270", "360"], 
-    # The `foreach` will build a rule for each of the angles we gave it.
-    {
+    }, {
       # The current angle will be bound to `i`, so we can concatenate
       # to build the command line and output.
-      "command": "$CONVERT -swirl " + i + " capitol.jpg capitol." + i + ".jpg",
-      "outputs": ["capitol." + i + ".jpg"],
+      "command": format("$CONVERT -swirl %d capitol.jpg capitol.%d.jpg", i, i),
+      "outputs": [format("capitol.%d.jpg", i)],
       "inputs": [CONVERT, "capitol.jpg"]
-    })
-})
+    } for i in ANGLES,
+    # the list comprehension here will repeat the previous expression for each angle
+  ]
+}

--- a/makeflow/src/parser_jx.c
+++ b/makeflow/src/parser_jx.c
@@ -21,6 +21,8 @@ See the file COPYING for details.
 #include "jx_match.h"
 #include "jx_print.h"
 
+#include <assert.h>
+
 static int environment_from_jx(struct dag *d, struct dag_node *n, struct hash_table *h, struct jx *env) {
 	int nodeid;
 

--- a/makeflow/src/parser_jx.c
+++ b/makeflow/src/parser_jx.c
@@ -111,21 +111,28 @@ static int resources_from_jx(struct hash_table *h, struct jx *j) {
 
 static int file_from_jx(struct dag_node *n, int input, struct jx *j) {
 	assert(j);
+	assert(n);
+	const char *path = NULL;
+	const char *remote = NULL;
 
-	if (!jx_istype(j, JX_OBJECT)) {
-		debug(D_MAKEFLOW_PARSER|D_NOTICE,
-			"Line %u: File must be specified as a JSON object",
+	if (jx_istype(j, JX_STRING)) {
+		path = j->u.string_value;
+	} else if (jx_istype(j, JX_OBJECT)) {
+		path = jx_lookup_string(j, "path");
+		remote = jx_lookup_string(j, "execution_path");
+		if (!path) {
+			debug(D_MAKEFLOW_PARSER | D_NOTICE,
+				"File at line %u: missing \"path\" key",
+				j->line);
+			return 0;
+		}
+	} else {
+		debug(D_MAKEFLOW_PARSER | D_NOTICE,
+			"Line %u: File must be specified as a string or object",
 			j->line);
 		return 0;
 	}
 
-	const char *path = jx_lookup_string(j, "path");
-	const char *remote = jx_lookup_string(j, "execution_path");
-	if (!path) {
-		debug(D_MAKEFLOW_PARSER|D_NOTICE,
-			"File at line %u: missing \"path\" key", j->line);
-		return 0;
-	}
 	if (input) {
 		debug(D_MAKEFLOW_PARSER, "Input %s, remote name %s", path, remote ? remote : "NULL");
 		dag_node_add_source_file(n, path, remote);

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -54,7 +54,7 @@ The following major problems must be fixed:
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
-
+#include <assert.h>
 #include <errno.h>
 #include <limits.h>
 #include <math.h>


### PR DESCRIPTION
This PR reworks a lot of the JX syntax. The docs aren't updated yet, as discussion could result in further changes. I ripped out most of the existing function infrastructure and cleaned things up here and there. The biggest change is the addition list comprehensions. Rather than a `foreach()` that returns an array, this PR adds Python-style list comprehensions. I experimented with different syntax variations, such as
- `foreach(i, range(10), i + 1)`
- `for (i in range(10)) i + 1`
- `[i + 1 for i in range(10)]`

Javascript doesn't really have list comprehensions, instead using `map` and passing functions. Short of adding first-class functions, real JS syntax isn't viable for JX. The second one is similar to a nonstandard JS extension that doesn't seem to exist anymore. With the first and second styles, it was always awkward to have to add lists together. The third style makes it visually apparent that the result is a list and allows for building up structures without adding them. I also stole Python's filtering functionality, so e.g.

    [i*i for i in range(10) if i%3 == 0]
evaluates to `[0, 9, 36, 81]`. 

This version of JX has lambdas under the hood, but the parser doesn't know how to read them. I also removed the LISP-style assignment expressions. The original design of JX just used an evaluation context to introduce name bindings, which I think is both simpler and sufficient.

As an example, @nhazekam and I translated BWA into JX format. Using existing JX syntax, it looks like this.

    let(
        {
            "BWA": "./bwa",
            "ARGS": " mem ",
    
            "SPLIT": "./fastq_reduce",
            "CONCAT": "./cat_bwa",
      
            "REF": "ref.fa",
            "REF_INDEX": foreach(i, ["amb", "ann", "bwt", "pac", "sa"],"ref.fa."+i),
    
            "INPUT_PRE": "test.fq",
            "SPLITS": 100,
            "SPLIT_SIZE": 1000,
        }, {
            "rules": [
                {
                    "command": join(SPLIT, INPUT_PRE, SPLIT_SIZE),
                    "outputs": foreach(i, range(0, SPLITS), join([INPUT_PRE, str(i)], ".")),
                    "inputs": [SPLIT, INPUT_PRE],
                    "local_job": true,
                }
            ] + foreach(i, range(0, SPLITS), {
                "command": join([BWA, ARGS, REF, INPUT_PRE]) + "." + str(i) + " " + INPUT_PRE + "." + str(i) + "sam ",
                "outputs": [join([INPUT_PRE, str(i), "sam"], ".")],
                "inputs": [BWA, join([INPUT_PRE, str(i)], "."), REF, REF_INDEX]
            }) + [
                {
                    "command": join([
                        CONCAT,
                        INPUT_PRE+".sam",
                        INPUT_PRE+"*.sam"
                    ]),
                    "outputs": [INPUT_PRE+".sam"],
                    "inputs": [
                        CONCAT
                    ] + foreach(i, range(0, SPLITS),
                        join([INPUT_PRE, str(i), "sam"], ".")
                    ),
                }
            ]
        }
    )

As of this PR, there's a separate context file with various knobs.

    {
      "BWA": "./bwa",
      "ARGS": "mem",
    
      "SPLIT": "./fastq_reduce",
      "CONCAT": "./cat_bwa",
      
      "REF": "ref.fastq",
      "REF_INDEX": ["ref.fastq." + x for x in ["amb", "ann", "bwt", "pac", "sa"]],
    
      "INPUT_PRE": "query.fastq",
      "SPLITS": 1000,
      "SPLIT_SIZE": 1000,
    }

The actual workflow looks like this.

    {
        "rules": [
            {
                "command": format("%s %s %d", SPLIT, INPUT_PRE, SPLIT_SIZE),
                "outputs": [format("%s.%d", INPUT_PRE, i) for i in range(SPLITS)],
                "inputs": [SPLIT, INPUT_PRE],
                "local_job": true,
            },
            {
                "command": format(
                    "%s %s %s %s.%d > %s.%d.sam 2> %s.%d.err",
                    BWA,
                    ARGS,
                    REF,
                    INPUT_PRE, i,
                    INPUT_PRE, i,
                    INPUT_PRE, i,
                ),
                "outputs": [
                    format("%s.%d.sam", INPUT_PRE, i),
                    format("%s.%d.err", INPUT_PRE, i),
                ],
                "inputs": [
                    BWA,
                    REF,
                    x for x in REF_INDEX,
                    format("%s.%d", INPUT_PRE, i)
                ],
            } for i in range(SPLITS),
            {
                "command": format(
                    "%s %s.sam %s*.sam",
                    CONCAT,
                    INPUT_PRE,
                    INPUT_PRE
                ),
                "outputs": [format("%s.sam", INPUT_PRE)],
                "inputs": [
                    CONCAT,
                    format("%s.%d.sam", INPUT_PRE, i) for i in range(SPLITS),
                ],
            },
        ],
    }

For larger structures, the postfix `for` looks a little odd, but I think the latter format looks more like the evaluated workflow. It doesn't have so much noise from converting things and applying operators to build up lists. This format also has a short edit distance from a small example someone might write before scaling up. The BWA example here expands to 1002 rules. Makeflow parsed and validated it without trouble and ran the workflow. I'm much happier with this format, so have a look @btovar @dthain.