### PR TITLE
rename resource to feature in function implementation

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4214,7 +4214,7 @@ void work_queue_task_specify_category(struct work_queue_task *t, const char *cat
 	t->category = xxstrdup(category ? category : "default");
 }
 
-void work_queue_task_specify_resource(struct work_queue_task *t, const char *name, int64_t count)
+void work_queue_task_specify_feature(struct work_queue_task *t, const char *name, int64_t count)
 {
 	if(!name)
 		return;


### PR DESCRIPTION
As reported by @annawoodard, python3 -mworkqueue would fail as the function was not defined (only declared).