### PR TITLE
use perl and python from host, not afs

### DIFF
--- a/configure.afs
+++ b/configure.afs
@@ -23,7 +23,8 @@ detect_packages()
 	echo "$0: Detecting packages ..."
 
 	PACKAGES_CONFIG=""
-	for package in fuse irods mysql python perl python3 globus swig xrootd cvmfs uuid
+        # perl and python taken from host
+	for package in fuse irods mysql python3 globus swig xrootd cvmfs uuid
 	do
 	packagepath=$EXTERNAL/${PLATFORM}/$package/cctools-dep
 


### PR DESCRIPTION
Use host's python and perl for the binary distributions.