### PR TITLE
Add string comparison function for list_sort

### DIFF
--- a/dttools/src/stringtools.c
+++ b/dttools/src/stringtools.c
@@ -24,6 +24,13 @@ See the file COPYING for details.
 #include <stdlib.h>
 #include <string.h>
 
+int string_compare(const void *p1, const void *p2) {
+	/* The actual arguments to this function are "pointers to
+	 * pointers to char", but strcmp(3) arguments are "pointers
+	 * to char", hence the following cast plus dereference */
+	return strcmp(* (char * const *) p1, * (char * const *) p2);
+}
+
 /*
  * Based on opengroup.org's definition of the Shell Command Language (also gnu's)
  * In section 2.2.3 on Double-Quoted Strings, it indicates you only need to

--- a/dttools/src/stringtools.h
+++ b/dttools/src/stringtools.h
@@ -15,6 +15,11 @@ See the file COPYING for details.
 
 typedef char *(*string_subst_lookup_t) (const char *name, void *arg);
 
+/** Comparison function for an array of strings.
+ * This is useful with qsort(3) and list_sort().
+ */
+int string_compare(const void *p1, const void *p2);
+
 /** Takes a command string and escapes special characters in the Shell Command
   language. Mallocs space for new string and does not modify original string.
   Characters dollar-sign $, backtick `, backslash \, and double-quote " are


### PR DESCRIPTION
I needed to use `strcmp()` to sort a list of strings. There are some pointer gymnastics required to work with list_sort, so I pulled this from `qsort(3)`.