### PR TITLE
Worker always clean on disk exhaustion

### DIFF
--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -64,7 +64,7 @@ typedef enum {
 	WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION = 2 << 3, /**< The task used more resources than requested **/
 	WORK_QUEUE_RESULT_TASK_TIMEOUT        = 3 << 3, /**< The task ran after the specified (absolute since epoch) end time. **/
 	WORK_QUEUE_RESULT_UNKNOWN             = 4 << 3, /**< The result could not be classified. **/
-	WORK_QUEUE_RESULT_FORSAKEN            = 5 << 3, /**< The task failed, but it was neither a task or worker error **/
+	WORK_QUEUE_RESULT_FORSAKEN            = 5 << 3, /**< The task failed, but it was not a task error **/
 	WORK_QUEUE_RESULT_MAX_RETRIES         = 6 << 3, /**< The task could not be completed successfully in the given number of retries. **/
 	WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME   = 7 << 3, /**< The task ran for more than the specified time (relative since running in a worker). **/
 	WORK_QUEUE_RESULT_DISK_ALLOC_FULL     = 8 << 3  /**< The task filled its loop device allocation but needed more space. **/

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1680,6 +1680,8 @@ static void work_for_master(struct link *master) {
 		 * marked them as RESOURCE_EXHAUSTION. */
 		if(!enforce_worker_limits(master)) {
 			finish_running_tasks(WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION);
+			// finish all tasks, disconnect from master, but don't kill the worker (no abort_flag = 1)
+			break;
 		}
 
 		int task_event = 0;
@@ -1716,7 +1718,9 @@ static void work_for_master(struct link *master) {
 		}
 
 
-		if(!ok) break;
+		if(!ok) {
+			break;
+		}
 
 		//Reset idle_stoptime if something interesting is happening at this worker.
 		if(list_size(procs_waiting) > 0 || itable_size(procs_table) > 0 || itable_size(procs_complete) > 0) {

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1676,10 +1676,10 @@ static void work_for_master(struct link *master) {
 		 * Mark offending process as RESOURCE_EXHASTION. */
 		enforce_processes_limits();
 
-		/* end running processes if worker resources are exhasusted, and
-		 * marked them as RESOURCE_EXHAUSTION. */
+		/* end running processes if worker resources are exhasusted, and marked
+		 * them as FORSAKEN, so they can be resubmitted somewhere else. */
 		if(!enforce_worker_limits(master)) {
-			finish_running_tasks(WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION);
+			finish_running_tasks(WORK_QUEUE_RESULT_FORSAKEN);
 			// finish all tasks, disconnect from master, but don't kill the worker (no abort_flag = 1)
 			break;
 		}


### PR DESCRIPTION
Before we would try to keep the worker around when a task filled the
disk alloted to the worker. However, this only works for inputs that are
not cached (e.g., not makeflow). CJ found that the master would keep sending tasks to a
worker, and those tasks eventually would fill the worker's disk. The
tasks were terminated, but the cached was not cleared, thus disk usage
at the worker kept increasing, and the tasks kept failing.

Since there is no easy way to tell at the worker which files are cached,
this commit makes it so that the worker disconnects.