### PR TITLE
Hook storage allocation

### DIFF
--- a/makeflow/src/Makefile
+++ b/makeflow/src/Makefile
@@ -11,7 +11,7 @@ PROGRAMS = makeflow makeflow_viz makeflow_analyze makeflow_linker makeflow_statu
 SCRIPTS = condor_submit_makeflow makeflow_graph_log makeflow_monitor starch makeflow_linker_perl_driver makeflow_linker_python_driver makeflow_archive_query mf_mesos_scheduler mf_mesos_executor mf_mesos_setting mf-mesos-executor makeflow_ec2_setup makeflow_ec2_cleanup
 MAKEFLOW_WRAPPERS =  makeflow_wrapper_monitor.o makeflow_wrapper_docker.o makeflow_wrapper_enforcement.o makeflow_wrapper_umbrella.o makeflow_mounts.o makeflow_wrapper_singularity.o
 MAKEFLOW_HOOKS = makeflow_hook_example.o
-
+MAKEFLOW_MODULES = makeflow_module_storage_allocation.o
 
 TARGETS = $(PROGRAMS)
 
@@ -21,7 +21,7 @@ makeflow makeflow_viz makeflow_analyze makeflow_status: $(OBJECTS)
 
 makeflow_status: makeflow_status.o
 
-makeflow: makeflow_alloc.o makeflow_summary.o makeflow_gc.o makeflow_log.o makeflow_wrapper.o makeflow_catalog_reporter.o makeflow_archive.o makeflow_local_resources.o $(MAKEFLOW_WRAPPERS) makeflow_hook.o $(MAKEFLOW_HOOKS)
+makeflow: makeflow_alloc.o makeflow_summary.o makeflow_gc.o makeflow_log.o makeflow_wrapper.o makeflow_catalog_reporter.o makeflow_archive.o makeflow_local_resources.o $(MAKEFLOW_WRAPPERS) makeflow_hook.o $(MAKEFLOW_HOOKS) $(MAKEFLOW_MODULES)
 
 $(PROGRAMS): $(EXTERNAL_DEPENDENCIES)
 

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -1309,6 +1309,8 @@ int main(int argc, char *argv[])
 	struct jx *jx_args = jx_object(NULL);
 	
 	struct jx *hook_args = jx_object(NULL);
+	extern struct makeflow_hook makeflow_hook_example;
+	extern struct makeflow_hook makeflow_hook_storage_allocation;
 
 	random_init();
 	debug_config(argv[0]);
@@ -1694,10 +1696,7 @@ int main(int argc, char *argv[])
 				cache_mode = 0;
 				break;
 			case LONG_OPT_HOOK_EXAMPLE:
-				{
-					extern struct makeflow_hook makeflow_hook_example;
-					makeflow_hook_register(&makeflow_hook_example);
-				}
+				makeflow_hook_register(&makeflow_hook_example);
 				break;
 			case LONG_OPT_WQ_WAIT_FOR_WORKERS:
 				wq_wait_queue_size = optarg;
@@ -1734,24 +1733,15 @@ int main(int argc, char *argv[])
 				list_push_head(shared_fs_list, xxstrdup(optarg));
 				break;
 			case LONG_OPT_STORAGE_TYPE:
-				{
-					extern struct makeflow_hook makeflow_hook_storage_allocation;
-					makeflow_hook_register(&makeflow_hook_storage_allocation);
-				}
+				makeflow_hook_register(&makeflow_hook_storage_allocation);
 				jx_insert(hook_args, jx_string("storage_allocation_type"), jx_integer(atoi(optarg)));
 				break;
 			case LONG_OPT_STORAGE_LIMIT:
-				{
-					extern struct makeflow_hook makeflow_hook_storage_allocation;
-					makeflow_hook_register(&makeflow_hook_storage_allocation);
-				}
+				makeflow_hook_register(&makeflow_hook_storage_allocation);
 				jx_insert(hook_args, jx_string("storage_allocation_limit"), jx_integer(string_metric_parse(optarg)));
 				break;
 			case LONG_OPT_STORAGE_PRINT:
-				{
-					extern struct makeflow_hook makeflow_hook_storage_allocation;
-					makeflow_hook_register(&makeflow_hook_storage_allocation);
-				}
+				makeflow_hook_register(&makeflow_hook_storage_allocation);
 				jx_insert(hook_args, jx_string("storage_allocation_print"), jx_string(optarg));
 				break;
 			case LONG_OPT_DOCKER:

