### PR TITLE
Build chirp (but chirp_fuse) statically.

### DIFF
--- a/chirp/src/Makefile
+++ b/chirp/src/Makefile
@@ -28,13 +28,22 @@ TARGETS = $(PROGRAMS) $(LIBRARIES) bindings
 all: $(TARGETS)
 
 chirp: chirp_tool.o
+ifeq ($(CCTOOLS_STATIC),1)
+	$(CCTOOLS_LD) -static -g -o $@ $(LOCAL_LINKAGE) $^ $(CCTOOLS_STATIC_LINKAGE)
+else
 	$(CCTOOLS_LD) -o $@ $(CCTOOLS_INTERNAL_LDFLAGS) $(LOCAL_LDFLAGS) $^ $(LOCAL_LINKAGE) $(CCTOOLS_READLINE_LDFLAGS) $(CCTOOLS_EXTERNAL_LINKAGE) $(CCTOOLS_READLINE_LDFLAGS)
+endif
 
+ifeq ($(CCTOOLS_STATIC),1)
+chirp_fuse:
+	@echo "chirp_fuse cannot be built statically"
+else
 chirp_fuse: chirp_fuse.o
 	$(CCTOOLS_LD) -o $@ $(CCTOOLS_INTERNAL_LDFLAGS) $(LOCAL_LDFLAGS) $^ $(LOCAL_LINKAGE) $(CCTOOLS_FUSE_LDFLAGS) $(CCTOOLS_EXTERNAL_LINKAGE)
 
 chirp_fuse.o: chirp_fuse.c
 	$(CCTOOLS_CC) -o $@ -c $(CCTOOLS_INTERNAL_CCFLAGS) $(LOCAL_CCFLAGS) $(CCTOOLS_FUSE_CCFLAGS) $<
+endif
 
 chirp_job.o chirp_fs_local_scheduler.o: chirp_sqlite.h
 

--- a/configure
+++ b/configure
@@ -1281,6 +1281,12 @@ fi
 
 # Check which packages we can build, according to the results above
 echo "checking for package compatibility..."
+
+if [ "${include_package_chirp}" = chirp ]
+then
+		internal_ccflags="${internal_ccflags} -DCCTOOLS_WITH_CHIRP"
+fi
+
 if [ "$include_package_parrot" = parrot ]
 then
 	if [ -d parrot -a $BUILD_SYS = LINUX ]
@@ -1307,17 +1313,6 @@ then
 	else
 		echo "resource_monitor is NOT supported on ${BUILD_SYS}"
 		include_package_resource_monitor=""
-	fi
-fi
-
-if [ "${include_package_chirp}" = chirp ]
-then
-	if [ "$optstatic" = 1 ]
-	then
-		echo "chirp cannot currently be build statically".
-		include_package_chirp=""
-	else
-		internal_ccflags="${internal_ccflags} -DCCTOOLS_WITH_CHIRP"
 	fi
 fi
 

--- a/resource_monitor/src/Makefile
+++ b/resource_monitor/src/Makefile
@@ -24,7 +24,7 @@ all: $(TARGETS) bindings
 # Note below: we use gcc on static builds so that the library gets to use the system linker.
 librmonitor_helper.$(CCTOOLS_DYNAMIC_SUFFIX): rmonitor_helper.o rmonitor_helper_comm.o
 ifeq ($(CCTOOLS_STATIC),1)
-	gcc           -shared -fPIC $^ -o $@ -ldl $(CCTOOLS_INTERNAL_CCFLAGS) $(LOCAL_LINKAGE) $(CCTOOLS_EXTERNAL_LINKAGE)
+	gcc -shared -fPIC $^ -o $@ -ldl $(CCTOOLS_INTERNAL_CCFLAGS) $(LOCAL_LINKAGE) $(CCTOOLS_EXTERNAL_LINKAGE)
 else
 	$(CCTOOLS_LD) -shared -fPIC $^ -o $@ -ldl $(CCTOOLS_INTERNAL_CCFLAGS) $(LOCAL_LDFLAGS) $(LOCAL_LINKAGE) $(CCTOOLS_EXTERNAL_LINKAGE)
 endif


### PR DESCRIPTION
Example:

LD=musl-gcc LD_FLAGS=-lm CC=musl-gcc ./configure --static --with-{readline,perl,python}-path=no
