### PR TITLE
First pass at fixing node level resources

### DIFF
--- a/makeflow/src/dag_node.c
+++ b/makeflow/src/dag_node.c
@@ -369,7 +369,7 @@ struct jx * dag_node_env_create( struct dag *d, struct dag_node *n, int should_s
 /* Return resources according to request. */
 
 const struct rmsummary *dag_node_dynamic_label(const struct dag_node *n) {
-	return category_dynamic_task_max_resources(n->category, NULL, n->resource_request);
+	return category_dynamic_task_max_resources(n->category, n->resources_requested, n->resource_request);
 }
 
 /* vim: set noexpandtab tabstop=4: */

--- a/makeflow/src/parser.h
+++ b/makeflow/src/parser.h
@@ -16,6 +16,7 @@ typedef enum {
 
 
 struct dag *dag_from_file(const char *filename, dag_syntax_type format, struct jx *args);
+void dag_close_over_nodes(struct dag *d);
 void dag_close_over_categories(struct dag *d);
 void dag_close_over_environment(struct dag *d);
 


### PR DESCRIPTION
@btovar The previous category resource specifications removed local node level resource specification support. This should add it back.

@trshaffer You are add due to changes in the `parser_jx.c` 

TODO: Add tests for resource resolution
TODO: Test more thoroughly with categories.