### PR TITLE
resource_monitor snapshots when watching (log) files

### DIFF
--- a/doc/man/resource_monitor.m4
+++ b/doc/man/resource_monitor.m4
@@ -258,7 +258,7 @@ LONGCODE_BEGIN
 }
 LONGCODE_END
 
-Generate snapshots everytime a line is added to "my.log":
+Generate snapshots every time a line is added to "my.log":
 
 LONGCODE_BEGIN
 {
@@ -298,7 +298,7 @@ LONGCODE_BEGIN
 }
 LONGCODE_END
 
-A task may be setup to generate a file everytime a snapshot is desired. The
+A task may be setup to generate a file every time a snapshot is desired. The
 monitor can detected this file, generate a snapshot, and delete the file to get
 ready for the next snapshot:
 
@@ -318,10 +318,11 @@ LONGCODE_BEGIN
 LONGCODE_END
 
 
-SECTION(BUGS)
+SECTION(BUGS AND KNOWN ISSUES)
 
 LIST_BEGIN
 LIST_ITEM(The monitor cannot track the children of statically linked executables.)
+LIST_ITEM(The option --snapshot-events assumes that the watched files are written by appending to them. File truncation may not be detected if between checks the size of the file is larger or equal to the size after truncation. File checks are fixed at intervals of 1 second.)
 LIST_END
 
 SECTION(COPYRIGHT)

--- a/doc/man/resource_monitor.m4
+++ b/doc/man/resource_monitor.m4
@@ -7,8 +7,6 @@ BOLD(resource_monitor) - monitors the cpu, memory, io, and disk usage of a tree 
 SECTION(SYNOPSIS)
 CODE(BOLD(resource_monitor [options] -- command [command-options]))
 
-CODE(BOLD(resource_monitorv [options] -- command [command-options]))
-
 SECTION(DESCRIPTION)
 
 BOLD(resource_monitor) is a tool to monitor the computational
@@ -40,47 +38,57 @@ as json with the maximum values of resource used, a time-series that shows the
 resources used at given time intervals, and a list of files that were opened
 during execution.
 
-The summary file has the following fields:
+The summary file is a JSON document with the following fields. Unless indicated, all fields are integers.
 
 LONGCODE_BEGIN
-command:                   [the command line given as an argument]
-start:                     [microseconds at the start of execution, since the epoch, int]
-end:                       [microseconds at the end of execution, since the epoch,   int]
-exit_type:                 [one of normal, signal or limit,                       string]
-signal:                    [number of the signal that terminated the process.
-                            Only present if exit_type is signal                      int]
-cores:                     [number of cores. Computed as cpu_time/wall_time        float]
-limits_exceeded:           [resources over the limit. Only present if
-                            exit_type is limit,                                   string]
-exit_status:               [final status of the parent process,                      int]
-max_concurrent_processes:  [the maximum number of processes running concurrently,    int]
-total_processes:           [count of all of the processes created,                   int]
-wall_time:                 [microseconds spent during execution, end - start,        int]
-cpu_time:                  [user + system time of the execution, in microseconds,    int]
-virtual_memory:            [maximum virtual memory across all processes, in MB,      int]
-memory:                    [maximum resident size across all processes, in MB,       int]
-swap_memory:               [maximum swap usage across all processes, in MB,          int]
-bytes_read:                [amount of data read from disk, in MB,                    int]
-bytes_written:             [amount of data written to disk, in MB,                   int]
-total_files:               [total maximum number of files and directories of
-                            all the working directories in the tree,                 int]
-disk:                      [size in MB of all working directories in the tree,       int]
+command:                  the command line given as an argument
+start:                    microseconds at start of execution, since the epoch
+end:                      microseconds at end of execution, since the epoch
+exit_type:                one of "normal", "signal" or "limit" (a string)
+signal:                   number of the signal that terminated the process
+                          Only present if exit_type is signal
+cores:                    maximum number of cores used
+cores_avg:                number of cores as cpu_time/wall_time (a float)
+exit_status:              final status of the parent process
+max_concurrent_processes: the maximum number of processes running concurrently
+total_processes:          count of all of the processes created
+wall_time:                microseconds spent during execution, end - start
+cpu_time:                 user+system time of the execution, in microseconds
+virtual_memory:           maximum virtual memory across all processes, in MB
+memory:                   maximum resident size across all processes, in MB
+swap_memory:              maximum swap usage across all processes, in MB
+bytes_read:               amount of data read from disk, in MB
+bytes_written:            amount of data written to disk, in MB
+bytes_received:           amount of data read from network interfaces, in MB
+bytes_sent:               amount of data written to network interfaces, in MB
+bandwidth:                maximum bandwidth used, in Mbps
+total_files:              total maximum number of files and directories of
+                          all the working directories in the tree
+disk:                     size in MB of all working directories in the tree
+limits_exceeded:          resources over the limit with -l, -L options (JSON)
+peak_times:               seconds from start when a maximum occured (JSON)
+snapshots:                List of intermediate measurements, identified by
+                          snapshot_name (JSON)
 LONGCODE_END
 
-The time-series log has a row per time sample. For each row, the columns have the following meaning:
+The time-series log has a row per time sample. For each row, the columns have the following meaning (all columns are integers):
 
 LONGCODE_BEGIN
