### PR TITLE
monitor does not kill task when it goes over stated limits

### DIFF
--- a/dttools/src/rmsummary.c
+++ b/dttools/src/rmsummary.c
@@ -599,11 +599,12 @@ struct jx *rmsummary_to_json(const struct rmsummary *s, int only_resources) {
 				jx_insert_integer(output, "signal", s->signal);
 				jx_insert_string(output, "exit_type", "signal");
 			} else if( strcmp(s->exit_type, "limits") == 0 ) {
+				jx_insert_string(output, "exit_type", "limits");
 				if(s->limits_exceeded) {
 					struct jx *lim = rmsummary_to_json(s->limits_exceeded, 1);
 					jx_insert(output, jx_string("limits_exceeded"), lim);
 				}
-				jx_insert_string(output, "exit_type", "limits");
+
 			} else {
 				jx_insert_string(output, "exit_type", s->exit_type);
 			}

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1460,7 +1460,7 @@ static void fetch_output_from_worker(struct work_queue *q, struct work_queue_wor
 	// Start receiving output...
 	t->time_when_retrieval = timestamp_get();
 
-	if(t->result == WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION) {
+	if(t->result == WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION && !q->monitor_do_not_enforce_limits) {
 		result = get_monitor_output_file(q,w,t);
 	} else {
 		result = get_output_files(q,w,t);

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -196,6 +196,8 @@ struct work_queue {
 	char *monitor_snapshot_file;           // Filename the monitor checks to produce snapshots.
 
 	char *monitor_exe;
+	int  monitor_do_not_enforce_limits;
+
 	struct rmsummary *measured_local_resources;
 	struct rmsummary *current_max_worker;
 
@@ -5090,6 +5092,12 @@ char *work_queue_monitor_wrap(struct work_queue *q, struct work_queue_worker *w,
 		free(tmp);
 	}
 
+	if(q->monitor_do_not_enforce_limits) {
+		char *tmp = extra_options;
+		extra_options = string_format("%s --without-limits", tmp);
+		free(tmp);
+	}
+
 	int extra_files = (q->monitor_mode == MON_FULL);
 
 	char *monitor_cmd = resource_monitor_write_command("./" RESOURCE_MONITOR_REMOTE_NAME, RESOURCE_MONITOR_REMOTE_NAME, limits, extra_options, /* debug */ extra_files, /* series */ extra_files, /* inotify */ 0);
@@ -5922,6 +5930,9 @@ int work_queue_tune(struct work_queue *q, const char *name, double value)
 
 	} else if(!strcmp(name, "category-steady-n-tasks")) {
 		category_tune_bucket_size("category-steady-n-tasks", (int) value);
+
+	} else if(!strcmp(name, "rmonitor-do-not-enforce-limits-use-carefully")) {
+		q->monitor_do_not_enforce_limits = (int) value;
 
 	} else {
 		debug(D_NOTICE|D_WQ, "Warning: tuning parameter \"%s\" not recognized\n", name);


### PR DESCRIPTION
adds --without-limits
adds q.tune("rmonitor-do-not-enforce-limits-use-carefully")

MEANT FOR DEBUGGING. 

The monitor does not terminate a task when it goes above the specified limits. The exhausted limits are still recorded, and the monitor still reports exit status 2. 

If using with wq, a task is still marked as a failure with WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION. However, as many output files as possible are transferred back from the worker.

