### PR TITLE
Support for absolute paths when moving failed Makeflow outputs

### DIFF
--- a/batch_job/src/batch_job_internal.h
+++ b/batch_job/src/batch_job_internal.h
@@ -62,7 +62,7 @@ struct batch_queue {
 #define batch_fs_stub_getcwd(name)  static int batch_fs_##name##_getcwd (struct batch_queue *Q, char *buf, size_t size) { getcwd(buf, size); return 0; }
 #define batch_fs_stub_mkdir(name)  static int batch_fs_##name##_mkdir (struct batch_queue *Q, const char *path, mode_t mode, int recursive) { if (recursive) return create_dir(path, mode); else return mkdir(path, mode); }
 #define batch_fs_stub_putfile(name)  static int batch_fs_##name##_putfile (struct batch_queue *Q, const char *lpath, const char *rpath) { return copy_file_to_file(lpath, rpath); }
-#define batch_fs_stub_rename(name)  static int batch_fs_##name##_rename (struct batch_queue *Q, const char *lpath, const char *rpath) { return rename(lpath, rpath); }
+#define batch_fs_stub_rename(name)  static int batch_fs_##name##_rename (struct batch_queue *Q, const char *lpath, const char *rpath) { return create_dir_parents(rpath, 0755) && !rename(lpath, rpath) ? 0 : -1; }
 #define batch_fs_stub_stat(name)  static int batch_fs_##name##_stat (struct batch_queue *Q, const char *path, struct stat *buf) { return stat(path, buf); }
 #define batch_fs_stub_unlink(name)  static int batch_fs_##name##_unlink (struct batch_queue *Q, const char *path) { return delete_dir(path); }
 

--- a/makeflow/src/dag.c
+++ b/makeflow/src/dag.c
@@ -4,6 +4,7 @@ This software is distributed under the GNU General Public License.
 See the file COPYING for details.
 */
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/makeflow/src/makeflow_gc.c
+++ b/makeflow/src/makeflow_gc.c
@@ -19,6 +19,7 @@ See the file COPYING for details.
 #include "makeflow_wrapper.h"
 #include "makeflow_gc.h"
 
+#include <assert.h>
 #include <dirent.h>
 #include <sys/types.h>
 #include <limits.h>
@@ -357,8 +358,7 @@ int makeflow_clean_prep_fail_dir(
 		goto FAILURE;
 	}
 	if (batch_fs_mkdir(q, f->filename, 0755, 0)) {
-		debug(D_MAKEFLOW_RUN,
-				"Unable to create failed output directory");
+		debug(D_MAKEFLOW_RUN, "Unable to create failed output directory: %s", strerror(errno));
 		goto FAILURE;
 	}
 
@@ -386,8 +386,8 @@ int makeflow_clean_failed_file(struct dag *d, struct dag_node *n,
 	struct dag_file *o = dag_file_lookup_fail(d, q, failout);
 	if (o) {
 		if (batch_fs_rename(q, f->filename, o->filename) < 0) {
-			debug(D_MAKEFLOW_RUN, "Failed to rename %s -> %s",
-					f->filename, o->filename);
+			debug(D_MAKEFLOW_RUN, "Failed to rename %s -> %s: %s",
+					f->filename, o->filename, strerror(errno));
 		} else {
 			makeflow_log_file_state_change(d, f, DAG_FILE_STATE_DELETE);
 			debug(D_MAKEFLOW_RUN, "Renamed %s -> %s",


### PR DESCRIPTION
Makeflow's new default of saving failed outputs gives up if it can't move the files, and doesn't try to handle unusual paths. This included absolute paths, so the rename would fail since the parent directory structure would not exist. This PR tries to create any parent directories before the rename. In the case of absolute paths, this will result in a slightly weird directory hierarchy (e.g. `makeflow.failed.3/home/john/workflow/output.log`), but the failed outputs should be there.

resolves #1451 (again)