### PR TITLE
JX eval errors

### DIFF
--- a/dttools/src/.gitignore
+++ b/dttools/src/.gitignore
@@ -28,3 +28,4 @@ worker
 worker_condor_submit
 libforce_halt_enospc.so
 jx_count_obj_test
+jx2env

--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -7,6 +7,7 @@ See the file COPYING for details.
 #include "jx.h"
 #include "stringtools.h"
 #include "buffer.h"
+#include "xxmalloc.h"
 
 #include <assert.h>
 #include <stdarg.h>
@@ -44,7 +45,7 @@ struct jx_comprehension *jx_comprehension(const char *variable, struct jx *eleme
 
 static struct jx * jx_create( jx_type_t type )
 {
-	struct jx *j = calloc(1, sizeof(*j));
+	struct jx *j = xxcalloc(1, sizeof(*j));
 	j->type = type;
 	return j;
 }
@@ -136,7 +137,7 @@ struct jx * jx_operator( jx_operator_t type, struct jx *left, struct jx *right )
 
 struct jx * jx_error( struct jx *err )
 {
-	if(!jx_error_valid(err)) return NULL;
+	if(!err) return NULL;
 	struct jx *j = jx_create(JX_ERROR);
 	j->u.err = err;
 	return j;
@@ -707,26 +708,4 @@ const char *jx_iterate_keys(struct jx *j, void **i) {
 struct jx * jx_iterate_values(struct jx *j, void **i) {
 	advance_object_iter(j, i);
 	return jx_get_value(i);
-}
-
-const char *jx_error_name(int code) {
-	switch (code) {
-	case 0: return "undefined symbol";
-	case 1: return "unsupported operator";
-	case 2: return "mismatched types";
-	case 3: return "key not found";
-	case 4: return "range error";
-	case 5: return "arithmetic error";
-	case 6: return "invalid arguments";
-	case 7: return "invalid context";
-	default: return "unknown error";
-	}
-}
-
-int jx_error_valid(struct jx *j) {
-	if (!jx_istype(j, JX_OBJECT)) return 0;
-	if (!jx_istype(jx_lookup(j, "source"), JX_STRING)) return 0;
-	if (!jx_istype(jx_lookup(j, "name"), JX_STRING)) return 0;
-	if (!jx_istype(jx_lookup(j, "message"), JX_STRING)) return 0;
-	return 1;
 }

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -170,7 +170,7 @@ struct jx * jx_format( const char *fmt, ... );
 */
 struct jx * jx_symbol( const char *symbol_name );
 
-/** Create a JX_ERROR. @param err The associated data for the error. This object MUST have a string at the "source" key. @return A JX error value, or NULL if "source" is missing. */
+/** Create a JX_ERROR. @param err The associated data for the error. This should be a string description of the error. @return A JX error value. */
 struct jx * jx_error( struct jx *err );
 
 /** Create a JX_FUNCTION. @param params The list of JX_STRING parameter names.
@@ -383,11 +383,5 @@ struct jx *jx_get_value(void **i);
 
 /** Merge an arbitrary number of JX_OBJECTs into a single new one. The constituent objects are not consumed. Objects are merged in the order given, i.e. a key can replace an identical key in a preceding object. The last argument must be NULL to mark the end of the list. @return A merged JX_OBJECT that must be deleted with jx_delete. */
 struct jx *jx_merge(struct jx *j, ...);
-
-/** Get a human-readable name from an error code. @param code The numeric error code to check. */
-const char *jx_error_name(int code);
-
-/** Check if the given JX object has all the required fields for an error. @param j The object to check. */
-int jx_error_valid(struct jx *j);
 
 #endif

--- a/dttools/src/jx_eval.c
+++ b/dttools/src/jx_eval.c
@@ -22,7 +22,6 @@ See the file COPYING for details.
 	jx_insert(ebidfgds, jx_string("operator"), jx_operator(op->type, left, right)); \
 	if (op->line) jx_insert_integer(ebidfgds, "line", op->line); \
 	jx_insert_string(ebidfgds, "message", message); \
-	jx_insert_string(ebidfgds, "name", jx_error_name(code)); \
 	jx_insert_string(ebidfgds, "source", "jx_eval"); \
 	return jx_error(ebidfgds); \
 } while (false)
@@ -35,7 +34,6 @@ See the file COPYING for details.
 	jx_insert(ekjhgsae, jx_string("index"), jx_copy(index)); \
 	if (index && index->line) jx_insert_integer(ekjhgsae, "line", index->line); \
 	jx_insert_string(ekjhgsae, "message", message); \
-	jx_insert_string(ekjhgsae, "name", jx_error_name(4)); \
 	jx_insert_string(ekjhgsae, "source", "jx_eval"); \
 	return jx_error(ekjhgsae); \
 } while (false)
@@ -48,7 +46,6 @@ See the file COPYING for details.
 	jx_insert(edgibijs, jx_string("key"), jx_copy(key)); \
 	if (key && key->line) jx_insert_integer(edgibijs, "line", key->line); \
 	jx_insert_string(edgibijs, "message", message); \
-	jx_insert_string(edgibijs, "name", jx_error_name(3)); \
 	jx_insert_string(edgibijs, "source", "jx_eval"); \
 	return jx_error(edgibijs); \
 } while (false)
@@ -259,7 +256,6 @@ static struct jx *jx_eval_slice(struct jx *array, struct jx *slice) {
 		jx_insert(err, jx_string("operator"), jx_operator(JX_OP_LOOKUP, jx_copy(array), jx_copy(slice)));
 		if (array->line) jx_insert_integer(err, "line", array->line);
 		jx_insert_string(err, "message", "only arrays support slicing");
-		jx_insert_string(err, "name", jx_error_name(code));
 		jx_insert_string(err, "source", "jx_eval");
 		return jx_error(err);
 	}
