### PR TITLE
Mf task migration

### DIFF
--- a/makeflow/src/dag_node.h
+++ b/makeflow/src/dag_node.h
@@ -86,7 +86,7 @@ struct dag_node {
 	
 	char *archive_id;
 
-	struct batch_task *task;            /* Batch Tax associated with job at batch_submit. */
+	struct batch_task *task;            /* Batch task associated with job at batch_submit. */
 
 	struct dag_node *next;              /* The next node in the list of nodes */
 };

--- a/makeflow/src/dag_node.h
+++ b/makeflow/src/dag_node.h
@@ -8,6 +8,7 @@ See the file COPYING for details.
 #define DAG_NODE_H
 
 #include "batch_job.h"
+#include "batch_task.h"
 #include "category.h"
 #include "set.h"
 #include "hash_table.h"
@@ -85,6 +86,8 @@ struct dag_node {
 	
 	char *archive_id;
 
+	struct batch_task *task;            /* Batch Tax associated with job at batch_submit. */
+
 	struct dag_node *next;              /* The next node in the list of nodes */
 };
 
@@ -116,5 +119,7 @@ struct jx * dag_node_env_create( struct dag *d, struct dag_node *n, int should_s
 const struct rmsummary *dag_node_dynamic_label(const struct dag_node *n);
 
 void dag_node_set_umbrella_spec(struct dag_node *n, const char *umbrella_spec);
+
+struct batch_task *dag_node_to_batch_task(struct dag_node *n, struct batch_queue *queue, int full_env_list);
 
 #endif

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -128,11 +128,11 @@ struct batch_queue * makeflow_get_local_queue(){
 }
 
 struct batch_queue * makeflow_get_queue(struct dag_node *n){
-    if(n->local_job && local_queue) {
-        return local_queue;
-    } else {
-        return remote_queue;
-    }
+	if(n->local_job && local_queue) {
+		return local_queue;
+	} else {
+		return remote_queue;
+	}
 }
 
 static struct rmsummary *local_resources = 0;
@@ -205,28 +205,12 @@ input files, and monitor input files. Relies on %% nodeid
 replacement for monitor file names.
 */
 
-static struct list *makeflow_generate_input_files( struct dag_node *n )
+void makeflow_generate_files( struct dag_node *n, struct batch_task *task )
 {
-	struct list *result = list_duplicate(n->source_files);
-
-	if(wrapper)  result = makeflow_wrapper_generate_files(result, wrapper->input_files, n, wrapper);
-	if(enforcer) result = makeflow_wrapper_generate_files(result, enforcer->input_files, n, enforcer);
-	if(umbrella) result = makeflow_wrapper_generate_files(result, umbrella->wrapper->input_files, n, umbrella->wrapper);
-	if(monitor)  result = makeflow_wrapper_generate_files(result, monitor->wrapper->input_files, n, monitor->wrapper);
-
-	return result;
-}
-
-static struct list *makeflow_generate_output_files( struct dag_node *n )
-{
-	struct list *result = list_duplicate(n->target_files);
-
-	if(wrapper)  result = makeflow_wrapper_generate_files(result, wrapper->output_files, n, wrapper);
-	if(enforcer) result = makeflow_wrapper_generate_files(result, enforcer->output_files, n, enforcer);
-	if(umbrella) result = makeflow_wrapper_generate_files(result, umbrella->wrapper->output_files, n, umbrella->wrapper);
-	if(monitor)  result = makeflow_wrapper_generate_files(result, monitor->wrapper->output_files, n, monitor->wrapper);
-
-	return result;
+	if(wrapper)  makeflow_wrapper_generate_files(task, wrapper->input_files, wrapper->output_files, n, wrapper);
+	if(enforcer) makeflow_wrapper_generate_files(task, enforcer->input_files, enforcer->output_files, n, enforcer);
+	if(umbrella) makeflow_wrapper_generate_files(task, umbrella->wrapper->input_files, umbrella->wrapper->output_files, n, umbrella->wrapper);
+	if(monitor)  makeflow_wrapper_generate_files(task, monitor->wrapper->input_files, monitor->wrapper->output_files, n, monitor->wrapper);
 }
 
 /*
@@ -242,12 +226,20 @@ static void makeflow_abort_job( struct dag *d, struct dag_node *n, struct batch_
 	makeflow_hook_node_abort(n);
 	makeflow_log_state_change(d, n, DAG_NODE_STATE_ABORTED);
 
-	struct list *outputs = makeflow_generate_output_files(n);
-	struct dag_file *f;
-	list_first_item(outputs);
+	struct batch_file *bf;
+	struct dag_file *df;
 
-	while((f = list_next_item(outputs)))
-		makeflow_clean_file(d, q, f, 0, storage_allocation);
+	/* Create generic task if one does not exist. This occurs in log recovery. */
+	if(!n->task){
+		n->task = dag_node_to_batch_task(n, makeflow_get_queue(n), should_send_all_local_environment);
+	}
+
+	/* Clean all files associated with task, includes node and hook files. */
+	list_first_item(n->task->output_files);
+	while((bf = list_next_item(n->task->output_files))){
+		df = dag_file_lookup_or_create(d, bf->outer_name);
+		makeflow_clean_file(d, q, df, 0, storage_allocation);
+	}
 
 	makeflow_clean_node(d, q, n, 1);
 }
@@ -346,6 +338,7 @@ Reset all state to cause a node to be re-run.
 void makeflow_node_force_rerun(struct itable *rerun_table, struct dag *d, struct dag_node *n)
 {
 	struct dag_node *p;
+	struct batch_file *bf;
 	struct dag_file *f1;
 	struct dag_file *f2;
 	int child_node_found;
@@ -366,12 +359,18 @@ void makeflow_node_force_rerun(struct itable *rerun_table, struct dag *d, struct
 			itable_remove(d->remote_job_table, n->jobid);
 		}
 	}
+
+	if(!n->task){
+		n->task = dag_node_to_batch_task(n, makeflow_get_queue(n), should_send_all_local_environment);
+	}
+
 	// Clean up things associated with this node
-	struct list *outputs = makeflow_generate_output_files(n);
-	list_first_item(outputs);
-	while((f1 = list_next_item(outputs)))
+	list_first_item(n->task->output_files);
+	while((bf = list_next_item(n->task->output_files))) {
+		f1 = dag_file_lookup_or_create(d, bf->outer_name);
 		makeflow_clean_file(d, remote_queue, f1, 0, storage_allocation);
-	list_delete(outputs);
+	}
+
 	makeflow_clean_node(d, remote_queue, n, 0);
 	makeflow_log_state_change(d, n, DAG_NODE_STATE_WAITING);
 
@@ -535,24 +534,30 @@ Submit one fully formed job, retrying failures up to the makeflow_submit_timeout
 This is necessary because busy batch systems occasionally do not accept a job submission.
 */
 
