### PR TITLE
remove old safeguard, as new workers needed cannot be negative

### DIFF
--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -911,8 +911,6 @@ static void mainloop( struct batch_queue *queue )
 		if(new_workers_needed>0) {
 			debug(D_WQ,"submitting %d new workers to reach target",new_workers_needed);
 			workers_submitted += submit_workers(queue,job_table,new_workers_needed);
-		} else if(new_workers_needed<0) {
-			debug(D_WQ,"too many workers, will wait for some to exit");
 		} else {
 			debug(D_WQ,"target number of workers is reached.");
 		}


### PR DESCRIPTION
As reported by @rlmv 