-wall_clock                [the sample time, since the epoch, in microseconds,      int]
-cpu_time                  [accumulated user + kernel time, in microseconds,        int]
-concurrent                [concurrent processes at the time of the sample,         int]
-virtual                   [current virtual memory size, in MB,                     int]
-resident                  [current resident memory size, in MB,                    int]
-swap                      [current swap usage, in MB,                              int]
-bytes_read                [accumulated number of bytes read,                       int]
-bytes_written             [accumulated number of bytes written,                    int]
-files                     [current number of files and directories, across all
-                           working directories in the tree,                        int]
-disk                      [current size of working directories in the tree, in MB  int]
+wall_clock                the sample time, since the epoch, in microseconds
+cpu_time                  accumulated user + kernel time, in microseconds
+cores                     current number of cores used
+max_concurrent_processes  concurrent processes at the time of the sample
+virtual_memory            current virtual memory size, in MB
+memory                    current resident memory size, in MB
+swap_memory               current swap usage, in MB
+bytes_read                accumulated number of bytes read, in bytes
+bytes_written             accumulated number of bytes written, in bytes
+bytes_received            accumulated number of bytes received, in bytes
+bytes_sent                accumulated number of bytes sent, in bytes
+bandwidth                 current bandwidth, in bps
+total_files               current number of files and directories, across all
+                          working directories in the tree
+disk                      current size of working directories in the tree, in MB
 LONGCODE_END
 
 SECTION(OPTIONS)
@@ -101,7 +109,7 @@ OPTION_ITEM(--measure-dir=<dir>)Follow the size of <dir>. If not specified, foll
 OPTION_ITEM(--without-time-series)Do not write the time-series log file.
 OPTION_ITEM(--without-opened-files)Do not write the list of opened files.
 OPTION_ITEM(--without-disk-footprint)Do not measure working directory footprint (default).
