### PR TITLE
Configure email alerts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ services: docker
 script: "./travis.sh"
 after_failure: "cat cctools.test.fail"
 
+notifications:
+  email:
+    recipients:
+      - ccl-team-list@nd.edu
+    on_success: always
+    on_failure: always
+
 matrix:
   include:
   - os: osx


### PR DESCRIPTION
This should turn on Travis email notifications to ccl-team-list@nd.edu for all builds. The docs mentioned that in some cases they will only send to addresses associated with a Github account. It wasn't clear if overriding the setting as in this PR skips that check.