@@ -329,7 +325,6 @@ static struct jx * jx_eval_lookup( struct jx *left, struct jx *right )
 		jx_insert(err, jx_string("operator"), jx_operator(JX_OP_LOOKUP, jx_copy(left), jx_copy(right)));
 		if (right && right->line) jx_insert_integer(err, "line", right->line);
 		jx_insert_string(err, "message", "invalid type for lookup");
-		jx_insert_string(err, "name", jx_error_name(code));
 		jx_insert_string(err, "source", "jx_eval");
 		return jx_error(err);
 
@@ -461,7 +456,6 @@ static struct jx_item *jx_eval_comprehension(struct jx *body, struct jx_comprehe
 		if (comp->line) jx_insert_integer(err, "line", comp->line);
 		jx_insert_string(
 			err, "message", "list comprehension takes an array");
-		jx_insert_string(err, "name", jx_error_name(2));
 		jx_insert_string(err, "source", "jx_eval");
 		return jx_item(jx_error(err), NULL);
 	}
@@ -493,7 +487,6 @@ static struct jx_item *jx_eval_comprehension(struct jx *body, struct jx_comprehe
 					jx_insert_integer(err, "line", cond->line);
 				jx_insert_string(err, "message",
 					"list comprehension condition takes a boolean");
-				jx_insert_string(err, "name", jx_error_name(2));
 				jx_insert_string(err, "source", "jx_eval");
 				return jx_item(jx_error(err), NULL);
 			}
@@ -617,7 +610,6 @@ struct jx * jx_eval( struct jx *j, struct jx *context )
 		jx_insert_integer(err, "code", code);
 		jx_insert(err, jx_string("context"), context);
 		jx_insert_string(err, "message", "context must be an object");
-		jx_insert_string(err, "name", jx_error_name(code));
 		jx_insert_string(err, "source", "jx_eval");
 		return jx_error(err);
 	}
@@ -646,8 +638,6 @@ struct jx * jx_eval( struct jx *j, struct jx *context )
 					jx_insert_integer(err, "line", j->line);
 				jx_insert_string(
 					err, "message", "undefined symbol");
-				jx_insert_string(
-					err, "name", jx_error_name(code));
 				jx_insert_string(err, "source", "jx_eval");
 				return jx_error(err);
 			}

--- a/dttools/src/jx_eval.c
+++ b/dttools/src/jx_eval.c
@@ -14,40 +14,33 @@ See the file COPYING for details.
 #include <stdbool.h>
 #include <math.h>
 
-// FAILOP(int code, jx_operator *op, struct jx *left, struct jx *right, const char *message)
+// FAILOP(jx_operator *op, struct jx *left, struct jx *right, const char *message)
 // left, right, and message are evaluated exactly once
-#define FAILOP(code, op, left, right, message) do { \
-	struct jx *ebidfgds = jx_object(NULL); \
-	jx_insert_integer(ebidfgds, "code", code); \
-	jx_insert(ebidfgds, jx_string("operator"), jx_operator(op->type, left, right)); \
-	if (op->line) jx_insert_integer(ebidfgds, "line", op->line); \
-	jx_insert_string(ebidfgds, "message", message); \
-	jx_insert_string(ebidfgds, "source", "jx_eval"); \
-	return jx_error(ebidfgds); \
+#define FAILOP(op, left, right, message) do { \
+	assert(op); \
+	assert(message); \
+	struct jx *t = jx_operator(op->type, left, right); \
+	char *s = jx_print_string(t); \
+	struct jx *e = jx_error(jx_format( \
+		"on line %d, %s: %s", \
+		op->line, \
+		s, \
+		message \
+	)); \
+	jx_delete(t); \
+	free(s); \
+	return e; \
 } while (false)
 
-// FAILARR(struct jx *array, struct jx *index, const char *message)
-#define FAILARR(array, index, message) do { \
-	struct jx *ekjhgsae = jx_object(NULL); \
-	jx_insert_integer(ekjhgsae, "code", 4); \
-	jx_insert(ekjhgsae, jx_string("array"), jx_copy(array)); \
-	jx_insert(ekjhgsae, jx_string("index"), jx_copy(index)); \
-	if (index && index->line) jx_insert_integer(ekjhgsae, "line", index->line); \
-	jx_insert_string(ekjhgsae, "message", message); \
-	jx_insert_string(ekjhgsae, "source", "jx_eval"); \
-	return jx_error(ekjhgsae); \
-} while (false)
-
-// FAILOBJ(struct jx *obj, struct jx *key, const char *message)
-#define FAILOBJ(obj, key, message) do { \
-	struct jx *edgibijs = jx_object(NULL); \
-	jx_insert_integer(edgibijs, "code", 3); \
-	jx_insert(edgibijs, jx_string("object"), jx_copy(obj)); \
-	jx_insert(edgibijs, jx_string("key"), jx_copy(key)); \
-	if (key && key->line) jx_insert_integer(edgibijs, "line", key->line); \
-	jx_insert_string(edgibijs, "message", message); \
-	jx_insert_string(edgibijs, "source", "jx_eval"); \
-	return jx_error(edgibijs); \
+// FAILARR(struct jx *array, const char *message)
+#define FAILARR(array, message) do { \
+	assert(array); \
+	assert(message); \
+	return jx_error(jx_format( \
+		"array reference on line %d: %s", \
+		array->line, \
+		message \
+	)); \
 } while (false)
 
 static struct jx *jx_check_errors(struct jx *j);
