### PR TITLE
Add hook add file helper functions

### DIFF
--- a/makeflow/src/makeflow_hook.c
+++ b/makeflow/src/makeflow_hook.c
@@ -1,6 +1,10 @@
-
 #include <assert.h>
+
 #include "debug.h"
+#include "stringtools.h"
+
+#include "batch_job.h"
+#include "batch_task.h"
 
 #include "makeflow_hook.h"
 #include "xxmalloc.h"
@@ -24,6 +28,45 @@ struct list * makeflow_hooks = NULL;
 			fatal("hook %s:" #hook_name " returned %d",h->module_name?h->module_name:"", rc); \
 	} \
 } while (0)
+
+
+
+struct dag_file *makeflow_hook_add_input_file(struct dag *d, struct batch_task *task, const char * name_on_submission_pattern, const char * name_on_execution_pattern)
+{
+    char *id = string_format("%d",task->taskid);
+    char * name_on_submission = string_replace_percents(name_on_submission_pattern, id);
+    char * name_on_execution = string_replace_percents(name_on_execution_pattern, id);
+
+    /* Output of dag_file is returned to use for final filename. */
+    struct dag_file *f = dag_file_lookup_or_create(d, name_on_submission);
+
+    batch_task_add_input_file(task, name_on_submission, name_on_execution);
+
+    free(id);
+    free(name_on_submission);
+    free(name_on_execution);
+
+    return f;
+}
+
+struct dag_file * makeflow_hook_add_output_file(struct dag *d, struct batch_task *task, const char * name_on_submission_pattern, const char * name_on_execution_pattern)
+{
+    char *id = string_format("%d",task->taskid);
+    char * name_on_submission = string_replace_percents(name_on_submission_pattern, id);
+    char * name_on_execution = string_replace_percents(name_on_execution_pattern, id);
+
+    /* Output of dag_file is returned to use for final filename. */
+    struct dag_file *f = dag_file_lookup_or_create(d, name_on_submission);
+
+    batch_task_add_output_file(task, name_on_submission, name_on_execution);
+
+    free(id);
+    free(name_on_submission);
+    free(name_on_execution);
+
+    return f;
+}
+
 
 void makeflow_hook_register(struct makeflow_hook *hook) {
 	assert(hook);

--- a/makeflow/src/makeflow_hook.h
+++ b/makeflow/src/makeflow_hook.h
@@ -14,10 +14,10 @@
  */
 
 #include "batch_job.h"
+#include "batch_task.h"
 #include "dag.h"
 #include "dag_node.h"
 #include "dag_file.h"
-#include "batch_job.h"
 #include "jx.h"
 
 /* ----------------------------------------------------------- *
@@ -383,6 +383,30 @@ typedef enum {
 struct batch_queue * makeflow_get_remote_queue();
 struct batch_queue * makeflow_get_local_queue();
 struct batch_queue * makeflow_get_queue(struct dag_node *node);
+
+/** Add file to batch_task and DAG.
+ *  This function takes a pattern for name_on_submission and name_on_exectution,
+ *   replaces %% with the taskid, creates a dag_file to associate with the DAG, 
+ *    and adds the specific names to the batch_task input files.
+ *    @param d The DAG these files are created in.
+ *    @param task The batch_task this file is added to.
+ *    @param name_on_submission The pattern of the name from the submission/host site.
+ *    @param name_on_execution The pattern of the name at execution site.
+ *    @return The DAG file that was either found or created in the dag.
+ *    */
+struct dag_file * makeflow_hook_add_input_file(struct dag *d, struct batch_task *task, const char * name_on_submission_pattern, const char * name_on_execution_pattern);
+
+/** Add file to batch_task and DAG.
+ *  This function takes a pattern for name_on_submission and name_on_exectution,
+ *   replaces %% with the taskid, creates a dag_file to associate with the DAG, 
+ *    and adds the specific names to the batch_task output files.
+ *    @param d The DAG these files are created in.
+ *    @param task The batch_task this file is added to.
+ *    @param name_on_submission The pattern of the name from the submission/host site.
+ *    @param name_on_execution The pattern of the name at execution site.
+ *    @return The DAG file that was either found or created in the dag.
+ *    */
+struct dag_file * makeflow_hook_add_output_file(struct dag *d, struct batch_task *task, const char * name_on_submission_pattern, const char * name_on_execution_pattern);
 
 /** Add/Register makeflow_hook struct in list of hooks.
  Example of use see above.


### PR DESCRIPTION
Simple helper functions for consistently adding inputs and outputs to batch_task from a hook.