### PR TITLE
Unbreak everything

### DIFF
--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -1361,9 +1361,8 @@ void set_snapshot_watch_events() {
 	}
 
 	void *i = NULL;
-	struct jx *key;
-	while((key = jx_iterate_keys(j, &i))) {
-		const char *fname = key->u.string_value;
+	const char *fname;
+	while((fname = jx_iterate_keys(j, &i))) {
 		struct jx *array  = jx_lookup(j, fname);
 
 		if(!jx_istype(array , JX_OBJECT)) {


### PR DESCRIPTION
I didn't rebase #1761 off the current master, and there were some changes in Resource Monitor in the meantime I didn't notice. This should get the red off Autobuild.