-OPTION_ITEM(--snapshot-file=<file>) If <file> exists at the end of a measurement interval, take a snapshot of current resources, and delete <file>. If <file> has a non-empty first line, it is used as a label for the snapshot.
+OPTION_ITEM(--snapshot-events=<file>)Configuration file for snapshots on file patterns. See below.
 OPTION_ITEM(`-v,--version')Show version string.
 OPTION_ITEM(`-h,--help')Show help text.
 OPTIONS_END
@@ -138,6 +146,66 @@ LIST_END
 
 To obtain the exit status of the original command, see the generated file with extension CODE(.summary).
 
+
+SECTION(SNAPSHOTS)
+
+The resource_monitor  can be directed to take snapshots of the resources used
+according to the files created by the processes monitored. The typical use of
+monitoring snapshots is to set a watch on a log file, and generate a snapshot
+when a line in the log matches a pattern. To activate the snapshot facility,
+use the command line argument --snapshot-events=<file>, in which <file> is a
+JSON-encoded document with the following format:
+
+LONGCODE_BEGIN
+    {
+        "FILENAME": {
+            "from-start":boolean,
+            "from-start-if-truncated":boolean,
+            "delete-if-found":boolean,
+            "events": [
+                {
+                    "label":"EVENT_NAME",
+                    "on-create":boolean,
+                    "on-truncate":boolean,
+                    "pattern":"REGEXP",
+                    "count":integer
+                },
+                {
+                    "label":"EVENT_NAME",
+                    ...
+                }
+            ]
+        },
+        "FILENAME": {
+            ...
+    }
+LONGCODE_END
+
+All fields but BOLD(label) are optional. 
+
+            FILENAME:                  Name of a file to watch.
+            from-start:boolean         If FILENAME exits when the monitor starts running, process from line 1. Default: false, as monitored processes may be appending to already existing files.
+            from-start-if-truncated    If FILENAME is truncated, process from line 1. Default: true, to account for log rotations.
+            delete-if-found            Delete FILENAME when found. Default: false
+
+            events:
+            label        Name that identifies the snapshot. Only alphanumeric, -,
+                         and _ characters are allowed. 
+            on-create    Take a snapshot evertyime the file is created. Default: false
+            on-truncate  Take a snapshot when the file is truncated.    Default: false
+            on-pattern   Take a snapshot when a line matches the regexp pattern.    Default: none
+            count        Maximum number of snapshots for this label. Default: -1 (no limit)
+
+The snapshots are recorded both in the main resource summary file under the key
+BOLD(snapshots), and as a JSON-encoded document, with the extension
+.snapshot.NN, in which NN is the sequence number of the snapshot. The snapshots
+are identified with the key "snapshot_name", which is a comma separated string
+of BOLD(label)`('count`)' elements. A label corresponds to a name that
+identifies the snapshot, and the count is the number of times an event was
+triggered since last check (several events may be triggered, for example, when
+several matching lines are written to the log). Several events may have the same label, and exactly one of on-create, on-truncate, and on-pattern should be specified per event.
+
+
 SECTION(EXAMPLES)
 
 To monitor 'sleep 10', at 2 second intervals, with output to sleep-log.summary, and with a monitor alarm at 5 seconds:
@@ -171,6 +239,84 @@ LONGCODE_END
 
 wraps every task with the monitor and writes the resulting summaries in
 CODE(some-log-file). 
+
+SECTION(SNAPSHOTS EXAMPLES)
+
+Generate a snapshot when "my.log" is created:
+
+LONGCODE_BEGIN
+{
+    "my.log":
+        {
+            "events":[
+                {
+                    "label":"MY_LOG_STARTED",
+                    "on-create:true
+                }
+            ]
+        }
+}
+LONGCODE_END
+
+Generate snapshots everytime a line is added to "my.log":
+
+LONGCODE_BEGIN
+{
+    "my.log":
+        {
+            "events":[
+                {
+                    "label":"MY_LOG_LINE",
+                    "pattern":"^.*$"
+                }
+            ]
+        }
+}
+LONGCODE_END
+
+Generate snapshots on particular lines of "my.log":
+
+LONGCODE_BEGIN
+{
+    "my.log":
+        {
+            "events":[
+                {
+                    "label":"started",
+                    "pattern":"^# START"
+                },
+                {
+                    "label":"end-of-start",
+                    "pattern":"^# PROCESSING"
+                }
+                {
+                    "label":"end-of-processing",
+                    "pattern":"^# ANALYSIS"
+                }
+            ]
+        }
+}
+LONGCODE_END
+
+A task may be setup to generate a file everytime a snapshot is desired. The
+monitor can detected this file, generate a snapshot, and delete the file to get
+ready for the next snapshot:
+
+LONGCODE_BEGIN
+{
+    "please-take-a-snapshot":
+        {
+            "delete-if-found":true,
+            "events":[
+                {
+                    "label":"manual-snapshot",
+                    "on-create":true
+                }
+            ]
+        }
+}
+LONGCODE_END
+
 
 SECTION(BUGS)
 

--- a/doc/man/resource_monitor.m4
+++ b/doc/man/resource_monitor.m4
@@ -191,7 +191,7 @@ All fields but BOLD(label) are optional.
             events:
             label        Name that identifies the snapshot. Only alphanumeric, -,
                          and _ characters are allowed. 
-            on-create    Take a snapshot evertyime the file is created. Default: false
+            on-create    Take a snapshot every time the file is created. Default: false
             on-truncate  Take a snapshot when the file is truncated.    Default: false
             on-pattern   Take a snapshot when a line matches the regexp pattern.    Default: none
             count        Maximum number of snapshots for this label. Default: -1 (no limit)

--- a/resource_monitor/src/Makefile
+++ b/resource_monitor/src/Makefile
@@ -6,7 +6,7 @@ include ../../rules.mk
 LIBRARIES = librmonitor_helper.$(CCTOOLS_DYNAMIC_SUFFIX)
 OBJECTS = resource_monitor_pb.o rmonitor_helper_comm.o resource_monitor.o resource_monitor_tools.o rmonitor_helper.o
 
-PROGRAMS = resource_monitor piggybacker rmonitor_poll_example
+PROGRAMS = resource_monitor piggybacker rmonitor_poll_example rmonitor_snapshot
 
 ifneq ($(CCTOOLS_STATIC),1)
 PROGRAMS += resource_monitor_histograms
@@ -44,6 +44,8 @@ $(PROGRAMS): ../../dttools/src/libdttools.a
 resource_monitor.o: resource_monitor.c rmonitor_piggyback.h
 
 resource_monitor: resource_monitor.o rmonitor_helper_comm.o
+
+rmonitor_snapshot: rmonitor_snapshot.o rmonitor_helper_comm.o
 
 rmonitor_poll_example: rmonitor_poll_example.o
 

--- a/resource_monitor/src/Makefile
+++ b/resource_monitor/src/Makefile
@@ -6,6 +6,8 @@ include ../../rules.mk
 LIBRARIES = librmonitor_helper.$(CCTOOLS_DYNAMIC_SUFFIX)
 OBJECTS = resource_monitor_pb.o rmonitor_helper_comm.o resource_monitor.o resource_monitor_tools.o rmonitor_helper.o rmonitor_file_watch.o
 
+LOCAL_LINKAGE = ../../dttools/src/libdttools.a
+
 PROGRAMS = resource_monitor piggybacker rmonitor_poll_example rmonitor_snapshot
 
 ifneq ($(CCTOOLS_STATIC),1)
@@ -22,9 +24,9 @@ all: $(TARGETS) bindings
 # Note below: we use gcc on static builds so that the library gets to use the system linker.
 librmonitor_helper.$(CCTOOLS_DYNAMIC_SUFFIX): rmonitor_helper.o rmonitor_helper_comm.o
 ifeq ($(CCTOOLS_STATIC),1)
-	gcc           -shared -fPIC $^ -o $@ -ldl $(CCTOOLS_INTERNAL_CCFLAGS) $(LOCAL_LINKAGE) ../../dttools/src/libdttools.a $(CCTOOLS_EXTERNAL_LINKAGE)
+	gcc           -shared -fPIC $^ -o $@ -ldl $(CCTOOLS_INTERNAL_CCFLAGS) $(LOCAL_LINKAGE) $(CCTOOLS_EXTERNAL_LINKAGE)
 else
-	$(CCTOOLS_LD) -shared -fPIC $^ -o $@ -ldl $(CCTOOLS_INTERNAL_CCFLAGS) $(LOCAL_LDFLAGS) ../../dttools/src/libdttools.a $(LOCAL_LINKAGE) $(CCTOOLS_EXTERNAL_LINKAGE)
+	$(CCTOOLS_LD) -shared -fPIC $^ -o $@ -ldl $(CCTOOLS_INTERNAL_CCFLAGS) $(LOCAL_LDFLAGS) $(LOCAL_LINKAGE) $(CCTOOLS_EXTERNAL_LINKAGE)
 endif
 
 piggybacker: piggybacker.o
@@ -38,8 +40,6 @@ ifeq ($(CCTOOLS_STATIC),1)
 else
 	$(CCTOOLS_LD) -O3 -fopenmp -o $@ $(CCTOOLS_INTERNAL_LDFLAGS) $(LOCAL_LDFLAGS) $^ $(LOCAL_LINKAGE) $(CCTOOLS_EXTERNAL_LINKAGE)
 endif
-
-$(PROGRAMS): ../../dttools/src/libdttools.a
 
 resource_monitor.o: resource_monitor.c rmonitor_piggyback.h
 

--- a/resource_monitor/src/Makefile
+++ b/resource_monitor/src/Makefile
@@ -4,7 +4,7 @@ include ../../config.mk
 include ../../rules.mk
 
 LIBRARIES = librmonitor_helper.$(CCTOOLS_DYNAMIC_SUFFIX)
-OBJECTS = resource_monitor_pb.o rmonitor_helper_comm.o resource_monitor.o resource_monitor_tools.o rmonitor_helper.o
+OBJECTS = resource_monitor_pb.o rmonitor_helper_comm.o resource_monitor.o resource_monitor_tools.o rmonitor_helper.o rmonitor_file_watch.o
 
 PROGRAMS = resource_monitor piggybacker rmonitor_poll_example rmonitor_snapshot
 
@@ -43,7 +43,7 @@ $(PROGRAMS): ../../dttools/src/libdttools.a
 
 resource_monitor.o: resource_monitor.c rmonitor_piggyback.h
 
-resource_monitor: resource_monitor.o rmonitor_helper_comm.o
+resource_monitor: resource_monitor.o rmonitor_helper_comm.o rmonitor_file_watch.o
 
 rmonitor_snapshot: rmonitor_snapshot.o rmonitor_helper_comm.o
 

--- a/resource_monitor/src/file_watch_example.json
+++ b/resource_monitor/src/file_watch_example.json
@@ -1,0 +1,32 @@
+{
+    "my.log":
+    {
+        "events":
+        [
+            {
+                "label":"start",
+                "on-create":true,
+                "count":1
+            },
+            {
+                "label":"rotated",
+                "on-truncate":true
+            },
+            {
+                "label":"before-analysis",
+                "on-pattern":"^# ANALYSIS.*"
+            }
+        ]
+    },
+    "myother.log":
+    {
+        "delete-if-found":true,
+        "events":[
+            {
+                "label":"manualsnapshot",
+                "on-creation":true
+            }
+        ]
+    }
+}
+

--- a/resource_monitor/src/file_watch_example.json
+++ b/resource_monitor/src/file_watch_example.json
@@ -24,7 +24,7 @@
         "events":[
             {
                 "label":"manualsnapshot",
-                "on-creation":true
+                "on-create":true
             }
         ]
     }

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -2199,7 +2199,6 @@ int main(int argc, char **argv) {
 				break;
 			case LONG_OPT_SNAPSHOT_FILE:
 				fatal("This option has been replaced with --snapshot-events. Please consult the manual of resource_monitor.");
-				snapshot_signal_file = xxstrdup(optarg);
 				break;
 			case LONG_OPT_SNAPSHOT_WATCH_CONF:
 				snapshot_watch_events_file = xxstrdup(optarg);
@@ -2286,28 +2285,12 @@ int main(int argc, char **argv) {
     snapshot->start  = summary->start;
 
 #if defined(RESOURCE_MONITOR_USE_INOTIFY)
-    if(log_inotify || snapshot_signal_file)
+    if(log_inotify)
     {
 	    rmonitor_inotify_fd     = inotify_init();
 	    alloced_inotify_watches = 100;
 	    inotify_watches         = (char **) calloc(alloced_inotify_watches, sizeof(char *));
 	}
-
-	if(snapshot_signal_file) {
-		char *full_path = malloc(PATH_MAX);
-
-		path_absolute(snapshot_signal_file, full_path, 0);
-
-		char *dir  = malloc(PATH_MAX);
-		path_dirname(full_path, dir);
-
-		free(snapshot_signal_file);
-		snapshot_signal_file = xxstrdup(path_basename(full_path));
-
-		rmonitor_add_file_watch(dir, 0, IN_CREATE);
-
-		free(full_path);
-    }
 #endif
 
 	/* if we are not following changes in directory, and no directory was manually added, we follow the current working directory. */

--- a/resource_monitor/src/rmonitor_file_watch.c
+++ b/resource_monitor/src/rmonitor_file_watch.c
@@ -1,0 +1,433 @@
+/*
+  Copyright (C) 2017- The University of Notre Dame
+  This software is distributed under the GNU General Public License.
+  See the file COPYING for details.
+*/
+
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <signal.h>
+
+#include "buffer.h"
+#include "debug.h"
+#include "rmonitor_helper_comm.h"
+#include "rmonitor_file_watch.h"
+#include "stringtools.h"
+#include "xxmalloc.h"
+
+#define WATCH_FILE_LINE_SIZE 4096
+
+int parse_boolean(const char *fname, struct jx *spec, const char *key, int default_value) {
+
+    int found = 0;
+    struct jx *val = jx_lookup_guard(spec, key, &found);
+
+    int result = default_value;
+    if(found) {
+        if(jx_istype(val, JX_BOOLEAN)) {
+            result = jx_istrue(val);
+        } else {
+            fatal("Value of %s for '%s' is not boolean.", key, fname);
+        }
+    }
+
+    return result;
+}
+
+char *parse_str(const char *fname, struct jx *spec, const char *key, const char *default_value) {
+
+    int found = 0;
+    struct jx *val = jx_lookup_guard(spec, key, &found);
+
+    const char *result = default_value;
+    if(found) {
+        if(jx_istype(val, JX_STRING)) {
+            result = val->u.string_value;
+        } else {
+            fatal("Value of %s for '%s' is not a string.", key, fname);
+        }
+    }
+
+    if(result) {
+        return xxstrdup(result);
+    } else {
+        return NULL;
+    }
+}
+
+jx_int_t parse_int(const char *fname, struct jx *spec, const char *key, jx_int_t default_value) {
+
+    int found = 0;
+    struct jx *val = jx_lookup_guard(spec, key, &found);
+
+    int result = default_value;
+    if(found) {
+        if(jx_istype(val, JX_INTEGER)) {
+            result = val->u.integer_value;
+        } else {
+            fatal("Value of %s for '%s' is not an integer.", key, fname);
+        }
+    }
+
+    return result;
+}
+
+struct rmonitor_file_watch_event *parse_event(const char *fname, struct jx *spec) {
+
+    struct rmonitor_file_watch_event *e = calloc(1, sizeof(*e));
+
+    //defaults:
+    e->on_creation = 0;
+    e->on_truncate = 0;
+    e->max_count   = -1;
+    e->total_count = 0;
+    e->cycle_count = 0;
+    e->on_pattern  = NULL;
+    e->label       = NULL;
+
+
+    e->label       = parse_str(fname,     spec, "label",       NULL);
+    e->max_count   = parse_int(fname,     spec, "count",       -1);
+    e->on_pattern  = parse_str(fname,     spec, "on-pattern",  e->on_pattern);
+    e->on_creation = parse_boolean(fname, spec, "on-create",   e->on_creation);
+    e->on_truncate = parse_boolean(fname, spec, "on-truncate", e->on_truncate);
+
+    int error = 0;
+
+    if(!e->label) {
+        error = 1;
+        warn(D_RMON | D_NOTICE, "A label for '%s' was not given.", fname);
+    } else if(string_match_regex(e->label, "[^A-Za-z0-9_-]")) {
+        error = 1;
+        warn(D_RMON | D_NOTICE, "Label for '%s' has characters not in [A-Za-z0-9_-]", fname);
+    } else {
+        int defined = 0;
+        if(e->on_creation) {
+            defined++;
+        }
+        if(e->on_truncate) {
+            defined++;
+        }
+        if(e->on_pattern) {
+            defined++;
+        }
+
+        if(defined != 1) {
+            error = 1;
+            warn(D_RMON | D_NOTICE, "Exactly one of on-create, on-truncate, or on-pattern should be specified for '%s'", fname);
+        }
+    }
+    
+    if(error) {
+        free(e->label);
+        free(e->on_pattern);
+        free(e);
+
+        return NULL;
+    }
+
+    return e;
+}
+
+void reset_events_counts(struct rmonitor_file_watch_info *f) {
+    struct rmonitor_file_watch_event *e;
+
+    // reset counts for cycle
+    list_first_item(f->events);
+    while((e = list_next_item(f->events))) {
+        e->cycle_count = 0;
+    }
+}
+
+int at_least_one_event_still_active(struct rmonitor_file_watch_info *f) {
+    struct rmonitor_file_watch_event *e;
+    int at_least_one_active = 0;
+
+    list_first_item(f->events);
+    while((e = list_next_item(f->events))) {
+        if(e->max_count < 0 || e->total_count < e->max_count) {
+            at_least_one_active = 1;
+            break;
+        }
+    }
+
+    return at_least_one_active;
+}
+
+const char *construct_label(struct rmonitor_file_watch_info *f) {
+    struct rmonitor_file_watch_event *e;
+    static buffer_t *b = NULL;
+
+    if(!b) {
+        b = malloc(sizeof(*b));
+        buffer_init(b);
+    }
+
+    buffer_rewind(b, 0);
+
+    int event_count = 0;
+    char *sep = "";
+
+    list_first_item(f->events);
+    while((e = list_next_item(f->events))) {
+        if(e->cycle_count > 0) {
+            e->total_count += e->cycle_count;
+            event_count    += e->cycle_count;
+
+            buffer_printf(b, "%s%s(%" PRId64 ")", sep, e->label, e->cycle_count);
+            sep = ",";
+        }
+    }
+
+    if(event_count) {
+        return buffer_tostring(b);
+    } else {
+        return NULL;
+    }
+}
+
+int request_snapshot(struct rmonitor_file_watch_info *f) {
+    const char *label = construct_label(f);
+
+    if(!label) {
+        //no snapshot to request
+        return 0;
+    }
+
+    struct rmonitor_msg msg;
+    bzero(&msg, sizeof(msg));
+
+    msg.type   = SNAPSHOT;
+    msg.error  = 0;
+    msg.origin = -1;
+
+    strncpy(msg.data.s, label, sizeof(msg.data.s) - 1);
+    int status = send_monitor_msg(&msg);
+
+    return status;
+}
+
+void rmonitor_watch_file_aux(struct rmonitor_file_watch_info *f) {
+
+    struct rmonitor_file_watch_event *e;
+    static char line[WATCH_FILE_LINE_SIZE];
+    struct stat s;
+
+    for(;;) {
+
+        int created = 0;
+        int shrank  = 0;
+
+        reset_events_counts(f);
+
+        // if file is there, check if it was there before
+        if(stat(f->filename, &s) == 0) {
+            if(!f->exists) {
+                created = 1;
+            }
+            f->exists = 1;
+        } else {
+            f->exists     = 0;
+            f->position   = 0;
+            f->last_mtime = 0;
+            f->last_size  = 0;
+            f->last_ino   = 0;
+        }
+
+        // check if file was truncated
+        if(f->exists && f->last_mtime < s.st_mtime) {
+            shrank = (f->last_size > s.st_size) || (f->last_ino != 0 && f->last_ino != s.st_ino);
+            if(shrank) {
+                if(f->from_start_if_truncated) {
+                    f->position = 0;
+                } else {
+                    debug(D_RMON, "File '%s' was truncated. Some events may be lost.", f->filename);
+                    f->position = s.st_size;
+                }
+            }
+
+            f->last_mtime = s.st_mtime;
+            f->last_size  = s.st_size;
+            f->last_ino   = s.st_ino;
+
+            // count created and shrank events
+            list_first_item(f->events);
+            while((e = list_next_item(f->events))) {
+                if(e->on_creation && created) {
+                    e->cycle_count++;
+                    e->total_count++;
+                } 
+
+                if(e->on_truncate && shrank) {
+                    e->cycle_count++;
+                    e->total_count++;
+                }
+            }
+
+            if(f->event_with_pattern) {
+                FILE *fp = fopen(f->filename, "r");
+                if(!fp) {
+                    fatal("Could not open file '%s': %s.", strerror(errno)); 
+                }
+
+                f->position = fseek(fp, f->position, SEEK_SET);
+                if(f->position < 0) {
+                    fatal("Could not seek file '%s': %s.", strerror(errno)); 
+                }
+
+                while(fgets(line, WATCH_FILE_LINE_SIZE, fp)) {
+                    list_first_item(f->events);
+                    while((e = list_next_item(f->events))) {
+                        if(e->max_count < 0 || e->max_count < e->total_count) { 
+                            if(string_match_regex(line, e->on_pattern)) {
+                                e->cycle_count++;
+                                e->total_count++;
+                            }
+                        }
+                    }
+                }
+
+                f->position = ftell(fp);
+                fclose(fp);
+            }
+
+            if(request_snapshot(f) < 0) {
+                fatal("Could not contact resource_monitor.");
+            }
+
+            if(!at_least_one_event_still_active(f)) {
+                debug(D_RMON, "No more active events for '%s'.", f->filename);
+                exit(0);
+            }
+
+            if(f->delete_if_found) {
+                unlink(f->filename);
+
+                f->exists     = 0;
+                f->position   = 0;
+                f->last_size  = 0;
+                f->last_mtime = 0;
+                f->last_ino   = 0;
+            }
+        } else {
+            sleep(1);
+        }
+    }
+}
+
+void initialize_watch_events(struct rmonitor_file_watch_info *f, struct jx *watch_spec) {
+
+    struct jx *events_array = jx_lookup(watch_spec, "events");
+
+    if(!events_array) {
+        fatal("File watch for '%s' did not define any events", f->filename);
+    }
+
+    if(!jx_istype(events_array, JX_ARRAY)) {
+        fatal("Value for key 'events' in file watch for '%s' is not an array.", f->filename);
+    }
+
+    f->events = list_create(0);
+
+    struct jx *event_spec;
+    int error = 0;
+    for (void *i = NULL; (event_spec = jx_iterate_array(events_array, &i));) {
+        struct rmonitor_file_watch_event *e = parse_event(f->filename, event_spec);
+        if(e) {
+            if(e->on_pattern) {
+                // at least one event defines a pattern, thus we need line by
+                // line processing.
+                f->event_with_pattern = 1;
+            }
+            list_push_tail(f->events, e);
+            debug(D_RMON, "Added event for file '%s', label '%s', max_count %" PRId64, f->filename, e->label, e->max_count);
+        } else {
+            error = 1;
+        }
+    }
+
+    if(error) {
+        fatal("Error parsing file watch for '%s'.", f->filename);
+    }
+}
+
+
+struct rmonitor_file_watch_info *initialize_watch(const char *fname, struct jx *watch_spec) {
+
+    struct rmonitor_file_watch_info *f;
+    f = calloc(1, sizeof(*f));
+    
+    f->delete_if_found = parse_boolean(fname, watch_spec, "delete-if-found", 0 /* default false */);
+    f->from_start = parse_boolean(fname, watch_spec, "from-start",  0 /* default false */);
+    f->from_start_if_truncated = parse_boolean(fname, watch_spec, "from-start-if-truncated",  1 /* default true */);
+
+    f->filename = fname;
+
+    f->exists     = 0;
+    f->position   = 0;
+    f->last_size  = 0;
+    f->last_mtime = 0;
+    f->last_ino   = 0;
+
+    f->event_with_pattern = 0;
+    initialize_watch_events(f, watch_spec);
+
+    struct stat s;
+    if(stat(fname, &s) == 0) {
+        f->exists   = 1;
+        f->last_ino = s.st_ino;
+
+        if(!f->from_start) {
+            f->position   = s.st_size;
+            f->last_size  = s.st_size;
+            f->last_mtime = s.st_mtime;
+        }
+    }
+
+    return f;
+}
+
+void rmonitor_file_watch_event_free(struct rmonitor_file_watch_event *e) {
+    free(e->label);
+    free(e->on_pattern);
+    free(e);
+}
+
+void rmonitor_file_watch_info_free(struct rmonitor_file_watch_info *f) {
+    struct rmonitor_file_watch_event *e;
+    list_first_item(f->events);
+    while((e = list_pop_head(f->events))) {
+        rmonitor_file_watch_event_free(e);
+    }
+    list_delete(f->events);
+    free(f);
+}
+
+pid_t rmonitor_watch_file(const char *fname, struct jx *watch_spec) {
+
+    struct rmonitor_file_watch_info *f = initialize_watch(fname, watch_spec);
+
+    pid_t pid = fork();
+    if(pid > 0) {
+        rmonitor_file_watch_info_free(f);
+        return pid;
+    }
+    else if(pid < 0) {
+        fatal("Could not start watch for: %s %s", fname, strerror(errno));
+        return pid;
+    }
+    else {
+
+        signal(SIGCHLD, SIG_DFL);
+        signal(SIGINT,  SIG_DFL);
+        signal(SIGQUIT, SIG_DFL);
+        signal(SIGTERM, SIG_DFL);
+
+        rmonitor_watch_file_aux(f);
+        exit(0);
+    }
+}
+
+

--- a/resource_monitor/src/rmonitor_file_watch.h
+++ b/resource_monitor/src/rmonitor_file_watch.h
@@ -1,0 +1,51 @@
+/*
+Copyright (C) 2017- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#ifndef RMONITOR_FILE_WATCH
+
+#include "sys/types.h"
+#include "unistd.h"
+#include "list.h"
+#include "jx.h"
+
+struct rmonitor_file_watch_info {
+    const char  *filename;
+
+    off_t position;
+
+    off_t  last_size;
+    time_t last_mtime;
+    ino_t  last_ino;
+
+    int from_start;
+    int from_start_if_truncated;
+
+    int exists;
+    int delete_if_found;
+
+    struct list *events;
+    int event_with_pattern;
+};
+
+struct rmonitor_file_watch_event {
+    char *label;
+
+    int on_creation;
+    int on_truncate;
+
+    char *on_pattern;
+
+    jx_int_t max_count;      // max number of occurances to report event
+    jx_int_t total_count;    // times the event has been found
+
+    jx_int_t cycle_count;    // times the event has been found since last check
+};
+
+/* Checks file for events. Forks and returns the pid of the child. */
+pid_t rmonitor_watch_file(const char *filename, struct jx *events_array);
+
+#endif
+

--- a/resource_monitor/src/rmonitor_helper.c
+++ b/resource_monitor/src/rmonitor_helper.c
@@ -378,9 +378,6 @@ ssize_t write(int fd, const void *buf, size_t count)
 		msg.type   = WRITE;
 	}
 
-
-	if(!original_write) rmonitor_helper_initialize();
-
 	ssize_t real_count;
 	START(msg)
 		real_count = original_write(fd, buf, count);
@@ -407,8 +404,6 @@ ssize_t read(int fd, void *buf, size_t count)
 	} else {
 		msg.type   = READ;
 	}
