### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: c
 sudo: required
 services: docker
 
-script: ./travis_build.sh
-after_failure: cat cctools.test.fail
+script: "./travis_build.sh"
+after_failure: "cat cctools.test.fail"
 
 matrix:
   include:
@@ -29,3 +29,13 @@ matrix:
   - os: linux
     compiler: gcc
     env: DOCKER_IMAGE=cclnd/cctools-env:x86_64-opensuse42.3
+deploy:
+  provider: releases
+  file: "/tmp/cctools-*.tar.gz"
+  file_glob: true
+  skip_cleanup: true
+  on:
+    repo: cooperative-computing-lab/cctools
+    tags: true
+  api-key:
+    secure: pVs2jvA+y0NYxjhw7zp6+OLssTxOe0lMwqWGWKOeeDihZMmsYeXJ9Z+oxOghfhbcqEv4TnMsYCBkDGLnlSUplWyDPqu/eW0QuvlPzY5VaqqK9aVw1abgKAp77vddub1kHPPqF2axaYIlor6wrMCkyG2ICwmr0mWX+ISNSspsyHzuEA/0XDOMAzY1QjMd08ASScGLAJxHYecRxnjCrUXiN1nMeh266eWsQmWs9PF+DcpKPB9uMohms0Ei7Kj7wnZOMRLRGwM07EYG6ZkDJTxOdjLkOYQ/xhOSTnWynfyaVK8ZLxOKhoCie7oHEuFQRaO8B96o/ddRI2gosMUMU57/Qj5YtPwnBAxIUpUmxe1eRWOGvAWmRuHUxfVR7ICdSsDc9HFKO22tFJCMShLTm528ASnyMVBF2whncSXiba33phFUNKTcJgCcIzvrKazKUzuHyGJrzpjKWYwHR7ufi0v3MrHROD8LGQ2g03YMKmp7/UrMES335Xs5mLCk7uFWh9kSiGvNrFxkk5hWLtzi3Qz81JiyExxjfl8iUVQyL5gggQnotQH7DGeBALmg3LRuXAT/YOEoaTMCh1nEzt16oifnpp+a1yaqwqtq8EHifqu0g3SkmfzhLO/Xz81qVedJ4rauwW0IFzlU81guclAFRDrTHRmmfTeQehZfKhsnO5ElkEo=

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ script: ./travis_build.sh
 after_failure: cat cctools.test.fail
 
 matrix:
-  allow_failures:
-  - env: DOCKER_IMAGE=base/devel
   include:
   - os: osx
     compiler: clang
@@ -18,7 +16,16 @@ matrix:
     compiler: clang
   - os: linux
     compiler: gcc
-    env: DOCKER_IMAGE=centos/s2i-base-centos7
+    env: DOCKER_IMAGE=cclnd/cctools-env:x86_64-centos6
   - os: linux
     compiler: gcc
-    env: DOCKER_IMAGE=base/devel
+    env: DOCKER_IMAGE=cclnd/cctools-env:x86_64-centos7
+  - os: linux
+    compiler: gcc
+    env: DOCKER_IMAGE=cclnd/cctools-env:x86_64-ubuntu16.04
+  - os: linux
+    compiler: gcc
+    env: DOCKER_IMAGE=cclnd/cctools-env:x86_64-debian9.2
+  - os: linux
+    compiler: gcc
+    env: DOCKER_IMAGE=cclnd/cctools-env:x86_64-opensuse42.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: c
 sudo: required
 services: docker
 
-script: "./travis_build.sh"
+script: "./travis.sh"
 after_failure: "cat cctools.test.fail"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: c
+
+sudo: required
+services: docker
+
+script: ./travis_build.sh
+after_failure: cat cctools.test.fail
+
+matrix:
+  allow_failures:
+  - env: DOCKER_IMAGE=base/devel
+  include:
+  - os: osx
+    compiler: clang
+  - os: linux
+    compiler: gcc
+  - os: linux
+    compiler: clang
+  - os: linux
+    compiler: gcc
+    env: DOCKER_IMAGE=centos/s2i-base-centos7
+  - os: linux
+    compiler: gcc
+    env: DOCKER_IMAGE=base/devel

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,19 +16,19 @@ matrix:
     compiler: clang
   - os: linux
     compiler: gcc
