### PR TITLE
Update resource monitor module

### DIFF
--- a/dttools/src/rmonitor.c
+++ b/dttools/src/rmonitor.c
@@ -98,7 +98,7 @@ char *resource_monitor_locate(const char *path_from_cmdline)
 
 //Using default sampling interval. We may want to add an option
 //to change it.
-char *resource_monitor_write_command(const char *monitor_path, const char *template_filename, const struct rmsummary *limits, const char *extra_monitor_options, int debug_output, int time_series, int inotify_stats)
+char *resource_monitor_write_command(const char *monitor_path, const char *template_filename, const struct rmsummary *limits, const char *extra_monitor_options, int debug_output, int time_series, int inotify_stats, const char *measure_dir)
 {
 	buffer_t cmd_builder;
 	buffer_init(&cmd_builder);
@@ -117,6 +117,9 @@ char *resource_monitor_write_command(const char *monitor_path, const char *templ
 
 	if(inotify_stats)
 		buffer_printf(&cmd_builder, " --with-inotify");
+
+	if(measure_dir)
+		buffer_printf(&cmd_builder, " --measure-dir %s", measure_dir);
 
 	if(limits) {
 		if(limits->end > -1)

--- a/dttools/src/rmonitor.h
+++ b/dttools/src/rmonitor.h
@@ -25,7 +25,7 @@ the corresponding log file options.
 @return A wrapper command line for string_wrap_command to wrap original command line with the resource monitor.
 */
 
-char *resource_monitor_write_command(const char *monitor_path, const char *template_filename, const struct rmsummary *limits, const char *extra_monitor_options, int debug_output, int time_series, int inotify_stats);
+char *resource_monitor_write_command(const char *monitor_path, const char *template_filename, const struct rmsummary *limits, const char *extra_monitor_options, int debug_output, int time_series, int inotify_stats, const char *measure_dir);
 
 /** Looks for a resource monitor executable, and makes a copy in
 current working directory.

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -1234,8 +1234,10 @@ int main(int argc, char *argv[])
 		LONG_OPT_LOCAL_MEMORY,
 		LONG_OPT_LOCAL_DISK,
 		LONG_OPT_MONITOR,
+		LONG_OPT_MONITOR_EXE,
 		LONG_OPT_MONITOR_INTERVAL,
 		LONG_OPT_MONITOR_LOG_NAME,
+		LONG_OPT_MONITOR_MEASURE_DIR,
 		LONG_OPT_MONITOR_OPENED_FILES,
 		LONG_OPT_MONITOR_TIME_SERIES,
 		LONG_OPT_MOUNTS,
@@ -1313,8 +1315,10 @@ int main(int argc, char *argv[])
 		{"max-local", required_argument, 0, 'j'},
 		{"max-remote", required_argument, 0, 'J'},
 		{"monitor", required_argument, 0, LONG_OPT_MONITOR},
+		{"monitor-exe", required_argument, 0, LONG_OPT_MONITOR_EXE},
 		{"monitor-interval", required_argument, 0, LONG_OPT_MONITOR_INTERVAL},
 		{"monitor-log-name", required_argument, 0, LONG_OPT_MONITOR_LOG_NAME},
+		{"monitor-measure-dir", no_argument, 0, LONG_OPT_MONITOR_MEASURE_DIR},
 		{"monitor-with-opened-files", no_argument, 0, LONG_OPT_MONITOR_OPENED_FILES},
 		{"monitor-with-time-series",  no_argument, 0, LONG_OPT_MONITOR_TIME_SERIES},
 		{"mounts",  required_argument, 0, LONG_OPT_MOUNTS},
@@ -1491,9 +1495,17 @@ int main(int argc, char *argv[])
 				makeflow_hook_register(&makeflow_hook_resource_monitor);
 				jx_insert(hook_args, jx_string("resource_monitor_log_dir"), jx_string(optarg));
 				break;
+			case LONG_OPT_MONITOR_EXE:
+				makeflow_hook_register(&makeflow_hook_resource_monitor);
+				jx_insert(hook_args, jx_string("resource_monitor_exe"), jx_string(optarg));
+				break;
 			case LONG_OPT_MONITOR_INTERVAL:
 				makeflow_hook_register(&makeflow_hook_resource_monitor);
 				jx_insert(hook_args, jx_string("resource_monitor_interval"), jx_integer(atoi(optarg)));
+				break;
+			case LONG_OPT_MONITOR_MEASURE_DIR:
+				makeflow_hook_register(&makeflow_hook_resource_monitor);
+				jx_insert(hook_args, jx_string("resource_monitor_measure_dir"), jx_integer(1));
 				break;
 			case LONG_OPT_MONITOR_TIME_SERIES:
 				makeflow_hook_register(&makeflow_hook_resource_monitor);

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -5195,7 +5195,7 @@ char *work_queue_monitor_wrap(struct work_queue *q, struct work_queue_worker *w,
 
 	int extra_files = (q->monitor_mode == MON_FULL);
 
-	char *monitor_cmd = resource_monitor_write_command("./" RESOURCE_MONITOR_REMOTE_NAME, RESOURCE_MONITOR_REMOTE_NAME, limits, extra_options, /* debug */ extra_files, /* series */ extra_files, /* inotify */ 0);
+	char *monitor_cmd = resource_monitor_write_command("./" RESOURCE_MONITOR_REMOTE_NAME, RESOURCE_MONITOR_REMOTE_NAME, limits, extra_options, /* debug */ extra_files, /* series */ extra_files, /* inotify */ 0, /* measure_dir */ NULL);
 	char *wrap_cmd  = string_wrap_command(t->command_line, monitor_cmd);
 
 	free(extra_options);


### PR DESCRIPTION
Add handling to specify resource monitor and also enable measuring a directory. 

When measuring the directory in a Makeflow task we use $PWD always. This allows
the directory to reflect wherever it is executed and not some assumed name.