### PR TITLE
condor scratch may not be accessible inside a container

### DIFF
--- a/makeflow/src/starch
+++ b/makeflow/src/starch
@@ -53,9 +53,9 @@ if [ -z "$SFX_DIR" ]; then
     SFX_DIR=$basename.$$.dir
     dir_lock=".${SFX_DIR}.lock"
 
-    if [ ! -z "$CONDOR_SCRATCH_DIR" ]; then
+    if [ -d "$CONDOR_SCRATCH_DIR" ] && [ -r "$CONDOR_SCRATCH_DIR" ] && [ -w "$CONDOR_SCRATCH_DIR" ] && [ -x "$CONDOR_SCRATCH_DIR" ]; then
         SFX_DIR=$CONDOR_SCRATCH_DIR/$SFX_DIR
-    elif [ ! -z "$_CONDOR_SCRATCH_DIR" ]; then
+    elif [ -d "$_CONDOR_SCRATCH_DIR" ] && [ -r "$_CONDOR_SCRATCH_DIR" ] && [ -w "$_CONDOR_SCRATCH_DIR" ] && [ -x "$_CONDOR_SCRATCH_DIR" ]; then
         SFX_DIR=$_CONDOR_SCRATCH_DIR/$SFX_DIR
     else
         SFX_DIR=`pwd`/$SFX_DIR

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1757,16 +1757,17 @@ static int workspace_create() {
 
 	// Setup working space(dir)
 	const char *workdir;
-	if (user_specified_workdir){
+	const char *workdir_tmp;
+	if (user_specified_workdir) {
 		workdir = user_specified_workdir;
-	} else if(getenv("_CONDOR_SCRATCH_DIR")) {
-		workdir = getenv("_CONDOR_SCRATCH_DIR");
-	} else if(getenv("TMPDIR")) {
-		workdir = getenv("TMPDIR");
-	} else if(getenv("TEMP")) {
-		workdir = getenv("TEMP");
-	} else if(getenv("TMP")) {
-		workdir = getenv("TMP");
+	} else if((workdir_tmp = getenv("_CONDOR_SCRATCH_DIR")) && access(workdir_tmp, R_OK|W_OK|X_OK) == 0) {
+		workdir = workdir_tmp;
+	} else if((workdir_tmp = getenv("TMPDIR")) && access(workdir_tmp, R_OK|W_OK|X_OK) == 0) {
+		workdir = workdir_tmp;
+	} else if((workdir_tmp = getenv("TEMP")) && access(workdir_tmp, R_OK|W_OK|X_OK) == 0) {
+		workdir = workdir_tmp;
+	} else if((workdir_tmp = getenv("TMP")) && access(workdir_tmp, R_OK|W_OK|X_OK) == 0) {
+		workdir = workdir_tmp;
 	} else {
 		workdir = "/tmp";
 	}


### PR DESCRIPTION
As we found out using singularity, sometimes _CONDOR_SCRATCH_DIR points to a directory that is not accessible outside the container. This causes trouble with the work_queue_worker.

This pr makes it so that the work_queue_worker and starch only use a temp directory if that directory is accessible.