### PR TITLE
Sing shell quote

### DIFF
--- a/makeflow/src/makeflow_module_singularity.c
+++ b/makeflow/src/makeflow_module_singularity.c
@@ -51,7 +51,9 @@ static int node_submit(struct dag_node *n, struct batch_task *t){
 	batch_wrapper_prefix(wrapper, CONTAINER_SINGULARITY_SH);
 
 	/* Assumes a /disk dir in the image. */
-	char *cmd = string_format("singularity exec --home $(pwd) %s %s %s", singularity_opt, singularity_image, t->command);
+	char *task_cmd = string_escape_shell(t->command);
+	char *cmd = string_format("singularity exec --home $(pwd) %s %s sh -c %s", singularity_opt, singularity_image, t->command);
+	free(task_cmd);
 	batch_wrapper_cmd(wrapper, cmd);
 	free(cmd);
 

--- a/makeflow/src/makeflow_module_singularity.c
+++ b/makeflow/src/makeflow_module_singularity.c
@@ -52,7 +52,7 @@ static int node_submit(struct dag_node *n, struct batch_task *t){
 
 	/* Assumes a /disk dir in the image. */
 	char *task_cmd = string_escape_shell(t->command);
-	char *cmd = string_format("singularity exec --home $(pwd) %s %s sh -c %s", singularity_opt, singularity_image, t->command);
+	char *cmd = string_format("singularity exec --home $(pwd) %s %s sh -c %s", singularity_opt, singularity_image, task_cmd);
 	free(task_cmd);
 	batch_wrapper_cmd(wrapper, cmd);
 	free(cmd);


### PR DESCRIPTION
Addresses issue of singularity using redirect from underlying command.

e.g.
bwa aln ref.fa query.fq > query.sai
and
singularity ... bwa aln ref.fa query.fq > query.sai

SAI in the second case is corrupted by singularity standard output.

This may be applicable to Docker...