@@ -59,7 +52,7 @@ static struct jx *jx_eval_null(struct jx_operator *op, struct jx *left, struct j
 			return jx_boolean(1);
 		case JX_OP_NE:
 			return jx_boolean(0);
-		default: FAILOP(1, op, jx_null(), jx_null(), "unsupported operator on null");
+		default: FAILOP(op, jx_null(), jx_null(), "unsupported operator on null");
 	}
 }
 
@@ -79,7 +72,7 @@ static struct jx *jx_eval_boolean(struct jx_operator *op, struct jx *left, struc
 			return jx_boolean(a||b);
 		case JX_OP_NOT:
 			return jx_boolean(!b);
-		default: FAILOP(1, op, jx_copy(left), jx_copy(right), "unsupported operator on boolean");
+		default: FAILOP(op, jx_copy(left), jx_copy(right), "unsupported operator on boolean");
 	}
 }
 
@@ -108,12 +101,12 @@ static struct jx *jx_eval_integer(struct jx_operator *op, struct jx *left, struc
 		case JX_OP_MUL:
 			return jx_integer(a*b);
 		case JX_OP_DIV:
-			if(b==0) FAILOP(5, op, jx_copy(left), jx_copy(right), "division by zero");
+			if(b==0) FAILOP(op, jx_copy(left), jx_copy(right), "division by zero");
 			return jx_integer(a/b);
 		case JX_OP_MOD:
-			if(b==0) FAILOP(5, op, jx_copy(left), jx_copy(right), "division by zero");
+			if(b==0) FAILOP(op, jx_copy(left), jx_copy(right), "division by zero");
 			return jx_integer(a%b);
-		default: FAILOP(1, op, jx_copy(left), jx_copy(right), "unsupported operator on integer");
+		default: FAILOP(op, jx_copy(left), jx_copy(right), "unsupported operator on integer");
 	}
 }
 
@@ -142,12 +135,12 @@ static struct jx *jx_eval_double(struct jx_operator *op, struct jx *left, struct
 		case JX_OP_MUL:
 			return jx_double(a*b);
 		case JX_OP_DIV:
-			if(b==0) FAILOP(5, op, jx_copy(left), jx_copy(right), "division by zero");
+			if(b==0) FAILOP(op, jx_copy(left), jx_copy(right), "division by zero");
 			return jx_double(a/b);
 		case JX_OP_MOD:
-			if(b==0) FAILOP(5, op, jx_copy(left), jx_copy(right), "division by zero");
+			if(b==0) FAILOP(op, jx_copy(left), jx_copy(right), "division by zero");
 			return jx_double((jx_int_t)a%(jx_int_t)b);
-		default: FAILOP(1, op, jx_copy(left), jx_copy(right), "unsupported operator on double");
+		default: FAILOP(op, jx_copy(left), jx_copy(right), "unsupported operator on double");
 	}
 }
 
