### PR TITLE
Save outputs of failed Makeflow rules

### DIFF
--- a/batch_job/src/batch_job.c
+++ b/batch_job/src/batch_job.c
@@ -40,7 +40,7 @@ static struct batch_queue_module batch_queue_unknown = {
 
 	{NULL, NULL, NULL},
 
-	{NULL, NULL, NULL, NULL, NULL, NULL},
+	{NULL, NULL, NULL, NULL, NULL, NULL, NULL},
 };
 
 #define BATCH_JOB_SYSTEMS  "local, wq, condor, sge, torque, mesos, moab, slurm, chirp, amazon, dryrun"
@@ -255,6 +255,11 @@ int batch_fs_mkdir (struct batch_queue *q, const char *path, mode_t mode, int re
 int batch_fs_putfile (struct batch_queue *q, const char *lpath, const char *rpath)
 {
 	return q->module->fs.putfile(q, lpath, rpath);
+}
+
+int batch_fs_rename (struct batch_queue *q, const char *lpath, const char *rpath)
+{
+	return q->module->fs.rename(q, lpath, rpath);
 }
 
 int batch_fs_stat (struct batch_queue *q, const char *path, struct stat *buf)

--- a/batch_job/src/batch_job.h
+++ b/batch_job/src/batch_job.h
@@ -112,6 +112,7 @@ int batch_fs_chdir (struct batch_queue *q, const char *path);
 int batch_fs_getcwd (struct batch_queue *q, char *buf, size_t size);
 int batch_fs_mkdir (struct batch_queue *q, const char *path, mode_t mode, int recursive);
 int batch_fs_putfile (struct batch_queue *q, const char *lpath, const char *rpath);
+int batch_fs_rename (struct batch_queue *q, const char *lpath, const char *rpath);
 int batch_fs_stat (struct batch_queue *q, const char *path, struct stat *buf);
 int batch_fs_unlink (struct batch_queue *q, const char *path);
 

--- a/batch_job/src/batch_job_amazon.c
+++ b/batch_job/src/batch_job_amazon.c
@@ -146,6 +146,7 @@ batch_fs_stub_chdir(amazon);
 batch_fs_stub_getcwd(amazon);
 batch_fs_stub_mkdir(amazon);
 batch_fs_stub_putfile(amazon);
+batch_fs_stub_rename(amazon);
 batch_fs_stub_stat(amazon);
 batch_fs_stub_unlink(amazon);
 
@@ -169,6 +170,7 @@ const struct batch_queue_module batch_queue_amazon = {
 	 batch_fs_amazon_getcwd,
 	 batch_fs_amazon_mkdir,
 	 batch_fs_amazon_putfile,
+	 batch_fs_amazon_rename,
 	 batch_fs_amazon_stat,
 	 batch_fs_amazon_unlink,
 	 },

--- a/batch_job/src/batch_job_blue_waters.c
+++ b/batch_job/src/batch_job_blue_waters.c
@@ -301,6 +301,7 @@ batch_fs_stub_chdir(cluster);
 batch_fs_stub_getcwd(cluster);
 batch_fs_stub_mkdir(cluster);
 batch_fs_stub_putfile(cluster);
+batch_fs_stub_rename(cluster);
 batch_fs_stub_stat(cluster);
 batch_fs_stub_unlink(cluster);
 
@@ -324,6 +325,7 @@ const struct batch_queue_module batch_queue_blue_waters = {
 		batch_fs_cluster_getcwd,
 		batch_fs_cluster_mkdir,
 		batch_fs_cluster_putfile,
+		batch_fs_cluster_rename,
 		batch_fs_cluster_stat,
 		batch_fs_cluster_unlink,
 	},

--- a/batch_job/src/batch_job_chirp.c
+++ b/batch_job/src/batch_job_chirp.c
@@ -333,6 +333,17 @@ int batch_fs_chirp_putfile (struct batch_queue *q, const char *lpath, const char
 	return -1;
 }
 
+int batch_fs_chirp_rename (struct batch_queue *q, const char *lpath, const char *rpath)
+{
+	char lresolved[CHIRP_PATH_MAX];
+	char rresolved[CHIRP_PATH_MAX];
+	snprintf(lresolved, sizeof(lresolved), "%s/%s", getroot(q), lpath);
+	snprintf(rresolved, sizeof(rresolved), "%s/%s", getroot(q), rpath);
+	if (chirp_reli_rename(gethost(q), lresolved, rresolved, STOPTIME) <= 0) return 0;
+	return -1;
+}
+
+
 #define COPY_STATC( a, b )\
 	memset(&(b),0,sizeof(b));\
 	(b).st_dev = (a).cst_dev;\
@@ -388,6 +399,7 @@ const struct batch_queue_module batch_queue_chirp = {
 		batch_fs_chirp_getcwd,
 		batch_fs_chirp_mkdir,
 		batch_fs_chirp_putfile,
+		batch_fs_chirp_rename,
 		batch_fs_chirp_stat,
 		batch_fs_chirp_unlink,
 	},

--- a/batch_job/src/batch_job_cluster.c
+++ b/batch_job/src/batch_job_cluster.c
@@ -349,6 +349,7 @@ batch_fs_stub_chdir(cluster);
 batch_fs_stub_getcwd(cluster);
 batch_fs_stub_mkdir(cluster);
 batch_fs_stub_putfile(cluster);
+batch_fs_stub_rename(cluster);
 batch_fs_stub_stat(cluster);
 batch_fs_stub_unlink(cluster);
 
@@ -372,6 +373,7 @@ const struct batch_queue_module batch_queue_cluster = {
 		batch_fs_cluster_getcwd,
 		batch_fs_cluster_mkdir,
 		batch_fs_cluster_putfile,
+		batch_fs_cluster_rename,
 		batch_fs_cluster_stat,
 		batch_fs_cluster_unlink,
 	},
@@ -397,6 +399,7 @@ const struct batch_queue_module batch_queue_moab = {
 		batch_fs_cluster_getcwd,
 		batch_fs_cluster_mkdir,
 		batch_fs_cluster_putfile,
+		batch_fs_cluster_rename,
 		batch_fs_cluster_stat,
 		batch_fs_cluster_unlink,
 	},
@@ -422,6 +425,7 @@ const struct batch_queue_module batch_queue_sge = {
 		batch_fs_cluster_getcwd,
 		batch_fs_cluster_mkdir,
 		batch_fs_cluster_putfile,
+		batch_fs_cluster_rename,
 		batch_fs_cluster_stat,
 		batch_fs_cluster_unlink,
 	},
@@ -447,6 +451,7 @@ const struct batch_queue_module batch_queue_pbs = {
 		batch_fs_cluster_getcwd,
 		batch_fs_cluster_mkdir,
 		batch_fs_cluster_putfile,
+		batch_fs_cluster_rename,
 		batch_fs_cluster_stat,
 		batch_fs_cluster_unlink,
 	},
@@ -472,6 +477,7 @@ const struct batch_queue_module batch_queue_torque = {
 		batch_fs_cluster_getcwd,
 		batch_fs_cluster_mkdir,
 		batch_fs_cluster_putfile,
+		batch_fs_cluster_rename,
 		batch_fs_cluster_stat,
 		batch_fs_cluster_unlink,
 	},
@@ -497,6 +503,7 @@ const struct batch_queue_module batch_queue_slurm = {
 		batch_fs_cluster_getcwd,
 		batch_fs_cluster_mkdir,
 		batch_fs_cluster_putfile,
+		batch_fs_cluster_rename,
 		batch_fs_cluster_stat,
 		batch_fs_cluster_unlink,
 	},

--- a/batch_job/src/batch_job_condor.c
+++ b/batch_job/src/batch_job_condor.c
@@ -355,6 +355,7 @@ batch_fs_stub_chdir(condor);
 batch_fs_stub_getcwd(condor);
 batch_fs_stub_mkdir(condor);
 batch_fs_stub_putfile(condor);
+batch_fs_stub_rename(condor);
 batch_fs_stub_stat(condor);
 batch_fs_stub_unlink(condor);
 
@@ -378,6 +379,7 @@ const struct batch_queue_module batch_queue_condor = {
 		batch_fs_condor_getcwd,
 		batch_fs_condor_mkdir,
 		batch_fs_condor_putfile,
+		batch_fs_condor_rename,
 		batch_fs_condor_stat,
 		batch_fs_condor_unlink,
 	},

--- a/batch_job/src/batch_job_dryrun.c
+++ b/batch_job/src/batch_job_dryrun.c
@@ -191,6 +191,22 @@ static int batch_fs_dryrun_putfile (struct batch_queue *q, const char *lpath, co
 	}
 }
 
