### PR TITLE
Fix jx2json eval so that context changes are visible to subsequent args

### DIFF
--- a/dttools/src/jx2json.c
+++ b/dttools/src/jx2json.c
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]) {
 						optarg);
 					return 1;
 				}
-				tmp = jx_eval(body, NULL);
+				tmp = jx_eval(body, ctx);
 				jx_delete(body);
 				body = tmp;
 				if (jx_istype(body, JX_ERROR)) {
@@ -94,7 +94,7 @@ int main(int argc, char *argv[]) {
 					fprintf(stderr, "malformed JX expression\n");
 					return 1;
 				}
-				tmp = jx_eval(body, NULL);
+				tmp = jx_eval(body, ctx);
 				jx_delete(body);
 				if (jx_istype(tmp, JX_ERROR)) {
 					printf("invalid expression\n");


### PR DESCRIPTION
I had just used an empty context as the default when `eval()`ing each piece, but context changes should be visible to other args, not just the final document. So for example, this PR lets you fill in variables in a context file by defining them earlier on the command line.