### PR TITLE
Fix reporting for CVMFS init errors

### DIFF
--- a/parrot/src/pfs_service_cvmfs.cc
+++ b/parrot/src/pfs_service_cvmfs.cc
@@ -461,6 +461,8 @@ static bool cvmfs_activate_filesystem(struct cvmfs_filesystem *f)
 		f->cvmfs_options.replace(cern_it1_key_pos-f->cvmfs_options.c_str(),strlen(CERN_IT1_KEY_PLACEHOLDER),cern_it1_key_fname);
 	}
 
+#if LIBCVMFS_VERSION == 1
+
 	// Internally, cvmfs will attempt to lock this file,
 	// and then block silently if it cannot run.  Since
 	// we are linked against cvmfs anyhow, we use the same
@@ -483,7 +485,6 @@ static bool cvmfs_activate_filesystem(struct cvmfs_filesystem *f)
 		}
 	}
 
-#if LIBCVMFS_VERSION == 1
 	debug(D_CVMFS, "cvmfs_init(%s)", f->cvmfs_options.c_str());
 	cvmfs_set_log_fn(cvmfs_parrot_logger);
 	int rc = cvmfs_init(f->cvmfs_options.c_str());
@@ -744,7 +745,7 @@ static void cvmfs_read_config()
 	cvmfs_set_log_fn(cvmfs_parrot_logger);
 	const int init_retval = cvmfs_init(cvmfs_global_options);
 	if (init_retval != 0) {
-		debug(D_CVMFS, "ERROR: failed to initialize cvmfs (%d)", init_retval);
+		debug(D_CVMFS|D_NOTICE, "ERROR: failed to initialize cvmfs (%d)", init_retval);
 		return;
 	}
 #else
@@ -768,7 +769,7 @@ static void cvmfs_read_config()
 		assert(cvmfs_global_options_v2);
 		int rc = cvmfs_options_parse(cvmfs_global_options_v2, pfs_cvmfs_option_file);
 		if (rc != 0) {
-			debug(D_CVMFS, "ERROR: failed to parse %s", pfs_cvmfs_option_file);
+			debug(D_CVMFS|D_NOTICE, "ERROR: failed to parse %s", pfs_cvmfs_option_file);
 			return;
 		}
 	}


### PR DESCRIPTION
Turns out Parrot was detecting the error in #1737, but wasn't saying anything unless debug logging was on. This PR should give an error message when CVMFS fails in init.