### PR TITLE
Makeflow: Fix bug in log consistency

### DIFF
--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -2249,6 +2249,8 @@ int main(int argc, char *argv[])
 		exit(EXIT_SUCCESS);
 	}
 
+	makeflow_log_close(d);
+
 	free(archive_directory);
 
 	return 0;

--- a/makeflow/src/makeflow_log.c
+++ b/makeflow/src/makeflow_log.c
@@ -115,10 +115,21 @@ static void makeflow_log_sync( struct dag *d, int force )
 {
 	static time_t last_fsync = 0;
 
+	/* Force buffered data to the kernel. */
+	fflush(d->logfile);
+
+	/* Every 60 seconds, force kernel buffered data to disk. */
 	if(force || (time(NULL)-last_fsync) > 60) {
 		fsync(fileno(d->logfile));
 		last_fsync = time(NULL);
 	}
+}
+
+void makeflow_log_close( struct dag *d )
+{
+	makeflow_log_sync(d,1);
+	fclose(d->logfile);
+	d->logfile = 0;
 }
 
 void makeflow_log_started_event( struct dag *d )

--- a/makeflow/src/makeflow_log.h
+++ b/makeflow/src/makeflow_log.h
@@ -27,6 +27,7 @@ void makeflow_log_state_change( struct dag *d, struct dag_node *n, int newstate 
 void makeflow_log_file_state_change( struct dag *d, struct dag_file *f, int newstate );
 void makeflow_log_file_list_state_change( struct dag *d, struct list *fl, int newstate );
 void makeflow_log_gc_event( struct dag *d, int collected, timestamp_t elapsed, int total_collected );
+void makeflow_log_close(struct dag *d );
 
 /* return 0 on success, return non-zero on failure. */
 int makeflow_log_recover( struct dag *d, const char *filename, int verbose_mode, struct batch_queue *queue, makeflow_clean_depth clean_mode, int skip_file_check );


### PR DESCRIPTION
The log must be flushed (not necessarily sync'd) after each event, and it must definitely be flushed and sync'd when makeflow exits.  This fixes a bug observed by Kyle that a completed makeflow may be missing log entries at the end.