### PR TITLE
Fix wq busywait

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -5572,7 +5572,7 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 	struct work_queue_task *t = NULL;
 	// time left?
 
-	while( (stoptime == 0) || (time(0) <= stoptime) ) {
+	while( (stoptime == 0) || (time(0) < stoptime) ) {
 
 		BEGIN_ACCUM_TIME(q, time_internal);
 


### PR DESCRIPTION
When there were no events, wq would wait for one more second since we were using stoptime <= time(0). Also, since time(0) rounds down, some poll times (stoptime - time(0)) were 0, causing busy waits (only for that last second).

As reported by @nhazekam 