### PR TITLE
make cvmfs_parrot_logger not static

### DIFF
--- a/parrot/src/pfs_service_cvmfs.cc
+++ b/parrot/src/pfs_service_cvmfs.cc
@@ -329,7 +329,7 @@ static void cvmfs_dirent_to_stat(struct cvmfs_dirent *d, struct pfs_stat *s)
 	s->st_ctime = d->mtime;
 }
 
-static void cvmfs_parrot_logger(const char *msg)
+void cvmfs_parrot_logger(const char *msg)
 {
 	debug(D_CVMFS, "%s", msg);
 }


### PR DESCRIPTION
cvmfs 2.4 does not use the function, and the compiler complains.