### PR TITLE
JX String Concatenation

### DIFF
--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -431,6 +431,19 @@ void jx_delete( struct jx *j )
 	free(j);
 }
 
+int jx_isatomic( struct jx *j )
+{
+	switch(j->type) {
+		case JX_BOOLEAN:
+		case JX_STRING:
+		case JX_INTEGER:
+		case JX_DOUBLE:
+			return 1;
+		default:
+			return 0;
+	}
+}
+
 int jx_istype( struct jx *j, jx_type_t type )
 {
 	return j && j->type==type;

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -209,6 +209,9 @@ struct jx_comprehension *jx_comprehension(const char *variable, struct jx *eleme
 /** Test an expression's type.  @param j An expression. @param type The desired type. @return True if the expression type matches, false otherwise. */
 int jx_istype( struct jx *j, jx_type_t type );
 
+/** Test for an atomic value. @param j An expression.  @return True if the expression is an atomic integer, float, string or boolean. */
+int jx_isatomic( struct jx *j );
+
 /** Test an expression for the boolean value TRUE.  @param j An expression to test.  @return True if the expression is boolean and true. */
 int jx_istrue( struct jx *j );
 

--- a/dttools/src/jx_eval.c
+++ b/dttools/src/jx_eval.c
@@ -398,6 +398,21 @@ static struct jx * jx_eval_operator( struct jx_operator *o, struct jx *context )
 			jx_delete(left);
 			jx_delete(right);
 			return r;
+		} else if(o->type==JX_OP_ADD && left->type==JX_STRING) {
+
+			char *str = jx_print_string(right);
+			jx_delete(right);
+			right = jx_string(str);
+			free(str);
+			/* fall through */
+
+		} else if(o->type==JX_OP_ADD && right->type==JX_STRING) {
+			char *str = jx_print_string(left);
+			jx_delete(left);
+			left = jx_string(str);
+			free(str);
+			/* fall through */
+ 			
 		} else {
 			FAILOP(2, o, left, right, "mismatched types for operator");
 		}

--- a/dttools/src/jx_eval.c
+++ b/dttools/src/jx_eval.c
@@ -340,8 +340,9 @@ static struct jx * jx_eval_lookup( struct jx *left, struct jx *right )
 Type conversion rules:
 Generally, operators are not meant to be applied to unequal types.
 NULL is the result of an operator on two incompatible expressions.
-Exception: When x and y are incompatible types, x==y returns FALSE and x!=y returns TRUE.
 Exception: integers are promoted to doubles as needed.
+Exception: string+x or x+string for atomic types results in converting x to string and concatenating.
+Exception: When x and y are incompatible types, x==y returns FALSE and x!=y returns TRUE.
 Exception: The lookup operation can be "object[string]" or "array[integer]"
 */
 
@@ -398,7 +399,7 @@ static struct jx * jx_eval_operator( struct jx_operator *o, struct jx *context )
 			jx_delete(left);
 			jx_delete(right);
 			return r;
-		} else if(o->type==JX_OP_ADD && left->type==JX_STRING) {
+		} else if(o->type==JX_OP_ADD && jx_istype(left,JX_STRING) && jx_isatomic(right) ) {
 
 			char *str = jx_print_string(right);
 			jx_delete(right);
@@ -406,7 +407,7 @@ static struct jx * jx_eval_operator( struct jx_operator *o, struct jx *context )
 			free(str);
 			/* fall through */
 
-		} else if(o->type==JX_OP_ADD && right->type==JX_STRING) {
+		} else if(o->type==JX_OP_ADD && jx_istype(right,JX_STRING) && jx_isatomic(left) ) {
 			char *str = jx_print_string(left);
 			jx_delete(left);
 			left = jx_string(str);

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -603,6 +603,15 @@ value:      "\"\\$(pwd)/\\\"test program\\\" -x \\`date\\`\""
 expression: escape("y\\x")
 value:      "\"y\\\\x\""
 
+expression: "hello "+1+" world"
+value:      "hello 1 world"
+
+expression: true+" maybe "+false
+value:      "true maybe false"
+
+expression: "pi is "+3.14159
+value:      "pi is 3.14159"
+
 expression: Error{"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"}
 value:      Error{"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"}
 

--- a/dttools/test/jx.input
+++ b/dttools/test/jx.input
@@ -249,6 +249,10 @@ escape("echo $PATH")
 escape("$(pwd)/\"test program\" -x `date`");
 escape("y\\x");
 
+"hello " + 1 + " world"
+true + " maybe " + false
+"pi is " + 3.141592654
+
 Error{"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"};
 
 #end


### PR DESCRIPTION
Overload the + operator to allow for string concatenation between unequal types.
