### PR TITLE
Work queue: Consider workers connected from other sources

### DIFF
--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -876,6 +876,7 @@ static void mainloop( struct batch_queue *queue )
 
 		int new_workers_needed         = MAX(0, workers_needed - workers_submitted);
 		int workers_waiting_to_connect = MAX(0, workers_submitted - workers_connected);
+		int workers_from_elsewhere     = MAX(0, workers_connected - workers_submitted);
 
 		if(workers_per_cycle > 0 && new_workers_needed > workers_per_cycle) {
 			debug(D_WQ,"applying maximum workers per cycle of %d",workers_per_cycle);
@@ -885,6 +886,11 @@ static void mainloop( struct batch_queue *queue )
 		if(workers_per_cycle > 0 && workers_waiting_to_connect > 0) {
 			debug(D_WQ,"waiting for %d previously submitted workers to connect", workers_waiting_to_connect);
 			new_workers_needed = MAX(0, new_workers_needed - workers_waiting_to_connect);
+		}
+
+		if(workers_per_cycle > 0 && workers_from_elsewhere > 0) {
+			debug(D_WQ,"%d workers already connected from other sources", workers_from_elsewhere);
+			new_workers_needed = MAX(0, new_workers_needed - workers_from_elsewhere);
 		}
 
 		debug(D_WQ,"workers needed: %d",    workers_needed);


### PR DESCRIPTION
I ran into this situation the other day: I started a work queue, and a work queue factory to handle workers. After letting the computation run for a while, I realized that I had underestimated the amount of time my tasks would take, and also underspecified the worker limits of the factory. I started another factory.

However, multiple factories don't play well together. I got to a point where all the tasks were distributed to workers but, because the factory doesn't check whether the number of connected workers meets the task needs, each factory was constantly spinning up new workers to meet a need that didn't exist. 

This patch fixes that by doing a sanity check to see whether there are workers connected from other sources, and considering that number when it computes `new_workers_needed`.

Cheers!