### PR TITLE
Adds new Makeflow example using packaged executable

### DIFF
--- a/makeflow/example/shakespeare/Makeflow
+++ b/makeflow/example/shakespeare/Makeflow
@@ -1,0 +1,64 @@
+#This is a sample Makeflow script which retrieves a sampling of William Shakespeare's plays (raw text modified from source at shakespeare.mit.edu),
+#runs an analysis of the amount of dialogue for each character in the sampled plays, and returns the character with the most dialogue and the
+#number of times that character spoke.
+#
+#For each text retrieved (Henry IV Part 1, Henry IV Part 2, Henry VI Part 1, Henry VI Part 2, and Henry VI Part 3) Makeflow will retrieve the text
+#file of the play, package the version of Perl at the local site (via Starch, another part of CCTools), and run the script text_analyzer.pl.
+#The text_analyzer.pl script reads the play it is given and produces a list of characters in the play and how many times they each speak.
+#
+#The execution flow for a single play would look like this:
+#curl->starch->perl->output.txt
+#
+#The final task in this makeflow produces top_character.txt which reports the character with the most dialogue out of all plays read.
+
+#This is the final task in the workflow. Notice that the order we write rules does not matter, Makeflow will figure it out for us.
+top_character.txt : characters_henry_iv_part_1.txt characters_henry_iv_part_2.txt characters_henry_vi_part_1.txt characters_henry_vi_part_2.txt characters_henry_vi_part_3.txt count_characters.pl
+	perl count_characters.pl
+
+characters_henry_iv_part_1.txt : henry_iv_part_1.txt henry_iv_part_1.sfx text_analyzer.pl
+	./henry_iv_part_1.sfx
+
+# If a rule is preceded by LOCAL, it executes at the local site.
+henry_iv_part_1.sfx : henry_iv_part_1.txt text_analyzer.pl
+	LOCAL starch -C starch.config -c "perl text_analyzer.pl henry_iv_part_1.txt" henry_iv_part_1.sfx
+
+henry_iv_part_1.txt :
+	LOCAL curl -o henry_iv_part_1.txt http://ccl.cse.nd.edu/workflows/shakespeare/henry_iv_part_1.txt
+
+#Notice this rule relies on characters_henry_iv_part_1.txt, so it will have to wait for the previous task to finish before it can run.
+characters_henry_iv_part_2.txt : characters_henry_iv_part_1.txt henry_iv_part_2.txt henry_iv_part_2.sfx text_analyzer.pl
+	./henry_iv_part_2.sfx
+
+henry_iv_part_2.sfx : henry_iv_part_2.txt text_analyzer.pl
+	LOCAL starch -C starch.config -c "perl text_analyzer.pl henry_iv_part_2.txt" henry_iv_part_2.sfx
+
+henry_iv_part_2.txt :
+	LOCAL curl -o henry_iv_part_2.txt http://ccl.cse.nd.edu/workflows/shakespeare/henry_iv_part_2.txt
+
+characters_henry_vi_part_1.txt : henry_vi_part_1.txt henry_vi_part_1.sfx text_analyzer.pl
+	./henry_vi_part_1.sfx
+
+henry_vi_part_1.sfx : henry_vi_part_1.txt text_analyzer.pl
+	LOCAL starch -C starch.config -c "perl text_analyzer.pl henry_vi_part_1.txt" henry_vi_part_1.sfx
+
+henry_vi_part_1.txt :
+	LOCAL curl -o henry_vi_part_1.txt http://ccl.cse.nd.edu/workflows/shakespeare/henry_vi_part_1.txt
+
+characters_henry_vi_part_2.txt : characters_henry_vi_part_1.txt henry_vi_part_2.txt henry_vi_part_2.sfx text_analyzer.pl
+	./henry_vi_part_2.sfx
+
+henry_vi_part_2.sfx : henry_vi_part_2.txt text_analyzer.pl
+	LOCAL starch -C starch.config -c "perl text_analyzer.pl henry_vi_part_2.txt" henry_vi_part_2.sfx
+
+henry_vi_part_2.txt :
+	LOCAL curl -o henry_vi_part_2.txt http://ccl.cse.nd.edu/workflows/shakespeare/henry_vi_part_2.txt
+
+characters_henry_vi_part_3.txt : characters_henry_vi_part_2.txt henry_vi_part_3.txt henry_vi_part_3.sfx text_analyzer.pl
+	./henry_vi_part_3.sfx
+
+henry_vi_part_3.sfx : henry_vi_part_3.txt text_analyzer.pl
+	LOCAL starch -C starch.config -c "perl text_analyzer.pl henry_vi_part_3.txt" henry_vi_part_3.sfx
+
+henry_vi_part_3.txt :
+	LOCAL curl -o henry_vi_part_3.txt http://ccl.cse.nd.edu/workflows/shakespeare/henry_vi_part_3.txt
+