+static int batch_fs_dryrun_rename (struct batch_queue *q, const char *lpath, const char *rpath) {
+	FILE *log;
+
+	if ((log = fopen(q->logfile, "a"))) {
+		char *escaped_lpath = string_escape_shell(lpath);
+		char *escaped_rpath = string_escape_shell(rpath);
+		fprintf(log, "mv %s %s\n", escaped_lpath, escaped_rpath);
+		free(escaped_lpath);
+		free(escaped_rpath);
+		fclose(log);
+		return 0;
+	} else {
+		return -1;
+	}
+}
+
 batch_queue_stub_free(dryrun);
 batch_queue_stub_port(dryrun);
 batch_queue_stub_option_update(dryrun);
@@ -215,6 +231,7 @@ const struct batch_queue_module batch_queue_dryrun = {
 		batch_fs_dryrun_getcwd,
 		batch_fs_dryrun_mkdir,
 		batch_fs_dryrun_putfile,
+		batch_fs_dryrun_rename,
 		batch_fs_dryrun_stat,
 		batch_fs_dryrun_unlink,
 	},

--- a/batch_job/src/batch_job_internal.h
+++ b/batch_job/src/batch_job_internal.h
@@ -35,6 +35,7 @@ struct batch_queue_module {
 		int (*getcwd) (struct batch_queue *q, char *buf, size_t size);
 		int (*mkdir) (struct batch_queue *q, const char *path, mode_t mode, int recursive);
 		int (*putfile) (struct batch_queue *q, const char *lpath, const char *rpath);
+		int (*rename) (struct batch_queue *q, const char *lpath, const char *rpath);
 		int (*stat) (struct batch_queue *q, const char *path, struct stat *buf);
 		int (*unlink) (struct batch_queue *q, const char *path);
 	} fs;
