### PR TITLE
Catalog Updates via TCP

### DIFF
--- a/doc/catalog.html
+++ b/doc/catalog.html
@@ -102,6 +102,17 @@ These updates must be repeated on a regular basis, typically every 5 minutes,
 in order to keep the catalog up to date.  If an update is not received after
 15 minutes, the entry is removed from the catalog.
 </p>
+
+<p>
+By default, catalog updates are sent via the UDP protocol, which is
+fast and efficient for small (<1KB) messages.  If you have large messages
+or unusual networking conditions, you can alternatively send catalog
+updates via TCP instead.  To do this, set the following environment variable:
+</p>
+
+<pre>
+CATALOG_UPDATE_PROTOCOL=tcp
+</pre>
  
 <h2 id="running">Running a Catalog Server<a class="sectionlink" href="#running" title="Link to this section.">&#x21d7;</a></h2>
 <p>You may want to establish your own catalog server.  This can be

--- a/dttools/src/catalog_query.c
+++ b/dttools/src/catalog_query.c
@@ -241,15 +241,17 @@ static void catalog_update_udp( const char *host, const char *address, int port,
 }
 
 
-static void catalog_update_tcp( const char *host, const char *address, int port, const char *text )
+static int catalog_update_tcp( const char *host, const char *address, int port, const char *text )
 {
 	debug(D_DEBUG, "sending update via tcp to %s(%s):%d", host, address, port);
 
 	time_t stoptime = time(0) + 15;
 	struct link *l = link_connect(address,port,stoptime);
 	if(!l) return 0;
+
 	link_write(l,text,strlen(text),stoptime);
 	link_close(l);
+	return 1;
 }
 
 
@@ -268,10 +270,10 @@ int catalog_query_send_update( const char *hosts, const char *text )
 		if (domain_name_cache_lookup(host, address)) {
 			if(use_udp) {
 				catalog_update_udp( host, address, port, text );
+				sent++;
 			} else {
-				catalog_update_tcp( host, address, port+1, text );
+				sent += catalog_update_tcp( host, address, port+1, text );
 			}
-			sent++;
 		} else {
 			debug(D_DEBUG, "unable to lookup address of host: %s", host);
 		}

--- a/dttools/src/catalog_server.c
+++ b/dttools/src/catalog_server.c
@@ -545,7 +545,7 @@ static void show_help(const char *cmd)
 
 int main(int argc, char *argv[])
 {
-	struct link *link, *list_port = 0;
+	struct link *link, *query_port = 0;
 	signed char ch;
 	time_t current;
 	int is_daemon = 0;
@@ -689,8 +689,8 @@ int main(int argc, char *argv[])
 	if(!table)
 		fatal("couldn't create directory %s: %s\n",history_dir,strerror(errno));
 
-	list_port = link_serve_address(interface, port);
-	if(list_port) {
+	query_port = link_serve_address(interface, port);
+	if(query_port) {
 		/*
 		If a port was chosen automatically, read it back
 		so that the same one can be used for the update port.
@@ -700,7 +700,7 @@ int main(int argc, char *argv[])
 
 		if(port==0) {
 			char addr[LINK_ADDRESS_MAX];
-			link_address_local(list_port,addr,&port);
+			link_address_local(query_port,addr,&port);
 		}
 	} else {
 		if(interface)
@@ -730,7 +730,7 @@ int main(int argc, char *argv[])
 	while(1) {
 		fd_set rfds;
 		int dfd = datagram_fd(update_dgram);
-		int lfd = link_fd(list_port);
+		int lfd = link_fd(query_port);
 		int ufd = link_fd(update_port);
 
 		int result, maxfd;
@@ -778,7 +778,7 @@ int main(int argc, char *argv[])
 		}
 
 		if(FD_ISSET(lfd, &rfds)) {
-			link = link_accept(list_port, time(0) + 5);
+			link = link_accept(query_port, time(0) + 5);
 			if(link) {
 				if(fork_mode) {
 					pid_t pid = fork();


### PR DESCRIPTION
Catalog clients and servers can perform updates via TCP.  This is not as optimal as UDP and may result in brief pauses at the catalog server.  To enable, set `CATALOG_UPDATE_PROTOCOL=tcp`