### PR TITLE
Parrot support for mounting ext images

### DIFF
--- a/configure
+++ b/configure
@@ -92,6 +92,7 @@ build_date=
 
 curl_path="/usr"
 cvmfs_path="/usr"
+ext2fs_path="/usr"
 fuse_path="/usr"
 globus_path="/usr"
 irods_path="/usr"
@@ -119,6 +120,7 @@ c_only_flags="-std=c99"
 
 config_zlib_path=yes
 
+config_ext2fs_path=auto
 config_fuse_path=auto
 config_mysql_path=auto
 config_perl_path=auto
@@ -196,6 +198,10 @@ do
 		--with-cvmfs-path)
 			cvmfs_path=${arg}
 			config_cvmfs_path=$(config_X_path ${arg})
+			;;
+		--with-ext2fs-path)
+			ext2fs_path=${arg}
+			config_ext2fs_path=$(config_X_path ${arg})
 			;;
 		--with-fuse-path)
 			fuse_path=${arg}
@@ -340,6 +346,7 @@ Where options are:
 Where PACKAGE may be:
 	curl
 	cvmfs
+	ext2fs
 	fuse
 	globus
 	irods
@@ -767,6 +774,32 @@ then
 		fi
 else
 	echo "*** skipping fuse support"
+fi
+
+if [ $config_ext2fs_path != no ]
+then
+		if library_search ext2fs ${ext2fs_path} || library_search ext2fs /
+		then
+				if [ "${ext2fs_path}" != / -a "${ext2fs_path}" != /usr ]
+				then
+						ext2fs_ccflags="-I${ext2fs_path}/include"
+				fi
+				ccflags="${ccflags} -DHAS_EXT2FS"
+				ext2fs_ldflags="${library_search_result} -lcom_err"
+				ext2fs_avail=yes
+		else
+				if [ $config_ext2fs_path = yes ]
+				then
+
+				echo "*** Sorry, I couldn't find ext2fs in $ext2fs_path"
+				echo "*** Check --with-ext2fs-path and try again."
+				exit 1
+				else
+						echo "*** skipping ext2fs support"
+				fi
+		fi
+else
+	echo "*** skipping ext2fs support"
 fi
 
 ##########################################################################
@@ -1597,6 +1630,10 @@ CCTOOLS_XROOTD_CCFLAGS=${xrootd_ccflags}
 
 CCTOOLS_CVMFS_LDFLAGS=${cvmfs_ldflags}
 CCTOOLS_CVMFS_CCFLAGS=${cvmfs_ccflags}
+
+CCTOOLS_EXT2FS_AVAILABLE=${ext2fs_avail}
+CCTOOLS_EXT2FS_LDFLAGS=${ext2fs_ldflags}
+CCTOOLS_EXT2FS_CCFLAGS=${ext2fs_ccflags}
 
 CCTOOLS_FUSE_AVAILABLE=${fuse_avail}
 CCTOOLS_FUSE_LDFLAGS=${fuse_ldflags}