--- a/makeflow/src/makeflow_gc.h
+++ b/makeflow/src/makeflow_gc.h
@@ -7,7 +7,7 @@ See the file COPYING for details.
 #ifndef MAKEFLOW_GC_H
 #define MAKEFLOW_GC_H
 
-#include "makeflow_alloc.h"
+#include "makeflow_hook.h"
 
 /*
 This module implements garbage collection on the dag.
@@ -32,15 +32,15 @@ typedef enum {
 } makeflow_clean_depth;
 
 void makeflow_parse_input_outputs( struct dag *d );
-void makeflow_gc( struct dag *d, struct batch_queue *queue, makeflow_gc_method_t method, uint64_t size, int count, struct makeflow_alloc *alloc );
-int  makeflow_clean_file( struct dag *d, struct batch_queue *queue, struct dag_file *f, int silent, struct makeflow_alloc *alloc );
+void makeflow_gc( struct dag *d, struct batch_queue *queue, makeflow_gc_method_t method, uint64_t size, int count );
+int  makeflow_clean_file( struct dag *d, struct batch_queue *queue, struct dag_file *f, int silent );
 void makeflow_clean_node( struct dag *d, struct batch_queue *queue, struct dag_node *n, int silent );
-int makeflow_clean_prep_fail_dir(struct dag *d, struct dag_node *n, struct batch_queue *q, struct makeflow_alloc *alloc);
-int makeflow_clean_rm_fail_dir(struct dag *d, struct dag_node *n, struct batch_queue *q, struct makeflow_alloc *alloc);
-int makeflow_clean_failed_file(struct dag *d, struct dag_node *n, struct batch_queue *q, struct dag_file *f, int prep_failed, int silent, struct makeflow_alloc *alloc);
+int makeflow_clean_prep_fail_dir(struct dag *d, struct dag_node *n, struct batch_queue *q );
+int makeflow_clean_rm_fail_dir(struct dag *d, struct dag_node *n, struct batch_queue *q );
+int makeflow_clean_failed_file(struct dag *d, struct dag_node *n, struct batch_queue *q, struct dag_file *f, int prep_failed, int silent );
 
 /* return 0 on success; return non-zero on failure. */
-int makeflow_clean( struct dag *d, struct batch_queue *queue, makeflow_clean_depth clean_depth, struct makeflow_alloc *alloc );
+int makeflow_clean( struct dag *d, struct batch_queue *queue, makeflow_clean_depth clean_depth );
 
 /* makeflow_clean_mount_target removes the target.
  * @param target: a file path

--- a/makeflow/src/makeflow_hook.h
+++ b/makeflow/src/makeflow_hook.h
@@ -420,8 +420,6 @@ int makeflow_hook_dag_abort(struct dag *d);
 
 int makeflow_hook_dag_success(struct dag *d);
 
-int makeflow_hook_node_create(struct dag_node *node, struct batch_queue *queue);
-
 int makeflow_hook_node_check(struct dag_node *node, struct batch_queue *queue);
 
 int makeflow_hook_node_submit(struct dag_node *node, struct batch_task *task);

--- a/makeflow/src/makeflow_log.c
+++ b/makeflow/src/makeflow_log.c
@@ -128,6 +128,9 @@ static void makeflow_log_sync( struct dag *d, int force )
 
 void makeflow_log_close( struct dag *d )
 {
+	/* In the case where Makeflow exits prior to opening log. */
+	if(!d->logfile) return;
+
 	makeflow_log_sync(d,1);
 	fclose(d->logfile);
 	d->logfile = 0;
@@ -141,18 +144,27 @@ void makeflow_log_started_event( struct dag *d )
 
 void makeflow_log_aborted_event( struct dag *d )
 {
+	/* In the case where Makeflow exits prior to opening log. */
+	if(!d->logfile) return;
+
 	fprintf(d->logfile, "# ABORTED %" PRIu64 "\n", timestamp_get());
 	makeflow_log_sync(d,1);
 }
 
 void makeflow_log_failed_event( struct dag *d )
 {
+	/* In the case where Makeflow exits prior to opening log. */
+	if(!d->logfile) return;
+
 	fprintf(d->logfile, "# FAILED %" PRIu64 "\n", timestamp_get());
 	makeflow_log_sync(d,1);
 }
 
 void makeflow_log_completed_event( struct dag *d )
 {
+	/* In the case where Makeflow exits prior to opening log. */
+	if(!d->logfile) return;
+
 	fprintf(d->logfile, "# COMPLETED %" PRIu64 "\n", timestamp_get());
 	makeflow_log_sync(d,1);
 }

