### PR TITLE
Detect magic symlinks under /proc and don't try to follow them

### DIFF
--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -421,6 +421,7 @@ void pfs_table::follow_symlink( struct pfs_name *pname, mode_t mode, int depth )
 		 * to follow symlinks of this form.
 		 */
 		if (in_proc && string_match_regex(link_target, "^[a-z]+:\\[[0-9]+\\]$")) return;
+		if (in_proc && string_match_regex(link_target, "^anon_inode:\\[?[a-zA-Z_0-9]+\\]?$")) return;
 
 		const char *basename_start = path_basename(pname->logical_name);
 		size_t dirname_len = basename_start - pname->logical_name;


### PR DESCRIPTION
Fixes #1847

This is basically the same issue as #1559. Rather than adding more special cases as we find them, this PR tries to detect any occurrences of magic symlinks. These symlinks have similar-looking targets, so when in `/proc` Parrot won't follow this kind of symlink. I don't think this will cause issues in not following normal symlinks that happen to have this form. Since they're always relative, there would have to be entries under `/proc` with unusual filenames (containing `:`, `[`, and `]`). Everything under `/proc` is managed by the kernel, so I think this should be a more reliable approach.