-    env: DOCKER_IMAGE=cclnd/cctools-env:x86_64-centos6
+    env: "DOCKER_IMAGE=cclnd/cctools-env:x86_64-centos6"
   - os: linux
     compiler: gcc
-    env: DOCKER_IMAGE=cclnd/cctools-env:x86_64-centos7
+    env: "DOCKER_IMAGE=cclnd/cctools-env:x86_64-centos7"
   - os: linux
     compiler: gcc
-    env: DOCKER_IMAGE=cclnd/cctools-env:x86_64-ubuntu16.04
+    env: "DOCKER_IMAGE=cclnd/cctools-env:x86_64-ubuntu16.04"
   - os: linux
     compiler: gcc
-    env: DOCKER_IMAGE=cclnd/cctools-env:x86_64-debian9.2
+    env: "DOCKER_IMAGE=cclnd/cctools-env:x86_64-debian9.5"
   - os: linux
     compiler: gcc
-    env: DOCKER_IMAGE=cclnd/cctools-env:x86_64-opensuse42.3
+    env: "DOCKER_IMAGE=cclnd/cctools-env:x86_64-opensuse42.3"
 deploy:
   provider: releases
   file: "/tmp/cctools-*.tar.gz"

--- a/chirp/test/TR_chirp_perl.sh
+++ b/chirp/test/TR_chirp_perl.sh
@@ -12,6 +12,7 @@ ticket=my.ticket
 check_needed()
 {
 	test -f ../src/perl/CChirp.so
+	command -v openssl >/dev/null 2>&1
 }
 
 prepare()

--- a/dttools/test/test_runner_common.sh
+++ b/dttools/test/test_runner_common.sh
@@ -104,7 +104,7 @@ run_local_worker()
 require_identical_files()
 {
 	echo "Comparing output $1 and $2"
-	if diff --brief $1 $2
+	if diff $1 $2
 	then
 		echo "$1 and $2 are the same."
 		return 0

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -101,6 +101,10 @@ echo ""
 echo "Test Results: ${FAILURE} of ${TOTAL} tests failed (${SKIP} skipped) in ${ELAPSED} seconds."
 echo ""
 
-exit $FAILURE
+if [ "$FAILURE" -eq 0 ]; then
+	exit 0
+else
+	exit 1
+fi
 
 # vim: set noexpandtab tabstop=4:

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -95,5 +95,6 @@ echo ""
 echo "Test Results: ${FAILURE} of ${TOTAL} tests failed (${SKIP} skipped) in ${ELAPSED} seconds."
 echo ""
 
+exit $FAILURE
 
 # vim: set noexpandtab tabstop=4:

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -19,6 +19,8 @@ if [ -z "$(echo $CCTOOLS_TEST_LOG | sed -n 's:^/.*$:x:p')" ]; then
 	CCTOOLS_TEST_LOG="$(pwd)/${CCTOOLS_TEST_LOG}"
 fi
 export CCTOOLS_TEST_LOG
+export CCTOOLS_TEST_FAIL=${CCTOOLS_TEST_LOG%.log}.fail
+export CCTOOLS_TEST_TMP=${CCTOOLS_TEST_LOG%.log}.tmp
 
 echo "[$(date)] Testing on $(uname -a)." > "$CCTOOLS_TEST_LOG"
 
@@ -63,8 +65,12 @@ for package in ${CCTOOLS_PACKAGES_TEST}; do
 						echo "======== ${script} CLEAN ========"
 						"./${script}" clean
 						exit $result
-					) >> "$CCTOOLS_TEST_LOG" 2>&1
+					) > "$CCTOOLS_TEST_TMP" 2>&1
 					result=$?
+					cat "$CCTOOLS_TEST_TMP" >> "$CCTOOLS_TEST_LOG"
+					if [ "$result" -ne 0 ]; then
+						cat "$CCTOOLS_TEST_TMP" >> "$CCTOOLS_TEST_FAIL"
+					fi
 				fi
 				TEST_STOP_TIME=$(date +%s)
 				TEST_ELAPSED=$(($TEST_STOP_TIME-$TEST_START_TIME))

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -ex
+
+if [ -z "$DOCKER_IMAGE" ]; then
+    ./travis_build.sh
+else
+    docker run \
+        --privileged \
+        --ulimit nofile=65536 \
+        -v "$(pwd):/root" \
+        -v /tmp:/tmp \
+        -w /root \
+        -e TRAVIS_TAG \
+        -e TRAVIS_COMMIT \
+        -e DOCKER_IMAGE \
+        "$DOCKER_IMAGE" \
+        ./travis_build.sh
+fi

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -3,7 +3,7 @@
 set -ex
 
 BUILD_ID=$(basename "${TRAVIS_TAG:-${TRAVIS_COMMIT:0:8}}")