-static batch_job_id_t makeflow_node_submit_retry( struct batch_queue *queue, const char *command, const char *input_files, const char *output_files, struct jx *envlist, const struct rmsummary *resources)
+static batch_job_id_t makeflow_node_submit_retry( struct batch_queue *queue, struct batch_task *task)
 {
 	time_t stoptime = time(0) + makeflow_submit_timeout;
 	int waittime = 1;
 	batch_job_id_t jobid = 0;
 
-	/* Display the fully elaborated command, just like Make does. */
-	printf("submitting job: %s\n", command);
 
-	/* As integration moves forward batch_task will be added in. */
-	makeflow_hook_batch_submit(queue);
+	/* Display the fully elaborated command, just like Make does. */
+	printf("submitting job: %s\n", task->command);
+
+	makeflow_hook_batch_submit(task);
 
 	while(1) {
 		if(makeflow_abort_flag) break;
 
-		jobid = batch_job_submit(queue, command, input_files, output_files, envlist, resources);
+		jobid = batch_job_submit(queue,
+								task->command,
+								batch_files_to_string(queue, task->input_files),
+								batch_files_to_string(queue, task->output_files),
+								task->envlist,
+								task->resources);
 		if(jobid >= 0) {
 			printf("submitted job %"PRIbjid"\n", jobid);
+			task->jobid = jobid;
 			return jobid;
 		}
 
@@ -580,28 +585,15 @@ and settings.  Used at both job submission and completion
 to obtain identical strings.
 */
 
-static void makeflow_node_expand( struct dag_node *n, struct batch_queue *queue, struct list **input_list, struct list **output_list, char **input_files, char **output_files, char **command )
+static void makeflow_node_expand( struct dag_node *n, struct batch_queue *queue, struct batch_task *task )
 {
-	makeflow_wrapper_umbrella_set_input_files(umbrella, queue, n);
-
-	if (*input_list == NULL) {
-		*input_list  = makeflow_generate_input_files(n);
-	}
-
-	if (*output_list == NULL) {
-		*output_list = makeflow_generate_output_files(n);
-	}
-
-	/* Create strings for all the files mentioned by this node. */
-	*input_files  = makeflow_file_list_format(n, 0, *input_list,  queue);
-	*output_files = makeflow_file_list_format(n, 0, *output_list, queue);
+	makeflow_generate_files(n, task);
 
 	/* Expand the command according to each of the wrappers */
-	*command = strdup(n->command);
-	*command = makeflow_wrap_wrapper(*command, n, wrapper);
-	*command = makeflow_wrap_enforcer(*command, n, enforcer, *input_list, *output_list);
-	*command = makeflow_wrap_umbrella(*command, n, umbrella, queue, *input_files, *output_files);
-	*command = makeflow_wrap_monitor(*command, n, queue, monitor);
+	makeflow_wrap_wrapper(task, n, wrapper);
+	makeflow_wrap_enforcer(task, n, enforcer);
+	makeflow_wrap_umbrella(task, n, umbrella, queue);
+	makeflow_wrap_monitor(task, n, queue, monitor);
 }
 
 /*
@@ -612,30 +604,18 @@ wrappers and options.
 
 static void makeflow_node_submit(struct dag *d, struct dag_node *n, const struct rmsummary *resources)
 {
-	struct batch_queue *queue;
-	struct dag_file *f;
-	struct list *input_list = NULL, *output_list = NULL;
-	char *input_files = NULL, *output_files = NULL, *command = NULL;
-
-	if(n->local_job && local_queue) {
-		queue = local_queue;
-	} else {
-		queue = remote_queue;
-	}
-
+	struct batch_queue *queue = makeflow_get_queue(n);
 	if(storage_allocation && makeflow_alloc_commit_space(storage_allocation, n)){
 		makeflow_log_alloc_event(d, storage_allocation);
 	} else if (storage_allocation && storage_allocation->locked)  {
 		printf("Unable to commit enough space for execution\n");
 	}
 
-	makeflow_node_expand(n, queue, &input_list, &output_list, &input_files, &output_files, &command);
-
 	/* Before setting the batch job options (stored in the "BATCH_OPTIONS"
 	 * variable), we must save the previous global queue value, and then
 	 * restore it after we submit. */
 	struct dag_variable_lookup_set s = { d, n->category, n, NULL };
-	char *batch_options          = dag_variable_lookup_string("BATCH_OPTIONS", &s);
+	char *batch_options		  = dag_variable_lookup_string("BATCH_OPTIONS", &s);
 
 	char *previous_batch_options = NULL;
 	if(batch_queue_get_option(queue, "batch-options"))
@@ -647,41 +627,39 @@ static void makeflow_node_submit(struct dag *d, struct dag_node *n, const struct
 		free(batch_options);
 	}
 
-	batch_queue_set_int_option(queue, "task-id", n->nodeid);
+	/* Create task from node information */
+	struct batch_task *task = dag_node_to_batch_task(n, queue, should_send_all_local_environment);
+	batch_queue_set_int_option(queue, "task-id", task->taskid);
 
-	/* Generate the environment vars specific to this node. */
-	struct jx *envlist = dag_node_env_create(d,n,should_send_all_local_environment);
+	/* This augments the task struct, should be replaced with node_submit in future. */
+	makeflow_node_expand(n, queue, task);
 
-	/* Logs the creation of output files. */
-	makeflow_log_dag_file_list_state_change(d,output_list,DAG_FILE_STATE_EXPECT);
+	makeflow_hook_node_submit(n, task);
 
-	/* As integration moves forward we will initialize and pass a batch_task. */
-	makeflow_hook_node_submit(n, queue);
+	/* Logs the expectation of output files. */
+	makeflow_log_batch_file_list_state_change(d,task->output_files,DAG_FILE_STATE_EXPECT);
 
 	/* check archiving directory to see if node has already been preserved */
-	if (d->should_read_archive && makeflow_archive_is_preserved(d, n, command, input_list, output_list)) {
+	if (d->should_read_archive && makeflow_archive_is_preserved(d, n, task->command, n->source_files, n->target_files)){
 		printf("node %d already exists in archive, replicating output files\n", n->nodeid);
 
 		/* copy archived files to working directory and update state for node and dag_files */
-		makeflow_archive_copy_preserved_files(d, n, output_list);
+		makeflow_archive_copy_preserved_files(d, n, n->target_files);
 		n->state = DAG_NODE_STATE_RUNNING;
-		list_first_item(n->target_files);
-		while((f = list_next_item(n->target_files))) {
-			makeflow_log_file_state_change(d, f, DAG_FILE_STATE_EXISTS);
-		}
+		makeflow_log_batch_file_list_state_change(d,task->output_files, DAG_FILE_STATE_EXISTS);
 		makeflow_log_state_change(d, n, DAG_NODE_STATE_COMPLETE);
 		did_find_archived_job = 1;
 	} else {
 		/* Now submit the actual job, retrying failures as needed. */
 
-		const struct rmsummary *resources = dag_node_dynamic_label(n);
-
-		n->jobid = makeflow_node_submit_retry(queue,command,input_files,output_files,envlist, resources);
+		n->jobid = makeflow_node_submit_retry(queue, task);
 
 		/* Update all of the necessary data structures. */
 		if(n->jobid >= 0) {
-			memcpy(n->resources_allocated, resources, sizeof(struct rmsummary));
+			memcpy(n->resources_allocated, task->resources, sizeof(struct rmsummary));
 			makeflow_log_state_change(d, n, DAG_NODE_STATE_RUNNING);
+
+			n->task = task;
 
 			if(is_local_job(n)) {
 				makeflow_local_resources_subtract(local_resources,n);
@@ -694,6 +672,7 @@ static void makeflow_node_submit(struct dag *d, struct dag_node *n, const struct
 			}
 		} else {
 			makeflow_log_state_change(d, n, DAG_NODE_STATE_FAILED);
+			batch_task_delete(task);
 			makeflow_failed_flag = 1;
 		}
 	}
@@ -704,12 +683,6 @@ static void makeflow_node_submit(struct dag *d, struct dag_node *n, const struct
 		free(previous_batch_options);
 	}
 
-	list_delete(input_list);
-	list_delete(output_list);
-	free(command);
-	free(input_files);
-	free(output_files);
-	jx_delete(envlist);
 }
 
 static int makeflow_node_ready(struct dag *d, struct dag_node *n, const struct rmsummary *resources)
@@ -752,10 +725,10 @@ static int makeflow_node_ready(struct dag *d, struct dag_node *n, const struct r
 	}
 
 
-    /* If all makeflow checks pass for this node we will 
-     return the result of the hooks, which will be 1 if all pass
-     and 0 if any fail. */
-    return (makeflow_hook_node_check(n, remote_queue) == MAKEFLOW_HOOK_SUCCESS);
+	/* If all makeflow checks pass for this node we will 
+	 return the result of the hooks, which will be 1 if all pass
+	 and 0 if any fail. */
+	return (makeflow_hook_node_check(n, remote_queue) == MAKEFLOW_HOOK_SUCCESS);
 }
 
 int makeflow_nodes_local_waiting_count(const struct dag *d) {
@@ -838,8 +811,9 @@ int makeflow_node_check_file_was_created(struct dag *d, struct dag_node *n, stru
 Mark the given task as completing, using the batch_job_info completion structure provided by batch_job.
 */
 
-static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct batch_queue *queue, struct batch_job_info *info)
+static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct batch_queue *queue, struct batch_task *task)
 {
+	struct batch_file *bf;
 	struct dag_file *f;
 	int job_failed = 0;
 	int monitor_retried = 0;
@@ -847,7 +821,7 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 	/* As integration moves forward batch_task will also be passed. */
 	/* This is intended for changes to the batch_task that need no
 		no context from dag_node/dag, such as shared_fs. */
-	makeflow_hook_batch_retrieve(queue);
+	makeflow_hook_batch_retrieve(task);
 
 	if(n->state != DAG_NODE_STATE_RUNNING)
 		return;
@@ -856,8 +830,7 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 		makeflow_local_resources_add(local_resources,n);
 	}
 
-	/* As integration moves forward batch_task will also be passed. */
-	makeflow_hook_node_end(n, info);
+	makeflow_hook_node_end(n, task);
 
 	if(monitor) {
 		char *nodeid = string_format("%d",n->nodeid);
@@ -883,24 +856,23 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 		free(summary_name);
 	}
 
-	struct list *outputs = makeflow_generate_output_files(n);
-
-	if(info->disk_allocation_exhausted) {
+	if(task->info->disk_allocation_exhausted) {
 		job_failed = 1;
 	}
-	else if(info->exited_normally && info->exit_code == 0) {
-		list_first_item(outputs);
-		while((f = list_next_item(outputs))) {
+	else if(task->info->exited_normally && task->info->exit_code == 0) {
+		list_first_item(n->task->output_files);
+		while((bf = list_next_item(n->task->output_files))) {
+			f = dag_file_lookup_or_create(d, bf->outer_name);
 			if(!makeflow_node_check_file_was_created(d, n, f))
 			{
 				job_failed = 1;
 			}
 		}
 	} else {
-		if(info->exited_normally) {
-			fprintf(stderr, "%s failed with exit code %d\n", n->command, info->exit_code);
+		if(task->info->exited_normally) {
+			fprintf(stderr, "%s failed with exit code %d\n", n->command, task->info->exit_code);
 		} else {
-			fprintf(stderr, "%s crashed with signal %d (%s)\n", n->command, info->exit_signal, strsignal(info->exit_signal));
+			fprintf(stderr, "%s crashed with signal %d (%s)\n", n->command, task->info->exit_signal, strsignal(task->info->exit_signal));
 		}
 		job_failed = 1;
 	}
@@ -909,7 +881,7 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 		/* As integration moves forward batch_task will also be passed. */
 		/* If a hook indicates failure here, it is not fatal, but will result
 			in a failed task. */
-		int hook_success = makeflow_hook_node_fail(n, info);
+		int hook_success = makeflow_hook_node_fail(n, task);
 
 		makeflow_log_state_change(d, n, DAG_NODE_STATE_FAILED);
 		int prep_failed = makeflow_clean_prep_fail_dir(d, n, remote_queue, storage_allocation);
@@ -919,9 +891,12 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 		}
 
 		/* Clean files created in node. Clean existing and expected and record deletion. */
-		list_first_item(outputs);
-		while((f = list_next_item(outputs))) {
-			if(f->state == DAG_FILE_STATE_EXPECT) {
+		list_first_item(n->task->output_files);
+		while((bf = list_next_item(n->task->output_files))) {
+			f = dag_file_lookup_or_create(d, bf->outer_name);
+
+			/* Either the file was created and not confirmed or a hook removed the file. */
+			if(f->state == DAG_FILE_STATE_EXPECT || f->state == DAG_FILE_STATE_DELETE) {
 				makeflow_clean_failed_file(d, n, remote_queue,
 						f, prep_failed, 1, storage_allocation);
 			} else {
@@ -930,7 +905,7 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 			}
 		}
 
-		if(info->disk_allocation_exhausted) {
+		if(task->info->disk_allocation_exhausted) {
 			fprintf(stderr, "\nrule %d failed because it exceeded its loop device allocation capacity.\n", n->nodeid);
 			if(n->resources_measured)
 			{
@@ -949,7 +924,7 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 			}
 		}
 
-		if(monitor && info->exit_code == RM_OVERFLOW)
+		if(monitor && task->info->exit_code == RM_OVERFLOW)
 		{
 			debug(D_MAKEFLOW_RUN, "rule %d failed because it exceeded the resources limits.\n", n->nodeid);
 			if(n->resources_measured && n->resources_measured->limits_exceeded)
@@ -970,7 +945,7 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 		}
 
 		if(!monitor_retried) {
-			if(!hook_success || makeflow_retry_flag || info->exit_code == 101) {
+			if(!hook_success || makeflow_retry_flag || task->info->exit_code == 101) {
 				n->failure_count++;
 				if(n->failure_count > makeflow_retry_max) {
 					notice(D_MAKEFLOW_RUN, "job %s failed too many times.", n->command);
@@ -1022,17 +997,7 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 		/* store node into archiving directory  */
 		if (d->should_write_to_archive) {
 			printf("archiving node within archiving directory\n");
-			struct list *input_list = NULL;
-			char *input_files = NULL, *output_files = NULL, *command = NULL;
-
-			makeflow_node_expand(n, queue, &input_list, &outputs, &input_files, &output_files, &command);
-
-			makeflow_archive_populate(d, n, command, input_list, outputs, info);
-
-			free(command);
-			free(input_files);
-			free(output_files);
-			list_delete(input_list);
+			makeflow_archive_populate(d, n, task->command, n->source_files, n->target_files, task->info);
 		}
 
 		if(storage_allocation && makeflow_alloc_release_space(storage_allocation, n, 0, MAKEFLOW_ALLOC_RELEASE_COMMIT)) {
@@ -1044,11 +1009,10 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 		/* As integration moves forward batch_task will also be passed. */
 		/* node_success is after file_complete to allow for the final state of the
 			files to be reflected in the structs. Allows for cleanup or archiving.*/
-		makeflow_hook_node_success(n, info);
+		makeflow_hook_node_success(n, task);
 
 		makeflow_log_state_change(d, n, DAG_NODE_STATE_COMPLETE);
 	}
-	list_delete(outputs);
 }
 
 /*
@@ -1215,8 +1179,11 @@ static void makeflow_run( struct dag *d )
 				printf("job %"PRIbjid" completed\n",jobid);
 				debug(D_MAKEFLOW_RUN, "Job %" PRIbjid " has returned.\n", jobid);
 				n = itable_remove(d->remote_job_table, jobid);
-				if(n)
-					makeflow_node_complete(d, n, remote_queue, &info);
+				if(n){
+					// Stop gap until batch_job_wait returns task struct
+					batch_task_set_info(n->task, &info);
+					makeflow_node_complete(d, n, remote_queue, n->task);
+				}
 			}
 		}
 
@@ -1235,8 +1202,11 @@ static void makeflow_run( struct dag *d )
 				cleaned_completed_jobs = 1;
 				debug(D_MAKEFLOW_RUN, "Job %" PRIbjid " has returned.\n", jobid);
 				n = itable_remove(d->local_job_table, jobid);
-				if(n)
-					makeflow_node_complete(d, n, local_queue, &info);
+				if(n){
+					// Stop gap until batch_job_wait returns task struct
+					batch_task_set_info(n->task, &info);
+					makeflow_node_complete(d, n, local_queue, n->task);
+				}
 			}
 		}
 

--- a/makeflow/src/makeflow_hook.c
+++ b/makeflow/src/makeflow_hook.c
@@ -179,23 +179,23 @@ int makeflow_hook_node_check(struct dag_node *node, struct batch_queue *queue){
     return MAKEFLOW_HOOK_SUCCESS;
 }
 
-int makeflow_hook_node_submit(struct dag_node *node, struct batch_queue *queue){
-	MAKEFLOW_HOOK_CALL(node_submit, node, queue);
+int makeflow_hook_node_submit(struct dag_node *node, struct batch_task *task){
+	MAKEFLOW_HOOK_CALL(node_submit, node, task);
 	return MAKEFLOW_HOOK_SUCCESS;
 }
 
-int makeflow_hook_node_end(struct dag_node *node, struct batch_job_info *info){
-    MAKEFLOW_HOOK_CALL(node_end, node, info);
+int makeflow_hook_node_end(struct dag_node *node, struct batch_task *task){
+    MAKEFLOW_HOOK_CALL(node_end, node, task);
     return MAKEFLOW_HOOK_SUCCESS;
 }
 
-int makeflow_hook_node_success(struct dag_node *node, struct batch_job_info *info){
-	MAKEFLOW_HOOK_CALL(node_success, node, info);
+int makeflow_hook_node_success(struct dag_node *node, struct batch_task *task){
+	MAKEFLOW_HOOK_CALL(node_success, node, task);
 	return MAKEFLOW_HOOK_SUCCESS;
 }
 
-int makeflow_hook_node_fail(struct dag_node *node, struct batch_job_info *info){
-	MAKEFLOW_HOOK_CALL(node_fail, node, info);
+int makeflow_hook_node_fail(struct dag_node *node, struct batch_task *task){
+	MAKEFLOW_HOOK_CALL(node_fail, node, task);
 	return MAKEFLOW_HOOK_SUCCESS;
 }
 
@@ -204,13 +204,13 @@ int makeflow_hook_node_abort(struct dag_node *node){
 	return MAKEFLOW_HOOK_SUCCESS;
 }
 
-int makeflow_hook_batch_submit(struct batch_queue *queue){
-    MAKEFLOW_HOOK_CALL(batch_submit, queue);
+int makeflow_hook_batch_submit(struct batch_task *task){
+    MAKEFLOW_HOOK_CALL(batch_submit, task);
     return MAKEFLOW_HOOK_SUCCESS;
 }
 
-int makeflow_hook_batch_retrieve(struct batch_queue *queue){
-    MAKEFLOW_HOOK_CALL(batch_retrieve, queue);
+int makeflow_hook_batch_retrieve(struct batch_task *task){
+    MAKEFLOW_HOOK_CALL(batch_retrieve, task);
     return MAKEFLOW_HOOK_SUCCESS;
 }
 

--- a/makeflow/src/makeflow_hook.h
+++ b/makeflow/src/makeflow_hook.h
@@ -239,11 +239,10 @@ struct makeflow_hook {
 	 * execution.
 	 *
 	 * @param dag_node The dag_node that is being submitted.
-	 * @param queue The queue being submitted to.
-	 * @param task The task being submitted. NOTE: NOT INCLUDED YET
+	 * @param task The task being submitted.
 	 * @return MAKEFLOW_HOOK_SUCCESS if successful, MAKEFLOW_HOOK_FAILURE if not.
 	 */
-	int (*node_submit)   (struct dag_node *node, struct batch_queue *queue);
+	int (*node_submit)   (struct dag_node *node, struct batch_task *task);
 
 	/* Hook after node is collected, but prior to qualifying node success.
 	 * 
@@ -251,29 +250,26 @@ struct makeflow_hook {
 	 * allows hooks to perform on outputted files and see exit status.
 	 *
 	 * @param dag_node The dag_node that was collected.
-	 * @param task The task being submitted. NOTE: NOT INCLUDED YET. Will include info
-	 * @param info The batch_job_info struct passed by batch queue. For now.
+	 * @param task The task being submitted.
 	 * @return MAKEFLOW_HOOK_SUCCESS if successful, MAKEFLOW_HOOK_FAILURE if not.
 	 */
-	int (*node_end)      (struct dag_node *node, struct batch_job_info *info);
+	int (*node_end)      (struct dag_node *node, struct batch_task *task);
 
 	/* Hook if node was successful.
 	 * 
 	 * @param dag_node The dag_node that was successful.
-	 * @param task The task being submitted. NOTE: NOT INCLUDED YET. Will include info
-	 * @param batch_job_info The info struct passed by batch queue.
+	 * @param task The task that succeeded.
 	 * @return MAKEFLOW_HOOK_SUCCESS if successful, MAKEFLOW_HOOK_FAILURE if not.
 	 */
-	int (*node_success)  (struct dag_node *node, struct batch_job_info *info);
+	int (*node_success)  (struct dag_node *node, struct batch_task *task);
 
 	/* Hook if node failed.
 	 * 
 	 * @param dag_node The dag_node that failed.
-	 * @param task The task being submitted. NOTE: NOT INCLUDED YET. Will include info
-	 * @param batch_job_info The info struct passed by batch queue.
+	 * @param task The task that failed.
 	 * @return MAKEFLOW_HOOK_SUCCESS if successful, MAKEFLOW_HOOK_FAILURE if not.
 	 */
-	int (*node_fail)     (struct dag_node *node, struct batch_job_info *info);
+	int (*node_fail)     (struct dag_node *node, struct batch_task *task);
 
 	/* Hook if node aborted.
 	 * 
@@ -293,11 +289,10 @@ struct makeflow_hook {
 	 * The batch_task contains the job to be passed
 	 * to allow for modifications of the structure.
 	 *
-	 * @param batch_queue specific queue being submitted to.
-	 * @param task The task being submitted. NOTE: NOT INCLUDED YET
+	 * @param task The task being submitted.
 	 * @return MAKEFLOW_HOOK_SUCCESS if successfully modified, MAKEFLOW_HOOK_FAILURE if not.
 	 */
-	int (*batch_submit) ( struct batch_queue *queue);
+	int (*batch_submit) ( struct batch_task *task);
 
 	/* Fix/Augment/Modify the job structure retrieved from batch system.
 	 *
@@ -308,11 +303,10 @@ struct makeflow_hook {
 	 * `forgotten` by sharedfs will be added back in so they 
 	 * are not forgotten in Makeflow.
 	 *
-	 * @param batch_queue specific queue being submitted to.
-	 * @param task The task being submitted. NOTE: NOT INCLUDED YET
+	 * @param task The task retrieved from queue.
 	 * @return MAKEFLOW_HOOK_SUCCESS if successfully modified, MAKEFLOW_HOOK_FAILURE if not.
 	 */
-	int (*batch_retrieve) ( struct batch_queue *queue);
+	int (*batch_retrieve) ( struct batch_task *task);
 
 
 	/* Hook when file is created.
@@ -438,17 +432,17 @@ int makeflow_hook_node_create(struct dag_node *node, struct batch_queue *queue);
 
 int makeflow_hook_node_check(struct dag_node *node, struct batch_queue *queue);
 
-int makeflow_hook_node_submit(struct dag_node *node, struct batch_queue *queue);
+int makeflow_hook_node_submit(struct dag_node *node, struct batch_task *task);
 
-int makeflow_hook_batch_submit(struct batch_queue *queue);
+int makeflow_hook_batch_submit(struct batch_task *task);
 
-int makeflow_hook_batch_retrieve(struct batch_queue *queue);
+int makeflow_hook_batch_retrieve(struct batch_task *task);
 
-int makeflow_hook_node_end(struct dag_node *node, struct batch_job_info *info);
+int makeflow_hook_node_end(struct dag_node *node, struct batch_task *task);
 
-int makeflow_hook_node_success(struct dag_node *node, struct batch_job_info *info);
+int makeflow_hook_node_success(struct dag_node *node, struct batch_task *task);
 
-int makeflow_hook_node_fail(struct dag_node *node, struct batch_job_info *info);
+int makeflow_hook_node_fail(struct dag_node *node, struct batch_task *task);
 
 int makeflow_hook_node_abort(struct dag_node *node);
 

--- a/makeflow/src/makeflow_wrapper.c
+++ b/makeflow/src/makeflow_wrapper.c
@@ -109,8 +109,10 @@ void makeflow_wrapper_generate_files( struct batch_task *task, struct list *inpu
 				remote = xxstrdup(p+1);
 				itable_insert(w->remote_names, (uintptr_t) file, (void *)remote);
 				hash_table_insert(w->remote_names_inv, remote, (void *)file);
+				makeflow_hook_add_input_file(n->d, task, f, remote);
+			} else {
+				makeflow_hook_add_output_file(n->d, task, f, NULL);
 			}
-			makeflow_hook_add_input_file(n->d, task, f, remote);
 			*p = '=';
 		} else {
 			file = dag_file_lookup_or_create(n->d, f);
@@ -136,8 +138,10 @@ void makeflow_wrapper_generate_files( struct batch_task *task, struct list *inpu
 				remote = xxstrdup(p+1);
 				itable_insert(w->remote_names, (uintptr_t) file, (void *)remote);
 				hash_table_insert(w->remote_names_inv, remote, (void *)file);
+				makeflow_hook_add_output_file(n->d, task, f, remote);
+			} else {
+				makeflow_hook_add_output_file(n->d, task, f, NULL);
 			}
-			makeflow_hook_add_output_file(n->d, task, f, remote);
 			*p = '=';
 		} else {
 			file = dag_file_lookup_or_create(n->d, f);

--- a/makeflow/src/makeflow_wrapper.h
+++ b/makeflow/src/makeflow_wrapper.h
@@ -35,8 +35,8 @@ void makeflow_wrapper_delete(struct makeflow_wrapper *w);
 void makeflow_wrapper_add_command(struct makeflow_wrapper *w, const char *cmd);
 void makeflow_wrapper_add_input_file(struct makeflow_wrapper *w, const char *file);
 void makeflow_wrapper_add_output_file(struct makeflow_wrapper *w, const char *file);
-struct list *makeflow_wrapper_generate_files(struct list *result, struct list *input, struct dag_node *n, struct makeflow_wrapper *w);
-char *makeflow_wrap_wrapper(char *result, struct dag_node *n, struct makeflow_wrapper *w);
+void makeflow_wrapper_generate_files(struct batch_task *task, struct list *input, struct list *output, struct dag_node *n, struct makeflow_wrapper *w);
+void makeflow_wrap_wrapper(struct batch_task *task, struct dag_node *n, struct makeflow_wrapper *w);
 
 const char *makeflow_wrapper_get_remote_name(struct makeflow_wrapper *w, struct dag *d, const char *filename);
 

--- a/makeflow/src/makeflow_wrapper_enforcement.c
+++ b/makeflow/src/makeflow_wrapper_enforcement.c
@@ -55,11 +55,11 @@ void makeflow_wrapper_enforcer_init(struct makeflow_wrapper *w, char *parrot_pat
 	w->command = xxstrdup("./" enforcer_pattern "%%");
 }
 
-char *makeflow_wrap_enforcer( char *result, struct dag_node *n, struct makeflow_wrapper *w, struct list *input_list, struct list *output_list )
+void makeflow_wrap_enforcer( struct batch_task *task, struct dag_node *n, struct makeflow_wrapper *w)
 {
-	if(!w) return result;
+	if(!w) return ;
 
-	struct dag_file *f;
+	struct batch_file *f;
 	FILE *enforcer = NULL;
 	char *enforcer_path = string_format(enforcer_pattern "%d", n->nodeid);
 	char *mountlist_path = string_format(mountlist_pattern "%d", n->nodeid);
@@ -102,13 +102,13 @@ char *makeflow_wrap_enforcer( char *result, struct dag_node *n, struct makeflow_
 	fprintf(enforcer, "$HOME/.Xauthority\trwx\n");
 	fprintf(enforcer, "/tmp/.X11-unix\trwx\n");
 
-	list_first_item(input_list);
-	while((f=list_next_item(input_list))) {
-		fprintf(enforcer, "$PWD/%s\trwx\n", f->filename);
+	list_first_item(task->input_files);
+	while((f=list_next_item(task->input_files))) {
+		fprintf(enforcer, "$PWD/%s\trwx\n", f->inner_name);
 	}
-	list_first_item(output_list);
-	while((f=list_next_item(output_list))) {
-		fprintf(enforcer, "$PWD/%s\trwx\n", f->filename);
+	list_first_item(task->output_files);
+	while((f=list_next_item(task->output_files))) {
+		fprintf(enforcer, "$PWD/%s\trwx\n", f->inner_name);
 	}
 	fprintf(enforcer, "EOF\n\n");
 	fprintf(enforcer, "mkdir -p \"$PWD/%s\"\n", tmp_path);
@@ -125,5 +125,5 @@ char *makeflow_wrap_enforcer( char *result, struct dag_node *n, struct makeflow_
 	free(mountlist_path);
 	free(tmp_path);
 
-	return makeflow_wrap_wrapper(result, n, w);
+	makeflow_wrap_wrapper(task, n, w);
 }

--- a/makeflow/src/makeflow_wrapper_enforcement.h
+++ b/makeflow/src/makeflow_wrapper_enforcement.h
@@ -9,6 +9,6 @@ See the file COPYING for details.
 #define MAKEFLOW_WRAPPER_ENFORCEMENT_H
 
 void makeflow_wrapper_enforcer_init( struct makeflow_wrapper *w, char *parrot_path );
-char *makeflow_wrap_enforcer( char *result, struct dag_node *n, struct makeflow_wrapper *w, struct list *input_list, struct list *output_list );
+void makeflow_wrap_enforcer( struct batch_task *task, struct dag_node *n, struct makeflow_wrapper *w);
 
 #endif

--- a/makeflow/src/makeflow_wrapper_monitor.c
+++ b/makeflow/src/makeflow_wrapper_monitor.c
@@ -5,6 +5,7 @@
  * */
 
 #include "create_dir.h"
+#include "batch_task.h"
 #include "debug.h"
 #include "path.h"
 #include "rmonitor.h"
@@ -14,6 +15,7 @@
 #include "dag.h"
 #include "dag_file.h"
 #include "makeflow_log.h"
+#include "makeflow_hook.h"
 #include "makeflow_wrapper.h"
 #include "makeflow_wrapper_monitor.h"
 
@@ -81,33 +83,6 @@ void makeflow_prepare_for_monitoring( struct dag *d, struct makeflow_monitor *m,
 	}
 
 	m->log_prefix = string_format("%s/%s", log_dir, log_format);
-	char *log_name;
-
-	if(m->exe_remote){
-		log_name = string_format("%s=%s", m->exe, m->exe_remote);
-		makeflow_wrapper_add_input_file(m->wrapper, log_name);
-		free(log_name);
-	} else {
-		makeflow_wrapper_add_input_file(m->wrapper, m->exe);
-	}
-
-	log_name = string_format("%s.summary", m->log_prefix);
-	makeflow_wrapper_add_output_file(m->wrapper, log_name);
-	free(log_name);
-
-	if(m->enable_time_series)
-	{
-		log_name = string_format("%s.series", m->log_prefix);
-		makeflow_wrapper_add_output_file(m->wrapper, log_name);
-		free(log_name);
-	}
-
-	if(m->enable_list_files)
-	{
-		log_name = string_format("%s.files", m->log_prefix);
-		makeflow_wrapper_add_output_file(m->wrapper, log_name);
-		free(log_name);
-	}
 }
 
 /*
@@ -154,15 +129,39 @@ char *makeflow_rmonitor_wrapper_command( struct makeflow_monitor *m, struct batc
 
 /* Takes node->command and wraps it in wrapper_command. Then, if in monitor
  *  * mode, wraps the wrapped command in the monitor command. */
-char *makeflow_wrap_monitor( char *result, struct dag_node *n, struct batch_queue *queue, struct makeflow_monitor *m )
+void makeflow_wrap_monitor(struct batch_task *task, struct dag_node *n, struct batch_queue *queue, struct makeflow_monitor *m )
 {
-	if(!m) return result;
+	if(!m) return ;
+
+	char *log_name;
+
+	if(m->exe_remote){
+		makeflow_hook_add_input_file(n->d, task, m->exe, m->exe_remote);
+	} else {
+		makeflow_hook_add_input_file(n->d, task, m->exe, NULL);
+	}
+
+	log_name = string_format("%s.summary", m->log_prefix);
+	makeflow_hook_add_input_file(n->d, task, log_name, NULL);
+	free(log_name);
+
+	if(m->enable_time_series)
+	{
+		log_name = string_format("%s.series", m->log_prefix);
+		makeflow_hook_add_input_file(n->d, task, log_name, NULL);
+		free(log_name);
+	}
+
+	if(m->enable_list_files)
+	{
+		log_name = string_format("%s.files", m->log_prefix);
+		makeflow_hook_add_input_file(n->d, task, log_name, NULL);
+		free(log_name);
+	}
 
 	char *monitor_command = makeflow_rmonitor_wrapper_command(m, queue, n);
-	result = string_wrap_command(result, monitor_command);
+	batch_task_wrap_command(task, monitor_command);
 	free(monitor_command);
-
-	return result;
 }
 
 int makeflow_monitor_move_output_if_needed(struct dag_node *n, struct batch_queue *queue, struct makeflow_monitor *m)

--- a/makeflow/src/makeflow_wrapper_monitor.h
+++ b/makeflow/src/makeflow_wrapper_monitor.h
@@ -31,7 +31,7 @@ void makeflow_monitor_delete(struct makeflow_monitor *m);
 
 void makeflow_prepare_for_monitoring( struct dag *d, struct makeflow_monitor *m, struct batch_queue *queue, char *log_dir, char *log_format);
 
-char *makeflow_wrap_monitor( char *result, struct dag_node *n, struct batch_queue *queue, struct makeflow_monitor *m );
+void makeflow_wrap_monitor(struct batch_task *task, struct dag_node *n, struct batch_queue *queue, struct makeflow_monitor *m );
 
 int makeflow_monitor_move_output_if_needed(struct dag_node *n, struct batch_queue *queue, struct makeflow_monitor *m);
 

--- a/makeflow/src/makeflow_wrapper_umbrella.c
+++ b/makeflow/src/makeflow_wrapper_umbrella.c
@@ -117,7 +117,7 @@ void makeflow_wrap_umbrella(struct batch_task *task, struct dag_node *n, struct 
 	if(n->umbrella_spec){
 		makeflow_hook_add_input_file(n->d, task, n->umbrella_spec, path_basename(n->umbrella_spec));
 	} else {
-		makeflow_hook_add_input_file(n->d, task, w->spec, path_basename(w->spec));
+		return;
 	}
 
 	if(w->binary) makeflow_hook_add_input_file(n->d, task, w->binary, path_basename(w->binary));

--- a/makeflow/src/makeflow_wrapper_umbrella.c
+++ b/makeflow/src/makeflow_wrapper_umbrella.c
@@ -112,6 +112,8 @@ char *makeflow_umbrella_print_files(struct list *files, bool is_output) {
 
 void makeflow_wrap_umbrella(struct batch_task *task, struct dag_node *n, struct makeflow_wrapper_umbrella *w, struct batch_queue *queue)
 {
+	if(!w) return;
+
 	if(n->umbrella_spec){
 		makeflow_hook_add_input_file(n->d, task, n->umbrella_spec, path_basename(n->umbrella_spec));
 	} else {

--- a/makeflow/src/makeflow_wrapper_umbrella.c
+++ b/makeflow/src/makeflow_wrapper_umbrella.c
@@ -16,6 +16,7 @@
 #include "debug.h"
 #include "dag.h"
 #include "xxmalloc.h"
+#include "makeflow_hook.h"
 #include "makeflow_wrapper.h"
 #include "makeflow_wrapper_umbrella.h"
 #include "path.h"
@@ -73,45 +74,7 @@ void makeflow_wrapper_umbrella_set_mode(struct makeflow_wrapper_umbrella *w, con
 	}
 }
 
-void makeflow_wrapper_umbrella_set_input_files(struct makeflow_wrapper_umbrella *w, struct batch_queue *queue, struct dag_node *n) {
-	bool remote_rename_support = false;
-
-	if(!w) return;
-
-	// every rule may have its own umbrella spec file.
-	// to avoid w->wrapper->input_files accumulating umbrella spec files for different rules, first delete it and then recreate it.
-	list_delete(w->wrapper->input_files);
-	w->wrapper->input_files = list_create();
-
-	if(!n->umbrella_spec)  return;
-
-	if (batch_queue_supports_feature(queue, "remote_rename")) {
-		remote_rename_support = true;
-	}
-
-	// add umbrella_spec (if specified) and umbrella_binary (if specified) into the input file list of w->wrapper
-	if (!remote_rename_support) {
-		makeflow_wrapper_add_input_file(w->wrapper, n->umbrella_spec);
-		if(w->binary) makeflow_wrapper_add_input_file(w->wrapper, w->binary);
-	} else {
-		{
-			char *s = string_format("%s=%s", n->umbrella_spec, path_basename(n->umbrella_spec));
-			if(!s) fatal("string_format for umbrella spec failed: %s.\n", strerror(errno));
-			makeflow_wrapper_add_input_file(w->wrapper, s);
-			free(s);
-		}
-		if(w->binary) {
-			char *s = string_format("%s=%s", w->binary, path_basename(w->binary));
-			if(!s) fatal("string_format for umbrella binary failed: %s.\n", strerror(errno));
-			makeflow_wrapper_add_input_file(w->wrapper, s);
-			free(s);
-		}
-	}
-}
-
 void makeflow_wrapper_umbrella_preparation(struct makeflow_wrapper_umbrella *w, struct dag *d) {
-	struct dag_node *cur;
-
 	if(!w->binary) {
 		debug(D_MAKEFLOW_RUN, "the --umbrella-binary option is not set, therefore an umbrella binary should be available on an execution node if umbrella is used to deliver the execution environment.\n");
 	}
@@ -122,28 +85,6 @@ void makeflow_wrapper_umbrella_preparation(struct makeflow_wrapper_umbrella *w, 
 		debug(D_MAKEFLOW_RUN, "setting wrapper_umbrella->log_prefix to %s\n", w->log_prefix);
 	}
 
-	cur = d->nodes;
-	while(cur) {
-		char *umbrella_logfile = NULL;
-
-		if(!cur->umbrella_spec) {
-			cur = cur->next;
-			continue;
-		}
-
-		umbrella_logfile = string_format("%s.%d", w->log_prefix, cur->nodeid);
-
-		// A makeflow run may fail if some jobs failed on some bad workers, and the user may want to
-		// retrying the makeflow to rerun these failed jobs.
-		// Checking the existence of umbrella_logfile would cause makeflow retries fail.
-		// Therefore, we stop check the existence of umbrella_logfile here.
-
-		// add umbrella_logfile into the target files of a dag_node
-		dag_node_add_target_file(cur, umbrella_logfile, NULL);
-		free(umbrella_logfile);
-		cur = cur->next;
-	}
-
 	if(!w->mode) {
 		w->mode = "local";
 		debug(D_MAKEFLOW_RUN, "setting wrapper_umbrella->mode to %s\n", w->mode);
@@ -151,114 +92,93 @@ void makeflow_wrapper_umbrella_preparation(struct makeflow_wrapper_umbrella *w, 
 }
 
 // the caller should free the result.
-char *create_umbrella_opt(bool remote_rename_support, char *files, bool is_output, const char *umbrella_logfile) {
-	char *s = files;
-	size_t size;
-	char *result = NULL;
-
-	// the result will be freed by the caller, therefore returning a copy of s is needed.
-	// Returning the original copy and free the original copy may cuase memory corruption.
-	if(!strcmp(s, "")) return xxstrdup(s);
+char *makeflow_umbrella_print_files(struct list *files, bool is_output) {
+	struct batch_file *f;
+	char *result = "";
 
 	// construct the --output or --inputs option of umbrella based on files
-	while((size = strcspn(s, ",\0")) > 0) {
-		char *t;
-		s[size] = '\0';
+	list_first_item(files);
+	while((f = list_next_item(files))){
+		result = string_combine(result, f->inner_name);
+		result = string_combine(result, "=");
+		result = string_combine(result, f->inner_name);
 
-		if(!remote_rename_support) {
-			t = s;
-		} else {
-			t = strchr(s, '=');
-			t++;
-		}
-
-		// avoid adding umbrella_logfile into umbrella_output_opt
-		if(strcmp(t, umbrella_logfile)) {
-			result = string_combine(result, t);
-			result = string_combine(result, "=");
-			result = string_combine(result, t);
-
-			if(is_output) result = string_combine(result, ":f,");
-			else result = string_combine(result, ",");
-		}
-
-		s[size] = ',';
-		s += size+1;
+		if(is_output) result = string_combine(result, ":f,");
+		else result = string_combine(result, ",");
 	}
 
 	return result;
 }
 
-char *makeflow_wrap_umbrella(char *result, struct dag_node *n, struct makeflow_wrapper_umbrella *w, struct batch_queue *queue, char *input_files, char *output_files) {
-	if(!n->umbrella_spec) return result;
+void makeflow_wrap_umbrella(struct batch_task *task, struct dag_node *n, struct makeflow_wrapper_umbrella *w, struct batch_queue *queue)
+{
+	if(n->umbrella_spec){
+		makeflow_hook_add_input_file(n->d, task, n->umbrella_spec, path_basename(n->umbrella_spec));
+	} else {
+		makeflow_hook_add_input_file(n->d, task, w->spec, path_basename(w->spec));
+	}
+
+	if(w->binary) makeflow_hook_add_input_file(n->d, task, w->binary, path_basename(w->binary));
+
+	debug(D_MAKEFLOW_HOOK, "input_files: %s\n", batch_files_to_string(queue, task->input_files));
+	char *umbrella_input_opt = makeflow_umbrella_print_files(task->input_files, false);
+	debug(D_MAKEFLOW_HOOK, "umbrella input opt: %s\n", umbrella_input_opt);
+
+	debug(D_MAKEFLOW_HOOK, "output_files: %s\n", batch_files_to_string(queue, task->output_files));
+	char *umbrella_output_opt = makeflow_umbrella_print_files(task->output_files, true);
+	debug(D_MAKEFLOW_HOOK, "umbrella output opt: %s\n", umbrella_output_opt);
+
+	struct dag_file *log_file = makeflow_hook_add_output_file(n->d, task, w->log_prefix, NULL);
+
+	char *local_binary = NULL;
+	/* If no binary is specified always assume umbrella is in path. */
+	if (!w->binary) {
+		local_binary = xxstrdup("umbrella");
+	/* If remote rename isn't allowed pass binary as specified locally. */
+	} else if (!batch_queue_supports_feature(queue, "remote_rename")) {
+		local_binary = xxstrdup(w->binary);
+	/* If we have the binary and can remotely rename, use ./binary (usually umbrella). */
+	} else {
+		local_binary = string_format("./%s",path_basename(w->binary));
+	}
+
+	char *local_spec = NULL;
+	/* If the node has a specific spec listed use this. */
+	if(n->umbrella_spec){
+		/* Use the basename if we can remote rename. */
+		if (!batch_queue_supports_feature(queue, "remote_rename")) {
+			local_spec = xxstrdup(n->umbrella_spec);
+		} else {
+			local_spec = xxstrdup(path_basename(n->umbrella_spec));
+		}
+	/* If no specific spec use generic. */
+	} else {
+		/* Use the basename if we can remote rename. */
+		if (!batch_queue_supports_feature(queue, "remote_rename")) {
+			local_spec = xxstrdup(w->spec);
+		} else {
+			local_spec = xxstrdup(path_basename(w->spec));
+		}
+	}
 
 	char *umbrella_command = NULL;
-	char *umbrella_input_opt = NULL;
-	char *umbrella_output_opt = NULL;
-	char *umbrella_logfile = NULL;
-	bool remote_rename_support = false;
 
-	if (batch_queue_supports_feature(queue, "remote_rename")) {
-		remote_rename_support = true;
-	}
+	umbrella_command = string_format("%s --spec \"%s\" \
+		--localdir ./umbrella_test \
+		--inputs \"%s\" \
+		--output \"%s\" \
+		--sandbox_mode \"%s\" \
+		--log \"%s\" \
+		run \'{}\'", local_binary, local_spec, umbrella_input_opt, umbrella_output_opt, w->mode, log_file->filename);
 
-	umbrella_logfile = string_format("%s.%d", w->log_prefix, n->nodeid);
+	debug(D_MAKEFLOW_HOOK, "umbrella wrapper command: %s\n", umbrella_command);
 
-	debug(D_MAKEFLOW_RUN, "input_files: %s\n", input_files);
-	umbrella_input_opt = create_umbrella_opt(remote_rename_support, input_files, false, umbrella_logfile);
-	debug(D_MAKEFLOW_RUN, "umbrella input opt: %s\n", umbrella_input_opt);
+	batch_task_wrap_command(task, umbrella_command);
+	debug(D_MAKEFLOW_HOOK, "umbrella command: %s\n", task->command);
 
-	debug(D_MAKEFLOW_RUN, "output_files: %s\n", output_files);
-	umbrella_output_opt = create_umbrella_opt(remote_rename_support, output_files, true, umbrella_logfile);
-	debug(D_MAKEFLOW_RUN, "umbrella output opt: %s\n", umbrella_output_opt);
-
-	// construct umbrella_command
-	if(!remote_rename_support) {
-		if(!w->binary) {
-			umbrella_command = string_format("umbrella --spec \"%s\" \
-				--localdir ./umbrella_test \
-				--inputs \"%s\" \
-				--output \"%s\" \
-				--sandbox_mode \"%s\" \
-				--log \"%s\" \
-				run \'{}\'", n->umbrella_spec, umbrella_input_opt, umbrella_output_opt, w->mode, umbrella_logfile);
-		} else {
-			umbrella_command = string_format("%s --spec \"%s\" \
-				--localdir ./umbrella_test \
-				--inputs \"%s\" \
-				--output \"%s\" \
-				--sandbox_mode \"%s\" \
-				--log \"%s\" \
-				run \'{}\'", w->binary, n->umbrella_spec, umbrella_input_opt, umbrella_output_opt, w->mode, umbrella_logfile);
-		}
-	} else {
-		if(!w->binary) {
-			umbrella_command = string_format("umbrella --spec \"%s\" \
-				--localdir ./umbrella_test \
-				--inputs \"%s\" \
-				--output \"%s\" \
-				--sandbox_mode \"%s\" \
-				--log \"%s\" \
-				run \'{}\'", path_basename(n->umbrella_spec), umbrella_input_opt, umbrella_output_opt, w->mode, umbrella_logfile);
-		} else {
-			umbrella_command = string_format("./%s --spec \"%s\" \
-				--localdir ./umbrella_test \
-				--inputs \"%s\" \
-				--output \"%s\" \
-				--sandbox_mode \"%s\" \
-				--log \"%s\" \
-				run \'{}\'", path_basename(w->binary), path_basename(n->umbrella_spec), umbrella_input_opt, umbrella_output_opt, w->mode, umbrella_logfile);
-		}
-	}
-
-	debug(D_MAKEFLOW_RUN, "umbrella wrapper command: %s\n", umbrella_command);
-
-	result = string_wrap_command(result, umbrella_command);
-	debug(D_MAKEFLOW_RUN, "umbrella command: %s\n", result);
-
+	free(local_binary);
+	free(local_spec);
 	free(umbrella_command);
 	free(umbrella_input_opt);
 	free(umbrella_output_opt);
-	free(umbrella_logfile);
-	return result;
 }

--- a/makeflow/src/makeflow_wrapper_umbrella.h
+++ b/makeflow/src/makeflow_wrapper_umbrella.h
@@ -25,10 +25,8 @@ void makeflow_wrapper_umbrella_set_log_prefix(struct makeflow_wrapper_umbrella *
 
 void makeflow_wrapper_umbrella_set_mode(struct makeflow_wrapper_umbrella *w, const char *mode);
 
-void makeflow_wrapper_umbrella_set_input_files(struct makeflow_wrapper_umbrella *w, struct batch_queue *queue, struct dag_node *n);
-
 void makeflow_wrapper_umbrella_preparation(struct makeflow_wrapper_umbrella *w, struct dag *d);
 
-char *makeflow_wrap_umbrella(char *result, struct dag_node *n, struct makeflow_wrapper_umbrella *w, struct batch_queue *queue, char *input_files, char *output_files);
+void makeflow_wrap_umbrella(struct batch_task *task, struct dag_node *n, struct makeflow_wrapper_umbrella *w, struct batch_queue *queue);
 
 #endif


### PR DESCRIPTION
This code change migrates Makeflow to creating a task when a node is submitted and then passing that task to node_complete. This currently stores the task with the associated node, but would prefer that it is retrieved from batch_job_wait. Once batch_job is updated to handle batch_task this will be changed.