--- a/makeflow/example/shakespeare/context.jx
+++ b/makeflow/example/shakespeare/context.jx
@@ -1,0 +1,9 @@
+{
+#Here is a list of the plays we will retrieve
+"PLAYS": ["henry_iv_part_1",
+			  "henry_iv_part_2",
+			  "henry_vi_part_1",
+			  "henry_vi_part_2",
+			  "henry_vi_part_3"
+	]
+}

--- a/makeflow/example/shakespeare/count_characters.pl
+++ b/makeflow/example/shakespeare/count_characters.pl
@@ -1,0 +1,62 @@
+#!/usr/bin/perl
+#
+#Copyright (C) 2016- The University of Notre Dame
+#This software is distributed under the GNU General Public License.
+#This program analyzes the works of William Shakespeare as provided
+#by MIT and parses each play using the MIT format.
+#
+
+use strict; 
+use Scalar::Util qw(looks_like_number);
+use Math::Complex;
+
+my @plays = ("alls_well_that_ends_well.txt", "henry_iv_part_1.txt", "julius_caesar.txt", "othello.txt", "the_merchant_of_venice.txt", "twelfth_night.txt", "a_midsummer_nights_dream.txt", "henry_iv_part_2.txt", "king_john.txt", "pericles_prince_of_tyre.txt", "the_merry_wives_of_windsor.txt", "two_gentlemen_of_verona.txt", "antony_and_cleopatra.txt", "henry_viii.txt", "king_lear.txt", "richard_iii.txt", "the_taming_of_the_shrew.txt", "winters_tale.txt", "as_you_like_it.txt", "henry_vi_part_1.txt", "loves_labours_lost.txt", "richard_ii.txt", "the_tempest.txt", "coriolanus.txt", "henry_vi_part_2.txt", "macbeth.txt", "romeo_and_juliet.txt", "timon_of_athens.txt", "cymbeline.txt", "henry_vi_part_3.txt", "measure_for_measure.txt", "text_analyzer.pl", "titus_andronicus.txt", "hamlet.txt", "henry_v.txt", "much_ado_about_nothing.txt", "the_comedy_of_errors.txt", "troilus_and_cressida.txt");
+
+my %hash = ();
+my $top_count_chars = 0;
+my @top_chars = ();
+
+foreach my $play (sort @plays) {
+	open(INPUT, "characters_$play");
+	my $lines = 0;
+	my $title;
+	while (my $line = <INPUT>) {
+		chomp $line;
+		my @words = split(":",$line);
+		$line = uc($line);
+		if($lines == 0) {
+			$title = $words[0];
+		}
+		else {
+			my $curr_char = "$title - $words[0]";
+			if(exists $hash{$curr_char}) {
+				$hash{$curr_char} += $words[1];
+			}
+			else {
+				$hash{$curr_char} = $words[1];
+			}
+		}
+		$lines++;
+	}
+	close(INPUT);
+}
+
+foreach my $val (sort keys(%hash)) {
+	my $count = $hash{$val};
+	if($count == $top_count_chars) {
+		push(@top_chars, $val);
+	}
+	elsif($count > $top_count_chars) {
+		@top_chars = ($val);
+		$top_count_chars = $count;
+	}
+}
+
+open(OUTPUT, ">>", "top_character.txt");
+print(OUTPUT "\nCHARACTER(S) WITH MOST LINES:\n");
+print(STDERR "\nCHARACTER(S) WITH MOST LINES:\n");
+foreach my $val (@top_chars) {
+	print(OUTPUT "\t$val : $top_count_chars\n\n");
+	print(STDERR "\t$val : $top_count_chars\n\n");
+}
+close(OUTPUT);

