### PR TITLE
Fix existing new workers calculations

### DIFF
--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -878,19 +878,19 @@ static void mainloop( struct batch_queue *queue )
 		int workers_waiting_to_connect = MAX(0, workers_submitted - workers_connected);
 		int workers_from_elsewhere     = MAX(0, workers_connected - workers_submitted);
 
-		if(workers_per_cycle > 0 && new_workers_needed > workers_per_cycle) {
-			debug(D_WQ,"applying maximum workers per cycle of %d",workers_per_cycle);
-			new_workers_needed = workers_per_cycle;
+		if(workers_from_elsewhere > 0) {
+			debug(D_WQ,"%d workers already connected from other sources", workers_from_elsewhere);
+			new_workers_needed = MAX(0, new_workers_needed - workers_from_elsewhere);
 		}
 
-		if(workers_per_cycle > 0 && workers_waiting_to_connect > 0) {
+		if(workers_waiting_to_connect > 0) {
 			debug(D_WQ,"waiting for %d previously submitted workers to connect", workers_waiting_to_connect);
 			new_workers_needed = MAX(0, new_workers_needed - workers_waiting_to_connect);
 		}
 
-		if(workers_per_cycle > 0 && workers_from_elsewhere > 0) {
-			debug(D_WQ,"%d workers already connected from other sources", workers_from_elsewhere);
-			new_workers_needed = MAX(0, new_workers_needed - workers_from_elsewhere);
+		if(workers_per_cycle > 0 && new_workers_needed > workers_per_cycle) {
+			debug(D_WQ,"applying maximum workers per cycle of %d",workers_per_cycle);
+			new_workers_needed = workers_per_cycle;
 		}
 
 		debug(D_WQ,"workers needed: %d",    workers_needed);


### PR DESCRIPTION
Fixes bug introduced in #1958.

Existing workers need to be applied *before* the max workers per cycle constraint, otherwise `new_workers_needed` can be reduced to 0 when the number of workers from other sources is greater than `workers_per_cycle`.

Sorry about that, @btovar. This seems to be working as expected now.