### PR TITLE
Failed cleanup

### DIFF
--- a/doc/makeflow.html
+++ b/doc/makeflow.html
@@ -276,6 +276,13 @@ about how each job is constructed and sent to the underlying batch system.
 </p>
 
 <p>
+When debugging failed tasks, it is often useful to examine any output produced.
+Makeflow automatically saves these files in a <tt>makeflow.failed.$ruleno</tt> directory for each failed rule.
+Only the specified outputs of a rule will be saved.
+If the rule is retried and later succeeds, the failed outputs will be automatically deleted.
+</p>
+
+<p>
 Finally, Makeflow was created by the Cooperative Computing Lab at the University of Notre Dame.
 We are always happy to learn more about how Makeflow is used and assist you if you
 have questions or difficulty.  <p>For the latest information about Makeflow, please visit our <a href="http://ccl.cse.nd.edu/software/makeflow">web site</a> and subscribe to our <a href="http://ccl.cse.nd.edu/software">mailing list</a> for more information.

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -852,6 +852,8 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 			makeflow_failed_flag = 1;
 		}
 	} else {
+		makeflow_clean_rm_fail_dir(d, n, remote_queue);
+
 		/* Mark source files that have been used by this node */
 		list_first_item(n->source_files);
 		while((f = list_next_item(n->source_files))) {

--- a/makeflow/src/makeflow_gc.h
+++ b/makeflow/src/makeflow_gc.h
@@ -34,6 +34,7 @@ void makeflow_gc( struct dag *d, struct batch_queue *queue, makeflow_gc_method_t
 int  makeflow_clean_file( struct dag *d, struct batch_queue *queue, struct dag_file *f, int silent );
 void makeflow_clean_node( struct dag *d, struct batch_queue *queue, struct dag_node *n, int silent );
 int makeflow_clean_prep_fail_dir(struct dag *d, struct dag_node *n, struct batch_queue *q);
+int makeflow_clean_rm_fail_dir(struct dag *d, struct dag_node *n, struct batch_queue *q);
 int makeflow_clean_failed_file(struct dag *d, struct dag_node *n, struct batch_queue *q, struct dag_file *f, int prep_failed, int silent);
 
 /* return 0 on success; return non-zero on failure. */


### PR DESCRIPTION
When debugging my JX BWA-GATK workflow, I was annoyed that there were failed output directories lying around for rules I had fixed. This PR cleans up failed outputs if a rule succeeds after retrying. This is how I would expect things to work when tweaking command lines, and turning on automatic retries implies that there will be intermittent failures we don't care about, so I think this is the right thing to do.