### PR TITLE
adds s->machine_load and s->machine_cpus to resource_monitor

### DIFF
--- a/dttools/src/rmonitor_poll_internal.h
+++ b/dttools/src/rmonitor_poll_internal.h
@@ -53,6 +53,8 @@ int rmonitor_get_sys_io_usage(  pid_t pid,        struct rmonitor_io_info *io);
 int rmonitor_get_map_io_usage(  pid_t pid,        struct rmonitor_io_info *io);
 int rmonitor_get_dsk_usage(     const char *path, struct statfs *disk);
 
+int rmonitor_get_loadavg(struct rmonitor_load_info *load);
+
 int rmonitor_get_wd_usage(struct rmonitor_wdir_info *d, int max_time_for_measurement);
 
 void acc_cpu_time_usage( struct rmonitor_cpu_time_info *acc, struct rmonitor_cpu_time_info *other);

--- a/dttools/src/rmonitor_types.h
+++ b/dttools/src/rmonitor_types.h
@@ -63,6 +63,11 @@ struct rmonitor_mem_info
 	uint64_t data;
 };
 
+struct rmonitor_load_info {
+    uint64_t last_minute;
+    uint64_t cpus;
+};
+
 struct rmonitor_io_info
 {
 	uint64_t chars_read;
@@ -129,6 +134,7 @@ struct rmonitor_process_info
 	struct rmonitor_mem_info      mem;
 	struct rmonitor_cpu_time_info cpu;
 	struct rmonitor_io_info       io;
+	struct rmonitor_load_info     load;
 	struct rmonitor_wdir_info    *wd;
 };
 

--- a/dttools/src/rmsummary.h
+++ b/dttools/src/rmsummary.h
@@ -58,6 +58,8 @@ struct rmsummary
 	int64_t  cores;                          /* peak usage in a small time window */
 	int64_t  cores_avg;
 	int64_t  gpus;
+    int64_t  machine_load;                   /* peak load of the host */
+    int64_t  machine_cpus;                   /* number of cpus of the host */
 
 	struct rmsummary *limits_exceeded;
 	struct rmsummary *peak_times;           /* from start, in usecs */

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -843,6 +843,7 @@ void rmonitor_summary_header()
 	    fprintf(log_series, " %s", "bytes_received");
 	    fprintf(log_series, " %s", "bytes_sent");
 	    fprintf(log_series, " %s", "bandwidth");
+	    fprintf(log_series, " %s", "machine_load");
 
 	    if(resources_flags->disk)
 	    {
@@ -961,6 +962,9 @@ void rmonitor_collate_tree(struct rmsummary *tr, struct rmonitor_process_info *p
 	tr->disk = (int64_t) (d->byte_count + ONE_MEGABYTE - 1) / ONE_MEGABYTE;
 
 	tr->fs_nodes          = (int64_t) f->disk.f_ffree;
+
+	tr->machine_load = p->load.last_minute;
+	tr->machine_cpus = p->load.cpus;
 }
 
 void rmonitor_find_max_tree(struct rmsummary *result, struct rmsummary *tr)
@@ -992,6 +996,7 @@ void rmonitor_log_row(struct rmsummary *tr)
 		fprintf(log_series, " %" PRId64, tr->bytes_received);
 		fprintf(log_series, " %" PRId64, tr->bytes_sent);
 		fprintf(log_series, " %" PRId64, tr->bandwidth);
+		fprintf(log_series, " %04.2lf" PRId64, tr->machine_load / 1000.0);
 
 		if(resources_flags->disk)
 		{


### PR DESCRIPTION
Fixes #1678 

In the resource summary now it will appear:

...
"machine_cpus":
    [
      4,
      "cores"
    ],
  "machine_load":
    [
      0.07,
      "procs"
    ],
...

The load is computed in 60s windows. The value in the summary is the peak load.