-
-	if(!original_read) rmonitor_helper_initialize();
 
 	ssize_t real_count;
 	START(msg)
@@ -456,8 +451,6 @@ ssize_t recvfrom(int fd, void *buf, size_t count, int flags, struct sockaddr *sr
 	msg.type   = RX;
 	msg.origin = getpid();
 
-	if(!original_recvfrom) rmonitor_helper_initialize();
-
 	ssize_t real_count;
 	START(msg)
 		real_count = original_recvfrom(fd, buf, count, flags, src, addrlen);
@@ -480,8 +473,6 @@ ssize_t send(int fd, const void *buf, size_t count, int flags)
 
 	msg.type   = TX;
 	msg.origin = getpid();
-
-	if(!original_send) rmonitor_helper_initialize();
 
 	ssize_t real_count;
 	START(msg)
@@ -506,8 +497,6 @@ ssize_t sendmsg(int fd, const struct msghdr *mg, int flags)
 	msg.type   = TX;
 	msg.origin = getpid();
 
-	if(!original_sendmsg) rmonitor_helper_initialize();
-
 	ssize_t real_count;
 	START(msg)
 		real_count = original_sendmsg(fd, mg, flags);
@@ -531,8 +520,6 @@ ssize_t recvmsg(int fd, struct msghdr *mg, int flags)
 
 	msg.type   = RX;
 	msg.origin = getpid();
-
-	if(!original_recvmsg) rmonitor_helper_initialize();
 
 	ssize_t real_count;
 	START(msg)
@@ -693,7 +680,6 @@ pid_t wait(int *status)
 void __attribute__((constructor)) init() {
 	/* find the dlsym values when loading the library. */
 	rmonitor_helper_initialize();
-	assert(original_fork);
 }
 
 /* wrap main ensures exit_wrapper_preamble runs, and thus monitoring

--- a/resource_monitor/src/rmonitor_helper_comm.c
+++ b/resource_monitor/src/rmonitor_helper_comm.c
@@ -67,6 +67,9 @@ const char *str_msgtype(enum rmonitor_msg_type n)
 		case TX:
 			return "sent";
 			break;
+		case SNAPSHOT:
+			return "snapshot";
+			break;
 		default:
 			return "unknown";
 			break;

--- a/resource_monitor/src/rmonitor_helper_comm.h
+++ b/resource_monitor/src/rmonitor_helper_comm.h
@@ -13,7 +13,7 @@ See the file COPYING for details.
 #define RESOURCE_MONITOR_HELPER_ENV_VAR "CCTOOLS_RESOURCE_MONITOR_HELPER"
 #define RESOURCE_MONITOR_INFO_ENV_VAR   "CCTOOLS_RESOURCE_MONITOR_INFO"
 
-enum rmonitor_msg_type { BRANCH, WAIT, END_WAIT, END, CHDIR, OPEN_INPUT, OPEN_OUTPUT, READ, WRITE, RX, TX };
+enum rmonitor_msg_type { BRANCH, WAIT, END_WAIT, END, CHDIR, OPEN_INPUT, OPEN_OUTPUT, READ, WRITE, RX, TX, SNAPSHOT };
 
 /* BRANCH: pid of parent
  * END:    pid of child that ended
@@ -22,8 +22,9 @@ enum rmonitor_msg_type { BRANCH, WAIT, END_WAIT, END, CHDIR, OPEN_INPUT, OPEN_OU
  * OPEN_OUTPUT: path of the file opened, or "" if not a regular file.
  * READ:   Number of bytes read.
  * WRITE:  Number of bytes written.
- * READ:   Number of bytes received.
- * WRITE:  Number of bytes sent.
+ * RX:     Number of bytes received.
+ * TX:     Number of bytes sent.
+ * SNAPSHOT: snapshot name
  */
 
 struct rmonitor_msg

--- a/resource_monitor/src/rmonitor_snapshot.c
+++ b/resource_monitor/src/rmonitor_snapshot.c
@@ -1,0 +1,31 @@
+/*
+  Copyright (C) 2017- The University of Notre Dame
+  This software is distributed under the GNU General Public License.
+  See the file COPYING for details.
+*/
+
+#include <string.h>
+
+#include "debug.h"
+#include "rmonitor_helper_comm.h"
+
+int main(int argc, char **argv) {
+
+    if(argc < 2) {
+        fatal("Use: %s MESSAGE", argv[0]);
+    }
+
+    struct rmonitor_msg msg;
+
+    msg.type   = SNAPSHOT;
+    msg.error  = 0;
+    msg.origin = -1;
+    strncpy(msg.data.s, argv[1], sizeof(msg.data.s) - 1);
+
+    int status = send_monitor_msg(&msg);
+    if(status < 0) {
+        fatal("Could not send message to resource_monitor");
+    }
+}
+
+

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -532,7 +532,21 @@ is a json encoded file with the following format:
             ...
     }
 