@@ -61,6 +62,7 @@ struct batch_queue {
 #define batch_fs_stub_getcwd(name)  static int batch_fs_##name##_getcwd (struct batch_queue *Q, char *buf, size_t size) { getcwd(buf, size); return 0; }
 #define batch_fs_stub_mkdir(name)  static int batch_fs_##name##_mkdir (struct batch_queue *Q, const char *path, mode_t mode, int recursive) { if (recursive) return create_dir(path, mode); else return mkdir(path, mode); }
 #define batch_fs_stub_putfile(name)  static int batch_fs_##name##_putfile (struct batch_queue *Q, const char *lpath, const char *rpath) { return copy_file_to_file(lpath, rpath); }
+#define batch_fs_stub_rename(name)  static int batch_fs_##name##_rename (struct batch_queue *Q, const char *lpath, const char *rpath) { return rename(lpath, rpath); }
 #define batch_fs_stub_stat(name)  static int batch_fs_##name##_stat (struct batch_queue *Q, const char *path, struct stat *buf) { return stat(path, buf); }
 #define batch_fs_stub_unlink(name)  static int batch_fs_##name##_unlink (struct batch_queue *Q, const char *path) { return delete_dir(path); }
 

--- a/batch_job/src/batch_job_local.c
+++ b/batch_job/src/batch_job_local.c
@@ -136,6 +136,7 @@ batch_fs_stub_chdir(local);
 batch_fs_stub_getcwd(local);
 batch_fs_stub_mkdir(local);
 batch_fs_stub_putfile(local);
+batch_fs_stub_rename(local);
 batch_fs_stub_stat(local);
 batch_fs_stub_unlink(local);
 
@@ -159,6 +160,7 @@ const struct batch_queue_module batch_queue_local = {
 		batch_fs_local_getcwd,
 		batch_fs_local_mkdir,
 		batch_fs_local_putfile,
+		batch_fs_local_rename,
 		batch_fs_local_stat,
 		batch_fs_local_unlink,
 	},

--- a/batch_job/src/batch_job_mesos.c
+++ b/batch_job/src/batch_job_mesos.c
@@ -375,6 +375,7 @@ batch_fs_stub_chdir(mesos);
 batch_fs_stub_getcwd(mesos);
 batch_fs_stub_mkdir(mesos);
 batch_fs_stub_putfile(mesos);
+batch_fs_stub_rename(mesos);
 batch_fs_stub_stat(mesos);
 batch_fs_stub_unlink(mesos);
 
@@ -398,6 +399,7 @@ const struct batch_queue_module batch_queue_mesos = {
 		batch_fs_mesos_getcwd,
 		batch_fs_mesos_mkdir,
 		batch_fs_mesos_putfile,
+		batch_fs_mesos_rename,
 		batch_fs_mesos_stat,
 		batch_fs_mesos_unlink,
 	},

--- a/batch_job/src/batch_job_work_queue.c
+++ b/batch_job/src/batch_job_work_queue.c
@@ -255,6 +255,7 @@ batch_fs_stub_chdir(wq);
 batch_fs_stub_getcwd(wq);
 batch_fs_stub_mkdir(wq);
 batch_fs_stub_putfile(wq);
+batch_fs_stub_rename(wq);
 batch_fs_stub_stat(wq);
 batch_fs_stub_unlink(wq);
 
@@ -278,6 +279,7 @@ const struct batch_queue_module batch_queue_wq = {
 		batch_fs_wq_getcwd,
 		batch_fs_wq_mkdir,
 		batch_fs_wq_putfile,
+		batch_fs_wq_rename,
 		batch_fs_wq_stat,
 		batch_fs_wq_unlink,
 	},

--- a/makeflow/src/dag.c
+++ b/makeflow/src/dag.c
@@ -448,4 +448,30 @@ int dag_mount_clean( struct dag *d ) {
 	return 0;
 }
 
+struct dag_file *dag_file_lookup_fail(
+		struct dag *d, struct batch_queue *q, const char *path) {
+	assert(d);
+	assert(q);
+	assert(path);
+	struct stat buf;
+	struct dag_file *f = dag_file_from_name(d, path);
+	if (f) {
+		if (f->type == DAG_FILE_TYPE_INPUT) {
+			debug(D_MAKEFLOW_RUN,
+					"skipping %s since it's specified as an input",
+					path);
+			return NULL;
+		}
+		return f;
+	} else {
+		if (!batch_fs_stat(q, path, &buf)) {
+			debug(D_MAKEFLOW_RUN,
+					"skipping %s since it already exists",
+					path);
+			return NULL;
+		}
+		return dag_file_lookup_or_create(d, path);
+	}
+}
+
 /* vim: set noexpandtab tabstop=4: */

--- a/makeflow/src/dag.h
+++ b/makeflow/src/dag.h
@@ -62,6 +62,7 @@ void dag_count_states(struct dag *d);
 
 struct dag_file *dag_file_lookup_or_create(struct dag *d, const char *filename);
 struct dag_file *dag_file_from_name(struct dag *d, const char *filename);
+struct dag_file *dag_file_lookup_fail(struct dag *d, struct batch_queue *q, const char *path);
 
 int dag_width( struct dag *d, int nested );
 int dag_depth( struct dag *d );

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -93,6 +93,7 @@ an example.
 */
 
 #define MAX_REMOTE_JOBS_DEFAULT 100
+#define FAIL_DIR "makeflow.failed.%d"
 
 static sig_atomic_t makeflow_abort_flag = 0;
 static int makeflow_failed_flag = 0;
@@ -713,6 +714,91 @@ int makeflow_node_check_file_was_created(struct dag_node *n, struct dag_file *f)
 	return file_created;
 }
 