@@ -171,13 +164,13 @@ static struct jx *jx_eval_string(struct jx_operator *op, struct jx *left, struct
 			return jx_boolean(strcmp(a,b)>=0);
 		case JX_OP_ADD:
 			return jx_format("%s%s",a,b);
-		default: FAILOP(1, op, jx_copy(left), jx_copy(right), "unsupported operator on string");
+		default: FAILOP(op, jx_copy(left), jx_copy(right), "unsupported operator on string");
 	}
 }
 
 static struct jx *jx_eval_array(struct jx_operator *op, struct jx *left, struct jx *right) {
 	assert(op);
-	if (!(left && right)) FAILOP(1, op, jx_copy(left), jx_copy(right), "missing arguments to array operator");
+	if (!(left && right)) FAILOP(op, jx_copy(left), jx_copy(right), "missing arguments to array operator");
 
 	switch(op->type) {
 		case JX_OP_EQ:
@@ -186,7 +179,7 @@ static struct jx *jx_eval_array(struct jx_operator *op, struct jx *left, struct 
 			return jx_boolean(!jx_equals(left, right));
 		case JX_OP_ADD:
 			return jx_check_errors(jx_array_concat(jx_copy(left), jx_copy(right), NULL));
-		default: FAILOP(1, op, jx_copy(left), jx_copy(right), "unsupported operator on array");
+		default: FAILOP(op, jx_copy(left), jx_copy(right), "unsupported operator on array");
 	}
 }
 
@@ -250,18 +243,14 @@ static struct jx *jx_eval_slice(struct jx *array, struct jx *slice) {
 	struct jx *right = slice->u.oper.right;
 
 	if (array->type != JX_ARRAY) {
-		int code = 2;
-		struct jx *err = jx_object(NULL);
-		jx_insert_integer(err, "code", code);
-		jx_insert(err, jx_string("operator"), jx_operator(JX_OP_LOOKUP, jx_copy(array), jx_copy(slice)));
-		if (array->line) jx_insert_integer(err, "line", array->line);
-		jx_insert_string(err, "message", "only arrays support slicing");
-		jx_insert_string(err, "source", "jx_eval");
-		return jx_error(err);
+		return jx_error(jx_format(
+			"on line %d, only arrays support slicing",
+			right->line
+		));
 	}
-	if (left && left->type != JX_INTEGER) FAILOP(2, (&slice->u.oper), jx_copy(left), jx_copy(right),
+	if (left && left->type != JX_INTEGER) FAILOP((&slice->u.oper), jx_copy(left), jx_copy(right),
 		"slice indices must be integers");
-	if (right && right->type != JX_INTEGER) FAILOP(2, (&slice->u.oper), jx_copy(left), jx_copy(right),
+	if (right && right->type != JX_INTEGER) FAILOP((&slice->u.oper), jx_copy(left), jx_copy(right),
 		"slice indices must be integers");
 
 	struct jx *result = jx_array(NULL);
@@ -289,14 +278,16 @@ Handle a lookup operator, which has two valid cases:
 
 static struct jx * jx_eval_lookup( struct jx *left, struct jx *right )
 {
-	struct jx *err;
-	int code;
+	assert(right);
 	if(left->type==JX_OBJECT && right->type==JX_STRING) {
 		struct jx *r = jx_lookup(left,right->u.string_value);
 		if(r) {
 			return jx_copy(r);
 		} else {
-			FAILOBJ(left, right, "key not found");
+			return jx_error(jx_format(
+				"lookup on line %d, key not found",
+				right->line
+			));
 		}
 	} else if(left->type==JX_ARRAY && right->type==JX_INTEGER) {
 		struct jx_item *item = left->u.items;
@@ -304,11 +295,11 @@ static struct jx * jx_eval_lookup( struct jx *left, struct jx *right )
 
 		if (count < 0) {
 			count += jx_array_length(left);
-			if (count < 0) FAILARR(left, right, "index out of range");
+			if (count < 0) FAILARR(right, "index out of range");
 		}
 
 		while (count > 0) {
-			if (!item) FAILARR(left, right, "index out of range");
+			if (!item) FAILARR(right, "index out of range");
 			item = item->next;
 			count--;
 		}
@@ -316,16 +307,16 @@ static struct jx * jx_eval_lookup( struct jx *left, struct jx *right )
 		if (item) {
 			return jx_copy(item->value);
 		} else {
-			FAILARR(left, right, "index out of range");
+			FAILARR(right, "index out of range");
 		}
 	} else {
-		code = 1;
-		err = jx_object(NULL);
-		jx_insert_integer(err, "code", code);
-		jx_insert(err, jx_string("operator"), jx_operator(JX_OP_LOOKUP, jx_copy(left), jx_copy(right)));
-		if (right && right->line) jx_insert_integer(err, "line", right->line);
-		jx_insert_string(err, "message", "invalid type for lookup");
-		jx_insert_string(err, "source", "jx_eval");
+		char *s = jx_print_string(right);
+		struct jx *err = jx_error(jx_format(
+			"on line %d, %s: invalid type for lookup",
+			right->line,
+			s
+		));
+		free(s);
 		return jx_error(err);
 
 	}
@@ -410,7 +401,7 @@ static struct jx * jx_eval_operator( struct jx_operator *o, struct jx *context )
 			/* fall through */
  			
 		} else {
-			FAILOP(2, o, left, right, "mismatched types for operator");
+			FAILOP(o, left, right, "mismatched types for operator");
 		}
 	}
 
@@ -433,7 +424,7 @@ static struct jx * jx_eval_operator( struct jx_operator *o, struct jx *context )
 		case JX_ARRAY:
 			result = jx_eval_array(o, left, right);
 			break;
-		default: FAILOP(1, o, left, right, "rvalue does not support operators");
+		default: FAILOP(o, left, right, "rvalue does not support operators");
 	}
 
 DONE:
@@ -450,14 +441,10 @@ static struct jx_item *jx_eval_comprehension(struct jx *body, struct jx_comprehe
 	struct jx *list = jx_eval(comp->elements, context);
 	if (jx_istype(list, JX_ERROR)) return jx_item(list, NULL);
 	if (!jx_istype(list, JX_ARRAY)) {
-		struct jx *err = jx_object(NULL);
-		jx_insert_integer(err, "code", 2);
-		jx_insert(err, jx_string("list"), list);
-		if (comp->line) jx_insert_integer(err, "line", comp->line);
-		jx_insert_string(
-			err, "message", "list comprehension takes an array");
-		jx_insert_string(err, "source", "jx_eval");
-		return jx_item(jx_error(err), NULL);
+		return jx_item(jx_error(jx_format(
+			"on line %d: list comprehension takes an array",
+			comp->line
+		)), NULL);
 	}
 
 	struct jx_item *result = NULL;
@@ -480,15 +467,14 @@ static struct jx_item *jx_eval_comprehension(struct jx *body, struct jx_comprehe
 				jx_delete(ctx);
 				jx_delete(list);
 				jx_item_delete(result);
-				struct jx *err = jx_object(NULL);
-				jx_insert_integer(err, "code", 2);
-				jx_insert(err, jx_string("condition"), cond);
-				if (cond->line)
-					jx_insert_integer(err, "line", cond->line);
-				jx_insert_string(err, "message",
-					"list comprehension condition takes a boolean");
-				jx_insert_string(err, "source", "jx_eval");
-				return jx_item(jx_error(err), NULL);
+				char *s = jx_print_string(cond);
+				struct jx *err = jx_error(jx_format(
+					"on line %d, %s: list comprehension condition takes a boolean",
+					cond->line,
+					s
+				));
+				free(s);
+				return jx_item(err, NULL);
 			}
 			int ok = cond->u.boolean_value;
 			jx_delete(cond);
@@ -605,13 +591,7 @@ struct jx * jx_eval( struct jx *j, struct jx *context )
 		context = jx_object(NULL);
 	}
 	if (!jx_istype(context, JX_OBJECT)) {
-		struct jx *err = jx_object(NULL);
-		int code = 7;
-		jx_insert_integer(err, "code", code);
-		jx_insert(err, jx_string("context"), context);
-		jx_insert_string(err, "message", "context must be an object");
-		jx_insert_string(err, "source", "jx_eval");
-		return jx_error(err);
+		return jx_error(jx_string("context must be an object"));
 	}
 	jx_eval_add_builtin(context, "range", JX_BUILTIN_RANGE);
 	jx_eval_add_builtin(context, "format", JX_BUILTIN_FORMAT);
@@ -629,17 +609,11 @@ struct jx * jx_eval( struct jx *j, struct jx *context )
 				result = jx_eval(t,context);
 				break;
 			} else {
-				struct jx *err = jx_object(NULL);
-				int code = 0;
-				jx_insert_integer(err, "code", code);
-				jx_insert(err, jx_string("symbol"), jx_copy(j));
-				jx_insert(err, jx_string("context"), context);
-				if (j->line)
-					jx_insert_integer(err, "line", j->line);
-				jx_insert_string(
-					err, "message", "undefined symbol");
-				jx_insert_string(err, "source", "jx_eval");
-				return jx_error(err);
+				return jx_error(jx_format(
+					"on line %d, %s: undefined symbol",
+					j->line,
+					j->u.symbol_name
+				));
 			}
 		}
 		case JX_DOUBLE:

