### PR TITLE
Compute a hash identifier for each DAG node

### DIFF
--- a/dttools/src/stringtools.c
+++ b/dttools/src/stringtools.c
@@ -24,6 +24,13 @@ See the file COPYING for details.
 #include <stdlib.h>
 #include <string.h>
 
+int string_compare(const void *p1, const void *p2) {
+	/* The actual arguments to this function are "pointers to
+	 * pointers to char", but strcmp(3) arguments are "pointers
+	 * to char", hence the following cast plus dereference */
+	return strcmp(* (char * const *) p1, * (char * const *) p2);
+}
+
 /*
  * Based on opengroup.org's definition of the Shell Command Language (also gnu's)
  * In section 2.2.3 on Double-Quoted Strings, it indicates you only need to

--- a/dttools/src/stringtools.h
+++ b/dttools/src/stringtools.h
@@ -15,6 +15,11 @@ See the file COPYING for details.
 
 typedef char *(*string_subst_lookup_t) (const char *name, void *arg);
 
+/** Comparison function for an array of strings.
+ * This is useful with qsort(3) and list_sort().
+ */
+int string_compare(const void *p1, const void *p2);
+
 /** Takes a command string and escapes special characters in the Shell Command
   language. Mallocs space for new string and does not modify original string.
   Characters dollar-sign $, backtick `, backslash \, and double-quote " are

--- a/makeflow/src/Makefile
+++ b/makeflow/src/Makefile
@@ -6,7 +6,7 @@ include ../../rules.mk
 LOCAL_LINKAGE=$(CCTOOLS_GLOBUS_LDFLAGS)
 
 EXTERNAL_DEPENDENCIES = ../../batch_job/src/libbatch_job.a ../../work_queue/src/libwork_queue.a ../../chirp/src/libchirp.a ../../dttools/src/libdttools.a
-OBJECTS = dag.o dag_node_footprint.o dag_node.o dag_file.o dag_variable.o dag_visitors.o dag_resources.o lexer.o parser.o parser_make.o parser_jx.o
+OBJECTS = dag.o dag_node_footprint.o dag_node_hash.o dag_node.o dag_file.o dag_variable.o dag_visitors.o dag_resources.o lexer.o parser.o parser_make.o parser_jx.o
 PROGRAMS = makeflow makeflow_viz makeflow_analyze makeflow_linker makeflow_status
 SCRIPTS = condor_submit_makeflow makeflow_graph_log makeflow_monitor starch makeflow_linker_perl_driver makeflow_linker_python_driver makeflow_archive_query mf_mesos_scheduler mf_mesos_executor mf_mesos_setting makeflow_ec2_setup makeflow_ec2_cleanup makeflow_lambda_setup makeflow_lambda_cleanup
 

--- a/makeflow/src/dag_node.h
+++ b/makeflow/src/dag_node.h
@@ -13,6 +13,7 @@ See the file COPYING for details.
 #include "set.h"
 #include "hash_table.h"
 #include "itable.h"
+#include "sha1.h"
 
 typedef enum {
 	DAG_NODE_STATE_WAITING = 0,
@@ -40,6 +41,7 @@ struct dag_node {
 	int nodeid;              /* The ordinal number as the rule appears in the makeflow file */
 	int linenum;             /* Line number of the node's rule definition */
 	int local_job;           /* Flag: does this node run locally? */
+	unsigned char hash[SHA1_DIGEST_LENGTH];
 
 	struct set *descendants; /* The nodes of which this node is an immediate ancestor */
 	struct set *ancestors;   /* The nodes of which this node is an immediate descendant */

