### PR TITLE
Replace inline JX strings with type-checked expressions

### DIFF
--- a/chirp/src/chirp_global.c
+++ b/chirp/src/chirp_global.c
@@ -125,7 +125,11 @@ static int server_table_load(time_t stoptime)
 
 	debug(D_CHIRP, "querying catalog at %s", CATALOG_HOST);
 
-	struct jx *jexpr = jx_parse_string("type==\"chirp\"");
+	struct jx *jexpr = jx_operator(
+		JX_OP_EQ,
+		jx_symbol("type"),
+		jx_string("chirp")
+	);
 	q = catalog_query_create(CATALOG_HOST, jexpr, stoptime);
 
 	if(!q) {

--- a/makeflow/src/makeflow_status.c
+++ b/makeflow/src/makeflow_status.c
@@ -139,22 +139,36 @@ int main(int argc, char** argv) {
     if(server==NULL){
         catalog_host = CATALOG_HOST;
     }
-    
-    //make query string
-    const char* query_expr = "type==\"makeflow\"";
-    if(project && username){
-        query_expr = string_format("%s && project==\"%s\" && username==\"%s\"",query_expr,project,username);
-    }else if(project) {
-        query_expr = string_format("%s && project==\"%s\"", query_expr, project);
-    } else if (username) {
-        query_expr = string_format("%s && username==\"%s\"", query_expr, username);
+
+    //make query
+    struct jx *jexpr = jx_operator(
+        JX_OP_EQ,
+        jx_symbol("type"),
+        jx_string("makeflow")
+    );
+
+    if (project) {
+        jexpr = jx_operator(
+            JX_OP_AND,
+            jexpr,
+            jx_operator(
+                JX_OP_EQ,
+                jx_symbol("project"),
+                jx_string(project)
+            )
+        );
     }
 
-    //turn query into jx
-    struct jx *jexpr = jx_parse_string(query_expr);
-    if (!jexpr) {
-        fprintf(stderr, "invalid expression: %s\n", query_expr);
-        return 1;
+    if (username) {
+        jexpr = jx_operator(
+            JX_OP_AND,
+            jexpr,
+            jx_operator(
+                JX_OP_EQ,
+                jx_symbol("username"),
+                jx_string(username)
+            )
+        );
     }
 
     time_t stoptime = time(0) + timeout;

--- a/work_queue/src/work_queue_status.c
+++ b/work_queue/src/work_queue_status.c
@@ -22,6 +22,7 @@ See the file COPYING for details.
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 typedef enum {
 	FORMAT_TABLE,
@@ -46,7 +47,7 @@ static int work_queue_status_timeout = 30;
 static char *catalog_host = NULL;
 int catalog_size = CATALOG_SIZE;
 static struct jx **global_catalog = NULL; //pointer to an array of jx pointers
-static const char *where_expr = "true";
+struct jx *jexpr = NULL;
 static int columns = 80;
 
 /* negative columns mean a minimum of abs(value), but the column may expand if
@@ -218,7 +219,11 @@ static void work_queue_status_parse_command_line_arguments(int argc, char *argv[
 			cctools_version_print(stdout, argv[0]);
 			exit(EXIT_SUCCESS);
 		case LONG_OPT_WHERE:
-			where_expr = optarg;
+			jexpr = jx_parse_string(optarg);
+			if (!jexpr) {
+				fprintf(stderr,"invalid expression: %s\n", optarg);
+				exit(1);
+			}
 			break;
 		default:
 			show_help(argv[0]);
@@ -226,6 +231,8 @@ static void work_queue_status_parse_command_line_arguments(int argc, char *argv[
 			break;
 		}
 	}
+
+	if (!jexpr) jexpr = jx_boolean(true);
 
 	if(query_mode == NO_QUERY)
 		query_mode = QUERY_QUEUE;
@@ -275,13 +282,15 @@ int get_masters( time_t stoptime )
 		catalog_host = strdup(CATALOG_HOST);
 	}
 
-	const char *query_expr = string_format("type==\"wq_master\" and %s",where_expr);
-
-	struct jx *jexpr = jx_parse_string(query_expr);
-	if(!jexpr) {
-		fprintf(stderr,"invalid expression: %s\n",query_expr);
-		exit(1);
-	}
+	jexpr = jx_operator(
+		JX_OP_AND,
+		jexpr,
+		jx_operator(
+			JX_OP_EQ,
+			jx_symbol("type"),
+			jx_string("wq_master")
+		)
+	);
 
 	cq = catalog_query_create(catalog_host, jexpr, stoptime );
 	if(!cq)


### PR DESCRIPTION
Recent changes to JX syntax broke a few places internal to the code that parsed hard-coded JX expressions from C code. I hadn't noticed them until something cropped up in #1712. The immediate fix was just to update the query strings. After that, I searched around the codebase and replaced the hard-coded strings with expressions to build up JX structures in memory. This is safer for wonky inputs, and lets the compiler do more to check the code. As far as I know, these are all the hard-coded JX expressions in CCTools.