### PR TITLE
Update failure condition in makeflow

### DIFF
--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -2134,7 +2134,7 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "makeflow: couldn't create batch queue.\n");
 		if(port != 0)
 			fprintf(stderr, "makeflow: perhaps port %d is already in use?\n", port);
-		goto FAILURE_LABEL;
+		goto EXIT_WITH_FAILURE;
 	}
 
 	if(!batchlogfilename) {
@@ -2250,7 +2250,7 @@ int main(int argc, char *argv[])
 			fprintf(stderr,"Instead, run your workflow from a local disk like /tmp.");
 			fprintf(stderr,"Or, use the Work Queue batch system with -T wq.\n");
 			free(cwd);
-			goto FAILURE_LABEL;
+			goto EXIT_WITH_FAILURE;
 		}
 		free(cwd);
 	}
@@ -2270,15 +2270,15 @@ int main(int argc, char *argv[])
 
 	printf("checking %s for consistency...\n",dagfile);
 	if(makeflow_hook_dag_check(d) == MAKEFLOW_HOOK_FAILURE) {
-		goto FAILURE_LABEL;
+		goto EXIT_WITH_FAILURE;
 	}
 
 	if(!makeflow_check(d)) {
-		goto FAILURE_LABEL;
+		goto EXIT_WITH_FAILURE;
 	}
 
 	if(!makeflow_check_batch_consistency(d) && clean_mode == MAKEFLOW_CLEAN_NONE) {
-		goto FAILURE_LABEL;
+		goto EXIT_WITH_FAILURE;
 	}
 
 	printf("%s has %d rules.\n",dagfile,d->nodeid_counter);
@@ -2292,7 +2292,7 @@ int main(int argc, char *argv[])
 	 * a cache dir logged, these two dirs must be the same. Otherwise exit.
 	 */
 	if(makeflow_log_recover(d, logfilename, log_verbose_mode, remote_queue, clean_mode, skip_file_check )) {
-		goto FAILURE_LABEL;
+		goto EXIT_WITH_FAILURE;
 	}
 
 	/* This check must happen after makeflow_log_recover which may load the cache_dir info into d->cache_dir.
@@ -2300,14 +2300,14 @@ int main(int argc, char *argv[])
 	 */
 	if(use_mountfile) {
 		if(makeflow_mount_check_target(d)) {
-			goto FAILURE_LABEL;
+			goto EXIT_WITH_FAILURE;
 		}
 	}
 
 	if(use_mountfile && !clean_mode) {
 		if(makeflow_mounts_install(d)) {
 			fprintf(stderr, "Failed to install the dependencies specified in the mountfile!\n");
-			goto FAILURE_LABEL;
+			goto EXIT_WITH_FAILURE;
 		}
 	}
 
@@ -2339,8 +2339,8 @@ int main(int argc, char *argv[])
 		makeflow_hook_dag_clean(d);
 		printf("cleaning filesystem...\n");
 		if(makeflow_clean(d, remote_queue, clean_mode, storage_allocation)) {
-			debug(D_NOTICE, "Failed to clean up makeflow!\n");
-			goto FAILURE_LABEL;
+			debug(D_ERROR, "Failed to clean up makeflow!\n");
+			goto EXIT_WITH_FAILURE;
 		}
 
 		if(clean_mode == MAKEFLOW_CLEAN_ALL) {
@@ -2377,7 +2377,7 @@ int main(int argc, char *argv[])
 	d->should_read_archive = should_read_archive;
 	d->should_write_to_archive = should_write_to_archive;
 
-	/* Makeflow fails by default if we goto FAILURE_LABEL.
+	/* Makeflow fails by default if we goto EXIT_WITH_FAILURE.
 		This indicates we have correctly initialized. */
 	makeflow_failed_flag = 0;
 
@@ -2386,9 +2386,10 @@ int main(int argc, char *argv[])
 	if(makeflow_failed_flag == 0 && makeflow_nodes_local_waiting_count(d) > 0) {
 		makeflow_failed_flag = 1;
 		debug(D_ERROR, "There are local jobs that could not be run. Usually this means that makeflow did not have enough local resources to run them.");
+		goto EXIT_WITH_FAILURE;
 	}
 
-FAILURE_LABEL:
+EXIT_WITH_FAILURE:
 	time_completed = timestamp_get();
 	runtime = time_completed - runtime;
 


### PR DESCRIPTION
Use go to to redirect failures. Allows for clean exit and finalization of code. Maybe not strictly necessary, but allows for clean up under failed initialization circumstances. This also lets us clean
up the batch_queue.