### PR TITLE
Remove redundant var in makeflow_clean

### DIFF
--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -253,10 +253,10 @@ static void makeflow_abort_job( struct dag *d, struct dag_node *n, struct batch_
 	list_first_item(n->task->output_files);
 	while((bf = list_next_item(n->task->output_files))){
 		df = dag_file_lookup_or_create(d, bf->outer_name);
-		makeflow_clean_file(d, q, df, 0);
+		makeflow_clean_file(d, q, df);
 	}
 
-	makeflow_clean_node(d, q, n, 1);
+	makeflow_clean_node(d, q, n);
 }
 
 /*
@@ -386,10 +386,10 @@ void makeflow_node_force_rerun(struct itable *rerun_table, struct dag *d, struct
 	list_first_item(n->task->output_files);
 	while((bf = list_next_item(n->task->output_files))) {
 		f1 = dag_file_lookup_or_create(d, bf->outer_name);
-		makeflow_clean_file(d, remote_queue, f1, 0);
+		makeflow_clean_file(d, remote_queue, f1);
 	}
 
-	makeflow_clean_node(d, remote_queue, n, 0);
+	makeflow_clean_node(d, remote_queue, n);
 	makeflow_log_state_change(d, n, DAG_NODE_STATE_WAITING);
 
 	// For each parent node, rerun it if input file was garbage collected
@@ -806,9 +806,9 @@ static void makeflow_node_complete(struct dag *d, struct dag_node *n, struct bat
 
 			/* Either the file was created and not confirmed or a hook removed the file. */
 			if(f->state == DAG_FILE_STATE_EXPECT || f->state == DAG_FILE_STATE_DELETE) {
-				makeflow_clean_file(d, remote_queue, f, 1);
+				makeflow_clean_file(d, remote_queue, f);
 			} else {
-				makeflow_clean_file(d, remote_queue, f, 0);
+				makeflow_clean_file(d, remote_queue, f);
 			}
 		}
 

--- a/makeflow/src/makeflow_gc.c
+++ b/makeflow/src/makeflow_gc.c
@@ -146,7 +146,7 @@ void makeflow_parse_input_outputs( struct dag *d )
 
 /* Clean a specific file, while emitting an appropriate message. */
 