-All fields but label are optional. For more information, consult the manual of the resource_monitor.
+All fields but label are optional.
+
+            from-start:boolean         If FILENAME exits when task starts running, process from line 1. Default: false, as the task may be appending to an already existing file.
+            from-start-if-truncated    If FILENAME is truncated, process from line 1. Default: true, to account for log rotations.
+            delete-if-found            Delete FILENAME when found. Default: false
+
+            events:
+            label        Name that identifies the snapshot. Only alphanumeric, -,
+                         and _ characters are allowed. 
+            on-create    Take a snapshot every time the file is created. Default: false
+            on-truncate  Take a snapshot when the file is truncated.    Default: false
+            pattern      Take a snapshot when a line matches the regexp pattern.    Default: none
+            count        Maximum number of snapshots for this label. Default: -1 (no limit)
+
+For more information, consult the manual of the resource_monitor.
 
 @param t A work queue task object.
 @param monitor_snapshot_file A filename.


### PR DESCRIPTION
 adds --snapshot-events=file to resource_monitor

file looks like:

```json
{
    "one.log":
    {
        "events":
        [
            {
                "label":"start",
                "pattern":"# START",
                "count":1
            }
        ]
    },
    "two.log":
    {
        "events":[
            {
                "label":"anyline",
                "pattern":"^.*$",
                "on-truncate":true
            }
        ]
    },
    "three.log":
    {
        "delete-if-found":true,
        "events":[
            {
                "label":"manualsnapshot",
                "on-creation":true
            }
        ]
    }
}

```

The monitor watches for changes in the files, and matches the regular
expressions. If there is a match, a snapshot is generated.

Still working on it... @klannon, is this what you had in mind for #1714?