### PR TITLE
JX Embedded Context

### DIFF
--- a/dttools/src/jx2json.c
+++ b/dttools/src/jx2json.c
@@ -143,7 +143,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	tmp = body;
-	body = jx_eval(body, ctx);
+	body = jx_eval_with_defines(body, ctx);
 	jx_delete(tmp);
 	print_stream(body, stdout);
 	printf("\n");

--- a/dttools/src/jx_eval.h
+++ b/dttools/src/jx_eval.h
@@ -19,4 +19,16 @@ If the expression is invalid in some way, an object of type @ref JX_NULL is retu
 */
 struct jx * jx_eval( struct jx *j, struct jx *context );
 
+/** Evaluate an expression with embedded definitions.
+Same as @ref jx_eval, except first looks for a "defines"
+clause and combines that with the context.  Allows an
+expression to have its own bound values, for convenience.
+@param j The expression to evaluate, which may contain a "defines" clause.
+@param context An object in which values will be found.
+@return A newly created result expression, which must be deleted with @ref jx_delete.
+If the expression is invalid in some way, an object of type @ref JX_NULL is returned.
+*/
+struct jx * jx_eval_with_defines( struct jx *j, struct jx* context );
+
+
 #endif

--- a/makeflow/src/dag_visitors.c
+++ b/makeflow/src/dag_visitors.c
@@ -1240,13 +1240,19 @@ struct jx *dag_nodes_to_json(struct dag_node *node) {
 
 	while(n) {
 		rule = jx_object(NULL);
-		jx_insert(rule, jx_string("local_job"), jx_boolean(n->local_job));
-		jx_insert(rule, jx_string("category"), jx_string(n->category->name));
+		if(n->local_job) {
+			jx_insert(rule, jx_string("local_job"), jx_boolean(n->local_job));
+		}
+		if(strcmp(n->category->name,"default")) {
+			jx_insert(rule, jx_string("category"), jx_string(n->category->name));
+		}
 		jx_insert_unless_empty(rule, jx_string("environment"), variables_to_json(n->variables));
 		jx_insert_unless_empty(rule, jx_string("resources"), resources_to_json(n->resources_requested));
 		jx_insert(rule, jx_string("inputs"), files_to_json(n->source_files, n->remote_names));
 		jx_insert(rule, jx_string("outputs"), files_to_json(n->target_files, n->remote_names));
-		jx_insert(rule, jx_string("allocation"), category_allocation_to_json(n->resource_request));
+		if(n->resource_request!=CATEGORY_ALLOCATION_FIRST) {
+			jx_insert(rule, jx_string("allocation"), category_allocation_to_json(n->resource_request));
+		}
 
 		if(n->nested_job) {
 			submakeflow = jx_object(NULL);

--- a/makeflow/src/dag_visitors.c
+++ b/makeflow/src/dag_visitors.c
@@ -1240,20 +1240,19 @@ struct jx *dag_nodes_to_json(struct dag_node *node) {
 
 	while(n) {
 		rule = jx_object(NULL);
-		if(n->local_job) {
-			jx_insert(rule, jx_string("local_job"), jx_boolean(n->local_job));
+		if(n->resource_request!=CATEGORY_ALLOCATION_FIRST) {
+			jx_insert(rule, jx_string("allocation"), category_allocation_to_json(n->resource_request));
 		}
 		if(strcmp(n->category->name,"default")) {
 			jx_insert(rule, jx_string("category"), jx_string(n->category->name));
 		}
-		jx_insert_unless_empty(rule, jx_string("environment"), variables_to_json(n->variables));
 		jx_insert_unless_empty(rule, jx_string("resources"), resources_to_json(n->resources_requested));
-		jx_insert(rule, jx_string("inputs"), files_to_json(n->source_files, n->remote_names));
+		jx_insert_unless_empty(rule, jx_string("environment"), variables_to_json(n->variables));
 		jx_insert(rule, jx_string("outputs"), files_to_json(n->target_files, n->remote_names));
-		if(n->resource_request!=CATEGORY_ALLOCATION_FIRST) {
-			jx_insert(rule, jx_string("allocation"), category_allocation_to_json(n->resource_request));
+		jx_insert(rule, jx_string("inputs"), files_to_json(n->source_files, n->remote_names));
+		if(n->local_job) {
+			jx_insert(rule, jx_string("local_job"), jx_boolean(n->local_job));
 		}
-
 		if(n->nested_job) {
 			submakeflow = jx_object(NULL);
 			jx_insert(submakeflow, jx_string("path"), jx_string(n->makeflow_dag));

--- a/makeflow/src/dag_visitors.c
+++ b/makeflow/src/dag_visitors.c
@@ -1213,15 +1213,21 @@ struct jx *category_to_json(struct category *c) {
 struct jx *files_to_json(struct list *files, struct itable *remote_names) {
 	struct jx *result = jx_array(NULL);
 	struct dag_file *file;
-	const char *r;
+
 	list_first_item(files);
 	while((file = list_next_item(files))) {
-		struct jx *f = jx_object(NULL);
-		jx_insert(f, jx_string("name"), jx_string(file->filename));
-		if((r = itable_lookup(remote_names, (uintptr_t) file))) {
-			jx_insert(f, jx_string("source"), jx_string(r));
+
+		const char *task_name = file->filename;
+		const char *dag_name = itable_lookup(remote_names,(uintptr_t)file);
+
+		if(dag_name) {
+			struct jx *f = jx_object(NULL);
+			jx_insert(f, jx_string("task_name"),jx_string(task_name));
+			jx_insert(f, jx_string("dag_name"),jx_string(dag_name));
+			jx_array_insert(result, f);
+		} else {
+			jx_array_insert(result,jx_string(task_name));
 		}
-		jx_array_insert(result, f);
 	}
 	return result;
 }

--- a/makeflow/src/parser.c
+++ b/makeflow/src/parser.c
@@ -63,9 +63,6 @@ struct dag *dag_from_file(const char *filename, dag_syntax_type format, struct j
 	FILE *dagfile = NULL;
 	struct jx *dag = NULL;
 	struct jx *jx_tmp = NULL;
-	struct jx *defines = NULL;
-	struct jx *context = NULL;
-	struct jx *econtext = NULL;
 	struct dag *d = NULL;
 
 	// Initial verification of file existence
@@ -98,24 +95,7 @@ struct dag *dag_from_file(const char *filename, dag_syntax_type format, struct j
 			fclose(dagfile);
 			break;
 		case DAG_SYNTAX_JX: //Evaluates the pending JX Variables from args file
-			// If the dag contains a "define" clause, then add that to the external context
-			defines = jx_lookup(dag,"define");
-			if(!defines) defines = jx_object(0);
-			if(!args) args = jx_object(0);
-
-			context = jx_merge(defines,args,0);
-
-			// Evaluate the context to resolve any shorthands
-			econtext = jx_eval(context,context);
-			if(!econtext) {
-			  fprintf(stderr,"makeflow: error in context definitions:\n");
-				jx_print_stream(context,stderr);
-				printf("\n");
-				return 0;
-			}
-
-			jx_tmp = jx_eval(dag,econtext);
-			jx_delete(context);
+			jx_tmp = jx_eval_with_defines(dag,args);
 			jx_delete(dag);
 			jx_delete(args);
 			dag = jx_tmp;

--- a/makeflow/src/parser.c
+++ b/makeflow/src/parser.c
@@ -65,6 +65,7 @@ struct dag *dag_from_file(const char *filename, dag_syntax_type format, struct j
 	struct jx *jx_tmp = NULL;
 	struct jx *defines = NULL;
 	struct jx *context = NULL;
+	struct jx *econtext = NULL;
 	struct dag *d = NULL;
 
 	// Initial verification of file existence
@@ -104,7 +105,17 @@ struct dag *dag_from_file(const char *filename, dag_syntax_type format, struct j
 
 			context = jx_merge(defines,args,0);
 
-			jx_tmp = jx_eval(dag,context);
+			// Evaluate the context to resolve any shorthands
+			econtext = jx_eval(context,context);
+			if(!econtext) {
+			  fprintf(stderr,"makeflow: error in context definitions:\n");
+				jx_print_stream(context,stderr);
+				printf("\n");
+				return 0;
+			}
+
+			jx_tmp = jx_eval(dag,econtext);
+			jx_delete(context);
 			jx_delete(dag);
 			jx_delete(args);
 			dag = jx_tmp;


### PR DESCRIPTION
Under the existing JX code, there is no obvious translation of our example "convert" workflow into a JX form, because one must always have a separate file in order to define values for substitution.  This PR allows a JX document to have a "define" section which is merged into the context for evaluation, allowing you to have a self-contained document.

Also, the context is evaluated against itself, which allows various definitions to build upon each other, or to use non-atomic values such as list comprehensions..

I'm not entirely sure about the appropriate name of this section.
Maybe "let" or "define" or "constants" or ...

For example:

```
{
  "define": {
    "CONVERT":"/usr/bin/convert",
    "CURL":"/usr/bin/curl",
    "URL":"http://ccl.cse.nd.edu/images/capitol.jpg",
    "RANGE":range(0,360,90)
  },
  "rules": [
    {
      "command": CONVERT+" -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.anim.gif",
      "local_job":true,
      "inputs": [
        "capitol.jpg",
        format("capitol.%d.jpg",N) for N in RANGE,
        CONVERT,
      ],
      "outputs": [ "capitol.anim.gif" ]
    },    
    {
      "command":format("%s -swirl %d capitol.jpg capitol.%d.jpg",CONVERT,N,N),
      "inputs": [ "capitol.jpg", CONVERT ],
      "outputs": [ format("capitol.%d.jpg",N) ]
    } for N in RANGE,
      
    {
      "command":CURL+" -o capitol.jpg http://ccl.cse.nd.edu/images/capitol.jpg",
      "local_job":true,
      "inputs" : [ CURL ],
      "outputs": [ "capitol.jpg" ]
    }
  ]
}
```

Now, I do realize we are slowly stretching the "pure" JX into something more when used with workflows. @btovar @nhazekam @trshaffer @nkremerh any thoughts on this?