--- a/makeflow/src/makeflow_log.c
+++ b/makeflow/src/makeflow_log.c
@@ -412,7 +412,7 @@ int makeflow_log_recover(struct dag *d, const char *filename, int verbose_mode, 
 				continue;
 			if(dag_file_should_exist(f) && !dag_file_is_source(f) && difftime(buf.st_mtime, f->creation_logged) > 0) {
 				fprintf(stderr, "makeflow: %s is reported as existing, but has been modified (%" SCNu64 " ,%" SCNu64 ").\n", f->filename, (uint64_t)buf.st_mtime, (uint64_t)f->creation_logged);
-				makeflow_clean_file(d, queue, f, 0, NULL);
+				makeflow_clean_file(d, queue, f, 0);
 				makeflow_log_file_state_change(d, f, DAG_FILE_STATE_UNKNOWN);
 			}
 		}

--- a/makeflow/src/makeflow_module_storage_allocation.c
+++ b/makeflow/src/makeflow_module_storage_allocation.c
@@ -11,19 +11,33 @@
 #include "dag_file.h"
 #include "jx.h"
 
-
 static struct makeflow_alloc *storage_allocation = NULL;
 
 /* Variables used to hold the time used for storage alloc. */
 uint64_t static_analysis = 0;
 char * storage_print = NULL;
 