-IMAGE_ID=$(basename "$DOCKER_IMAGE")
+IMAGE_ID=$(basename "${DOCKER_IMAGE:-travis}")
 D=/tmp/cctools-$BUILD_ID-${IMAGE_ID#cctools-env:}
 
 DEPS_DIR=/opt/vc3/cctools-deps
@@ -17,4 +17,6 @@ done
 make install
 make test
 
-tar -cz -C "$(dirname "$D")" -f "$D.tar.gz" "$(basename "$D")"
+if [ -n "$DOCKER_IMAGE" ]; then
+    tar -cz -C "$(dirname "$D")" -f "$D.tar.gz" "$(basename "$D")"
+fi

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+COMMAND="./configure --strict && make && make test"
+
+if [ -z "$DOCKER_IMAGE" ]; then
+    eval "$COMMAND"
+else
+    docker run \
+        --privileged \
+        --ulimit nofile=65536 \
+        -v "$(pwd):/root" -w '/root' \
+        "$DOCKER_IMAGE" \
+        /bin/sh -c "$COMMAND"
+fi

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -2,15 +2,13 @@
 
 set -ex
 
-COMMAND="./configure --strict --with-cvmfs-path /opt/libcvmfs --with-uuid-path /opt/uuid && make && make test"
-
 if [ -z "$DOCKER_IMAGE" ]; then
-    eval "$COMMAND"
+    ./configure --strict && make && make test
 else
     docker run \
         --privileged \
         --ulimit nofile=65536 \
         -v "$(pwd):/root" -w '/root' \
         "$DOCKER_IMAGE" \
-        /bin/sh -c "$COMMAND"
+        /bin/sh -c "./configure --strict --with-cvmfs-path /opt/libcvmfs --with-uuid-path /opt/uuid && make && make test"
 fi

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-COMMAND="./configure --strict && make && make test"
+COMMAND="./configure --strict --with-cvmfs-path /opt/libcvmfs --with-uuid-path /opt/uuid && make && make test"
 
 if [ -z "$DOCKER_IMAGE" ]; then
     eval "$COMMAND"

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -2,19 +2,19 @@
 
 set -ex
 
-BUILD_ID="$(basename ${TRAVIS_TAG:-${TRAVIS_COMMIT:0:8}})"
-D="/tmp/cctools-$BUILD_ID-${DOCKER_IMAGE#cclnd/cctools-env:}"
+BUILD_ID=$(basename "${TRAVIS_TAG:-${TRAVIS_COMMIT:0:8}}")
+IMAGE_ID=$(basename "$DOCKER_IMAGE")
+D=/tmp/cctools-$BUILD_ID-${IMAGE_ID#cctools-env:}
 
-if [ -z "$DOCKER_IMAGE" ]; then
-    ./configure --strict && make && make test
-else
-    docker run \
-        --privileged \
-        --ulimit nofile=65536 \
-        -v "$(pwd):/root" \
-        -v /tmp:/tmp \
-        -w '/root' \
-        "$DOCKER_IMAGE" \
-        /bin/sh -c "./configure --strict --prefix $D --with-irods-path /opt/irods/ --with-xrootd-path /opt/xrootd/ --with-uuid-path /opt/uuid/ --with-cvmfs-path /opt/libcvmfs && make install && make test"
-    tar -cz -C $(dirname $D) -f $D.tar.gz $(basename $D)
-fi
+DEPS_DIR=/opt/vc3/cctools-deps
+DEPS=$(/bin/ls "$DEPS_DIR" || true)
+DEP_ARGS=""
+for dep in $DEPS; do
+    DEP_ARGS="$DEP_ARGS --with-$dep-path $DEPS_DIR/$dep"
+done
+
+./configure --strict --prefix "$D" $DEP_ARGS
+make install
+make test
+
+tar -cz -C "$(dirname "$D")" -f "$D.tar.gz" "$(basename "$D")"

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -15,6 +15,6 @@ else
         -v /tmp:/tmp \
         -w '/root' \
         "$DOCKER_IMAGE" \
-        /bin/sh -c "./configure --strict --prefix $D --with-cvmfs-path /opt/libcvmfs --with-uuid-path /opt/uuid && make install && make test"
+        /bin/sh -c "./configure --strict --prefix $D --with-irods-path /opt/irods/ --with-xrootd-path /opt/xrootd/ --with-uuid-path /opt/uuid/ --with-cvmfs-path /opt/libcvmfs && make install && make test"
     tar -cz -C $(dirname $D) -f $D.tar.gz $(basename $D)
 fi

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -2,13 +2,19 @@
 
 set -ex
 
+BUILD_ID="$(basename ${TRAVIS_TAG:-${TRAVIS_COMMIT:0:8}})"
+D="/tmp/cctools-$BUILD_ID-${DOCKER_IMAGE#cclnd/cctools-env:}"
+
 if [ -z "$DOCKER_IMAGE" ]; then
     ./configure --strict && make && make test
 else
     docker run \
         --privileged \
         --ulimit nofile=65536 \
-        -v "$(pwd):/root" -w '/root' \
+        -v "$(pwd):/root" \
+        -v /tmp:/tmp \
+        -w '/root' \
         "$DOCKER_IMAGE" \
-        /bin/sh -c "./configure --strict --with-cvmfs-path /opt/libcvmfs --with-uuid-path /opt/uuid && make && make test"
+        /bin/sh -c "./configure --strict --prefix $D --with-cvmfs-path /opt/libcvmfs --with-uuid-path /opt/uuid && make install && make test"
+    tar -cz -C $(dirname $D) -f $D.tar.gz $(basename $D)
 fi

--- a/work_queue/test/TR_work_queue_foreman.sh
+++ b/work_queue/test/TR_work_queue_foreman.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-CORES=1
-TASKS=12
-FOREMAN=1
-
-. ./work_queue_common.sh
-
-# vim: set noexpandtab tabstop=4:

--- a/work_queue/test/work_queue_common.sh
+++ b/work_queue/test/work_queue_common.sh
@@ -23,16 +23,7 @@ EOF
 	echo "waiting for master to get ready"
 	wait_for_file_creation master.port 5
 
-	if [ X$FOREMAN = X1 ]
-	then
-		echo "starting foreman"
-		work_queue_worker -d all -o foreman.log -b 1 --foreman -Z foreman.port localhost `cat master.port` --timeout 20 --single-shot &
-		wait_for_file_creation foreman.port 5
-
-		port=`cat foreman.port`
-	else
-		port=`cat master.port`
-	fi
+	port=`cat master.port`
 
 	echo "starting worker"
 	work_queue_worker -d all -o worker.log localhost $port -b 1 --timeout 20 --cores $CORES --memory-threshold 10 --memory 50 --single-shot
@@ -52,12 +43,6 @@ EOF
 				cat master.log
 			fi
 
-			if [ -f foreman.log  ]
-			then
-				echo "foreman log:"
-				cat foreman.log
-			fi
-
 			if [ -f worker.log  ]
 			then
 				echo "worker log:"
@@ -75,7 +60,7 @@ EOF
 
 clean()
 {
-	rm -f master.script master.log master.port foreman.log foreman.port worker.log output.* input.*
+	rm -f master.script master.log master.port worker.log output.* input.*
 }
 
 dispatch "$@"


### PR DESCRIPTION
This PR will enable Travis on the main repo. I've been testing on my fork, and things seem to be working well. This configuration tests on Travis' default Linux and Mac environments, and in Docker environments we currently use for Autobuild. A couple of points might require discussion:
- The behavior of `run_all_tests.sh` changes so that failed tests result in non-zero exit status. This will likely break the current Autobuild setup. I'm of the opinion that any failed tests should be considered an overall failure, but we might need to drop this commit and keep the current setup with different levels of failure for compatibility with Autobuild.
- I removed the test for WQ Foreman. From a quick glance at the Autobuild display, this test fails about a third of the time, and is ignored in practice.