### PR TITLE
Automatic size/compression of catalog updates.

### DIFF
--- a/dttools/src/catalog_query.c
+++ b/dttools/src/catalog_query.c
@@ -243,7 +243,7 @@ char *catalog_query_compress_update(const char *text, unsigned long *data_length
 	}
 }
 
-int catalog_query_send_update(const char *hosts, const char *text)
+static int catalog_query_send_update_internal(const char *hosts, const char *text, int fail_if_too_big )
 {
 	int sent = 0;
 	unsigned long data_length;
@@ -272,8 +272,8 @@ int catalog_query_send_update(const char *hosts, const char *text)
 
 		debug(D_DEBUG,"compressed update message from %d to %d bytes",(int)strlen(text),(int)data_length);
 
-		if(data_length>compress_limit) {
-			debug(D_NOTICE,"compressed update message exceeds limit of %d bytes (CATALOG_UPDATE_LIMIT)",(int)compress_limit);
+		if(data_length>compress_limit && fail_if_too_big) {
+			debug(D_DEBUG,"compressed update message exceeds limit of %d bytes (CATALOG_UPDATE_LIMIT)",(int)compress_limit);
 			datagram_delete(d);
 			return 0;
 		}
@@ -297,6 +297,16 @@ int catalog_query_send_update(const char *hosts, const char *text)
 	free(update_data);
 	datagram_delete(d);
 	return sent;
+}
+
+int catalog_query_send_update(const char *hosts, const char *text)
+{
+	return catalog_query_send_update_internal(hosts,text,0);
+}
+
+int catalog_query_send_update_conditional(const char *hosts, const char *text)
+{
+	return catalog_query_send_update_internal(hosts,text,1);
 }
 
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/catalog_query.c
+++ b/dttools/src/catalog_query.c
@@ -218,13 +218,6 @@ void catalog_query_delete(struct catalog_query *q)
 
 char *catalog_query_compress_update(const char *text, unsigned long *data_length)
 {
-	char *do_compress = getenv("CATALOG_COMPRESS_UPDATES");
-
-	/* Do not compress if env var is set to off.*/
-	if(!do_compress || strcmp(do_compress, "on")) {
-		return NULL;
-	}
-
 	unsigned long compress_data_length;
 	/* Default to buffer error incase we don't compress. */
 	int success = Z_BUF_ERROR;
@@ -241,11 +234,9 @@ char *catalog_query_compress_update(const char *text, unsigned long *data_length
 	if(success!=Z_OK) {
 		/* Compression failed, fall back to original uncompressed update. */
 		debug(D_DEBUG,"warning: Unable to compress data for update.\n");
-
 		free(compress_data);
 		return NULL;
 	} else {
-		debug(D_DEBUG,"Sending compressed update to catalog.\n");
 		/* Add 1 to the compresed data length to account for the leading 0x1A. */
 		*data_length = compress_data_length + 1;
 		return compress_data;
@@ -254,13 +245,10 @@ char *catalog_query_compress_update(const char *text, unsigned long *data_length
 
 int catalog_query_send_update(const char *hosts, const char *text)
 {
-	int port;
 	int sent = 0;
 	unsigned long data_length;
 	const char *next_host = hosts;
-	char address[DATAGRAM_ADDRESS_MAX];
-	char host[DOMAIN_NAME_MAX];
-	char *compress_data;
+	char *update_data = 0;
 	struct datagram *d = datagram_create(DATAGRAM_PORT_ANY);
 
 	if (!d) {
@@ -269,24 +257,44 @@ int catalog_query_send_update(const char *hosts, const char *text)
 	
 	data_length = strlen(text)+1;
 
-	compress_data = catalog_query_compress_update(text, &data_length);
+	size_t compress_limit = 1200;
+	const char *compress_limit_str = getenv("CATALOG_UPDATE_LIMIT");
+	if(compress_limit_str) compress_limit = atoi(compress_limit_str);
+
+	if(strlen(text)<compress_limit) {
+		update_data = strdup(text);
+	} else {
+		update_data = catalog_query_compress_update(text, &data_length);
+		if(!update_data) {
+			datagram_delete(d);
+			return 0;
+		}
+
+		debug(D_DEBUG,"compressed update message from %d to %d bytes",(int)strlen(text),(int)data_length);
+
+		if(data_length>compress_limit) {
+			debug(D_NOTICE,"compressed update message exceeds limit of %d bytes (CATALOG_UPDATE_LIMIT)",(int)compress_limit);
+			datagram_delete(d);
+			return 0;
+		}
+	}
 
 	do {
+		char address[DATAGRAM_ADDRESS_MAX];
+		char host[DOMAIN_NAME_MAX];
+		int port;
+
 		next_host = parse_hostlist(next_host, host, &port);
 		if (domain_name_cache_lookup(host, address)) {
 			debug(D_DEBUG, "sending update to %s(%s):%d", host, address, port);
-			if(!compress_data) {
-				datagram_send(d, text, data_length, address, port);
-			} else {
-				datagram_send(d, compress_data, data_length, address, port);
-			}
+			datagram_send(d, update_data, data_length, address, port);
 			sent++;
 		} else {
 			debug(D_DEBUG, "unable to lookup address of host: %s", host);
 		}
 	} while (next_host);
 
-	free(compress_data);
+	free(update_data);
 	datagram_delete(d);
 	return sent;
 }

--- a/dttools/src/catalog_query.h
+++ b/dttools/src/catalog_query.h
@@ -57,4 +57,12 @@ hosts is a comma delimited list of hosts, each of which can be host or host:port
 */
 int catalog_query_send_update(const char *hosts, const char *text);
 
+/** Send update text to the given hosts, but fail if the update text
+cannot be compressed to a suitable size.
+@param hosts A list of hosts to which to send updates
+@param text String to send
+@return The number of updates successfully sent, 
+*/
+int catalog_query_send_update_conditional(const char *hosts, const char *text);
+
 #endif

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -756,7 +756,7 @@ void update_catalog(struct work_queue *q, struct link *foreman_uplink, int force
 
 	// Send the buffer.
 	debug(D_WQ, "Advertising master status to the catalog server(s) at %s ...", q->catalog_hosts);
-	if(!catalog_query_send_update(q->catalog_hosts, str)) {
+	if(!catalog_query_send_update_conditional(q->catalog_hosts, str)) {
 
 		// If the send failed b/c the buffer is too big, send the lean version instead.
 		struct jx *lj = queue_lean_to_jx(q,foreman_uplink);


### PR DESCRIPTION
Catalog updates are now automatically compressed if they exceed a size threshhold (1200 bytes).
WQ in particular will attempt to send a "full" update if it can be compressed within this limit.
If not, it sends a "lean" update.

Fixes #1744 