--- a/dttools/src/jx_function.c
+++ b/dttools/src/jx_function.c
@@ -19,21 +19,18 @@ See the file COPYING for details.
 #include "stringtools.h"
 #include "xxmalloc.h"
 
-// FAIL(const char *name, jx_builtin_t b struct jx *args, const char *message)
-#define FAIL(name, b, args, message)                                           \
-	do {                                                                   \
-		int ciuygssd = 6;                                              \
-		struct jx *ebijuaef = jx_object(NULL);                         \
-		jx_insert_integer(ebijuaef, "code", ciuygssd);                 \
-		jx_insert(ebijuaef, jx_string("function"),                     \
-			jx_operator(JX_OP_CALL,                                \
-				jx_function(name, b, NULL, NULL),              \
-				jx_copy(args)));                               \
-		if (args->line)                                                \
-			jx_insert_integer(ebijuaef, "line", args->line);       \
-		jx_insert_string(ebijuaef, "message", message);                \
-		jx_insert_string(ebijuaef, "source", "jx_eval");               \
-		return jx_error(ebijuaef);                                     \
+// FAIL(const char *name, struct jx *args, const char *message)
+#define FAIL(name, args, message) \
+	do { \
+		assert(name); \
+		assert(args); \
+		assert(message); \
+		return jx_error(jx_format( \
+			"function %s on line %d: %s", \
+			name, \
+			args->line, \
+			message \
+		)); \
 	} while (false)
 
 static char *jx_function_format_value(char spec, struct jx *args) {
@@ -133,7 +130,7 @@ FAILURE:
 	jx_delete(args);
 	free(result);
 	free(format);
-	FAIL(funcname, JX_BUILTIN_FORMAT, orig_args, err);
+	FAIL(funcname, orig_args, err);
 }
 
 // see https://docs.python.org/2/library/functions.html#range
@@ -151,12 +148,11 @@ struct jx *jx_function_range(struct jx *args) {
 		case 2: step = 1; break;
 		case 3: break;
 		default:
-			FAIL(funcname, JX_BUILTIN_RANGE, args,
-				"invalid arguments");
+			FAIL(funcname, args, "invalid arguments");
 	}
 
 	if (step == 0)
-		FAIL(funcname, JX_BUILTIN_RANGE, args, "step must be nonzero");
+		FAIL(funcname, args, "step must be nonzero");
 
 	struct jx *result = jx_array(NULL);
 
@@ -232,11 +228,11 @@ struct jx *jx_function_join(struct jx *orig_args) {
 	return j;
 	
 	FAILURE:
-	    jx_delete(args);
-	    jx_delete(list);
-		jx_delete(delimeter);
-		free(result);
-	    FAIL(funcname, JX_BUILTIN_JOIN, orig_args, err);
+	jx_delete(args);
+	jx_delete(list);
+	jx_delete(delimeter);
+	free(result);
+	FAIL(funcname, orig_args, err);
 }
 
 struct jx *jx_function_ceil(struct jx *orig_args) {
@@ -274,9 +270,9 @@ struct jx *jx_function_ceil(struct jx *orig_args) {
 	return result;
 	
 	FAILURE:
-	    jx_delete(args);
-	    jx_delete(val);
-	    FAIL(funcname, JX_BUILTIN_CEIL, orig_args, err);
+	jx_delete(args);
+	jx_delete(val);
+	FAIL(funcname, orig_args, err);
 }
 
 struct jx *jx_function_floor(struct jx *orig_args) {
@@ -314,9 +310,9 @@ struct jx *jx_function_floor(struct jx *orig_args) {
 	return result;
 	
 	FAILURE:
-	    jx_delete(args);
-	    jx_delete(val);
-	    FAIL(funcname, JX_BUILTIN_FLOOR, orig_args, err);
+	jx_delete(args);
+	jx_delete(val);
+	FAIL(funcname, orig_args, err);
 }
 
 
@@ -347,7 +343,7 @@ struct jx *jx_function_basename(struct jx *args) {
 	return result;
 
 	FAILURE:
-	FAIL(funcname, JX_BUILTIN_BASENAME, args, err);
+	FAIL(funcname, args, err);
 }
 
 struct jx *jx_function_dirname(struct jx *args) {
@@ -377,7 +373,7 @@ struct jx *jx_function_dirname(struct jx *args) {
 	return result;
 
 	FAILURE:
-	FAIL(funcname, JX_BUILTIN_DIRNAME, args, err);
+	FAIL(funcname, args, err);
 }
 
 struct jx *jx_function_escape(struct jx *args) {
@@ -407,5 +403,5 @@ struct jx *jx_function_escape(struct jx *args) {
 	return result;
 
 	FAILURE:
-	FAIL(funcname, JX_BUILTIN_ESCAPE, args, err);
+	FAIL(funcname, args, err);
 }

--- a/dttools/src/jx_function.c
+++ b/dttools/src/jx_function.c
@@ -32,7 +32,6 @@ See the file COPYING for details.
 		if (args->line)                                                \
 			jx_insert_integer(ebijuaef, "line", args->line);       \
 		jx_insert_string(ebijuaef, "message", message);                \
-		jx_insert_string(ebijuaef, "name", jx_error_name(ciuygssd));   \
 		jx_insert_string(ebijuaef, "source", "jx_eval");               \
 		return jx_error(ebijuaef);                                     \
 	} while (false)

--- a/dttools/src/jx_parse.c
+++ b/dttools/src/jx_parse.c
@@ -22,6 +22,7 @@ typedef enum {
 	JX_TOKEN_INTEGER,
 	JX_TOKEN_DOUBLE,
 	JX_TOKEN_STRING,
+	JX_TOKEN_ERROR,
 	JX_TOKEN_LBRACKET,
 	JX_TOKEN_RBRACKET,
 	JX_TOKEN_LBRACE,
@@ -405,6 +406,8 @@ static jx_token_t jx_scan( struct jx_parser *s )
 					return JX_TOKEN_IN;
 				} else if (!strcmp(s->token, "if")) {
 					return JX_TOKEN_IF;
+				} else if(!strcmp(s->token, "Error")) {
+					return JX_TOKEN_ERROR;
 				} else {
 					return JX_TOKEN_SYMBOL;
 				}
@@ -833,6 +836,18 @@ static struct jx * jx_parse_unary( struct jx_parser *s )
 			j = jx_operator(jx_token_to_operator(t), NULL, j);
 			j->line = line;
 			j->u.oper.line = line;
+			return j;
+		}
+		case JX_TOKEN_ERROR: {
+			unsigned line = s->line;
+			struct jx *j = jx_parse_postfix(s);
+			if (!j) {
+				jx_parse_error(s, "error is missing a required field");
+				return NULL;
+			}
+			j = jx_error(j);
+			j->line = line;
+			j->u.err->line = line;
 			return j;
 		}
 		default: {

--- a/dttools/src/jx_parse.c
+++ b/dttools/src/jx_parse.c
@@ -22,7 +22,6 @@ typedef enum {
 	JX_TOKEN_INTEGER,
 	JX_TOKEN_DOUBLE,
 	JX_TOKEN_STRING,
-	JX_TOKEN_ERROR,
 	JX_TOKEN_LBRACKET,
 	JX_TOKEN_RBRACKET,
 	JX_TOKEN_LBRACE,
@@ -406,8 +405,6 @@ static jx_token_t jx_scan( struct jx_parser *s )
 					return JX_TOKEN_IN;
 				} else if (!strcmp(s->token, "if")) {
 					return JX_TOKEN_IF;
-				} else if(!strcmp(s->token, "Error")) {
-					return JX_TOKEN_ERROR;
 				} else {
 					return JX_TOKEN_SYMBOL;
 				}
@@ -836,18 +833,6 @@ static struct jx * jx_parse_unary( struct jx_parser *s )
 			j = jx_operator(jx_token_to_operator(t), NULL, j);
 			j->line = line;
 			j->u.oper.line = line;
-			return j;
-		}
-		case JX_TOKEN_ERROR: {
-			unsigned line = s->line;
-			struct jx *j = jx_parse_postfix(s);
-			if (!j) {
-				jx_parse_error_c(s, "error is missing a required field");
-				return NULL;
-			}
-			j = jx_error(j);
-			j->line = line;
-			j->u.err->line = line;
 			return j;
 		}
 		default: {

--- a/dttools/src/jx_parse.c
+++ b/dttools/src/jx_parse.c
@@ -845,11 +845,6 @@ static struct jx * jx_parse_unary( struct jx_parser *s )
 				jx_parse_error_c(s, "error is missing a required field");
 				return NULL;
 			}
-			if (!jx_error_valid(j)) {
-				jx_delete(j);
-				jx_parse_error_c(s, "invalid error specification");
-				return NULL;
-			}
 			j = jx_error(j);
 			j->line = line;
 			j->u.err->line = line;

--- a/dttools/src/jx_parse.c
+++ b/dttools/src/jx_parse.c
@@ -843,7 +843,7 @@ static struct jx * jx_parse_unary( struct jx_parser *s )
 
 			t = jx_scan(s);
 			if (t != JX_TOKEN_LPAREN) {
-				jx_parse_error(s, "expected parentheses following error()");
+				jx_parse_error_c(s, "expected parentheses following error()");
 				return NULL;
 			}
 
@@ -856,7 +856,7 @@ static struct jx * jx_parse_unary( struct jx_parser *s )
 			t = jx_scan(s);
 			if (t != JX_TOKEN_RPAREN) {
 				jx_delete(j);
-				jx_parse_error(s, "expected closing parenthesis for error()");
+				jx_parse_error_c(s, "expected closing parenthesis for error()");
 				return NULL;
 			}
 

--- a/dttools/src/jx_print.c
+++ b/dttools/src/jx_print.c
@@ -191,8 +191,9 @@ void jx_print_buffer( struct jx *j, buffer_t *b )
 			break;
 		case JX_FUNCTION: buffer_putstring(b, j->u.func.name); break;
 		case JX_ERROR:
-			buffer_putstring(b,"Error");
+			buffer_putstring(b, "error(");
 			jx_print_buffer(j->u.err, b);
+			buffer_putstring(b, ")");
 			break;
 	}
 }

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -178,16 +178,16 @@ expression: a!=b
 value:      true
 
 expression: a<b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":82,"operator":true<false,"code":1}
+value:      error("on line 82, true<false: unsupported operator on boolean")
 
 expression: a>b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":83,"operator":true>false,"code":1}
+value:      error("on line 83, true>false: unsupported operator on boolean")
 
 expression: a<=b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":84,"operator":true<=false,"code":1}
+value:      error("on line 84, true<=false: unsupported operator on boolean")
 
 expression: a>=b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":85,"operator":true>=false,"code":1}
+value:      error("on line 85, true>=false: unsupported operator on boolean")
 
 expression: f==g
 value:      false
@@ -226,19 +226,19 @@ expression: x>=y
 value:      false
 
 expression: a+b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":101,"operator":true+false,"code":1}
+value:      error("on line 101, true+false: unsupported operator on boolean")
 
 expression: a-b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":102,"operator":true-false,"code":1}
+value:      error("on line 102, true-false: unsupported operator on boolean")
 
 expression: a*b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":103,"operator":true*false,"code":1}
+value:      error("on line 103, true*false: unsupported operator on boolean")
 
 expression: a/b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":104,"operator":true/false,"code":1}
+value:      error("on line 104, true/false: unsupported operator on boolean")
 
 expression: a%b
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on boolean","line":105,"operator":true%false,"code":1}
+value:      error("on line 105, true%false: unsupported operator on boolean")
 
 expression: f+g
 value:      3.64159
@@ -271,16 +271,16 @@ expression: x%y
 value:      10
 
 expression: x and y
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on integer","line":118,"operator":10 and 20,"code":1}
+value:      error("on line 118, 10 and 20: unsupported operator on integer")
 
 expression: x or y
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on integer","line":119,"operator":10 or 20,"code":1}
+value:      error("on line 119, 10 or 20: unsupported operator on integer")
 
 expression: x and y
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on integer","line":120,"operator":10 and 20,"code":1}
+value:      error("on line 120, 10 and 20: unsupported operator on integer")
 
 expression: x or y
-value:      Error{"source":"jx_eval","name":"unsupported operator","message":"unsupported operator on integer","line":121,"operator":10 or 20,"code":1}
+value:      error("on line 121, 10 or 20: unsupported operator on integer")
 
 expression: (x+y)*(f+g)
 value:      109.248
@@ -310,7 +310,7 @@ expression: [[[i,j] for j in range(3)] for i in [10-i for i in range(4)]]
 value:      [[[10,0],[10,1],[10,2]],[[9,0],[9,1],[9,2]],[[8,0],[8,1],[8,2]],[[7,0],[7,1],[7,2]]]
 
 expression: [null for i in 7]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"list comprehension takes an array","line":134,"list":7,"code":2}
