### PR TITLE
use HTTP_PROXY when -p is not specified

### DIFF
--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -129,12 +129,14 @@ INT64_T pfs_write_count = 0;
 
 const char * pfs_cvmfs_repo_arg = 0;
 const char * pfs_cvmfs_config_arg = 0;
+const char * pfs_cvmfs_http_proxy = 0;
 bool pfs_cvmfs_repo_switching = false;
 char pfs_cvmfs_alien_cache_dir[PATH_MAX];
 char pfs_cvmfs_locks_dir[PATH_MAX];
 bool pfs_cvmfs_enable_alien  = true;
 char pfs_cvmfs_option_file[PATH_MAX];
 struct jx *pfs_cvmfs_options = NULL;
+
 
 int pfs_irods_debug_level = 0;
 char *stats_file = NULL;
@@ -596,7 +598,6 @@ int main( int argc, char *argv[] )
 	int c;
 	int chose_auth = 0;
 	char *tickets = NULL;
-	char *http_proxy = NULL;
 	pid_t pid;
 	struct pfs_process *p;
 	char envlist[PATH_MAX] = "";
@@ -983,7 +984,7 @@ int main( int argc, char *argv[] )
 			debug_config_file_size(string_metric_parse(optarg));
 			break;
 		case 'p':
-			http_proxy = xxstrdup(optarg);
+			pfs_cvmfs_http_proxy = xxstrdup(optarg);
 			break;
 		case 'P':
 			pfs_paranoid_mode = 1;
@@ -1215,10 +1216,10 @@ int main( int argc, char *argv[] )
 		fclose(fp);
 	}
 
-	if (http_proxy)
-		setenv("PARROT_HTTP_PROXY", http_proxy, 1);
-
-	http_proxy = (char *)realloc(http_proxy, 0);
+	// if -p not given, check if HTTP_PROXY is set.
+	if(!pfs_cvmfs_http_proxy && getenv("HTTP_PROXY")) {
+		pfs_cvmfs_http_proxy = xxstrdup(getenv("HTTP_PROXY"));
+	}
 
 	if (!create_dir(pfs_temp_dir, S_IRWXU))
 		fatal("could not create directory '%s': %s", pfs_temp_dir, strerror(errno));

--- a/parrot/src/pfs_service_cvmfs.cc
+++ b/parrot/src/pfs_service_cvmfs.cc
@@ -51,6 +51,8 @@ extern bool pfs_cvmfs_enable_alien;
 extern char pfs_cvmfs_option_file[];
 extern struct jx *pfs_cvmfs_options;
 
+extern char * pfs_cvmfs_http_proxy;
+
 
 static bool cvmfs_configured = false;
 static struct cvmfs_filesystem *cvmfs_active_filesystem = 0;
@@ -614,9 +616,8 @@ static cvmfs_filesystem *cvmfs_filesystem_create(const char *repo_name, bool wil
 	f->cvmfs_ctx = NULL;
 #endif
 
-	char *proxy = getenv("PARROT_HTTP_PROXY");
 #if LIBCVMFS_REVISION < 23
-	if( !proxy || !proxy[0] || !strcmp(proxy,"DIRECT") ) {
+	if( !pfs_cvmfs_http_proxy || !pfs_cvmfs_http_proxy[0] || !strcmp(pfs_cvmfs_http_proxy,"DIRECT") ) {
 		if( !strstr(user_options,"proxies=") ) {
 			debug(D_CVMFS|D_NOTICE,"CVMFS requires an http proxy.  None has been configured!");
 			debug(D_CVMFS,"Ignoring configuration of CVMFS repository %s:%s",repo_name,user_options);
@@ -658,8 +659,8 @@ static cvmfs_filesystem *cvmfs_filesystem_create(const char *repo_name, bool wil
 
 			pfs_master_timeout,
 			pfs_master_timeout,
-			proxy ? ",proxies=" : "",
-			proxy ? proxy : "",
+			pfs_cvmfs_http_proxy ? ",proxies=" : "",
+			pfs_cvmfs_http_proxy ? pfs_cvmfs_http_proxy : "",
 			&f->subst_offset,
 			user_options);
 #else
@@ -669,8 +670,8 @@ static cvmfs_filesystem *cvmfs_filesystem_create(const char *repo_name, bool wil
 
 			pfs_master_timeout,
 			pfs_master_timeout,
-			proxy ? ",proxies=" : "",
-			proxy ? proxy : "",
+			pfs_cvmfs_http_proxy ? ",proxies=" : "",
+			pfs_cvmfs_http_proxy ? pfs_cvmfs_http_proxy : "",
 			&f->subst_offset,
 			user_options);
 #endif


### PR DESCRIPTION
As reported by @khurtado. 

Also, cleaned it up so that we don't pass the proxy value to cvmfs via an environment variable. 