### PR TITLE
adds --send-environment

### DIFF
--- a/doc/man/makeflow.m4
+++ b/doc/man/makeflow.m4
@@ -54,6 +54,7 @@ OPTION_TRIPLET(-l, makeflow-log, logfile)Use this file for the makeflow log. (de
 OPTION_TRIPLET(-L, batch-log, logfile)Use this file for the batch system log. (default is X.PARAM(type)log)
 OPTION_ITEM(`-R, --retry')Automatically retry failed batch jobs up to 100 times.
 OPTION_TRIPLET(-r, retry-count, n)Automatically retry failed batch jobs up to n times.
+OPTION_ITEM(`--send-environment')Send all local environment variables in remote execution.
 OPTION_PAIR(--wait-for-files-upto, #)Wait for output files to be created upto this many seconds (e.g., to deal with NFS semantics).
 OPTION_TRIPLET(-S, submission-timeout, timeout)Time to retry failed batch job submission. (default is 3600s)
 OPTION_TRIPLET(-T, batch-type, type)Batch system type: local, dryrun, condor, sge, pbs, torque, blue_waters, slurm, moab, cluster, wq, amazon, mesos. (default is local)

--- a/makeflow/src/dag_node.h
+++ b/makeflow/src/dag_node.h
@@ -111,7 +111,7 @@ void dag_node_print_debug_resources(struct dag_node *n);
 const char *dag_node_state_name(dag_node_state_t state);
 void dag_node_state_change(struct dag *d, struct dag_node *n, int newstate);
 
-struct jx * dag_node_env_create( struct dag *d, struct dag_node *n );
+struct jx * dag_node_env_create( struct dag *d, struct dag_node *n, int should_send_all_local_environment );
 
 const struct rmsummary *dag_node_dynamic_label(const struct dag_node *n);
 

--- a/makeflow/src/makeflow_gc.c
+++ b/makeflow/src/makeflow_gc.c
@@ -65,7 +65,7 @@ and would be better handled by invoking batch_job_local.
 
 static void makeflow_node_export_variables( struct dag *d, struct dag_node *n )
 {
-	struct jx *j = dag_node_env_create(d,n);
+	struct jx *j = dag_node_env_create(d,n,0);
 	if(j) {
 		jx_export(j);
 		jx_delete(j);


### PR DESCRIPTION
Sends local environment variables where the makeflow is running to the
remote execution sites.

Fix for #1796 