### PR TITLE
use LDFLAGS not CCFLAGS (!) when linking monitoring library

### DIFF
--- a/resource_monitor/src/Makefile
+++ b/resource_monitor/src/Makefile
@@ -24,9 +24,9 @@ all: $(TARGETS) bindings
 # Note below: we use gcc on static builds so that the library gets to use the system linker.
 librmonitor_helper.$(CCTOOLS_DYNAMIC_SUFFIX): rmonitor_helper.o rmonitor_helper_comm.o
 ifeq ($(CCTOOLS_STATIC),1)
-	gcc -shared -fPIC $^ -o $@ -ldl $(CCTOOLS_INTERNAL_CCFLAGS) $(LOCAL_LINKAGE) $(CCTOOLS_EXTERNAL_LINKAGE)
+	gcc           -shared -fPIC $^ -o $@ -ldl $(CCTOOLS_INTERNAL_LDFLAGS) $(LOCAL_LINKAGE) $(CCTOOLS_EXTERNAL_LINKAGE)
 else
-	$(CCTOOLS_LD) -shared -fPIC $^ -o $@ -ldl $(CCTOOLS_INTERNAL_CCFLAGS) $(LOCAL_LDFLAGS) $(LOCAL_LINKAGE) $(CCTOOLS_EXTERNAL_LINKAGE)
+	$(CCTOOLS_LD) -shared -fPIC $^ -o $@ -ldl $(CCTOOLS_INTERNAL_LDFLAGS) $(LOCAL_LINKAGE) $(CCTOOLS_EXTERNAL_LINKAGE)
 endif
 
 piggybacker: piggybacker.o


### PR DESCRIPTION
This was making the static-libgcc to be excluded from the compilation line, and libraries not being included as needed. The result was that a task in lobster was seg-faulting mysteriously.