### PR TITLE
Makeflow Local Resources

### DIFF
--- a/doc/man/makeflow.m4
+++ b/doc/man/makeflow.m4
@@ -50,6 +50,10 @@ OPTIONS_BEGIN
 OPTION_TRIPLET(-B, batch-options, options)Add these options to all batch submit files.
 OPTION_TRIPLET(-j, max-local, #)Max number of local jobs to run at once. (default is # of cores)
 OPTION_TRIPLET(-J, max-remote, #)Max number of remote jobs to run at once. (default is 1000 for -Twq, 100 otherwise)
+OPTION_ITEM(--local-cores,#) Max number of cores to use for local jobs.
+OPTION_ITEM(--local-memory,#) Max MB of memory to use for local jobs.
+OPTION_ITEM(--local-disk,#) Max MB of disk to use for local jobs.
+
 OPTION_TRIPLET(-l, makeflow-log, logfile)Use this file for the makeflow log. (default is X.makeflowlog)
 OPTION_TRIPLET(-L, batch-log, logfile)Use this file for the batch system log. (default is X.PARAM(type)log)
 OPTION_ITEM(`-R, --retry')Automatically retry failed batch jobs up to 100 times.

--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -101,6 +101,7 @@ SOURCES = \
 	stringtools.c \
 	text_array.c \
 	text_list.c \
+	terminal_size.c \
 	timer.c \
 	timestamp.c \
 	unlink_recursive.c \

--- a/dttools/src/terminal_size.c
+++ b/dttools/src/terminal_size.c
@@ -1,0 +1,26 @@
+#include "terminal_size.h"
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+
+void terminal_size( int *rows, int *columns )
+{
+	*rows = 25;
+	*columns = 80;
+
+       	struct winsize window;
+	if(ioctl(STDOUT_FILENO, TIOCGWINSZ, &window) >= 0) {
+		if(window.ws_row>1) *rows = window.ws_row;
+		if(window.ws_col>1) *columns = window.ws_col;
+	}
+
+	char *str;
+
+	str = getenv("COLUMNS");
+	if(str && atoi(str)>1) *columns = atoi(str);
+
+	str = getenv("ROWS");
+	if(str && atoi(str)>1) *rows = atoi(str);
+}
+

--- a/dttools/src/terminal_size.h
+++ b/dttools/src/terminal_size.h
@@ -1,0 +1,6 @@
+#ifndef TERMINAL_SIZE_H
+#define TERMINAL_SIZE_H
+
+void terminal_size( int *rows, int *columns );
+
+#endif

--- a/makeflow/src/Makefile
+++ b/makeflow/src/Makefile
@@ -18,7 +18,7 @@ makeflow makeflow_viz makeflow_analyze makeflow_status: $(OBJECTS)
 
 makeflow_status: makeflow_status.o
 
-makeflow: makeflow_summary.o makeflow_gc.o makeflow_log.o makeflow_wrapper.o makeflow_wrapper_monitor.o makeflow_wrapper_docker.o makeflow_wrapper_enforcement.o makeflow_catalog_reporter.o makeflow_wrapper_umbrella.o makeflow_mounts.o makeflow_wrapper_singularity.o makeflow_archive.o
+makeflow: makeflow_summary.o makeflow_gc.o makeflow_log.o makeflow_wrapper.o makeflow_wrapper_monitor.o makeflow_wrapper_docker.o makeflow_wrapper_enforcement.o makeflow_catalog_reporter.o makeflow_wrapper_umbrella.o makeflow_mounts.o makeflow_wrapper_singularity.o makeflow_archive.o makeflow_local_resources.o
 
 $(PROGRAMS): $(EXTERNAL_DEPENDENCIES)
 

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -1917,10 +1917,10 @@ int main(int argc, char *argv[])
 				remote_jobs_max = MAX_REMOTE_JOBS_DEFAULT;
 			}
 		}
-		printf("max running remote jobs (-J): %d\n",remote_jobs_max);
+		printf("max running remote jobs: %d\n",remote_jobs_max);
 	}
 
-	printf("max running local jobs (-j): %d\n",local_jobs_max);
+	printf("max running local jobs: %d\n",local_jobs_max);
 
 	remote_queue = batch_queue_create(batch_queue_type);
 	if(!remote_queue) {

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -50,6 +50,7 @@ See the file COPYING for details.
 #include "makeflow_wrapper_singularity.h"
 #include "makeflow_archive.h"
 #include "makeflow_catalog_reporter.h"
+#include "makeflow_local_resources.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -115,6 +116,8 @@ static double makeflow_gc_task_ratio = 0.05;
 static batch_queue_type_t batch_queue_type = BATCH_QUEUE_TYPE_LOCAL;
 static struct batch_queue *local_queue = 0;
 static struct batch_queue *remote_queue = 0;
+
+static struct makeflow_local_resources *local_resources = 0;
 
 static int local_jobs_max = 1;
 static int remote_jobs_max = MAX_REMOTE_JOBS_DEFAULT;
@@ -1815,6 +1818,10 @@ int main(int argc, char *argv[])
 	if(!d) {
 		fatal("makeflow: couldn't load %s: %s\n", dagfile, strerror(errno));
 	}
+
+	local_resources = makeflow_local_resources_create();
+	makeflow_local_resources_measure(local_resources);
+	makeflow_local_resources_print(local_resources);
 
 	d->allocation_mode = allocation_mode;
 

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -1546,6 +1546,15 @@ int main(int argc, char *argv[])
 			case 'm':
 				email_summary_to = xxstrdup(optarg);
 				break;
+			case LONG_OPT_LOCAL_CORES:
+				explicit_local_cores = atoi(optarg);
+				break;
+			case LONG_OPT_LOCAL_MEMORY:
+				explicit_local_memory = atoi(optarg);
+				break;
+			case LONG_OPT_LOCAL_DISK:
+				explicit_local_disk = atoi(optarg);
+				break;
 			case LONG_OPT_MONITOR:
 				if (!monitor) monitor = makeflow_monitor_create();
 				if(log_dir) free(log_dir);

--- a/makeflow/src/makeflow_local_resources.c
+++ b/makeflow/src/makeflow_local_resources.c
@@ -21,19 +21,19 @@ void makeflow_local_resources_delete( struct makeflow_local_resources *r )
 
 void makeflow_local_resources_print( struct makeflow_local_resources *r )
 {
-	printf("local resources: %d jobs, %d cores, %d MB memory, %d MB disk\n",r->jobs,r->cores,r->memory,r->disk);
+	printf("local resources: %d cores, %d MB memory, %d MB disk\n",r->cores,r->memory,r->disk);
 }
 
 void makeflow_local_resources_debug( struct makeflow_local_resources *r )
 {
-	debug(D_MAKEFLOW,"local resources: %d jobs, %d cores, %d MB memory, %d MB disk\n",r->jobs,r->cores,r->memory,r->disk);
+	debug(D_MAKEFLOW,"local resources: %d cores, %d MB memory, %d MB disk\n",r->cores,r->memory,r->disk);
 }
 
 void makeflow_local_resources_measure( struct makeflow_local_resources *r )
 {
 	UINT64_T avail, total;
 
-	r->jobs = r->cores = load_average_get_cpus();
+	r->cores = load_average_get_cpus();
 
 	host_memory_info_get(&avail,&total);
 	r->memory = total / MEGA;
@@ -45,13 +45,12 @@ void makeflow_local_resources_measure( struct makeflow_local_resources *r )
 int  makeflow_local_resources_available( struct makeflow_local_resources *r, struct dag_node *n )
 {
 	struct rmsummary *s = n->resources_requested;
-	return r->jobs>0 && s->cores<=r->cores && s->memory<=r->memory && s->disk<=r->disk;
+	return s->cores<=r->cores && s->memory<=r->memory && s->disk<=r->disk;
 }
 
 void makeflow_local_resources_subtract( struct makeflow_local_resources *r, struct dag_node *n )
 {
 	struct rmsummary *s = n->resources_requested;
-	r->jobs--;
 	if(s->cores>=0)  r->cores -= s->cores;
 	if(s->memory>=0) r->memory -= s->memory;		
 	if(s->disk>=0)   r->disk -= s->disk;
@@ -61,7 +60,6 @@ void makeflow_local_resources_subtract( struct makeflow_local_resources *r, stru
 void makeflow_local_resources_add( struct makeflow_local_resources *r, struct dag_node *n )
 {
 	struct rmsummary *s = n->resources_requested;
-	r->jobs++;
 	if(s->cores>=0)  r->cores += s->cores;
 	if(s->memory>=0) r->memory += s->memory;		
 	if(s->disk>=0)   r->disk += s->disk;

--- a/makeflow/src/makeflow_local_resources.c
+++ b/makeflow/src/makeflow_local_resources.c
@@ -1,0 +1,63 @@
+
+#include "makeflow_local_resources.h"
+
+#include "host_disk_info.h"
+#include "host_memory_info.h"
+#include "load_average.h"
+#include "macros.h"
+
+struct makeflow_local_resources * makeflow_local_resources_create()
+{
+	struct makeflow_local_resources *r = malloc(sizeof(*r));
+	memset(r,0,sizeof(*r));
+	return r;
+}
+
+void makeflow_local_resources_delete( struct makeflow_local_resources *r )
+{
+	free(r);
+}
+
+void makeflow_local_resources_print( struct makeflow_local_resources *r )
+{
+	printf("local resources: %d jobs, %d cores, %d MB memory, %d MB disk\n",r->jobs,r->cores,r->memory,r->disk);
+}
+
+void makeflow_local_resources_measure( struct makeflow_local_resources *r )
+{
+	UINT64_T avail, total;
+
+	r->jobs = r->cores = load_average_get_cpus();
+
+	host_memory_info_get(&avail,&total);
+	r->memory = total / MEGA;
+
+	host_disk_info_get(".",&avail,&total);
+	r->disk = avail / MEGA;
+}
+
+int  makeflow_local_resources_available( struct makeflow_local_resources *r, struct dag_node *n )
+{
+	struct rmsummary *s = n->resources_requested;
+	return r->jobs>0 && s->cores<=r->cores && s->memory<=r->memory && s->disk<=r->disk;
+}
+
+void makeflow_local_resources_subtract( struct makeflow_local_resources *r, struct dag_node *n )
+{
+	struct rmsummary *s = n->resources_requested;
+	r->jobs--;
+	if(s->cores>=0)  r->cores -= s->cores;
+	if(s->memory>=0) r->memory -= s->memory;		
+	if(s->disk>=0)   r->disk -= s->disk;
+}
+
+void makeflow_local_resources_add( struct makeflow_local_resources *r, struct dag_node *n )
+{
+	struct rmsummary *s = n->resources_requested;
+	r->jobs++;
+	if(s->cores>=0)  r->cores += s->cores;
+	if(s->memory>=0) r->memory += s->memory;		
+	if(s->disk>=0)   r->disk += s->disk;
+}
+
+

--- a/makeflow/src/makeflow_local_resources.c
+++ b/makeflow/src/makeflow_local_resources.c
@@ -5,6 +5,7 @@
 #include "host_memory_info.h"
 #include "load_average.h"
 #include "macros.h"
+#include "debug.h"
 
 struct makeflow_local_resources * makeflow_local_resources_create()
 {
@@ -21,6 +22,11 @@ void makeflow_local_resources_delete( struct makeflow_local_resources *r )
 void makeflow_local_resources_print( struct makeflow_local_resources *r )
 {
 	printf("local resources: %d jobs, %d cores, %d MB memory, %d MB disk\n",r->jobs,r->cores,r->memory,r->disk);
+}
+
+void makeflow_local_resources_debug( struct makeflow_local_resources *r )
+{
+	debug(D_MAKEFLOW,"local resources: %d jobs, %d cores, %d MB memory, %d MB disk\n",r->jobs,r->cores,r->memory,r->disk);
 }
 
 void makeflow_local_resources_measure( struct makeflow_local_resources *r )
@@ -49,6 +55,7 @@ void makeflow_local_resources_subtract( struct makeflow_local_resources *r, stru
 	if(s->cores>=0)  r->cores -= s->cores;
 	if(s->memory>=0) r->memory -= s->memory;		
 	if(s->disk>=0)   r->disk -= s->disk;
+	makeflow_local_resources_debug(r);
 }
 
 void makeflow_local_resources_add( struct makeflow_local_resources *r, struct dag_node *n )
@@ -58,6 +65,7 @@ void makeflow_local_resources_add( struct makeflow_local_resources *r, struct da
 	if(s->cores>=0)  r->cores += s->cores;
 	if(s->memory>=0) r->memory += s->memory;		
 	if(s->disk>=0)   r->disk += s->disk;
+	makeflow_local_resources_debug(r);
 }
 
 

--- a/makeflow/src/makeflow_local_resources.h
+++ b/makeflow/src/makeflow_local_resources.h
@@ -1,0 +1,24 @@
+#ifndef MAKEFLOW_LOCAL_RESOURCES_H
+#define MAKEFLOW_LOCAL_RESOURCES_H
+
+#include "dag_node.h"
+
+struct makeflow_local_resources {
+	int jobs;
+	int cores;
+	int memory;
+	int disk;
+};
+
+struct makeflow_local_resources * makeflow_local_resources_create();
+void makeflow_local_resources_delete( struct makeflow_local_resources *r );
+
+void makeflow_local_resources_print( struct makeflow_local_resources *r );
+
+void makeflow_local_resources_measure( struct makeflow_local_resources *r );
+int  makeflow_local_resources_available( struct makeflow_local_resources *r, struct dag_node *n );
+void makeflow_local_resources_subtract( struct makeflow_local_resources *r, struct dag_node *n );
+void makeflow_local_resources_add( struct makeflow_local_resources *r, struct dag_node *n );
+
+
+#endif

--- a/makeflow/src/makeflow_local_resources.h
+++ b/makeflow/src/makeflow_local_resources.h
@@ -4,7 +4,6 @@
 #include "dag_node.h"
 
 struct makeflow_local_resources {
-	int jobs;
 	int cores;
 	int memory;
 	int disk;

--- a/work_queue/src/work_queue_status.c
+++ b/work_queue/src/work_queue_status.c
@@ -22,7 +22,6 @@ See the file COPYING for details.
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sys/ioctl.h>
 
 typedef enum {
 	FORMAT_TABLE,
@@ -48,7 +47,7 @@ static char *catalog_host = NULL;
 int catalog_size = CATALOG_SIZE;
 static struct jx **global_catalog = NULL; //pointer to an array of jx pointers
 static const char *where_expr = "true";
-static int columns = 80;
+static int rows=25, columns=80;
 
 /* negative columns mean a minimum of abs(value), but the column may expand if
  * columns available. */
@@ -488,16 +487,7 @@ int main(int argc, char *argv[])
 
 	cctools_version_debug(D_DEBUG, argv[0]);
 
-	struct winsize window;
-	char *columns_str = getenv("COLUMNS");
-	if(columns_str) {
-		columns = atoi(columns_str);
-		/* use default of 80 columns when the value of columns_str is suspect. */
-		columns = columns < 1 ? 80 : columns;
-	} else if(ioctl(STDOUT_FILENO, TIOCGWINSZ, &window) >= 0) {
-		columns = window.ws_col > 0 ? window.ws_col : columns;
-	}
-
+	terminal_size(&rows,&columns);
 
 	time_t stoptime = time(0) + work_queue_status_timeout;
 

--- a/work_queue/src/work_queue_status.c
+++ b/work_queue/src/work_queue_status.c
@@ -18,6 +18,7 @@ See the file COPYING for details.
 #include "getopt.h"
 #include "stringtools.h"
 #include "xxmalloc.h"
+#include "terminal_size.h"
 
 #include <errno.h>
 #include <string.h>


### PR DESCRIPTION
@btovar please take a look at this PR.  I believe the overall structure is right, except that it seems like resources are not propagated to dag nodes.  Am I misunderstanding something about how resources are handled?

For example, this workflow should (correctly) hang if run with `makeflow --local-cores 4`

```
CORES=8
output:
    echo hello > output
```

If you set gdb to break on `makeflow_local_resources_subtract` and then examine `n->resources_requested` then all the fields are undefined.  Any ideas?