+value:      error("on line 134: list comprehension takes an array")
 
 expression: [i for i in range(10) if i%3==0]
 value:      [0,3,6,9]
@@ -328,7 +328,7 @@ expression: [[i,j] for i in range(5) if i%2==0 for j in range(4) if j%2==1]
 value:      [[0,1],[0,3],[2,1],[2,3],[4,1],[4,3]]
 
 expression: [[i,j] for i in range(5) if j%2==0 for j in range(4) if i%2==1]
-value:      Error{"source":"jx_eval","name":"undefined symbol","message":"undefined symbol","line":140,"context":{"i":0,"escape":escape,"dirname":dirname,"basename":basename,"floor":floor,"ceil":ceil,"join":join,"format":format,"range":range,"outfile":"results","infile":"mydata","a":true,"b":false,"f":0.5,"g":3.14159,"x":10,"y":20,"list":[100,200,300],"object":{"house":"home"}},"symbol":j,"code":0}
+value:      error("on line 140, j: undefined symbol")
 
 expression: [[i,j,k,l] for i in range(4) for j in range(3) for k in range(3) for l in [true,false]]
 value:      [[0,0,0,true],[0,0,0,false],[0,0,1,true],[0,0,1,false],[0,0,2,true],[0,0,2,false],[0,1,0,true],[0,1,0,false],[0,1,1,true],[0,1,1,false],[0,1,2,true],[0,1,2,false],[0,2,0,true],[0,2,0,false],[0,2,1,true],[0,2,1,false],[0,2,2,true],[0,2,2,false],[1,0,0,true],[1,0,0,false],[1,0,1,true],[1,0,1,false],[1,0,2,true],[1,0,2,false],[1,1,0,true],[1,1,0,false],[1,1,1,true],[1,1,1,false],[1,1,2,true],[1,1,2,false],[1,2,0,true],[1,2,0,false],[1,2,1,true],[1,2,1,false],[1,2,2,true],[1,2,2,false],[2,0,0,true],[2,0,0,false],[2,0,1,true],[2,0,1,false],[2,0,2,true],[2,0,2,false],[2,1,0,true],[2,1,0,false],[2,1,1,true],[2,1,1,false],[2,1,2,true],[2,1,2,false],[2,2,0,true],[2,2,0,false],[2,2,1,true],[2,2,1,false],[2,2,2,true],[2,2,2,false],[3,0,0,true],[3,0,0,false],[3,0,1,true],[3,0,1,false],[3,0,2,true],[3,0,2,false],[3,1,0,true],[3,1,0,false],[3,1,1,true],[3,1,1,false],[3,1,2,true],[3,1,2,false],[3,2,0,true],[3,2,0,false],[3,2,1,true],[3,2,1,false],[3,2,2,true],[3,2,2,false]]
