### PR TITLE
copy_dir_real fix in copy_tree.c

### DIFF
--- a/dttools/src/copy_tree.c
+++ b/dttools/src/copy_tree.c
@@ -95,7 +95,7 @@ int copy_dir_real(const char *source, const char *target) {
 		return -1;
 	}
 
-	while((entry = readdir(dir)))
+	while((entry = readdir(dir)) != NULL)
 	{
 		char *s = NULL;
 		char *t = NULL;
@@ -116,7 +116,7 @@ int copy_dir_real(const char *source, const char *target) {
 			goto finish;
 		}
 
-		if (copy_direntry(s, t) != 0) {
+		if (copy_direntry(s, t) == -1) {
 			free(s);
 			free(t);
 			goto finish;


### PR DESCRIPTION
This error would always produce a logic error where only one entry in the directory is being copied over due to breaking from the while loop when something other than 0 returning from copy_direntry. This function will not necessarily always return 0 when it successfully runs but it will return -1 on error. The change in the conditional statement may not be necessary but was added for clarity on when the while loop will terminate.