--- a/makeflow/src/dag_node_hash.c
+++ b/makeflow/src/dag_node_hash.c
@@ -1,0 +1,116 @@
+/*
+Copyright (C) 2018- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include <assert.h>
+#include <string.h>
+#include "xxmalloc.h"
+#include "list.h"
+#include "dag_node_hash.h"
+#include "sha1.h"
+#include "stringtools.h"
+
+struct dag_node_hash {
+	char *command;
+	char *makeflow;
+	char *cwd;
+	struct list *sources;
+	struct list *targets;
+};
+
+struct dag_node_hash *dag_node_hash_create(void) {
+	struct dag_node_hash *h = xxcalloc(1, sizeof(*h));
+	h->sources = list_create();
+	h->targets = list_create();
+	return h;
+}
+
+void dag_node_hash_command(struct dag_node_hash *h, const char *cmd) {
+	assert(h);
+	assert(cmd);
+	assert(!h->command);
+	assert(!h->makeflow);
+	assert(!h->cwd);
+	h->command = xxstrdup(cmd);
+}
+
+void dag_node_hash_makeflow(struct dag_node_hash *h, const char *dag, const char *cwd) {
+	assert(h);
+	assert(dag);
+	assert(cwd);
+	assert(!h->command);
+	assert(!h->makeflow);
+	assert(!h->cwd);
+	h->makeflow = xxstrdup(dag);
+	h->cwd = xxstrdup(cwd);
+}
+
+
+void dag_node_hash_source(struct dag_node_hash *h, const char *src) {
+	assert(h);
+	assert(src);
+	list_push_tail(h->sources, xxstrdup(src));
+}
+
+void dag_node_hash_target(struct dag_node_hash *h, const char *tgt) {
+	assert(h);
+	assert(tgt);
+	list_push_tail(h->targets, xxstrdup(tgt));
+}
+
+void dag_node_hash(struct dag_node_hash *h, unsigned char digest[SHA1_DIGEST_LENGTH]) {
+	assert(h);
+	assert(digest);
+	assert(!(h->command && h->makeflow));
+
+	char *tmp;
+	struct list_cursor *cur;
+	sha1_context_t ctx;
+	sha1_init(&ctx);
+
+	list_sort(h->sources, string_compare);
+	list_sort(h->targets, string_compare);
+
+	if (h->command) {
+		sha1_update(&ctx, "C", 1);
+		sha1_update(&ctx, h->command, strlen(h->command));
+		sha1_update(&ctx, "\0", 1);
+	}
+	if (h->makeflow) {
+		assert(h->cwd);
+		sha1_update(&ctx, "M", 1);
+		sha1_update(&ctx, h->makeflow, strlen(h->makeflow));
+		sha1_update(&ctx, "\0", 1);
+		sha1_update(&ctx, h->cwd, strlen(h->cwd));
+		sha1_update(&ctx, "\0", 1);
+	}
+
+	cur = list_cursor_create(h->sources);
+	for (list_seek(cur, 0); list_get(cur, (void **) &tmp); list_next(cur)) {
+		sha1_update(&ctx, "S", 1);
+		sha1_update(&ctx, tmp, strlen(tmp));
+		sha1_update(&ctx, "\0", 1);
+	}
+	list_cursor_destroy(cur);
+
+	cur = list_cursor_create(h->targets);
+	for (list_seek(cur, 0); list_get(cur, (void **) &tmp); list_next(cur)) {
+		sha1_update(&ctx, "T", 1);
+		sha1_update(&ctx, tmp, strlen(tmp));
+		sha1_update(&ctx, "\0", 1);
+	}
+	list_cursor_destroy(cur);
+
+	sha1_final(digest, &ctx);
+
+	free(h->command);
+	free(h->makeflow);
+	free(h->cwd);
+	list_free(h->sources);
+	list_free(h->targets);
+	list_delete(h->sources);
+	list_delete(h->targets);
+	free(h);
+}

--- a/makeflow/src/dag_node_hash.c
+++ b/makeflow/src/dag_node_hash.c
@@ -28,7 +28,7 @@ struct dag_node_hash *dag_node_hash_create(void) {
 }
 
 void dag_node_hash_command(struct dag_node_hash *h, const char *cmd) {
-	assert(h);
+	if (!h) return;
 	assert(cmd);
 	assert(!h->command);
 	assert(!h->makeflow);

--- a/makeflow/src/dag_node_hash.h
+++ b/makeflow/src/dag_node_hash.h
@@ -1,0 +1,22 @@
+/*
+Copyright (C) 2018- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#ifndef DAG_NODE_HASH_H
+#define DAG_NODE_HASH_H
+
+#include "sha1.h"
+
+struct dag_node_hash *dag_node_hash_create(void);
+
+void dag_node_hash_command(struct dag_node_hash *h, const char *cmd);
+void dag_node_hash_makeflow(struct dag_node_hash *h, const char *dag, const char *cwd);
+void dag_node_hash_source(struct dag_node_hash *h, const char *src);
+void dag_node_hash_target(struct dag_node_hash *h, const char *tgt);
+
+// frees h
+void dag_node_hash(struct dag_node_hash *h, unsigned char digest[SHA1_DIGEST_LENGTH]);
+
+#endif


### PR DESCRIPTION
This PR adds a hash to each `struct dag_node` based on its rule definition. I'm only hashing the following fields.

+ command
+ inputs
+ outputs

The hash is derived based on textual names, not file contents. Thus we can assign hash IDs while parsing. Archive mode would need to take more into account, such as file contents, environment, etc. These hashes are insensitive to ordering, both in the input/output lists and among the rules themselves. Adding a new rule is safe since it produces a fresh hash that's distinct from the existing rules. In addition, modifications to a rule will also result in a fresh hash.

This PR only defines a hashing scheme required for #1873. There are no changes to the log or to Makeflow's behavior. I imagine there will be some discussion about what should be covered by the hash, so I wanted to get this sorted out and merged before moving on.

CC @nhazekam @dthain @btovar 