### PR TITLE
work_queue_graph_log

### DIFF
--- a/work_queue/src/work_queue_graph_log
+++ b/work_queue/src/work_queue_graph_log
@@ -248,7 +248,7 @@ def check_gnuplot_version(gnuplot_cmd):
 
             version = result.group(1)
 
-            if float(version) <= 4.6:
+            if float(version) < 4.6:
                 sys.stderr.write("gnuplot is version %s, at least version 4.6 is required." % (version,))
                 exit(1)
 


### PR DESCRIPTION
fix gnuplot version bug: did not allow gnuplot version 4.6 to be used