+static struct dag_file *makeflow_lookup_fail_file(
+		struct dag *d, struct batch_queue *q, const char *path) {
+	assert(d);
+	assert(q);
+	assert(path);
+	struct stat buf;
+	struct dag_file *f = hash_table_lookup(d->files, path);
+	if (f) {
+		if (f->type == DAG_FILE_TYPE_INPUT) {
+			debug(D_MAKEFLOW_RUN,
+					"skipping %s since it's specified as an input",
+					path);
+			return NULL;
+		}
+		return f;
+	} else {
+		if (!batch_fs_stat(q, path, &buf)) {
+			debug(D_MAKEFLOW_RUN,
+					"skipping %s since it already exists",
+					path);
+			return NULL;
+		}
+		return dag_file_lookup_or_create(d, path);
+	}
+}
+
+static int makeflow_prep_fail_dir(
+		struct dag *d, struct dag_node *n, struct batch_queue *q) {
+	assert(d);
+	assert(n);
+	assert(q);
+	int rc = 1;
+	char *faildir = string_format(FAIL_DIR, n->nodeid);
+	struct dag_file *f = makeflow_lookup_fail_file(d, q, faildir);
+	if (!f) goto FAILURE;
+
+	if (makeflow_clean_file(d, q, f, 1)) {
+		debug(D_MAKEFLOW_RUN, "Unable to clean failed output");
+		goto FAILURE;
+	}
+	if (batch_fs_mkdir(q, f->filename, 0755, 0)) {
+		debug(D_MAKEFLOW_RUN,
+				"Unable to create failed output directory");
+		goto FAILURE;
+	}
+
+	makeflow_log_file_state_change(d, f, DAG_FILE_STATE_COMPLETE);
+	fprintf(stderr, "rule %d failed, copying any outputs to %s\n",
+			n->nodeid, faildir);
+	rc = 0;
+FAILURE:
+	free(faildir);
+	return rc;
+}
+
+static int makeflow_clean_failed_file(struct dag *d, struct dag_node *n,
+		struct batch_queue *q, struct dag_file *f, int prep_failed,
+		int silent) {
+	assert(d);
+	assert(n);
+	assert(q);
+	assert(f);
+	if (!prep_failed) {
+		char *failout = string_format(
+				FAIL_DIR "/%s", n->nodeid, f->filename);
+		struct dag_file *o = makeflow_lookup_fail_file(d, q, failout);
+		if (o) {
+			if (batch_fs_putfile(q, f->filename, o->filename) < 0) {
+				debug(D_MAKEFLOW_RUN, "Failed to copy %s -> %s",
+						f->filename, o->filename);
+			} else {
+				debug(D_MAKEFLOW_RUN, "Copied %s -> %s",
+						f->filename, o->filename);
+				makeflow_log_file_state_change(
+						d, o, DAG_FILE_STATE_COMPLETE);
+			}
+		} else {
+			fprintf(stderr, "Skipping copy %s -> %s", f->filename,
+					failout);
+		}
+		free(failout);
+	}
+	return makeflow_clean_file(d, q, f, silent);
+}
+
 /*
 Mark the given task as completing, using the batch_job_info completion structure provided by batch_job.
 */
