### PR TITLE
Add No Eval Option to jx2json

### DIFF
--- a/dttools/src/jx2json.c
+++ b/dttools/src/jx2json.c
@@ -28,6 +28,7 @@ static void show_help() {
 	printf(optfmt, "-d", "--define <VAR>=<EXPR>", "Bind EXPR to the variable VAR.");
 	printf(optfmt, "-c", "--context <FILE>", "Deprecated.");
 	printf(optfmt, "-p", "--pretty", "Print more readable JSON");
+	printf(optfmt, "-n", "--noeval", "Don't evaluate, just print parsed JX.");
 	printf(optfmt, "-v", "--version", "Show version number");
 	printf(optfmt, "-h", "--help", "Help: Show these options");
 }
@@ -36,6 +37,7 @@ static const struct option long_options[] = {
 	{"help", no_argument, 0, 'h'},
 	{"version", no_argument, 0, 'v'},
 	{"pretty", no_argument, 0, 'p'},
+	{"noeval", no_argument, 0, 'n'},
 	{"context", required_argument, 0, 'a'},
 	{"define", required_argument, 0, 'd'},
 	{"args", required_argument, 0, 'a'},
@@ -49,9 +51,10 @@ int main(int argc, char *argv[]) {
 	struct jx *tmp = NULL;
 	char *s;
 	void (*print_stream)(struct jx *, FILE *) = jx_print_stream;
+	int do_eval = 1;
 
 	int c;
-	while ((c = getopt_long(argc, argv, "vha:d:p", long_options, NULL)) > -1) {
+	while ((c = getopt_long(argc, argv, "vha:d:pn", long_options, NULL)) > -1) {
 		switch (c) {
 			case 'a': {
 				FILE *f = fopen(optarg, "r");
@@ -67,9 +70,13 @@ int main(int argc, char *argv[]) {
 						optarg);
 					return 1;
 				}
-				tmp = jx_eval(body, ctx);
-				jx_delete(body);
-				body = tmp;
+
+				if(do_eval) {
+					tmp = jx_eval(body, ctx);
+					jx_delete(body);
+					body = tmp;
+				}
+
 				if (jx_istype(body, JX_ERROR)) {
 					printf("invalid args\n");
 					print_stream(ctx, stdout);
@@ -94,18 +101,25 @@ int main(int argc, char *argv[]) {
 					fprintf(stderr, "malformed JX expression\n");
 					return 1;
 				}
-				tmp = jx_eval(body, ctx);
-				jx_delete(body);
-				if (jx_istype(tmp, JX_ERROR)) {
+				if(do_eval) {
+					tmp = jx_eval(body, ctx);
+					jx_delete(body);
+					body = tmp;
+				}
+
+				if (jx_istype(body, JX_ERROR)) {
 					printf("invalid expression\n");
 					print_stream(ctx, stdout);
 					printf("\n");
 					return 1;
 				}
-				jx_insert(ctx, jx_string(optarg), tmp);
+				jx_insert(ctx, jx_string(optarg), body);
 				break;
 			case 'p':
 				print_stream = jx_pretty_print_stream;
+				break;
+			case 'n':
+				do_eval = 0;
 				break;
 			case 'h':
 				show_help();
@@ -142,9 +156,12 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 
-	tmp = body;
-	body = jx_eval_with_defines(body, ctx);
-	jx_delete(tmp);
+	if(do_eval) {
+		tmp = jx_eval_with_defines(body, ctx);
+		jx_delete(body);
+		body = tmp;
+	}
+
 	print_stream(body, stdout);
 	printf("\n");
 	jx_delete(body);


### PR DESCRIPTION
Allows for `jx2json -np < file.jx` to pretty-print JX without evaluating it to JSON.
Handy for reformatting workflows.
