### PR TITLE
Flag Additions for S3 Archive

### DIFF
--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -1056,6 +1056,9 @@ static void show_help_run(const char *cmd)
 	printf("    --archive                   Read jobs from and write completed jobs into archive.\n");
 	printf("    --archive-s3=<s3_bucket>    Base s3 bucket name (DEFAULT: makeflows3archive).\n");
 	printf("    --archive-s3-no-check=<s3_bucket> Don't check for files in s3 bucket before uploading.\n");
+	printf("    --s3-hostname=<s3 hostname> Base s3 hostname. Use if using a library similar to AWS S3.\n");
+	printf("    --s3-keyid=<key id>         Access Key for cloud server. Use if using a library similar to AWS S3.\n");
+	printf("    --s3-secretkey=<secret key> Secret Key for cloud server. Use if using a library similar to AWS S3.\n");
 	printf("    --archive-read              Read jobs from archive.\n");
 	printf("    --archive-write             Write jobs into archive.\n");
 	printf("    --archive-dir=<dir>         Base archive directory (default: /tmp/makeflow.archive.USERID).\n");
@@ -1293,6 +1296,9 @@ int main(int argc, char *argv[])
 		LONG_OPT_ARCHIVE,
 		LONG_OPT_ARCHIVE_S3,
 		LONG_OPT_ARCHIVE_S3_NO_CHECK,
+		LONG_OPT_S3_HOSTNAME,
+		LONG_OPT_S3_KEYID,
+		LONG_OPT_S3_SECRETKEY,
 		LONG_OPT_ARCHIVE_DIR,
 		LONG_OPT_ARCHIVE_READ,
 		LONG_OPT_ARCHIVE_WRITE,
@@ -1401,6 +1407,9 @@ int main(int argc, char *argv[])
 		{"archive", no_argument, 0, LONG_OPT_ARCHIVE},
 		{"archive-s3", optional_argument, 0, LONG_OPT_ARCHIVE_S3},
 		{"archive-s3-no-check", optional_argument, 0, LONG_OPT_ARCHIVE_S3_NO_CHECK},
+		{"s3-hostname",required_argument,0,LONG_OPT_S3_HOSTNAME},
+		{"s3-keyid",required_argument,0,LONG_OPT_S3_KEYID},
+		{"s3-secretkey",required_argument,0,LONG_OPT_S3_SECRETKEY},
 		{"archive-dir", required_argument, 0, LONG_OPT_ARCHIVE_DIR},
 		{"archive-read", no_argument, 0, LONG_OPT_ARCHIVE_READ},
 		{"archive-write", no_argument, 0, LONG_OPT_ARCHIVE_WRITE},
@@ -1785,6 +1794,21 @@ int main(int argc, char *argv[])
 				k8s_image = xxstrdup(optarg);
 				break;
 #ifdef HAS_CURL
+			case LONG_OPT_S3_HOSTNAME:
+				if (makeflow_hook_register(&makeflow_hook_archive, &hook_args) == MAKEFLOW_HOOK_FAILURE)
+                    goto EXIT_WITH_FAILURE;
+				jx_insert(hook_args, jx_string("s3_hostname"), jx_string(xxstrdup(optarg)));
+				break;
+			case LONG_OPT_S3_KEYID:
+				if (makeflow_hook_register(&makeflow_hook_archive, &hook_args) == MAKEFLOW_HOOK_FAILURE)
+                    goto EXIT_WITH_FAILURE;
+				jx_insert(hook_args, jx_string("s3_keyid"), jx_string(xxstrdup(optarg)));
+				break;
+			case LONG_OPT_S3_SECRETKEY:
+				if (makeflow_hook_register(&makeflow_hook_archive, &hook_args) == MAKEFLOW_HOOK_FAILURE)
+                    goto EXIT_WITH_FAILURE;
+				jx_insert(hook_args, jx_string("s3_secretkey"), jx_string(xxstrdup(optarg)));
+				break;
 			case LONG_OPT_ARCHIVE_S3_NO_CHECK:
 				if (makeflow_hook_register(&makeflow_hook_archive, &hook_args) == MAKEFLOW_HOOK_FAILURE)
                     goto EXIT_WITH_FAILURE;

--- a/makeflow/src/makeflow_module_archive.c
+++ b/makeflow/src/makeflow_module_archive.c
@@ -80,7 +80,11 @@ struct archive_instance *archive_instance_create()
 }
 
 static int create( void ** instance_struct, struct jx *hook_args )
-{
+{	
+	aws_init ();
+        aws_set_debug (0);
+        char line[256];
+
 	if(s3_files_in_archive == NULL){
                 s3_files_in_archive = hash_table_create(0,0);
         }
@@ -111,6 +115,32 @@ static int create( void ** instance_struct, struct jx *hook_args )
 	}
 	else{
 		a->s3 = 0;
+	}
+
+	if(jx_lookup_string(hook_args, "s3_hostname")){
+		s3_set_host(xxstrdup(jx_lookup_string(hook_args, "s3_hostname")));
+	}
+
+	if(jx_lookup_string(hook_args, "s3_keyid")){
+		aws_set_keyid(xxstrdup(jx_lookup_string(hook_args, "s3_keyid")));	
+	}
+	else{
+		FILE *fp = popen("grep aws_access_key_id ~/.aws/credentials | cut -d ""="" -f 2 | tr -d ' '","r");
+        	fgets(line, 255, fp);
+        	line[strlen(line)-1] = '\0';
+        	aws_set_keyid(line);
+        	pclose(fp);	
+	}
+
+	if(jx_lookup_string(hook_args, "s3_secretkey")){
+		aws_set_key(xxstrdup(jx_lookup_string(hook_args, "s3_secretkey")));
+	}
+	else{
+		FILE *ft = popen("grep aws_secret_access_key ~/.aws/credentials | cut -d ""="" -f 2 | tr -d ' '","r");
+        	fgets(line, 255, ft);
+        	line[strlen(line)-1] = '\0';
+        	aws_set_key(line);
+        	pclose(ft);
 	}
 
 	if(jx_lookup_boolean(hook_args, "archive_read")){
@@ -144,19 +174,7 @@ static int create( void ** instance_struct, struct jx *hook_args )
 		return MAKEFLOW_HOOK_FAILURE;
 	}
 	free(tasks_dir);
-	aws_init ();
-        aws_set_debug (0);
-	FILE *fp = popen("grep aws_access_key_id ~/.aws/credentials | cut -d ""="" -f 2 | tr -d ' '","r");
-        char line[256];
-        fgets(line, 255, fp);
-	line[strlen(line)-1] = '\0';
-	aws_set_keyid(line);
-        pclose(fp);
-        FILE *ft = popen("grep aws_secret_access_key ~/.aws/credentials | cut -d ""="" -f 2 | tr -d ' '","r");
-        fgets(line, 255, fp);
-	line[strlen(line)-1] = '\0';
-	aws_set_key(line);
-        pclose(ft); 
+	
 	s3_set_bucket (a->s3_dir);
 
 


### PR DESCRIPTION
Added flags to change the s3 hostname, s3 access key, and s3 secret key. This will make it useful for when a user wants to use an s3 like library like Minio over regular s3 use. 