### PR TITLE
Enable AFS check for both Docker and Condor.

### DIFF
--- a/batch_job/src/batch_job_condor.c
+++ b/batch_job/src/batch_job_condor.c
@@ -100,19 +100,6 @@ static batch_job_id_t batch_job_condor_submit (struct batch_queue *q, const char
 		return -1;
 	}
 
-	if(!string_istrue(hash_table_lookup(q->options, "skip-afs-check"))) {
-		char *cwd = path_getcwd();
-		if(!strncmp(cwd, "/afs", 4)) {
-			debug(D_NOTICE|D_BATCH, "The working directory is '%s':", cwd);
-			debug(D_NOTICE|D_BATCH, "This won't work because Condor is not able to write to files in AFS.");
-			debug(D_NOTICE|D_BATCH, "Instead, run makeflow from a local disk like /tmp.");
-			debug(D_NOTICE|D_BATCH, "Or, use the Work Queue with -T wq and condor_submit_workers.");
-			free(cwd);
-			exit(EXIT_FAILURE);
-		}
-		free(cwd);
-	}
-
 	file = fopen("condor.submit", "w");
 	if(!file) {
 		debug(D_BATCH, "could not create condor.submit: %s", strerror(errno));


### PR DESCRIPTION
Move check early in Makeflow to allow for a clearer error.