### PR TITLE
Makeflow Local Waitpid

### DIFF
--- a/batch_job/src/batch_job_local.c
+++ b/batch_job/src/batch_job_local.c
@@ -104,15 +104,14 @@ static batch_job_id_t batch_job_local_wait (struct batch_queue * q, struct batch
 
 static int batch_job_local_remove (struct batch_queue *q, batch_job_id_t jobid)
 {
-	int status;
-
 	if(kill(jobid, SIGTERM) == 0) {
 		if(!itable_lookup(q->job_table, jobid)) {
 			debug(D_BATCH, "runaway process %" PRIbjid "?\n", jobid);
 			return 0;
 		} else {
 			debug(D_BATCH, "waiting for process %" PRIbjid, jobid);
-			waitpid(jobid, &status, 0);
+			struct process_info *p = process_waitpid(jobid,0);
+			if(p) free(p);
 			return 1;
 		}
 	} else {

--- a/dttools/src/process.c
+++ b/dttools/src/process.c
@@ -94,6 +94,8 @@ struct process_info *process_waitpid( pid_t pid, int timeout)
 		if(p) return list_remove(complete_list,(void*)p);
 
 	} while(process_work(timeout));
+
+	return 0;
 }
 
 void process_putback(struct process_info *p)

--- a/dttools/src/process.c
+++ b/dttools/src/process.c
@@ -76,6 +76,26 @@ struct process_info *process_wait(int timeout)
 	return list_pop_head(complete_list);
 }
 
+static int pid_compare( void *a, const void *b )
+{
+	pid_t *pa = (pid_t *)a;
+	pid_t *pb = (pid_t *)b;
+
+	return *pa==*pb;
+}
+
+struct process_info *process_waitpid( pid_t pid, int timeout)
+{
+	if(!complete_list)
+		complete_list = list_create();
+
+	do {
+		struct process_info *p = list_find( complete_list, pid_compare, &pid );
+		if(p) return list_remove(complete_list,(void*)p);
+
+	} while(process_work(timeout));
+}
+
 void process_putback(struct process_info *p)
 {
 	if(!complete_list)

--- a/dttools/src/process.h
+++ b/dttools/src/process.h
@@ -46,6 +46,12 @@ process completed in the available time.
 
 struct process_info *process_wait(int timeout);
 
+/** Wait for a specific process to complete and return its status.
+Like @ref process_wait, but waits for a specific pid.
+*/
+
+struct process_info *process_waitpid(pid_t pid, int timeout);
+
 /** Detect if a child process has completed.
 If so, its status may be obtained without delay by calling @ref process_wait .
 @return True if a child process has completed.


### PR DESCRIPTION
Makeflow local execution should use `process_waitpid` instead of `waitpid` directly so as to interact cleanly with multiple points of fork and wait.