@@ -343,7 +343,7 @@ expression: list[(-3)]
 value:      100
 
 expression: list[(-10)]
-value:      Error{"source":"jx_eval","name":"range error","message":"index out of range","index":-10,"array":[100,200,300],"code":4}
+value:      error("array reference on line 0: index out of range")
 
 expression: list[1:]
 value:      [200,300]
@@ -376,13 +376,13 @@ expression: list[0:100]
 value:      [100,200,300]
 
 expression: list[true:4]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"slice indices must be integers","operator":true:4,"code":2}
+value:      error("on line 0, true:4: slice indices must be integers")
 
 expression: list[4:null]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"slice indices must be integers","operator":4:null,"code":2}
+value:      error("on line 0, 4:null: slice indices must be integers")
 
 expression: list[true:false]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"slice indices must be integers","operator":true:false,"code":2}
+value:      error("on line 0, true:false: slice indices must be integers")
 
 expression: object["house"]
 value:      "home"
@@ -403,7 +403,7 @@ expression: range(-1,10,2)
 value:      [-1,1,3,5,7,9]
 
 expression: range(1,10,0)
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"step must be nonzero","function":range(1,10,0),"code":6}
+value:      error("function range on line 0: step must be nonzero")
 
 expression: range(0,5,-1)
 value:      []
