### PR TITLE
Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+BasedOnStyle: LLVM
+IndentWidth: 8
+UseTab: Always
+BreakBeforeBraces: Linux
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false


### PR DESCRIPTION
I want to autoformat, but I don't want to reformat the **entire** codebase. I'm looking at setting things up to autoformat only the parts of the code I touch while committing. To that end, I'd like to add a `.clang-format` for CCTools. The one in this PR is an [example](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#examples) from the LLVM folks that's "similar to the Linux Kernel style". It looks close enough to our current stuff, and I'd rather avoid coming up with a complicated format that's matched to my taste.