--- a/dttools/src/debug.c
+++ b/dttools/src/debug.c
@@ -106,6 +106,7 @@ static struct flag_info table[] = {
 	{"makeflow_lexer",    D_MAKEFLOW_LEXER},
 	{"makeflow_parser",   D_MAKEFLOW_PARSER},
 	{"makeflow_hook",   D_MAKEFLOW_HOOK},
+	{"ext", D_EXT},
 	{"rmonitor", D_RMON},
 	{"confuga", D_CONFUGA},
 	{"jx", D_JX},

--- a/dttools/src/debug.h
+++ b/dttools/src/debug.h
@@ -92,6 +92,7 @@ unless it has the flags D_NOTICE or D_FATAL.  For example, a main program might 
 #define D_CONFUGA  (1LL<<44)  /**< Debug Confuga Storage Cluster */
 #define D_JX       (1LL<<45)  /**< Debug JX */
 #define D_MAKEFLOW_HOOK  (1LL<<46)  /**< Debug makeflow's hook system */
+#define D_EXT      (1LL<<47)  /**< Debug the ext module in Parrot */
 
 /** Debug all remote I/O operations. */
 #define D_REMOTE   (D_HTTP|D_FTP|D_NEST|D_CHIRP|D_DCAP|D_RFIO|D_LFC|D_GFAL|D_MULTI|D_GROW|D_IRODS|D_HDFS|D_BXGRID|D_XROOTD|D_CVMFS)

--- a/parrot/src/Makefile
+++ b/parrot/src/Makefile
@@ -4,7 +4,7 @@ include ../../rules.mk
 EXTERNAL_DEPENDENCIES = ../../ftp_lite/src/libftp_lite.a ../../chirp/src/libchirp.a ../../grow/src/grow.o ../../dttools/src/libdttools.a
 LIBRARIES = libparrot_helper.$(CCTOOLS_DYNAMIC_SUFFIX) libparrot_client.a
 OBJECTS = $(OBJECTS_PARROT_RUN) parrot_client.o pfs_resolve_mount.o
-OBJECTS_PARROT_RUN = pfs_main.o tracer.o pfs_paranoia.o pfs_dispatch.o pfs_dispatch64.o pfs_process.o pfs_channel.o pfs_sys.o pfs_time.o pfs_table.o pfs_resolve.o pfs_mountfile.o pfs_service.o pfs_file.o pfs_file_cache.o pfs_dir.o pfs_dircache.o pfs_pointer.o pfs_location.o ibox_acl.o pfs_service_local.o pfs_service_http.o pfs_service_grow.o pfs_service_chirp.o pfs_service_multi.o pfs_service_nest.o pfs_service_ftp.o pfs_service_irods.o irods_reli.o pfs_service_hdfs.o pfs_service_bxgrid.o pfs_service_xrootd.o pfs_service_cvmfs.o
+OBJECTS_PARROT_RUN = pfs_main.o tracer.o pfs_paranoia.o pfs_dispatch.o pfs_dispatch64.o pfs_process.o pfs_channel.o pfs_sys.o pfs_time.o pfs_table.o pfs_resolve.o pfs_mountfile.o pfs_service.o pfs_file.o pfs_file_cache.o pfs_dir.o pfs_dircache.o pfs_pointer.o pfs_location.o ibox_acl.o pfs_service_local.o pfs_service_http.o pfs_service_grow.o pfs_service_chirp.o pfs_service_multi.o pfs_service_nest.o pfs_service_ftp.o pfs_service_irods.o irods_reli.o pfs_service_hdfs.o pfs_service_bxgrid.o pfs_service_xrootd.o pfs_service_cvmfs.o pfs_service_ext.o
 PROGRAMS = parrot_run $(UTILITIES)
 HEADERS_PUBLIC = parrot_client.h
 SCRIPTS = parrot_identity_box parrot_run_hdfs parrot_package_run chroot_package_run
@@ -50,7 +50,7 @@ tracer.table.h: syscall_32.tbl
 	cat $< syscall_parrot.tbl | perl tracer.table.pl header 32 > $@
 
 parrot_run: $(OBJECTS_PARROT_RUN) libparrot_client.a
-	$(CCTOOLS_CXX) -o $@ $(CCTOOLS_INTERNAL_LDFLAGS) $^ $(CCTOOLS_IRODS_LDFLAGS) $(CCTOOLS_MYSQL_LDFLAGS) $(CCTOOLS_XROOTD_LDFLAGS) $(CCTOOLS_CVMFS_LDFLAGS) $(CCTOOLS_GLOBUS_LDFLAGS) $(CCTOOLS_EXTERNAL_LINKAGE)
+	$(CCTOOLS_CXX) -o $@ $(CCTOOLS_INTERNAL_LDFLAGS) $^ $(CCTOOLS_IRODS_LDFLAGS) $(CCTOOLS_MYSQL_LDFLAGS) $(CCTOOLS_XROOTD_LDFLAGS) $(CCTOOLS_CVMFS_LDFLAGS) $(CCTOOLS_EXT2FS_LDFLAGS) $(CCTOOLS_GLOBUS_LDFLAGS) $(CCTOOLS_EXTERNAL_LINKAGE)
 
 parrot_cvmfs_static_run: $(OBJECTS_PARROT_RUN) libparrot_client.a $(CCTOOLS_CVMFS_LDFLAGS) $(EXTERNAL_DEPENDENCIES)
 	$(CCTOOLS_CXX) -static -static-libstdc++ -static-libgcc -o $@ $^ $(CCTOOLS_INTERNAL_LDFLAGS) -Wl,-Bstatic $(CCTOOLS_EXTERNAL_LINKAGE)
@@ -66,6 +66,9 @@ pfs_service_xrootd.o: pfs_service_xrootd.cc
 
 pfs_service_cvmfs.o: pfs_service_cvmfs.cc
 	$(CCTOOLS_CXX) -o $@ -c $(CCTOOLS_INTERNAL_CXXFLAGS) $< $(CCTOOLS_CVMFS_CCFLAGS)
+
+pfs_service_ext.o: pfs_service_ext.cc
+	$(CCTOOLS_CXX) -o $@ -c $(CCTOOLS_INTERNAL_CXXFLAGS) $< $(CCTOOLS_EXT2FS_CCFLAGS)
 
 pfs_service_ftp.o: pfs_service_ftp.cc
 	$(CCTOOLS_CXX) -o $@ -c $(CCTOOLS_INTERNAL_CXXFLAGS) $< $(CCTOOLS_GLOBUS_CCFLAGS)

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -289,7 +289,7 @@ static void show_help( const char *cmd )
 	printf( " %-30s Make flock a no-op.\n", "--no-flock");
 	printf("\n");
 	printf("Filesystem Options:\n");
-	printf( " %-30s Mount an ext[234] disk image read-only at /ext_n.\n", "--ext-image=<image>");
+	printf( " %-30s Mount a read-only ext[234] disk image.\n", "--ext <image>=<mountpoint>");
 	printf("FTP / GridFTP options:\n");
 	printf( " %-30s Enable data channel authentication in GridFTP.\n", "-C,--channel-auth");
 	printf("\n");

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -142,7 +142,7 @@ char *stats_file = NULL;
 int parrot_fd_max = -1;
 int parrot_fd_start = -1;
 
-pfs_service *pfs_service_ext_init(const char *image);
+pfs_service *pfs_service_ext_init(const char *image, const char *mountpoint);
 
 /*
 This process at the very top of the traced tree
@@ -1139,7 +1139,7 @@ int main( int argc, char *argv[] )
 			strncpy(image, optarg, MIN((size_t) (split - optarg), sizeof(image) - 1));
 			strncpy(mountpoint, split + 1, sizeof(mountpoint) - 1);
 			if (mountpoint[0] != '/') fatal("mountpoint for ext image %s must be an absolute path", image);
-			struct pfs_service *s = pfs_service_ext_init(image);
+			struct pfs_service *s = pfs_service_ext_init(image, mountpoint);
 			if (!s) fatal("failed to load ext image %s", image);
 
 			service_instances.push_back(s);

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -40,7 +40,6 @@ extern "C" {
 #include "getopt.h"
 #include "int_sizes.h"
 #include "itable.h"
-#include "macros.h"
 #include "md5.h"
 #include "password_cache.h"
 #include "random.h"
@@ -1129,25 +1128,12 @@ int main( int argc, char *argv[] )
 			pfs_no_flock = 1;
 			break;
 		case LONG_OPT_EXT_IMAGE: {
-			char image[PATH_MAX] = {0};
-			char label[128] = {0};
-			char *split = strchr(optarg, '=');
-			if (split) {
-				strncpy(image, optarg, MIN((size_t) (split - optarg), sizeof(image) - 1));
-				snprintf(label, sizeof(label), "ext_%s", image);
-				strncpy(image, split + 1, sizeof(image) - 1);
-			} else {
-				strcpy(label, "ext");
-				strncpy(image, optarg, sizeof(image) - 1);
-			}
-			if (strchr(label, '/')) fatal("Image label %s may not contain slashes", label);
-			if (hash_table_lookup(available_services, label)) fatal(
-				"Image already mounted at /%s\n"
-				"You might want to specify a different label as --ext LABEL=PATH",
-				label);
-			struct pfs_service *s = pfs_service_ext_init(image);
-			if (!s) fatal("failed to load ext image %s", image);
-			hash_table_insert(available_services, label, s);
+			struct pfs_service *s = pfs_service_ext_init(optarg);
+			if (!s) fatal("failed to load ext image %s", optarg);
+			static unsigned ext_fs_number = 0;
+			char ext_fs_name[128];
+			snprintf(ext_fs_name, sizeof(ext_fs_name), "ext_%u", ext_fs_number++);
+			hash_table_insert(available_services, ext_fs_name, s);
 			service_instances.push_back(s);
 			break;
 		}

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -289,7 +289,7 @@ static void show_help( const char *cmd )
 	printf( " %-30s Make flock a no-op.\n", "--no-flock");
 	printf("\n");
 	printf("Filesystem Options:\n");
-	printf( " %-30s Mount an ext[234] disk image at /ext_n.\n", "--ext-image=<image>");
+	printf( " %-30s Mount an ext[234] disk image read-only at /ext_n.\n", "--ext-image=<image>");
 	printf("FTP / GridFTP options:\n");
 	printf( " %-30s Enable data channel authentication in GridFTP.\n", "-C,--channel-auth");
 	printf("\n");

--- a/parrot/src/pfs_service_ext.cc
+++ b/parrot/src/pfs_service_ext.cc
@@ -20,6 +20,7 @@ See the file COPYING for details.
 
 extern "C" {
 	#include "debug.h"
+	#include "macros.h"
 	#include "xxmalloc.h"
 }
 
@@ -119,13 +120,14 @@ static void inode2stat(ext2_ino_t i, struct ext2_inode *b, struct pfs_stat *p) {
 }
 
 static int append_dirents(struct ext2_dir_entry *dirent, int offset, int blocksize, char *buf, void *p) {
-	char name[PATH_MAX];
+	char name[PATH_MAX] = {0};
+	pfs_dir *d = (pfs_dir *) p;
 
 	assert(dirent);
-	assert(p);
+	assert(d);
 
-	pfs_dir *d = (pfs_dir *) p;
-	snprintf(name, dirent->name_len, "%s", dirent->name);
+	size_t name_len = dirent->name_len & ((1<<8) - 1);
+	strncpy(name, dirent->name, MIN(name_len, sizeof(name) - 1));
 	d->append(name);
 
 	return 0;

--- a/parrot/src/pfs_service_ext.cc
+++ b/parrot/src/pfs_service_ext.cc
@@ -94,7 +94,6 @@ static int fix_errno(errcode_t rc) {
 		case EXT2_ET_FILE_RO: return EROFS;
 		case EXT2_ET_DIR_EXISTS: return EEXIST;
 		case EXT2_ET_UNIMPLEMENTED: return ENOSYS;
-		case EXT2_ET_FILE_EXISTS: return EEXIST;
 		case EXT2_ET_FILE_TOO_BIG: return EFBIG;
 		default: return EINVAL;
 	}

--- a/parrot/src/pfs_service_ext.cc
+++ b/parrot/src/pfs_service_ext.cc
@@ -26,7 +26,7 @@ extern "C" {
 #ifdef HAS_EXT2FS
 
 #include <ext2fs/ext2fs.h>
-#include <com_err.h>
+#include <et/com_err.h>
 
 #define LOOKUP_INODE(name, inode, follow, fail) { \
 	errcode_t rc; \

--- a/parrot/src/pfs_service_ext.cc
+++ b/parrot/src/pfs_service_ext.cc
@@ -6,12 +6,6 @@ See the file COPYING for details.
 
 #ifdef HAS_EXT2FS
 
-#include "pfs_service.h"
-
-extern "C" {
-#include "debug.h"
-}
-
 #include <assert.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -31,6 +25,16 @@ extern "C" {
 #ifndef ENOATTR
 #define ENOATTR  EINVAL
 #endif
+
+#include <ext2fs/ext2fs.h>
+#include <com_err.h>
+
+#include "pfs_service.h"
+
+extern "C" {
+	#include "debug.h"
+	#include "xxmalloc.h"
+}
 
 class pfs_file_ext : public pfs_file {
 public:
@@ -128,136 +132,99 @@ public:
 };
 
 class pfs_service_ext: public pfs_service {
+private:
+	ext2_filsys fs;
+	char *path;
+
 public:
-	pfs_service_ext(const char *image) {
+	pfs_service_ext(ext2_filsys handle, const char *img) {
+		fs = handle;
+		path = xxstrdup(img);
+	}
+
+	~pfs_service_ext() {
+		debug(D_EXT, "closing ext fs %s", path);
+		errcode_t rc = ext2fs_close(fs);
+		if (rc != 0) {
+			debug(D_NOTICE, "failed to close ext filesystem at %s: %s", path, error_message(rc));
+		}
+		free(path);
 	}
 
 	virtual pfs_file *open(pfs_name *name, int flags, mode_t mode) {
+		assert(name);
+		debug(D_EXT, "open %s %d %d", name->rest, flags, mode);
 		return NULL;
 	}
 
 	virtual pfs_dir *getdir(pfs_name *name) {
+		assert(name);
+		debug(D_EXT, "getdir %s", name->rest);
 		return NULL;
 	}
 
 	virtual int stat(pfs_name *name, struct pfs_stat *buf) {
+		assert(name);
+		assert(buf);
+		debug(D_EXT, "stat %s", name->rest);
 		return -1;
 	}
 
 	virtual int statfs(pfs_name *name, struct pfs_statfs *buf) {
+		assert(name);
+		assert(buf);
+		debug(D_EXT, "statfs %s", name->rest);
 		return -1;
 	}
 
 	virtual int lstat(pfs_name *name, struct pfs_stat *buf) {
+		assert(name);
+		assert(buf);
+		debug(D_EXT, "lstat %s", name->rest);
 		return -1;
 	}
 
 	virtual int access(pfs_name *name, mode_t mode) {
+		assert(name);
+		debug(D_EXT, "access %s %d", name->rest, mode);
 		return -1;
 	}
 
-	virtual int chmod(pfs_name *name, mode_t mode) {
-		return -1;
-	}
-
-	virtual int chown(pfs_name *name, uid_t uid, gid_t gid) {
-		return -1;
-	}
-
-	virtual int lchown(pfs_name *name, uid_t uid, gid_t gid) {
-		return -1;
-	}
-
-	virtual int truncate(pfs_name *name, pfs_off_t length) {
-		return -1;
-	}
-
-	virtual int utime(pfs_name *name, struct utimbuf *buf) {
-		return -1;
-	}
-
-	virtual int utimens(pfs_name *name, const struct timespec times[2]) {
-		return -1;
-	}
-
-	virtual int lutimens(pfs_name *name, const struct timespec times[2]) {
-		return -1;
-	}
-
-	virtual int unlink(pfs_name *name) {
-		return -1;
-	}
-
-	virtual int rename(pfs_name *oldname, pfs_name *newname) {
+	virtual int readlink(pfs_name *name, char *buf, pfs_size_t bufsiz) {
+		assert(name);
+		assert(buf);
+		debug(D_EXT, "readlink %s", name->rest);
 		return -1;
 	}
 
 	virtual ssize_t getxattr(pfs_name *name, const char *attrname, void *data, size_t size) {
+		assert(name);
+		assert(attrname);
+		assert(data);
+		debug(D_EXT, "getxattr %s %s", name->rest, attrname);
 		return -1;
 	}
 
 	virtual ssize_t lgetxattr(pfs_name *name, const char *attrname, void *data, size_t size) {
+		assert(name);
+		assert(attrname);
+		assert(data);
+		debug(D_EXT, "lgetxattr %s %s", name->rest, attrname);
 		return -1;
 	}
 
 	virtual ssize_t listxattr(pfs_name *name, char *list, size_t size) {
+		assert(name);
+		assert(list);
+		debug(D_EXT, "listxattr %s", name->rest);
 		return -1;
 	}
 
 	virtual ssize_t llistxattr(pfs_name *name, char *list, size_t size) {
+		assert(name);
+		assert(list);
+		debug(D_EXT, "llistxattr %s", name->rest);
 		return -1;
-	}
-
-	virtual int setxattr(pfs_name *name, const char *attrname, const void *data, size_t size, int flags) {
-		return -1;
-	}
-
-	virtual int lsetxattr(pfs_name *name, const char *attrname, const void *data, size_t size, int flags) {
-		return -1;
-	}
-
-	virtual int removexattr(pfs_name *name, const char *attrname) {
-		return -1;
-	}
-
-	virtual int lremovexattr(pfs_name *name, const char *attrname) {
-		return -1;
-	}
-
-	virtual int chdir(pfs_name *name, char *newpath) {
-		return -1;
-	}
-
-	virtual int link(pfs_name *oldname, pfs_name *newname) {
-		return -1;
-	}
-
-	virtual int symlink(const char *linkname, pfs_name *newname) {
-		return -1;
-	}
-
-	virtual int readlink(pfs_name *name, char *buf, pfs_size_t size) {
-		return -1;
-	}
-
-	virtual int mknod(pfs_name *name, mode_t mode, dev_t dev) {
-		return -1;
-	}
-
-	virtual int mkdir(pfs_name *name, mode_t mode) {
-		return -1;
-	}
-
-	virtual int rmdir(pfs_name *name) {
-		return -1;
-	}
-
-	virtual int whoami(pfs_name *name, char *buf, int size) {
-		return -1;
-	}
-
-	virtual pfs_location* locate(pfs_name *name) {
-		return NULL;
 	}
 
 	virtual int is_seekable() {
@@ -271,7 +238,23 @@ public:
 
 pfs_service *pfs_service_ext_init(const char *image) {
 	assert(image);
-	return new pfs_service_ext(image);
+
+	initialize_ext2_error_table();
+	debug(D_EXT, "loading ext image %s", image);
+
+	ext2_filsys fs;
+	errcode_t rc = ext2fs_open(image, 0, 0, 0, unix_io_manager, &fs);
+	if (rc != 0) {
+		fatal("failed to load ext image %s: %s", image, error_message(rc));
+	}
+
+	return new pfs_service_ext(fs, image);
+}
+
+#else
+
+pfs_service *pfs_service_ext_init(const char *image) {
+	fatal("parrot was not configured with ext2fs support");
 }
 
 #endif

--- a/parrot/src/pfs_service_ext.cc
+++ b/parrot/src/pfs_service_ext.cc
@@ -4,8 +4,6 @@ This software is distributed under the GNU General Public License.
 See the file COPYING for details.
 */
 
-#ifdef HAS_EXT2FS
-
 #include <assert.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -18,24 +16,17 @@ See the file COPYING for details.
 #include <sys/types.h>
 #include <dirent.h>
 
-#if defined(HAS_ATTR_XATTR_H)
-#include <attr/xattr.h>
-#elif defined(HAS_SYS_XATTR_H)
-#include <sys/xattr.h>
-#endif
-#ifndef ENOATTR
-#define ENOATTR  EINVAL
-#endif
-
-#include <ext2fs/ext2fs.h>
-#include <com_err.h>
-
 #include "pfs_service.h"
 
 extern "C" {
 	#include "debug.h"
 	#include "xxmalloc.h"
 }
+
+#ifdef HAS_EXT2FS
+
+#include <ext2fs/ext2fs.h>
+#include <com_err.h>
 
 #define LOOKUP_INODE(name, inode, follow, fail) { \
 	errcode_t rc; \

--- a/parrot/src/pfs_service_ext.cc
+++ b/parrot/src/pfs_service_ext.cc
@@ -405,6 +405,8 @@ pfs_service *pfs_service_ext_init(const char *image) {
 
 pfs_service *pfs_service_ext_init(const char *image) {
 	fatal("parrot was not configured with ext2fs support");
+	// unreachable
+	return NULL;
 }
 
 #endif

--- a/parrot/src/pfs_service_ext.cc
+++ b/parrot/src/pfs_service_ext.cc
@@ -8,6 +8,7 @@ See the file COPYING for details.
 
 #include <assert.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <string.h>
@@ -36,10 +37,122 @@ extern "C" {
 	#include "xxmalloc.h"
 }
 
+#define LOOKUP_INODE(name, inode, follow, fail) { \
+	errcode_t rc; \
+	if (follow) { \
+		rc = ext2fs_namei_follow(fs, EXT2_ROOT_INO, EXT2_ROOT_INO, name, inode); \
+	} else { \
+		rc = ext2fs_namei(fs, EXT2_ROOT_INO, EXT2_ROOT_INO, name, inode); \
+	} \
+	if (rc == 0) { \
+		debug(D_EXT, "lookup %s -> inode %d", name, *inode); \
+	} else { \
+		debug(D_EXT, "lookup %s failed: %s", name, error_message(rc)); \
+		errno = fix_errno(rc); \
+		return fail; \
+	} \
+} while (false)
+
+#define READ_INODE(inode, buf, fail) { \
+	errcode_t rc = ext2fs_read_inode(fs, inode, buf); \
+	if (rc == 0) { \
+		debug(D_EXT, "read inode %d", inode); \
+	} else { \
+		debug(D_EXT, "read inode %d failed: %s", inode, error_message(rc)); \
+		return fail; \
+	} \
+} while (false)
+
+#define OPEN_FILE(inode, file, fail) { \
+	errcode_t rc = ext2fs_file_open(fs, inode, 0, file); \
+	if (rc == 0) { \
+		debug(D_EXT, "open inode %d -> file %p", inode, *file); \
+	} else { \
+		debug(D_EXT, "open inode %d failed: %s", inode, error_message(rc)); \
+		return fail; \
+	} \
+} while (false)
+
+#define CLOSE_FILE(file, fail) { \
+	errcode_t rc = ext2fs_file_close(file); \
+	if (rc == 0) { \
+		debug(D_EXT, "close file %p", file); \
+	} else { \
+		debug(D_EXT, "close file %p failed: %s", file, error_message(rc)); \
+		return fail; \
+	} \
+} while (false)
+
+static int fix_errno(errcode_t rc) {
+	if (((rc>>8) & ((1<<24) - 1)) == 0) {
+		// literal errno value
+		return rc;
+	}
+	// very rough translation
+	switch (rc) {
+		case 0: return 0;
+		case EXT2_ET_RO_FILSYS: return EROFS;
+		case EXT2_ET_SYMLINK_LOOP: return ELOOP;
+		case EXT2_ET_NO_MEMORY: return ENOMEM;
+		case EXT2_ET_UNSUPP_FEATURE: return ENOSYS;
+		case EXT2_ET_RO_UNSUPP_FEATURE: return ENOSYS;
+		case EXT2_ET_INVALID_ARGUMENT: return EINVAL;
+		case EXT2_ET_NO_DIRECTORY: return ENOENT;
+		case EXT2_ET_TOO_MANY_REFS: return EMLINK;
+		case EXT2_ET_FILE_NOT_FOUND: return ENOENT;
+		case EXT2_ET_FILE_RO: return EROFS;
+		case EXT2_ET_DIR_EXISTS: return EEXIST;
+		case EXT2_ET_UNIMPLEMENTED: return ENOSYS;
+		case EXT2_ET_FILE_EXISTS: return EEXIST;
+		case EXT2_ET_FILE_TOO_BIG: return EFBIG;
+		default: return EINVAL;
+	}
+}
+
+static void inode2stat(ext2_ino_t i, struct ext2_inode *b, struct pfs_stat *p) {
+	assert(i);
+	assert(p);
+
+	memset(p, 0, sizeof(*p));
+	p->st_dev = (dev_t) -1;
+	p->st_ino = i;
+	p->st_mode = b->i_mode;
+	p->st_uid = b->i_uid;
+	p->st_gid = b->i_gid;
+	p->st_size = b->i_size;
+	p->st_nlink = b->i_links_count;
+	p->st_blksize = 65336;
+	p->st_blocks = b->i_blocks;
+	p->st_atime = b->i_atime;
+	p->st_ctime = b->i_ctime;
+	p->st_mtime = b->i_mtime;
+}
+
+static int append_dirents(struct ext2_dir_entry *dirent, int offset, int blocksize, char *buf, void *p) {
+	char name[PATH_MAX];
+
+	assert(dirent);
+	assert(p);
+
+	pfs_dir *d = (pfs_dir *) p;
+	snprintf(name, dirent->name_len, "%s", dirent->name);
+	d->append(name);
+
+	return 0;
+}
+
 class pfs_file_ext : public pfs_file {
+private:
+	ext2_ino_t inode;
+	ext2_filsys fs;
+
 public:
-	pfs_file_ext(pfs_name *name) : pfs_file(name) {
-		last_offset = 0;
+	pfs_file_ext(pfs_name *name, ext2_ino_t inode, ext2_filsys fs)
+			: pfs_file(name)
+			, inode(inode)
+			, fs(fs) {
+		assert(name);
+		debug(D_EXT, "open %s (inode %d) -> %p", name->rest, inode, this);
 	}
 
 	virtual int canbenative(char *path, size_t len) {
@@ -47,82 +160,64 @@ public:
 	}
 
 	virtual int close() {
-		return -1;
+		debug(D_EXT, "close %p", this);
+		// not holding any resources open, so noop here
+		return 0;
 	}
 
 	virtual pfs_ssize_t read(void *data, pfs_size_t length, pfs_off_t offset) {
-		return -1;
-	}
+		ext2_file_t file;
+		unsigned size;
 
-	virtual pfs_ssize_t write(const void *data, pfs_size_t length, pfs_off_t offset) {
-		return -1;
+		assert(data);
+
+		debug(D_EXT, "read %" PRIi64 "B from %p at %" PRIi64, length, this, offset);
+		OPEN_FILE(inode, &file, -1);
+		errcode_t rc = ext2fs_file_llseek(file, offset, EXT2_SEEK_SET, NULL);
+		if (rc != 0) {
+			debug(D_EXT, "failed to seek to %" PRIi64 " in %p: %s", offset, this, error_message(rc));
+			errno = fix_errno(rc);
+			return -1;
+		}
+
+		rc = ext2fs_file_read(file, data, length, &size);
+		if (rc == 0) {
+			debug(D_EXT, "read %u/%" PRIi64 " bytes from file %p", size, length, file);
+		} else {
+			debug(D_EXT, "read file %p failed: %s", file, error_message(rc));
+			CLOSE_FILE(file, -1);
+			return -1;
+		}
+
+		CLOSE_FILE(file, -1);
+
+		return size;
+
 	}
 
 	virtual int fstat(struct pfs_stat *buf) {
-		return -1;
+		struct ext2_inode inode_buf;
+
+		assert(buf);
+
+		debug(D_EXT, "fstat %p", this);
+		READ_INODE(inode, &inode_buf, -1);
+		inode2stat(inode, &inode_buf, buf);
+
+		return 0;
 	}
 
 	virtual int fstatfs(struct pfs_statfs *buf) {
-		return -1;
-	}
+		assert(buf);
 
-	virtual int ftruncate(pfs_size_t length) {
-		return -1;
-	}
+		debug(D_EXT, "fstatfs %p", this);
+		pfs_service_emulate_statfs(buf);
 
-	virtual int fsync() {
-		return -1;
+		return 0;
 	}
-
-	virtual int fcntl(int cmd, void *arg) {
-		return -1;
-	}
-
-	virtual int fchmod(mode_t mode) {
-		return -1;
-	}
-
-	virtual int fchown(uid_t uid, gid_t gid) {
-		return -1;
-	}
-
-#if defined(HAS_SYS_XATTR_H) || defined(HAS_ATTR_XATTR_H)
-	virtual ssize_t fgetxattr(const char *name, void *data, size_t size) {
-		return -1;
-	}
-
-	virtual ssize_t flistxattr(char *list, size_t size) {
-		return -1;
-	}
-
-	virtual int fsetxattr(const char *name, const void *data, size_t size, int flags) {
-		return -1;
-	}
-
-	virtual int fremovexattr(const char *name) {
-		return -1;
-	}
-
-#endif
 
 	virtual int flock(int op) {
-		return -1;
-	}
-
-	virtual void *mmap() {
-		return NULL;
-	}
-
-	virtual pfs_ssize_t get_size() {
-		return -1;
-	}
-
-	virtual int get_real_fd() {
-		return -1;
-	}
-
-	virtual int get_local_name(char *n) {
-		strcpy(n, name.rest);
+		// just noop this
 		return 0;
 	}
 
@@ -137,9 +232,9 @@ private:
 	ext2_filsys fs;
 
 public:
-	pfs_service_ext(ext2_filsys handle, const char *img) {
+	pfs_service_ext(ext2_filsys fs, const char *img)
+			: fs(fs) {
 		image = strdup(img);
-		fs = handle;
 	}
 
 	~pfs_service_ext() {
@@ -152,79 +247,144 @@ public:
 	}
 
 	virtual pfs_file *open(pfs_name *name, int flags, mode_t mode) {
+		ext2_ino_t inode;
+		struct ext2_inode inode_buf;
+
 		assert(name);
+		if (mode&(O_WRONLY|O_RDWR)) {
+			errno = EROFS;
+			return NULL;
+		}
+
 		debug(D_EXT, "open %s %d %d", name->rest, flags, mode);
-		return NULL;
+		LOOKUP_INODE(name->rest, &inode, !(flags&O_NOFOLLOW), NULL);
+		READ_INODE(inode, &inode_buf, NULL);
+		if (S_ISLNK(inode_buf.i_mode)) {
+			errno = ELOOP;
+			return NULL;
+		}
+
+		pfs_file_ext *result = new pfs_file_ext(name, inode, fs);
+		debug(D_EXT, "open %s in image %s -> %p", name->rest, image, result);
+		return result;
 	}
 
 	virtual pfs_dir *getdir(pfs_name *name) {
-		assert(name);
-		debug(D_EXT, "getdir %s", name->rest);
-		return NULL;
-	}
+		ext2_ino_t inode;
+		struct ext2_inode inode_buf;
 
-	virtual int stat(pfs_name *name, struct pfs_stat *buf) {
 		assert(name);
-		assert(buf);
-		debug(D_EXT, "stat %s", name->rest);
-		return -1;
+
+		debug(D_EXT, "getdir %s", name->rest);
+		LOOKUP_INODE(name->rest, &inode, true, NULL);
+		READ_INODE(inode, &inode_buf, NULL);
+		if (!S_ISDIR(inode_buf.i_mode)) {
+			errno = ENOTDIR;
+			return NULL;
+		}
+		pfs_dir *result = new pfs_dir(name);
+		ext2fs_dir_iterate(fs, inode, 0, NULL, append_dirents, result);
+
+		return result;
 	}
 
 	virtual int statfs(pfs_name *name, struct pfs_statfs *buf) {
+		ext2_ino_t inode;
+
 		assert(name);
 		assert(buf);
+
 		debug(D_EXT, "statfs %s", name->rest);
-		return -1;
+		LOOKUP_INODE(name->rest, &inode, true, -1);
+		pfs_service_emulate_statfs(buf);
+
+		return 0;
+	}
+
+	virtual int stat(pfs_name *name, struct pfs_stat *buf) {
+		ext2_ino_t inode;
+		struct ext2_inode inode_buf;
+
+		assert(name);
+		assert(buf);
+
+		debug(D_EXT, "stat %s", name->rest);
+		LOOKUP_INODE(name->rest, &inode, true, -1);
+		READ_INODE(inode, &inode_buf, -1);
+		inode2stat(inode, &inode_buf, buf);
+
+		return 0;
 	}
 
 	virtual int lstat(pfs_name *name, struct pfs_stat *buf) {
+		ext2_ino_t inode;
+		struct ext2_inode inode_buf;
+
 		assert(name);
 		assert(buf);
+
 		debug(D_EXT, "lstat %s", name->rest);
-		return -1;
+		LOOKUP_INODE(name->rest, &inode, false, -1);
+		READ_INODE(inode, &inode_buf, -1);
+		inode2stat(inode, &inode_buf, buf);
+
+		return 0;
 	}
 
 	virtual int access(pfs_name *name, mode_t mode) {
+		ext2_ino_t inode;
+
 		assert(name);
+
 		debug(D_EXT, "access %s %d", name->rest, mode);
-		return -1;
+		LOOKUP_INODE(name->rest, &inode, true, -1);
+
+		// we don't do permission checks, so just go ahead
+		return 0;
 	}
 
 	virtual int readlink(pfs_name *name, char *buf, pfs_size_t bufsiz) {
+		ext2_ino_t inode;
+		ext2_file_t file;
+		struct ext2_inode inode_buf;
+		unsigned size;
+
 		assert(name);
 		assert(buf);
+
 		debug(D_EXT, "readlink %s", name->rest);
-		return -1;
-	}
+		LOOKUP_INODE(name->rest, &inode, false, -1);
 
-	virtual ssize_t getxattr(pfs_name *name, const char *attrname, void *data, size_t size) {
-		assert(name);
-		assert(attrname);
-		assert(data);
-		debug(D_EXT, "getxattr %s %s", name->rest, attrname);
-		return -1;
-	}
+		errcode_t rc = ext2fs_read_inode(fs, inode, &inode_buf);
+		if (rc == 0) {
+			debug(D_EXT, "read full inode %d", inode);
+		} else {
+			debug(D_EXT, "read full inode %d failed: %s", inode, error_message(rc));
+			return -1;
+		}
 
-	virtual ssize_t lgetxattr(pfs_name *name, const char *attrname, void *data, size_t size) {
-		assert(name);
-		assert(attrname);
-		assert(data);
-		debug(D_EXT, "lgetxattr %s %s", name->rest, attrname);
-		return -1;
-	}
+		if (!S_ISLNK(inode_buf.i_mode)) {
+			errno = EINVAL;
+			return -1;
+		}
+		OPEN_FILE(inode, &file, -1);
 
-	virtual ssize_t listxattr(pfs_name *name, char *list, size_t size) {
-		assert(name);
-		assert(list);
-		debug(D_EXT, "listxattr %s", name->rest);
-		return -1;
-	}
+		rc = ext2fs_file_read(file, buf, bufsiz, &size);
+		if (rc == 0) {
+			debug(D_EXT, "read %u/%" PRIu64 " bytes from file %p", size, bufsiz, file);
+		} else if (rc == EXT2_ET_SHORT_READ) {
+			debug(D_EXT, "short read on %p, inline link", file);
+			size = inode_buf.i_size;
+			memcpy(buf, inode_buf.i_block, size);
+		} else {
+			debug(D_EXT, "read file %p failed: %s", file, error_message(rc));
+			CLOSE_FILE(file, -1);
+			return -1;
+		}
 
-	virtual ssize_t llistxattr(pfs_name *name, char *list, size_t size) {
-		assert(name);
-		assert(list);
-		debug(D_EXT, "llistxattr %s", name->rest);
-		return -1;
+		CLOSE_FILE(file, -1);
+
+		return size;
 	}
 
 	virtual int is_seekable() {

--- a/parrot/src/pfs_service_ext.cc
+++ b/parrot/src/pfs_service_ext.cc
@@ -494,7 +494,12 @@ public:
 	}
 };
 
+#endif
+
 pfs_service *pfs_service_ext_init(const char *image, const char *mountpoint) {
+
+#ifdef HAS_EXT2FS
+
 	assert(image);
 
 	initialize_ext2_error_table();
@@ -510,16 +515,15 @@ pfs_service *pfs_service_ext_init(const char *image, const char *mountpoint) {
 	}
 
 	return new pfs_service_ext(fs, image, mountpoint);
-}
 
 #else
 
-pfs_service *pfs_service_ext_init(const char *image) {
 	fatal("parrot was not configured with ext2fs support");
 	// unreachable
 	return NULL;
-}
 
 #endif
+
+}
 
 /* vim: set noexpandtab tabstop=4: */

--- a/parrot/src/pfs_service_ext.cc
+++ b/parrot/src/pfs_service_ext.cc
@@ -394,6 +394,9 @@ pfs_service *pfs_service_ext_init(const char *image) {
 	ext2_filsys fs;
 	errcode_t rc = ext2fs_open(image, 0, 0, 0, unix_io_manager, &fs);
 	if (rc != 0) {
+		if (rc == EXT2_ET_SHORT_READ) {
+			fprintf(stderr, "got short read on %s, could indicate trying to open directory as ext image\n", image);
+		}
 		fatal("failed to load ext image %s: %s", image, error_message(rc));
 	}
 

--- a/parrot/src/pfs_service_ext.cc
+++ b/parrot/src/pfs_service_ext.cc
@@ -1,0 +1,279 @@
+/*
+Copyright (C) 2018- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#ifdef HAS_EXT2FS
+
+#include "pfs_service.h"
+
+extern "C" {
+#include "debug.h"
+}
+
+#include <assert.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <dirent.h>
+
+#if defined(HAS_ATTR_XATTR_H)
+#include <attr/xattr.h>
+#elif defined(HAS_SYS_XATTR_H)
+#include <sys/xattr.h>
+#endif
+#ifndef ENOATTR
+#define ENOATTR  EINVAL
+#endif
+
+class pfs_file_ext : public pfs_file {
+public:
+	pfs_file_ext(pfs_name *name) : pfs_file(name) {
+		last_offset = 0;
+	}
+
+	virtual int canbenative(char *path, size_t len) {
+		return 0;
+	}
+
+	virtual int close() {
+		return -1;
+	}
+
+	virtual pfs_ssize_t read(void *data, pfs_size_t length, pfs_off_t offset) {
+		return -1;
+	}
+
+	virtual pfs_ssize_t write(const void *data, pfs_size_t length, pfs_off_t offset) {
+		return -1;
+	}
+
+	virtual int fstat(struct pfs_stat *buf) {
+		return -1;
+	}
+
+	virtual int fstatfs(struct pfs_statfs *buf) {
+		return -1;
+	}
+
+	virtual int ftruncate(pfs_size_t length) {
+		return -1;
+	}
+
+	virtual int fsync() {
+		return -1;
+	}
+
+	virtual int fcntl(int cmd, void *arg) {
+		return -1;
+	}
+
+	virtual int fchmod(mode_t mode) {
+		return -1;
+	}
+
+	virtual int fchown(uid_t uid, gid_t gid) {
+		return -1;
+	}
+
+#if defined(HAS_SYS_XATTR_H) || defined(HAS_ATTR_XATTR_H)
+	virtual ssize_t fgetxattr(const char *name, void *data, size_t size) {
+		return -1;
+	}
+
+	virtual ssize_t flistxattr(char *list, size_t size) {
+		return -1;
+	}
+
+	virtual int fsetxattr(const char *name, const void *data, size_t size, int flags) {
+		return -1;
+	}
+
+	virtual int fremovexattr(const char *name) {
+		return -1;
+	}
+
+#endif
+
+	virtual int flock(int op) {
+		return -1;
+	}
+
+	virtual void *mmap() {
+		return NULL;
+	}
+
+	virtual pfs_ssize_t get_size() {
+		return -1;
+	}
+
+	virtual int get_real_fd() {
+		return -1;
+	}
+
+	virtual int get_local_name(char *n) {
+		strcpy(n, name.rest);
+		return 0;
+	}
+
+	virtual int is_seekable() {
+		return 1;
+	}
+};
+
+class pfs_service_ext: public pfs_service {
+public:
+	pfs_service_ext(const char *image) {
+	}
+
+	virtual pfs_file *open(pfs_name *name, int flags, mode_t mode) {
+		return NULL;
+	}
+
+	virtual pfs_dir *getdir(pfs_name *name) {
+		return NULL;
+	}
+
+	virtual int stat(pfs_name *name, struct pfs_stat *buf) {
+		return -1;
+	}
+
+	virtual int statfs(pfs_name *name, struct pfs_statfs *buf) {
+		return -1;
+	}
+
+	virtual int lstat(pfs_name *name, struct pfs_stat *buf) {
+		return -1;
+	}
+
+	virtual int access(pfs_name *name, mode_t mode) {
+		return -1;
+	}
+
+	virtual int chmod(pfs_name *name, mode_t mode) {
+		return -1;
+	}
+
+	virtual int chown(pfs_name *name, uid_t uid, gid_t gid) {
+		return -1;
+	}
+
+	virtual int lchown(pfs_name *name, uid_t uid, gid_t gid) {
+		return -1;
+	}
+
+	virtual int truncate(pfs_name *name, pfs_off_t length) {
+		return -1;
+	}
+
+	virtual int utime(pfs_name *name, struct utimbuf *buf) {
+		return -1;
+	}
+
+	virtual int utimens(pfs_name *name, const struct timespec times[2]) {
+		return -1;
+	}
+
+	virtual int lutimens(pfs_name *name, const struct timespec times[2]) {
+		return -1;
+	}
+
+	virtual int unlink(pfs_name *name) {
+		return -1;
+	}
+
+	virtual int rename(pfs_name *oldname, pfs_name *newname) {
+		return -1;
+	}
+
+	virtual ssize_t getxattr(pfs_name *name, const char *attrname, void *data, size_t size) {
+		return -1;
+	}
+
+	virtual ssize_t lgetxattr(pfs_name *name, const char *attrname, void *data, size_t size) {
+		return -1;
+	}
+
+	virtual ssize_t listxattr(pfs_name *name, char *list, size_t size) {
+		return -1;
+	}
+
+	virtual ssize_t llistxattr(pfs_name *name, char *list, size_t size) {
+		return -1;
+	}
+
+	virtual int setxattr(pfs_name *name, const char *attrname, const void *data, size_t size, int flags) {
+		return -1;
+	}
+
+	virtual int lsetxattr(pfs_name *name, const char *attrname, const void *data, size_t size, int flags) {
+		return -1;
+	}
+
+	virtual int removexattr(pfs_name *name, const char *attrname) {
+		return -1;
+	}
+
+	virtual int lremovexattr(pfs_name *name, const char *attrname) {
+		return -1;
+	}
+
+	virtual int chdir(pfs_name *name, char *newpath) {
+		return -1;
+	}
+
+	virtual int link(pfs_name *oldname, pfs_name *newname) {
+		return -1;
+	}
+
+	virtual int symlink(const char *linkname, pfs_name *newname) {
+		return -1;
+	}
+
+	virtual int readlink(pfs_name *name, char *buf, pfs_size_t size) {
+		return -1;
+	}
+
+	virtual int mknod(pfs_name *name, mode_t mode, dev_t dev) {
+		return -1;
+	}
+
+	virtual int mkdir(pfs_name *name, mode_t mode) {
+		return -1;
+	}
+
+	virtual int rmdir(pfs_name *name) {
+		return -1;
+	}
+
+	virtual int whoami(pfs_name *name, char *buf, int size) {
+		return -1;
+	}
+
+	virtual pfs_location* locate(pfs_name *name) {
+		return NULL;
+	}
+
+	virtual int is_seekable() {
+		return 1;
+	}
+
+	virtual int is_local() {
+		return 1;
+	}
+};
+
+pfs_service *pfs_service_ext_init(const char *image) {
+	assert(image);
+	return new pfs_service_ext(image);
+}
+
+#endif
+
+/* vim: set noexpandtab tabstop=4: */

--- a/parrot/src/pfs_service_ext.cc
+++ b/parrot/src/pfs_service_ext.cc
@@ -133,22 +133,22 @@ public:
 
 class pfs_service_ext: public pfs_service {
 private:
+	char *image;
 	ext2_filsys fs;
-	char *path;
 
 public:
 	pfs_service_ext(ext2_filsys handle, const char *img) {
+		image = strdup(img);
 		fs = handle;
-		path = xxstrdup(img);
 	}
 
 	~pfs_service_ext() {
-		debug(D_EXT, "closing ext fs %s", path);
+		debug(D_EXT, "closing ext fs %s", image);
+		free(image);
 		errcode_t rc = ext2fs_close(fs);
 		if (rc != 0) {
-			debug(D_NOTICE, "failed to close ext filesystem at %s: %s", path, error_message(rc));
+			debug(D_NOTICE, "failed to close ext filesystem at %s: %s", image, error_message(rc));
 		}
-		free(path);
 	}
 
 	virtual pfs_file *open(pfs_name *name, int flags, mode_t mode) {

--- a/parrot/src/pfs_service_ext.cc
+++ b/parrot/src/pfs_service_ext.cc
@@ -338,7 +338,7 @@ public:
 		struct ext2_inode inode_buf;
 
 		assert(name);
-		if (mode&(O_WRONLY|O_RDWR)) {
+		if (flags&(O_WRONLY|O_RDWR)) {
 			errno = EROFS;
 			return NULL;
 		}

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -520,8 +520,8 @@ int pfs_table::resolve_name(int is_special_syscall, const char *cname, struct pf
 			pname->is_local = 1;
 		} else if (!strncmp(pname->service_name, "ext_", 4)) {
 			strcpy(pname->rest, tmp);
-			pname->host[0] = '\0';
-			pname->hostport[0] = '\0';
+			strcpy(pname->host, "ext");
+			strcpy(pname->hostport, "ext");
 			pname->port = 0;
 		} else {
 			if(!strcmp(pname->service_name,"multi")) {// if we're dealing with a multivolume, split off at the @

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -518,6 +518,11 @@ int pfs_table::resolve_name(int is_special_syscall, const char *cname, struct pf
 			strcpy(pname->hostport,"localhost");
 			strcpy(pname->rest,pname->path);
 			pname->is_local = 1;
+		} else if (!strncmp(pname->service_name, "ext_", 4)) {
+			strcpy(pname->rest, tmp);
+			pname->host[0] = '\0';
+			pname->hostport[0] = '\0';
+			pname->port = 0;
 		} else {
 			if(!strcmp(pname->service_name,"multi")) {// if we're dealing with a multivolume, split off at the @
 				path_split_multi(tmp,pname->host,pname->rest);

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -518,7 +518,7 @@ int pfs_table::resolve_name(int is_special_syscall, const char *cname, struct pf
 			strcpy(pname->hostport,"localhost");
 			strcpy(pname->rest,pname->path);
 			pname->is_local = 1;
-		} else if (!strncmp(pname->service_name, "ext_", 4)) {
+		} else if (!strncmp(pname->service_name, "ext", 3)) {
 			strcpy(pname->rest, tmp);
 			strcpy(pname->host, "ext");
 			strcpy(pname->hostport, "ext");

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -518,7 +518,7 @@ int pfs_table::resolve_name(int is_special_syscall, const char *cname, struct pf
 			strcpy(pname->hostport,"localhost");
 			strcpy(pname->rest,pname->path);
 			pname->is_local = 1;
-		} else if (!strncmp(pname->service_name, "ext", 3)) {
+		} else if (!strncmp(pname->service_name, "ext_", 4)) {
 			strcpy(pname->rest, tmp);
 			strcpy(pname->host, "ext");
 			strcpy(pname->hostport, "ext");


### PR DESCRIPTION
This PR adds ext2fs as an optional dependency so that Parrot can mount ext[234] disk images. This could be expanded to support read/write access, but for the moment I kept things RO. Users specify the path to an image file which Parrot loads and exposes as a directory tree under `/ext_%d`. I might adjust how images are specified on the command line and the paths they get to improve ergonomics. I've done enough testing to make sure basic functionality works (look around directories, read files, exec programs, follow symlinks).

See also #1947