-int makeflow_clean_file( struct dag *d, struct batch_queue *queue, struct dag_file *f, int silent)
+int makeflow_clean_file( struct dag *d, struct batch_queue *queue, struct dag_file *f)
 {
 	if(!f)
 		return 1;
@@ -169,7 +169,7 @@ int makeflow_clean_file( struct dag *d, struct batch_queue *queue, struct dag_fi
 	return 0;
 }
 
-void makeflow_clean_node(struct dag *d, struct batch_queue *queue, struct dag_node *n, int silent)
+void makeflow_clean_node(struct dag *d, struct batch_queue *queue, struct dag_node *n)
 {
 	if(n->nested_job){
 		char *command = xxmalloc(sizeof(char) * (strlen(n->command) + 4));
@@ -191,13 +191,10 @@ int makeflow_clean(struct dag *d, struct batch_queue *queue, makeflow_clean_dept
 
 	hash_table_firstkey(d->files);
 	while(hash_table_nextkey(d->files, &name, (void **) &f)) {
-		int silent = 1;
-		if(dag_file_should_exist(f))
-			silent = 0;
 
 		/* We have a record of the file, but it is no longer created or used so delete */
 		if(dag_file_is_source(f) && dag_file_is_sink(f) && !set_lookup(d->inputs, f))
-			makeflow_clean_file(d, queue, f, silent);
+			makeflow_clean_file(d, queue, f);
 
 		if(dag_file_is_source(f)) {
 			if(f->source && (clean_depth == MAKEFLOW_CLEAN_CACHE || clean_depth == MAKEFLOW_CLEAN_ALL)) { 
@@ -211,11 +208,11 @@ int makeflow_clean(struct dag *d, struct batch_queue *queue, makeflow_clean_dept
 		}
 
 		if(clean_depth == MAKEFLOW_CLEAN_ALL){
-			makeflow_clean_file(d, queue, f, silent);
+			makeflow_clean_file(d, queue, f);
 		} else if(set_lookup(d->outputs, f) && (clean_depth == MAKEFLOW_CLEAN_OUTPUTS)) {
-			makeflow_clean_file(d, queue, f, silent);
+			makeflow_clean_file(d, queue, f);
 		} else if(!set_lookup(d->outputs, f) && (clean_depth == MAKEFLOW_CLEAN_INTERMEDIATES)){
-			makeflow_clean_file(d, queue, f, silent);
+			makeflow_clean_file(d, queue, f);
 		}
 	}
 
@@ -266,7 +263,7 @@ static void makeflow_gc_all( struct dag *d, struct batch_queue *queue, int maxfi
 			&& !dag_file_is_source(f)
 			&& !set_lookup(d->outputs, f)
 			&& !set_lookup(d->inputs, f)
-			&& makeflow_clean_file(d, queue, f, 0)){
+			&& makeflow_clean_file(d, queue, f)){
 			collected++;
 		}
 	}

--- a/makeflow/src/makeflow_gc.h
+++ b/makeflow/src/makeflow_gc.h
@@ -33,8 +33,8 @@ typedef enum {
 
 void makeflow_parse_input_outputs( struct dag *d );
 void makeflow_gc( struct dag *d, struct batch_queue *queue, makeflow_gc_method_t method, uint64_t size, int count );
-int  makeflow_clean_file( struct dag *d, struct batch_queue *queue, struct dag_file *f, int silent );
-void makeflow_clean_node( struct dag *d, struct batch_queue *queue, struct dag_node *n, int silent );
+int  makeflow_clean_file( struct dag *d, struct batch_queue *queue, struct dag_file *f );
+void makeflow_clean_node( struct dag *d, struct batch_queue *queue, struct dag_node *n );
 
 /* return 0 on success; return non-zero on failure. */
 int makeflow_clean( struct dag *d, struct batch_queue *queue, makeflow_clean_depth clean_depth );

--- a/makeflow/src/makeflow_log.c
+++ b/makeflow/src/makeflow_log.c
@@ -424,7 +424,7 @@ int makeflow_log_recover(struct dag *d, const char *filename, int verbose_mode, 
 				continue;
 			if(dag_file_should_exist(f) && !dag_file_is_source(f) && difftime(buf.st_mtime, f->creation_logged) > 0) {
 				fprintf(stderr, "makeflow: %s is reported as existing, but has been modified (%" SCNu64 " ,%" SCNu64 ").\n", f->filename, (uint64_t)buf.st_mtime, (uint64_t)f->creation_logged);
-				makeflow_clean_file(d, queue, f, 0);
+				makeflow_clean_file(d, queue, f);
 				makeflow_log_file_state_change(d, f, DAG_FILE_STATE_UNKNOWN);
 			}
 		}

--- a/makeflow/src/makeflow_module_fail_dir.c
+++ b/makeflow/src/makeflow_module_fail_dir.c
@@ -71,7 +71,7 @@ int makeflow_module_clean_fail_file(struct dag *d, struct dag_node *n, struct ba
 	}
 	free(failout);
 CLEANUP:
-	return makeflow_clean_file(d, q, f, silent);
+	return makeflow_clean_file(d, q, f);
 }
 
 int makeflow_module_prep_fail_dir(struct dag *d, struct dag_node *n, struct batch_queue *q) {
@@ -84,7 +84,7 @@ int makeflow_module_prep_fail_dir(struct dag *d, struct dag_node *n, struct batc
 	struct dag_file *f = makeflow_module_lookup_fail_dir(d, q, faildir);
 	if (!f) goto FAILURE;
 
-	if (makeflow_clean_file(d, q, f, 1)) {
+	if (makeflow_clean_file(d, q, f)) {
 		debug(D_MAKEFLOW_HOOK, "Unable to clean failed output");
 		goto FAILURE;
 	}
@@ -115,7 +115,7 @@ static int node_success(struct dag_node *n, struct batch_task *task){
 	struct dag_file *f = makeflow_module_lookup_fail_dir(d, q, faildir);
 	if (!f) goto OUT;
 
-	if (makeflow_clean_file(n->d, q, f, 1)) {
+	if (makeflow_clean_file(n->d, q, f)) {
 		debug(D_MAKEFLOW_HOOK, "Unable to clean failed output");
 		goto OUT;
 	}

--- a/makeflow/src/makeflow_module_storage_allocation.c
+++ b/makeflow/src/makeflow_module_storage_allocation.c
@@ -140,7 +140,7 @@ static int node_success(struct dag_node *n, struct batch_task *task){
     while((f = list_next_item(n->source_files))) {
         if(f->state == DAG_FILE_STATE_COMPLETE){
             if(storage_allocation->locked && f->type != DAG_FILE_TYPE_OUTPUT)
-				makeflow_clean_file(n->d, makeflow_get_queue(n), f, 0);
+				makeflow_clean_file(n->d, makeflow_get_queue(n), f);
 		}
 	}
 
@@ -149,7 +149,7 @@ static int node_success(struct dag_node *n, struct batch_task *task){
         list_first_item(n->target_files);
 		while((f = list_next_item(n->target_files))){
 			if(f->reference_count == 0 && f->type != DAG_FILE_TYPE_OUTPUT)
-				makeflow_clean_file(n->d, makeflow_get_queue(n), f, 0);
+				makeflow_clean_file(n->d, makeflow_get_queue(n), f);
 		}
 	}
 


### PR DESCRIPTION
Realized this functionality was removed but the variables are still there. They are now removed.