-static int create(struct jx *args){
-	if(jx_lookup_string(args, "allocation_storage_print"))
-		storage_print = xxstrdup(jx_lookup_string(args, "allocation_storage_print"));
+/* Flag to indicate that jobs were cleaned and to loop again. */
+int cleaned_completed_node = 0;
 
-	uint64_t storage_limit = jx_lookup_integer(args, "allocation_storage_limit");
-	int storage_type  = jx_lookup_integer(args, "allocation_storage_type");
+/* Both of these flags are used to signal if there where tasks that
+ * were skipped and never run as a result of storage allocation. */
+/* Flag to indicate that the allocation failed to find available space. */
+int failed_allocation_check = 0;
+
+/* Flag to indicate a node was skipped to active node dependecies. */
+int failed_dependencies_check = 0;
+
+static int create(struct jx *args){
+	if(jx_lookup_string(args, "storage_allocation_print")){
+		storage_print = xxstrdup(jx_lookup_string(args, "storage_allocation_print"));
+		printf("Storage Print = %s\n", storage_print);
+	}
+
+	uint64_t storage_limit = jx_lookup_integer(args, "storage_allocation_limit");
+	printf("Storage Limit = %" PRIu64 "\n", storage_limit);
+	int storage_type  = jx_lookup_integer(args, "storage_allocation_type");
+	printf("Storage Type = %d\n", storage_type);
     if(storage_limit || storage_type != MAKEFLOW_ALLOC_TYPE_NOT_ENABLED){
         storage_allocation = makeflow_alloc_create(-1, NULL, storage_limit, 1, storage_type);
     }
@@ -36,7 +50,7 @@ static int destroy(){
 	return MAKEFLOW_HOOK_SUCCESS;
 }
 
-static int dag_start(struct dag *d){
+static int dag_check(struct dag *d){
     uint64_t start = timestamp_get();
     struct dag_node *n = dag_node_create(d, -1);
     n->state = DAG_NODE_STATE_COMPLETE;
@@ -52,13 +66,23 @@ static int dag_start(struct dag *d){
     if(storage_print){
         dag_node_footprint_find_largest_residual(n, NULL);
         dag_node_footprint_print(d, n, storage_print);
-        exit(0);
+        return MAKEFLOW_HOOK_END;
     }
     uint64_t end = timestamp_get();
     static_analysis += end - start;
     dag_node_delete(n);
 
 	return MAKEFLOW_HOOK_SUCCESS;
+}
+
+static int dag_loop(struct dag *d){
+	if(cleaned_completed_node == 1){
+		cleaned_completed_node = 0;
+		failed_allocation_check = 0;
+		failed_dependencies_check = 0;
+		return MAKEFLOW_HOOK_SUCCESS;
+	}
+	return MAKEFLOW_HOOK_END;
 }
 
 static int dag_end(struct dag *d){
@@ -69,18 +93,24 @@ static int dag_end(struct dag *d){
         makeflow_log_event(d, "DYNAMIC_ALLOC", makeflow_alloc_get_dynamic_alloc_time());
     }
 
+	if(failed_allocation_check || failed_dependencies_check){
+		return MAKEFLOW_HOOK_FAILURE;
+	}
+
 	return MAKEFLOW_HOOK_SUCCESS;
 }
 
-static int node_create(struct dag_node *n, struct batch_queue *q){
+static int node_check(struct dag_node *n, struct batch_queue *q){
 
-    if(storage_allocation && storage_allocation->locked){
+    if(storage_allocation->locked){
         if(!( makeflow_alloc_check_space(storage_allocation, n))){
-            return MAKEFLOW_HOOK_FAILURE;
+			failed_allocation_check = 1;
+            return MAKEFLOW_HOOK_SKIP;
         }
 
         if (!(dag_node_footprint_dependencies_active(n))){
-            return MAKEFLOW_HOOK_FAILURE;
+			failed_dependencies_check = 1;
+            return MAKEFLOW_HOOK_SKIP;
         }
     }
 
@@ -88,11 +118,10 @@ static int node_create(struct dag_node *n, struct batch_queue *q){
 }
 
 static int node_submit(struct dag_node *n, struct batch_task *task){
-
-    if(storage_allocation && makeflow_alloc_commit_space(storage_allocation, n)){
+    if(makeflow_alloc_commit_space(storage_allocation, n)){
         makeflow_log_alloc_event(n->d, storage_allocation);
-    } else if (storage_allocation && storage_allocation->locked)  {
-        fatal("Unable to commit enough space for execution\n");
+    } else if (storage_allocation->locked)  {
+        debug(D_MAKEFLOW_HOOK, "Unable to commit enough space for execution\n");
 		return MAKEFLOW_HOOK_FAILURE;
     }
 	return MAKEFLOW_HOOK_SUCCESS;
@@ -100,34 +129,34 @@ static int node_submit(struct dag_node *n, struct batch_task *task){
 
 static int node_success(struct dag_node *n, struct batch_task *task){
 	struct dag_file *f = NULL;
+	cleaned_completed_node = 1;
 	
-    if(storage_allocation && makeflow_alloc_use_space(storage_allocation, n)){
+    if(makeflow_alloc_use_space(storage_allocation, n)){
 		makeflow_log_alloc_event(n->d, storage_allocation);
 	}
 
     /* Mark source files that have been used by this node */
     list_first_item(n->source_files);
     while((f = list_next_item(n->source_files))) {
-        f->reference_count+= -1;
-        if(f->reference_count == 0 && f->state == DAG_FILE_STATE_EXISTS){
-            if(storage_allocation && storage_allocation->locked && f->type != DAG_FILE_TYPE_OUTPUT)
-				makeflow_clean_file(n->d, makeflow_get_remote_queue(), f, 0);
+        if(f->state == DAG_FILE_STATE_COMPLETE){
+            if(storage_allocation->locked && f->type != DAG_FILE_TYPE_OUTPUT)
+				makeflow_clean_file(n->d, makeflow_get_queue(n), f, 0);
 		}
 	}
 
     /* Delete output files that have no use and are not actual outputs */
-    if(storage_allocation && storage_allocation->locked){
+    if(storage_allocation->locked){
         list_first_item(n->target_files);
 		while((f = list_next_item(n->target_files))){
 			if(f->reference_count == 0 && f->type != DAG_FILE_TYPE_OUTPUT)
-				makeflow_clean_file(n->d, makeflow_get_remote_queue(), f, 0);
+				makeflow_clean_file(n->d, makeflow_get_queue(n), f, 0);
 		}
 	}
 
-    if(storage_allocation && makeflow_alloc_release_space(storage_allocation, n, 0, MAKEFLOW_ALLOC_RELEASE_COMMIT)) {
+    if(makeflow_alloc_release_space(storage_allocation, n, 0, MAKEFLOW_ALLOC_RELEASE_COMMIT)) {
         makeflow_log_alloc_event(n->d, storage_allocation);
-    } else if (storage_allocation && storage_allocation->locked) {
-        printf("Unable to release space\n");
+    } else if (storage_allocation->locked) {
+        debug(D_MAKEFLOW_HOOK, "Unable to release space\n");
     }
 
 	return MAKEFLOW_HOOK_SUCCESS;
@@ -148,10 +177,10 @@ struct dag *file_find_dag(struct dag_file *f){
 
 static int file_deleted(struct dag_file *f){
 	struct dag *d = file_find_dag(f);
-	if(storage_allocation && f->created_by)
+	if(f->created_by)
 		makeflow_alloc_release_space(storage_allocation, f->created_by, f->actual_size, MAKEFLOW_ALLOC_RELEASE_USED);
-	if(storage_allocation)
-		makeflow_log_alloc_event(d, storage_allocation);
+
+	makeflow_log_alloc_event(d, storage_allocation);
 	
 	return MAKEFLOW_HOOK_SUCCESS;
 }
@@ -161,10 +190,11 @@ struct makeflow_hook makeflow_hook_storage_allocation = {
 	.create = create,
 	.destroy = destroy,
 
-	.dag_start = dag_start,
+	.dag_check = dag_check,
+	.dag_loop = dag_loop,
 	.dag_end = dag_end,
 
-	.node_create = node_create,
+	.node_check = node_check,
 	.node_submit = node_submit,
 	.node_success = node_success,
 

--- a/makeflow/src/makeflow_module_storage_allocation.c
+++ b/makeflow/src/makeflow_module_storage_allocation.c
@@ -1,0 +1,174 @@
+
+#include "debug.h"
+#include "makeflow_hook.h"
+#include "xxmalloc.h"
+#include "makeflow_log.h"
+#include "makeflow_alloc.h"
+#include "batch_task.h"
+#include "dag.h"
+#include "dag_node.h"
+#include "dag_node_footprint.h"
+#include "dag_file.h"
+#include "jx.h"
+
+
+static struct makeflow_alloc *storage_allocation = NULL;
+
+/* Variables used to hold the time used for storage alloc. */
+uint64_t static_analysis = 0;
+char * storage_print = NULL;
+
+static int create(struct jx *args){
+	if(jx_lookup_string(args, "allocation_storage_print"))
+		storage_print = xxstrdup(jx_lookup_string(args, "allocation_storage_print"));
+
+	uint64_t storage_limit = jx_lookup_integer(args, "allocation_storage_limit");
+	int storage_type  = jx_lookup_integer(args, "allocation_storage_type");
+    if(storage_limit || storage_type != MAKEFLOW_ALLOC_TYPE_NOT_ENABLED){
+        storage_allocation = makeflow_alloc_create(-1, NULL, storage_limit, 1, storage_type);
+    }
+	
+	return MAKEFLOW_HOOK_SUCCESS;
+}
+
+static int destroy(){
+	free(storage_print);
+	return MAKEFLOW_HOOK_SUCCESS;
+}
+
+static int dag_start(struct dag *d){
+    uint64_t start = timestamp_get();
+    struct dag_node *n = dag_node_create(d, -1);
+    n->state = DAG_NODE_STATE_COMPLETE;
+    struct dag_node *p;
+
+    for(p = d->nodes; p; p = p->next) {
+        if(set_size(p->ancestors) == 0) {
+            set_push(n->descendants, p);
+        }
+    }
+
+    dag_node_footprint_calculate(n);
+    if(storage_print){
+        dag_node_footprint_find_largest_residual(n, NULL);
+        dag_node_footprint_print(d, n, storage_print);
+        exit(0);
+    }
+    uint64_t end = timestamp_get();
+    static_analysis += end - start;
+    dag_node_delete(n);
+
+	return MAKEFLOW_HOOK_SUCCESS;
+}
+
+static int dag_end(struct dag *d){
+
+    if(storage_allocation){
+        makeflow_log_alloc_event(d, storage_allocation);
+        makeflow_log_event(d, "STATIC_ANALYSIS", static_analysis);
+        makeflow_log_event(d, "DYNAMIC_ALLOC", makeflow_alloc_get_dynamic_alloc_time());
+    }
+
+	return MAKEFLOW_HOOK_SUCCESS;
+}
+
+static int node_create(struct dag_node *n, struct batch_queue *q){
+
+    if(storage_allocation && storage_allocation->locked){
+        if(!( makeflow_alloc_check_space(storage_allocation, n))){
+            return MAKEFLOW_HOOK_FAILURE;
+        }
+
+        if (!(dag_node_footprint_dependencies_active(n))){
+            return MAKEFLOW_HOOK_FAILURE;
+        }
+    }
+
+	return MAKEFLOW_HOOK_SUCCESS;
+}
+
+static int node_submit(struct dag_node *n, struct batch_task *task){
+
+    if(storage_allocation && makeflow_alloc_commit_space(storage_allocation, n)){
+        makeflow_log_alloc_event(n->d, storage_allocation);
+    } else if (storage_allocation && storage_allocation->locked)  {
+        fatal("Unable to commit enough space for execution\n");
+		return MAKEFLOW_HOOK_FAILURE;
+    }
+	return MAKEFLOW_HOOK_SUCCESS;
+}
+
+static int node_success(struct dag_node *n, struct batch_task *task){
+	struct dag_file *f = NULL;
+	
+    if(storage_allocation && makeflow_alloc_use_space(storage_allocation, n)){
+		makeflow_log_alloc_event(n->d, storage_allocation);
+	}
+
+    /* Mark source files that have been used by this node */
+    list_first_item(n->source_files);
+    while((f = list_next_item(n->source_files))) {
+        f->reference_count+= -1;
+        if(f->reference_count == 0 && f->state == DAG_FILE_STATE_EXISTS){
+            if(storage_allocation && storage_allocation->locked && f->type != DAG_FILE_TYPE_OUTPUT)
+				makeflow_clean_file(n->d, makeflow_get_remote_queue(), f, 0);
+		}
+	}
+
+    /* Delete output files that have no use and are not actual outputs */
+    if(storage_allocation && storage_allocation->locked){
+        list_first_item(n->target_files);
+		while((f = list_next_item(n->target_files))){
+			if(f->reference_count == 0 && f->type != DAG_FILE_TYPE_OUTPUT)
+				makeflow_clean_file(n->d, makeflow_get_remote_queue(), f, 0);
+		}
+	}
+
+    if(storage_allocation && makeflow_alloc_release_space(storage_allocation, n, 0, MAKEFLOW_ALLOC_RELEASE_COMMIT)) {
+        makeflow_log_alloc_event(n->d, storage_allocation);
+    } else if (storage_allocation && storage_allocation->locked) {
+        printf("Unable to release space\n");
+    }
+
+	return MAKEFLOW_HOOK_SUCCESS;
+}
+
+struct dag *file_find_dag(struct dag_file *f){
+	struct dag *d = NULL;
+	if(f->created_by){
+		d = f->created_by->d;
+	} else {
+		struct dag_node *n;
+		list_first_item(f->needed_by);
+		n = list_next_item(f->needed_by);
+		d = n->d;
+	}
+	return d;
+}
+
+static int file_deleted(struct dag_file *f){
+	struct dag *d = file_find_dag(f);
+	if(storage_allocation && f->created_by)
+		makeflow_alloc_release_space(storage_allocation, f->created_by, f->actual_size, MAKEFLOW_ALLOC_RELEASE_USED);
+	if(storage_allocation)
+		makeflow_log_alloc_event(d, storage_allocation);
+	
+	return MAKEFLOW_HOOK_SUCCESS;
+}
+
+struct makeflow_hook makeflow_hook_storage_allocation = {
+	.module_name = "Storage Allocation",
+	.create = create,
+	.destroy = destroy,
+
+	.dag_start = dag_start,
+	.dag_end = dag_end,
+
+	.node_create = node_create,
+	.node_submit = node_submit,
+	.node_success = node_success,
+
+	.file_deleted = file_deleted,
+};
+
+


### PR DESCRIPTION
Migrates the storage allocation code out of Makeflow main into a module. This also removes several unnecessary hooks.

A change of note is that this continues moving all exits success or failure to using gotos and properly cleaning up. As a result some logging events needed to check for null to avoid segfaults. Let me know if this is an unacceptable change.