### PR TITLE
Fix space in dir recursive get for wq

### DIFF
--- a/makeflow/test/dirs/testcase.subdir.01.makeflow
+++ b/makeflow/test/dirs/testcase.subdir.01.makeflow
@@ -4,4 +4,4 @@ MAKEFLOW_OUTPUTS=mydir
 
 # a single directory as a target
 mydir: input/hello
-	mkdir -p mydir; cp input/hello mydir/1.txt; cp input/hello mydir/2.txt
+	mkdir -p mydir; cp input/hello mydir/1.txt; cp input/hello mydir/2.txt; cp input/hello "mydir/3space\ .txt"

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -46,6 +46,7 @@ The following major problems must be fixed:
 #include "url_encode.h"
 #include "jx_print.h"
 #include "shell.h"
+#include "pattern.h"
 
 #include "host_disk_info.h"
 
@@ -1073,20 +1074,24 @@ static work_queue_result_code_t get_file_or_directory( struct work_queue *q, str
 
 	work_queue_result_code_t result = SUCCESS; //return success unless something fails below
 
+	char *tmp_remote_path = NULL;
+	char *length_str      = NULL;
+	char *errnum_str      = NULL;
+
 	// Process the recursive file/dir responses as they are sent.
 	while(1) {
 		char line[WORK_QUEUE_LINE_MAX];
-		char tmp_remote_path[WORK_QUEUE_LINE_MAX];
-		int64_t length;
-		int errnum;
+
+		free(tmp_remote_path);
+		free(length_str);
 
 		if(recv_worker_msg_retry(q, w, line, sizeof(line)) == MSG_FAILURE) {
 			result = WORKER_FAILURE;
 			break;
 		}
 
-		if(sscanf(line,"dir %s", tmp_remote_path)==1) {
-			char *tmp_local_name = string_format("%s%s",local_name,&tmp_remote_path[remote_name_len]);
+		if(pattern_match(line, "^dir (%S+) (%d+)$", &tmp_remote_path, &length_str) >= 0) {
+			char *tmp_local_name = string_format("%s%s",local_name, (tmp_remote_path + remote_name_len));
 			int result_dir = create_dir(tmp_local_name,0777);
 			if(!result_dir) {
 				debug(D_WQ, "Could not create directory - %s (%s)", tmp_local_name, strerror(errno));
@@ -1095,16 +1100,18 @@ static work_queue_result_code_t get_file_or_directory( struct work_queue *q, str
 				break;
 			}
 			free(tmp_local_name);
-		} else if(sscanf(line,"file %s %"SCNd64, tmp_remote_path, &length)==2) {
-			char *tmp_local_name = string_format("%s%s",local_name,&tmp_remote_path[remote_name_len]);
+		} else if(pattern_match(line, "^file (.+) (%d+)$", &tmp_remote_path, &length_str) >= 0) {
+			int64_t length = strtoll(length_str, NULL, 10);
+			char *tmp_local_name = string_format("%s%s",local_name, (tmp_remote_path + remote_name_len));
 			result = get_file(q,w,t,tmp_local_name,length,total_bytes);
 			free(tmp_local_name);
 			//Return if worker failure. Else wait for end message from worker.
 			if(result == WORKER_FAILURE) break;
-		} else if(sscanf(line,"missing %s %d",tmp_remote_path,&errnum)==2) {
+		} else if(pattern_match(line, "^missing (.+) (%d+)$", &tmp_remote_path, &errnum_str) >= 0) {
 			// If the output file is missing, we make a note of that in the task result,
 			// but we continue and consider the transfer a 'success' so that other
 			// outputs are transferred and the task is given back to the caller.
+			int errnum = atoi(errnum_str);
 			debug(D_WQ, "%s (%s): could not access requested file %s (%s)",w->hostname,w->addrport,remote_name,strerror(errnum));
 			update_task_result(t, WORK_QUEUE_RESULT_OUTPUT_MISSING);
 		} else if(!strcmp(line,"end")) {
@@ -1120,6 +1127,9 @@ static work_queue_result_code_t get_file_or_directory( struct work_queue *q, str
 			break;
 		}
 	}
+
+	free(tmp_remote_path);
+	free(length_str);
 
 	// If we failed to *transfer* the output file, then that is a hard
 	// failure which causes this function to return failure and the task

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -39,6 +39,7 @@ See the file COPYING for details.
 #include "url_encode.h"
 #include "md5.h"
 #include "disk_alloc.h"
+#include "pattern.h"
 
 #include <unistd.h>
 #include <dirent.h>
@@ -1397,18 +1398,28 @@ static int handle_master(struct link *master) {
 	char path[WORK_QUEUE_LINE_MAX];
 	int64_t length;
 	int64_t taskid = 0;
-	int flags = WORK_QUEUE_NOCACHE;
 	int mode, r, n;
 
 	if(recv_master_message(master, line, sizeof(line), idle_stoptime )) {
 		if(sscanf(line,"task %" SCNd64, &taskid)==1) {
 			r = do_task(master, taskid,time(0)+active_timeout);
-		} else if((n = sscanf(line, "put %s %" SCNd64 " %o %d", filename, &length, &mode, &flags)) >= 3) {
-			if(path_within_dir(filename, workspace)) {
-				r = do_put(master, filename, length, mode);
-				reset_idle_timer();
+		} else if(string_prefix_is(line, "put ")) {
+			char *f = NULL, *l = NULL, *m = NULL, *g = NULL;
+			if(pattern_match(line, "^put (.+) (%d+) ([0-7]+) (%d+)$", &f, &l, &m, &g) >= 0) {
+				strncpy(filename, f, WORK_QUEUE_LINE_MAX); free(f);
+				length = strtoll(l, 0, 10); free(l);
+				mode   = atoi(m);           free(m);
+				free(g); //flags are not used anymore.
+				
+				if(path_within_dir(filename, workspace)) {
+					r = do_put(master, filename, length, mode);
+					reset_idle_timer();
+				} else {
+					debug(D_WQ, "Path - %s is not within workspace %s.", filename, workspace);
+					r = 0;
+				}
 			} else {
-				debug(D_WQ, "Path - %s is not within workspace %s.", filename, workspace);
+				debug(D_WQ, "Malformed put message.");
 				r = 0;
 			}
 		} else if(sscanf(line, "url %s %" SCNd64 " %o", filename, &length, &mode) == 3) {


### PR DESCRIPTION
This is a quick fix for #1892. Instead of using scanf, we use pattern_match.

This should be the final solution, as it breaks the syntax of the protocol (i.e., tokens separated by a space). It does preserve, however, backwards compatibility.