--- a/makeflow/example/shakespeare/shakespeare.jx
+++ b/makeflow/example/shakespeare/shakespeare.jx
@@ -1,0 +1,92 @@
+#This is a sample Makeflow script written in JX which retrieves a sampling of William Shakespeare's plays (raw text modified from 
+#source at shakespeare.mit.edu), runs an analysis of the amount of dialogue for each character in the sampled plays, and returns 
+#the character with the most dialogue and the number of times that character spoke.
+#
+#For each text retrieved (Henry IV Part 1, Henry IV Part 2, Henry VI Part 1, Henry VI Part 2, and Henry VI Part 3) Makeflow will retrieve the text
+#file of the play, package the version of Perl at the local site (via Starch, another part of CCTools), and run the script text_analyzer.pl.
+#The text_analyzer.pl script reads the play it is given and produces a list of characters in the play and how many times they each speak.
+#
+#The execution flow for a single play would look like this:
+#curl->starch->perl->output.txt
+#
+#The final task in this makeflow produces top_character.txt which reports the character with the most dialogue out of all plays read.
+
+{
+"rules": [
+#This is the final task in the workflow. Notice that the order we write rules does not matter, Makeflow will figure it out for us.
+{
+	"command": "perl count_characters.pl",
+	"inputs": [format("characters_%s.txt", p) for p in PLAYS,
+			   "count_characters.pl"
+	],
+	"outputs": ["top_character.txt"]
+},
+
+#JX allows us to condense rules down to patterns using list comprehension.
+#In the rule below, we tell Makeflow to get all the plays listed in our context.jx file.
+#Look at example in shakespeare.makeflow to see the expanded version using the Make syntax.
+{
+	"command": format("curl -o %s.txt http://ccl.cse.nd.edu/workflows/shakespeare/%s.txt", p, p),
+	"inputs": [],
+	"outputs": [format("%s.txt", p)],
+	"local_job": true
+} for p in PLAYS,
+
+# If a rule has local_job set to true, it executes at the local site.
+{
+	"command": format("starch -C starch.config -c \"perl text_analyzer.pl %s.txt\" %s.sfx", p, p),
+	"inputs": [format("%s.txt", p),
+			   "text_analyzer.pl"
+	],
+	"outputs": [format("%s.sfx", p)],
+	"local_job": true
+} for p in PLAYS,
+
+{
+	"command": "./henry_iv_part_1.sfx",
+	"inputs": ["henry_iv_part_1.txt",
+			   "henry_iv_part_1.sfx",
+			   "text_analyzer.pl"
+	],
+	"outputs": ["characters_henry_iv_part_1.txt"]
+},
+{
+	"command": "./henry_iv_part_2.sfx",
+	"inputs": ["characters_henry_iv_part_1.txt",
+			   "henry_iv_part_2.txt",
+			   "henry_iv_part_2.sfx",
+			   "text_analyzer.pl"
+	],
+	"outputs": ["characters_henry_iv_part_2.txt"]
+},
+
+{
+	"command": "./henry_vi_part_1.sfx",
+	"inputs": ["henry_vi_part_1.txt",
+			   "henry_vi_part_1.sfx",
+			   "text_analyzer.pl"
+	],
+	"outputs": ["characters_henry_vi_part_1.txt"]
+},
+#Notice this next rule relies on characters_henry_iv_part_1.txt, so it will have to wait for the previous task to finish before it can run.
+{
+	"command": "./henry_vi_part_2.sfx",
+	"inputs": ["characters_henry_vi_part_1.txt",
+			   "henry_vi_part_2.txt",
+			   "henry_vi_part_2.sfx",
+			   "text_analyzer.pl"
+	],
+	"outputs": ["characters_henry_vi_part_2.txt"]
+},
+{
+	"command": "./henry_vi_part_3.sfx",
+	"inputs": ["characters_henry_vi_part_1.txt",
+			   "characters_henry_vi_part_2.txt",
+			   "henry_vi_part_3.txt",
+			   "henry_vi_part_3.sfx",
+			   "text_analyzer.pl"
+	],
+	"outputs": ["characters_henry_vi_part_3.txt"]
+}
+
+]}