@@ -774,14 +860,21 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 
 	if(job_failed) {
 		makeflow_log_state_change(d, n, DAG_NODE_STATE_FAILED);
+		int prep_failed = makeflow_prep_fail_dir(d, n, remote_queue);
+		if (prep_failed) {
+			fprintf(stderr, "rule %d failed, cannot copy outputs\n",
+					n->nodeid);
+		}
 
 		/* Clean files created in node. Clean existing and expected and record deletion. */
 		list_first_item(outputs);
 		while((f = list_next_item(outputs))) {
 			if(f->state == DAG_FILE_STATE_EXPECT) {
-				makeflow_clean_file(d, remote_queue, f, 1);
+				makeflow_clean_failed_file(d, n, remote_queue,
+						f, prep_failed, 1);
 			} else {
-				makeflow_clean_file(d, remote_queue, f, 0);
+				makeflow_clean_failed_file(d, n, remote_queue,
+						f, prep_failed, 0);
 			}
 		}
 

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -787,8 +787,6 @@ static int makeflow_clean_failed_file(struct dag *d, struct dag_node *n,
 			} else {
 				debug(D_MAKEFLOW_RUN, "Copied %s -> %s",
 						f->filename, o->filename);
-				makeflow_log_file_state_change(
-						d, o, DAG_FILE_STATE_COMPLETE);
 			}
 		} else {
 			fprintf(stderr, "Skipping copy %s -> %s", f->filename,

--- a/makeflow/src/makeflow_gc.c
+++ b/makeflow/src/makeflow_gc.c
@@ -37,6 +37,8 @@ include measuring available space and inodes consumed.
 /* XXX this should be configurable. */
 #define	MAKEFLOW_MIN_SPACE 10*1024*1024	/* 10 MB */
 
+#define FAIL_DIR "makeflow.failed.%d"
+
 static int makeflow_gc_collected = 0;
 
 /*
@@ -340,6 +342,63 @@ int makeflow_clean_mount_target(const char *target) {
 	return 0;
 }
 
+int makeflow_clean_prep_fail_dir(
+		struct dag *d, struct dag_node *n, struct batch_queue *q) {
+	assert(d);
+	assert(n);
+	assert(q);
+	int rc = 1;
+	char *faildir = string_format(FAIL_DIR, n->nodeid);
+	struct dag_file *f = dag_file_lookup_fail(d, q, faildir);
+	if (!f) goto FAILURE;
 
+	if (makeflow_clean_file(d, q, f, 1)) {
+		debug(D_MAKEFLOW_RUN, "Unable to clean failed output");
+		goto FAILURE;
+	}
+	if (batch_fs_mkdir(q, f->filename, 0755, 0)) {
+		debug(D_MAKEFLOW_RUN,
+				"Unable to create failed output directory");
+		goto FAILURE;
+	}
+
+	makeflow_log_file_state_change(d, f, DAG_FILE_STATE_COMPLETE);
+	fprintf(stderr, "rule %d failed, moving any outputs to %s\n",
+			n->nodeid, faildir);
+	rc = 0;
+FAILURE:
+	free(faildir);
+	return rc;
+}
+
+int makeflow_clean_failed_file(struct dag *d, struct dag_node *n,
+		struct batch_queue *q, struct dag_file *f, int prep_failed,
+		int silent) {
+	assert(d);
+	assert(n);
+	assert(q);
+	assert(f);
+
+	if (prep_failed) goto CLEANUP;
+
+	char *failout = string_format(
+			FAIL_DIR "/%s", n->nodeid, f->filename);
+	struct dag_file *o = dag_file_lookup_fail(d, q, failout);
+	if (o) {
+		if (batch_fs_rename(q, f->filename, o->filename) < 0) {
+			debug(D_MAKEFLOW_RUN, "Failed to rename %s -> %s",
+					f->filename, o->filename);
+		} else {
+			makeflow_log_file_state_change(d, f, DAG_FILE_STATE_DELETE);
+			debug(D_MAKEFLOW_RUN, "Renamed %s -> %s",
+					f->filename, o->filename);
+		}
+	} else {
+		fprintf(stderr, "Skipping rename %s -> %s", f->filename, failout);
+	}
+	free(failout);
+CLEANUP:
+	return makeflow_clean_file(d, q, f, silent);
+}
 
 /* vim: set noexpandtab tabstop=4: */

--- a/makeflow/src/makeflow_gc.h
+++ b/makeflow/src/makeflow_gc.h
@@ -33,6 +33,8 @@ void makeflow_parse_input_outputs( struct dag *d );
 void makeflow_gc( struct dag *d, struct batch_queue *queue, makeflow_gc_method_t method, uint64_t size, int count );
 int  makeflow_clean_file( struct dag *d, struct batch_queue *queue, struct dag_file *f, int silent );
 void makeflow_clean_node( struct dag *d, struct batch_queue *queue, struct dag_node *n, int silent );
+int makeflow_clean_prep_fail_dir(struct dag *d, struct dag_node *n, struct batch_queue *q);
+int makeflow_clean_failed_file(struct dag *d, struct dag_node *n, struct batch_queue *q, struct dag_file *f, int prep_failed, int silent);
 
 /* return 0 on success; return non-zero on failure. */
 int makeflow_clean( struct dag *d, struct batch_queue *queue, makeflow_clean_depth clean_depth);//, struct makeflow_wrapper *w, struct makeflow_monitor *m );


### PR DESCRIPTION
This PR changes Makeflow's default behavior for failed tasks. Assuming there isn't an input file or an existing file not managed by Makeflow with a conflicting name, any outputs produced by a failed rule are copied to a `makeflow.failed.n` directory, where `n` is the node ID, and print a message for the user. Running `makeflow -c` will remove failed directories. This should make debugging failures much easier, as logs and such can be brought back as long as they're specified as outputs. I tested locally, on Condor, and with Work Queue.

resolves #1451