### PR TITLE
Fix Bug in Symlink Handling

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -660,7 +660,7 @@ static double get_queue_transfer_rate(struct work_queue *q, char **data_source)
 	int64_t     q_total_bytes_transferred = q->stats->bytes_sent + q->stats->bytes_received;
 	timestamp_t q_total_transfer_time     = q->stats->time_send  + q->stats->time_receive;
 
-	// Note q_total_transfer_time is timestamp_t with units of milliseconds.
+	// Note q_total_transfer_time is timestamp_t with units of microseconds.
 	if(q_total_transfer_time>1000000) {
 		queue_transfer_rate = 1000000.0 * q_total_bytes_transferred / q_total_transfer_time;
 		if (data_source) {
@@ -698,7 +698,7 @@ static int get_transfer_wait_time(struct work_queue *q, struct work_queue_worker
 	char *data_source;
 
 	if(w->total_transfer_time>1000000) {
-		// Note w->total_transfer_time is timestamp_t with units of milliseconds.
+		// Note w->total_transfer_time is timestamp_t with units of microseconds.
 		avg_transfer_rate = 1000000 * w->total_bytes_transferred / w->total_transfer_time;
 		data_source = xxstrdup("worker's observed");
 	} else {

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -65,10 +65,6 @@ The following major problems must be fixed:
 #include <string.h>
 #include <time.h>
 
-#ifdef CCTOOLS_OPSYS_SUNOS
-extern int setenv(const char *name, const char *value, int overwrite);
-#endif
-
 // The default tasks capacity reported before information is available.
 // Default capacity also implies 1 core, 1024 MB of disk and 512 memory per task.
 #define WORK_QUEUE_DEFAULT_CAPACITY_TASKS 10
@@ -98,7 +94,6 @@ typedef enum {
 	WORKER_FAILURE, 
 	APP_FAILURE
 } work_queue_result_code_t;
-
 
 typedef enum {
 	MSG_PROCESSED = 0,

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -75,7 +75,7 @@ typedef enum {
 	CONTAINER_MODE_UMBRELLA
 } container_mode_t;
 
-#define DEFAULT_WORK_DIR "/home/worker"
+#define DOCKER_WORK_DIR "/home/worker"
 
 // In single shot mode, immediately quit when disconnected.
 // Useful for accelerating the test suite.
@@ -2613,8 +2613,8 @@ int main(int argc, char *argv[])
 		sprintf(container_name, "worker-%d-%d", (int) getuid(), (int) getpid());
 		char container_mnt_point[1024];
 		char start_container_cmd[1024];
-		sprintf(container_mnt_point, "%s:%s", workspace, DEFAULT_WORK_DIR);
-		sprintf(start_container_cmd, "docker run -i -d --name=\"%s\" -v %s -w %s %s", container_name, container_mnt_point, DEFAULT_WORK_DIR, img_name);
+		sprintf(container_mnt_point, "%s:%s", workspace, DOCKER_WORK_DIR);
+		sprintf(start_container_cmd, "docker run -i -d --name=\"%s\" -v %s -w %s %s", container_name, container_mnt_point, DOCKER_WORK_DIR, img_name);
 		system(start_container_cmd);
 	}
 

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -63,10 +63,6 @@ See the file COPYING for details.
 #include <sys/utsname.h>
 #include <sys/wait.h>
 
-#ifdef CCTOOLS_OPSYS_SUNOS
-extern int setenv(const char *name, const char *value, int overwrite);
-#endif
-
 #define WORKER_MODE_WORKER  1
 #define WORKER_MODE_FOREMAN 2
 

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -472,7 +472,13 @@ int link_recursive( const char *source, const char *target )
 	} else {
 		if(link(source, target)==0) return 1;
 
-		if( (errno == EXDEV || errno == EPERM) && symlinks_enabled) {
+		/*
+		If the hard link failed, perhaps because the source
+		was a directory, or if hard links are not supported
+		in that file system, fall back to a symlink.
+		*/
+
+		if(symlinks_enabled) {
 
 			/*
 			Use an absolute path when symlinking, otherwise the link will


### PR DESCRIPTION
Noted at the tutorial today: People trying to transfer directories containing broken symlinks (such as those created by editors as lock files) would result in mysterious failures in WQ.

Also, some code hygeine commits.