@@ -415,7 +415,7 @@ expression: range(5,0,-1)
 value:      [5,4,3,2,1]
 
 expression: format()
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"invalid/missing format string","function":format(),"code":6}
+value:      error("function format on line 0: invalid/missing format string")
 
 expression: format("%%")
 value:      "%"
@@ -424,13 +424,13 @@ expression: format("value: %i!!",x+y)
 value:      "value: 30!!"
 
 expression: format("%i",x,y)
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"too many arguments for format specifier","function":format("%i",10,20),"code":6}
+value:      error("function format on line 0: too many arguments for format specifier")
 
 expression: format("(%d, %i)",x,y)
 value:      "(10, 20)"
 
 expression: format("%i")
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"mismatched format specifier","function":format("%i"),"code":6}
+value:      error("function format on line 0: mismatched format specifier")
 
 expression: format("%e",1.2e-22)
 value:      "1.200000e-22"
@@ -454,10 +454,10 @@ expression: format("%s","foo")
 value:      "foo"
 
 expression: 10+[1]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":195,"operator":10+[1],"code":2}
+value:      error("on line 195, 10+[1]: mismatched types for operator")
 
 expression: "abc"+[2]
-value:      Error{"source":"jx_eval","name":"mismatched types","message":"mismatched types for operator","line":196,"operator":"abc"+[2],"code":2}
+value:      error("on line 196, \"abc\"+[2]: mismatched types for operator")
 
 expression: []+[]
 value:      []
@@ -490,10 +490,10 @@ expression: ceil(f)
 value:      1
 
 expression: ceil()
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"too few arguments","function":ceil(),"code":6}
+value:      error("function ceil on line 0: too few arguments")
 
 expression: ceil([])
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"arg of invalid type","function":ceil([]),"code":6}
+value:      error("function ceil on line 0: arg of invalid type")
 
 expression: ceil(x)
 value:      10
@@ -502,19 +502,19 @@ expression: ceil(g)
 value:      4
 
 expression: ceil(x,f)
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"too many arguments","function":ceil(10,0.5),"code":6}
+value:      error("function ceil on line 0: too many arguments")
 
 expression: ceil("foo")
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"arg of invalid type","function":ceil("foo"),"code":6}
+value:      error("function ceil on line 0: arg of invalid type")
 
 expression: floor(f)
 value:      0
 
 expression: floor()
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"too few arguments","function":floor(),"code":6}
+value:      error("function floor on line 0: too few arguments")
 
 expression: floor([])
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"arg of invalid type","function":floor([]),"code":6}
+value:      error("function floor on line 0: arg of invalid type")
 
 expression: floor(x)
 value:      10
@@ -523,10 +523,10 @@ expression: floor(g)
 value:      3
 
 expression: floor(x,f)
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"too many arguments","function":floor(10,0.5),"code":6}
+value:      error("function floor on line 0: too many arguments")
 
 expression: floor("foo")
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"arg of invalid type","function":floor("foo"),"code":6}
+value:      error("function floor on line 0: arg of invalid type")
 
 expression: join([])
 value:      ""
@@ -538,16 +538,16 @@ expression: join(["a","b","c","d"]," ")
 value:      "a b c d"
 
 expression: join()
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"too few arguments to join","function":join(),"code":6}
+value:      error("function join on line 0: too few arguments to join")
 
 expression: join([a,b,c])
-value:      Error{"source":"jx_eval","name":"undefined symbol","message":"undefined symbol","line":227,"context":{"escape":escape,"dirname":dirname,"basename":basename,"floor":floor,"ceil":ceil,"join":join,"format":format,"range":range,"outfile":"results","infile":"mydata","a":true,"b":false,"f":0.5,"g":3.14159,"x":10,"y":20,"list":[100,200,300],"object":{"house":"home"}},"symbol":c,"code":0}
+value:      error("on line 227, c: undefined symbol")
 
 expression: join(["a","b","c","d"])
 value:      "a b c d"
 
 expression: join(",",["a","b"])
-value:      Error{"source":"jx_eval","name":"invalid arguments","message":"A list must be the first argument in join","function":join(",",["a","b"]),"code":6}
+value:      error("function join on line 0: A list must be the first argument in join")
 
 expression: join(["a","b"],",")
 value:      "a,b"
@@ -612,6 +612,6 @@ value:      "true maybe false"
 expression: "pi is "+3.14159
 value:      "pi is 3.14159"
 
-expression: Error{"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"}
-value:      Error{"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"}
+expression: error({"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"})
+value:      error({"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"})
 

--- a/dttools/test/jx.input
+++ b/dttools/test/jx.input
@@ -253,6 +253,6 @@ escape("y\\x");
 true + " maybe " + false
 "pi is " + 3.141592654
 
-Error{"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"};
+error({"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"});
 
 #end


### PR DESCRIPTION
Resolves #1922

This replaces the existing JX error messages (hard to read) with simpler function-looking messages. Errors are reported as normal strings.

See the new [expected test](https://github.com/trshaffer/cctools/blob/c1687324df43e34471b529e215138a711aecc6a1/dttools/test/jx.expected#L181) for how things look now.