--- a/makeflow/example/shakespeare/shakespeare.jx
+++ b/makeflow/example/shakespeare/shakespeare.jx
@@ -34,56 +34,56 @@
 
 # If a rule has local_job set to true, it executes at the local site.
 {
-	"command": format("starch -C starch.config -c \"perl text_analyzer.pl %s.txt\" %s.sfx", p, p),
-	"inputs": [format("%s.txt", p),
+	"command": "starch -C starch.config -c \"perl text_analyzer.pl\" perl.sfx",
+	"inputs": ["/usr/bin/perl",
 			   "text_analyzer.pl"
 	],
-	"outputs": [format("%s.sfx", p)],
+	"outputs": ["perl.sfx"],
 	"local_job": true
-} for p in PLAYS,
+},
 
 {
-	"command": "./henry_iv_part_1.sfx",
+	"command": "./perl.sfx henry_iv_part_1.txt",
 	"inputs": ["henry_iv_part_1.txt",
-			   "henry_iv_part_1.sfx",
+			   "perl.sfx",
 			   "text_analyzer.pl"
 	],
 	"outputs": ["characters_henry_iv_part_1.txt"]
 },
 {
-	"command": "./henry_iv_part_2.sfx",
+	"command": "./perl.sfx henry_iv_part_2.txt",
 	"inputs": ["characters_henry_iv_part_1.txt",
 			   "henry_iv_part_2.txt",
-			   "henry_iv_part_2.sfx",
+			   "perl.sfx",
 			   "text_analyzer.pl"
 	],
 	"outputs": ["characters_henry_iv_part_2.txt"]
 },
 
 {
-	"command": "./henry_vi_part_1.sfx",
+	"command": "./perl.sfx henry_vi_part_1.txt",
 	"inputs": ["henry_vi_part_1.txt",
-			   "henry_vi_part_1.sfx",
+			   "perl.sfx",
 			   "text_analyzer.pl"
 	],
 	"outputs": ["characters_henry_vi_part_1.txt"]
 },
 #Notice this next rule relies on characters_henry_iv_part_1.txt, so it will have to wait for the previous task to finish before it can run.
 {
-	"command": "./henry_vi_part_2.sfx",
+	"command": "./perl.sfx henry_vi_part_2.txt",
 	"inputs": ["characters_henry_vi_part_1.txt",
 			   "henry_vi_part_2.txt",
-			   "henry_vi_part_2.sfx",
+			   "perl.sfx",
 			   "text_analyzer.pl"
 	],
 	"outputs": ["characters_henry_vi_part_2.txt"]
 },
 {
-	"command": "./henry_vi_part_3.sfx",
+	"command": "./perl.sfx henry_vi_part_3.txt",
 	"inputs": ["characters_henry_vi_part_1.txt",
 			   "characters_henry_vi_part_2.txt",
 			   "henry_vi_part_3.txt",
-			   "henry_vi_part_3.sfx",
+			   "perl.sfx",
 			   "text_analyzer.pl"
 	],
 	"outputs": ["characters_henry_vi_part_3.txt"]

--- a/makeflow/example/shakespeare/shakespeare.makeflow
+++ b/makeflow/example/shakespeare/shakespeare.makeflow
@@ -15,49 +15,37 @@
 top_character.txt : characters_henry_iv_part_1.txt characters_henry_iv_part_2.txt characters_henry_vi_part_1.txt characters_henry_vi_part_2.txt characters_henry_vi_part_3.txt count_characters.pl
 	perl count_characters.pl
 
-characters_henry_iv_part_1.txt : henry_iv_part_1.txt henry_iv_part_1.sfx text_analyzer.pl
-	./henry_iv_part_1.sfx
-
 #If a rule is preceded by LOCAL, it executes at the local site.
-henry_iv_part_1.sfx : henry_iv_part_1.txt text_analyzer.pl
-	LOCAL starch -C starch.config -c "perl text_analyzer.pl henry_iv_part_1.txt" henry_iv_part_1.sfx
+perl.sfx : /usr/bin/perl text_analyzer.pl
+	LOCAL starch -C starch.config -c "perl text_analyzer.pl" perl.sfx
+
+characters_henry_iv_part_1.txt : henry_iv_part_1.txt perl.sfx text_analyzer.pl
+	./perl.sfx henry_iv_part_1.txt
 
 henry_iv_part_1.txt :
 	LOCAL curl -o henry_iv_part_1.txt http://ccl.cse.nd.edu/workflows/shakespeare/henry_iv_part_1.txt
 
 #Notice this rule relies on characters_henry_iv_part_1.txt, so it will have to wait for the previous task to finish before it can run.
-characters_henry_iv_part_2.txt : characters_henry_iv_part_1.txt henry_iv_part_2.txt henry_iv_part_2.sfx text_analyzer.pl
-	./henry_iv_part_2.sfx
-
-henry_iv_part_2.sfx : henry_iv_part_2.txt text_analyzer.pl
-	LOCAL starch -C starch.config -c "perl text_analyzer.pl henry_iv_part_2.txt" henry_iv_part_2.sfx
+characters_henry_iv_part_2.txt : characters_henry_iv_part_1.txt henry_iv_part_2.txt perl.sfx text_analyzer.pl
+	./perl.sfx henry_iv_part_2.txt
 
 henry_iv_part_2.txt :
 	LOCAL curl -o henry_iv_part_2.txt http://ccl.cse.nd.edu/workflows/shakespeare/henry_iv_part_2.txt
 
-characters_henry_vi_part_1.txt : henry_vi_part_1.txt henry_vi_part_1.sfx text_analyzer.pl
-	./henry_vi_part_1.sfx
-
-henry_vi_part_1.sfx : henry_vi_part_1.txt text_analyzer.pl
-	LOCAL starch -C starch.config -c "perl text_analyzer.pl henry_vi_part_1.txt" henry_vi_part_1.sfx
+characters_henry_vi_part_1.txt : henry_vi_part_1.txt perl.sfx text_analyzer.pl
+	./perl.sfx henry_vi_part_1.txt
 
 henry_vi_part_1.txt :
 	LOCAL curl -o henry_vi_part_1.txt http://ccl.cse.nd.edu/workflows/shakespeare/henry_vi_part_1.txt
 
-characters_henry_vi_part_2.txt : characters_henry_vi_part_1.txt henry_vi_part_2.txt henry_vi_part_2.sfx text_analyzer.pl
-	./henry_vi_part_2.sfx
-
-henry_vi_part_2.sfx : henry_vi_part_2.txt text_analyzer.pl
-	LOCAL starch -C starch.config -c "perl text_analyzer.pl henry_vi_part_2.txt" henry_vi_part_2.sfx
+characters_henry_vi_part_2.txt : characters_henry_vi_part_1.txt henry_vi_part_2.txt perl.sfx text_analyzer.pl
+	./perl.sfx henry_vi_part_2.txt
 
 henry_vi_part_2.txt :
 	LOCAL curl -o henry_vi_part_2.txt http://ccl.cse.nd.edu/workflows/shakespeare/henry_vi_part_2.txt
 
-characters_henry_vi_part_3.txt : characters_henry_vi_part_2.txt henry_vi_part_3.txt henry_vi_part_3.sfx text_analyzer.pl
-	./henry_vi_part_3.sfx
-
-henry_vi_part_3.sfx : henry_vi_part_3.txt text_analyzer.pl
-	LOCAL starch -C starch.config -c "perl text_analyzer.pl henry_vi_part_3.txt" henry_vi_part_3.sfx
+characters_henry_vi_part_3.txt : characters_henry_vi_part_2.txt henry_vi_part_3.txt perl.sfx text_analyzer.pl
+	./perl.sfx henry_vi_part_3.txt
 
 henry_vi_part_3.txt :
 	LOCAL curl -o henry_vi_part_3.txt http://ccl.cse.nd.edu/workflows/shakespeare/henry_vi_part_3.txt

--- a/makeflow/example/shakespeare/shakespeare.makeflow
+++ b/makeflow/example/shakespeare/shakespeare.makeflow
@@ -18,7 +18,7 @@ top_character.txt : characters_henry_iv_part_1.txt characters_henry_iv_part_2.tx
 characters_henry_iv_part_1.txt : henry_iv_part_1.txt henry_iv_part_1.sfx text_analyzer.pl
 	./henry_iv_part_1.sfx
 
-# If a rule is preceded by LOCAL, it executes at the local site.
+#If a rule is preceded by LOCAL, it executes at the local site.
 henry_iv_part_1.sfx : henry_iv_part_1.txt text_analyzer.pl
 	LOCAL starch -C starch.config -c "perl text_analyzer.pl henry_iv_part_1.txt" henry_iv_part_1.sfx
 

--- a/makeflow/example/shakespeare/starch.config
+++ b/makeflow/example/shakespeare/starch.config
@@ -1,0 +1,4 @@
+[starch]
+executables = perl
+libraries = /usr/lib64/perl5/CORE/libperl.so /lib64/libresolv.so.2 /lib64/libnsl.so.1 /lib64/libdl.so.2 /lib64/libm.so.6 /lib64/libcrypt.so.1 /lib64/libutil.so.1 /lib64/libpthread.so.0 /lib64/libc.so.6 /lib64/ld-linux-x86-64.so.2 /lib64/libfreebl3.so
+command = perl text_analyzer.pl

--- a/makeflow/example/shakespeare/text_analyzer.pl
+++ b/makeflow/example/shakespeare/text_analyzer.pl
@@ -1,0 +1,66 @@
+#!/usr/bin/perl
+#
+#Copyright (C) 2016- The University of Notre Dame
+#This software is distributed under the GNU General Public License.
+#This program analyzes the works of William Shakespeare as provided
+#by MIT and parses each play using the MIT format.
+#
+
+use strict; 
+use Scalar::Util qw(looks_like_number);
+use Math::Complex;
+
+my $num_args = $#ARGV + 1;
+if($num_args != 1) {
+	print "Must specify: input file.\n";
+	exit 1;
+}
+
+my $in = $ARGV[0];
+my %char_hash = ();
+my $top_count_chars = 0;
+my @top_chars = ();
+my $curr_char;
+my $title;
+my $lines = 0;
+open(INPUT, $in);
+open(OUTPUT, ">>", "characters_$in");
+
+while (my $line = <INPUT>) {
+	chomp $line;
+	my @words = split(" ",$line);
+
+	$line = uc($line);
+	if($lines == 0) {
+		$title = $line;
+		print(STDERR "Now Reading: $title\n");
+		print(OUTPUT "$title\n");
+	}
+	if($words[0] eq "SCENE" or $words[0] eq "ACT" or $words[0] eq "PROLOGUE" or $words[0] eq "EPILOGUE" or $words[0] eq "SONG" or $words[0] eq "SONG.") {
+		$lines++;
+	}
+	elsif(@words == 1 and $words[0] =~ m/^[^a-z]*$/ and length($words[0]) >= 3) {
+		$curr_char = $words[0];
+		if(exists $char_hash{$curr_char}) {
+			$char_hash{$curr_char}++;
+		}
+		else {
+			$char_hash{$curr_char} = 1;
+		}
+	}
+	$lines++;
+}
+
+close(INPUT);
+foreach my $val (sort keys(%char_hash)) {
+	my $count = $char_hash{$val};
+	print(OUTPUT "$val:$count\n");
+	if($count == $top_count_chars) {
+		push(@top_chars, $val);
+	}
+	elsif($count > $top_count_chars) {
+		@top_chars = ($val);
+		$top_count_chars = $count;
+	}
+}
+close(OUTPUT);


### PR DESCRIPTION
Addresses #1149.

This example makeflow  has four general steps:
locally curl needed text files, starch the local /usr/bin/perl, run a perl script over the text files, gather results to output final result.

@btovar, mind taking another look at this?