### PR TITLE
Update SGE resource parsing

### DIFF
--- a/batch_job/src/batch_job_cluster.c
+++ b/batch_job/src/batch_job_cluster.c
@@ -104,6 +104,7 @@ static char *cluster_set_resource_string(struct batch_queue *q, const struct rms
 {
 	char *cluster_resources = NULL;
 	const char *ignore_mem = hash_table_lookup(q->options, "ignore-mem-spec");
+	const char *mem_type = hash_table_lookup(q->options, "mem-type");
 
 	if(q->type == BATCH_QUEUE_TYPE_TORQUE || q->type == BATCH_QUEUE_TYPE_PBS){
 		char *mem = string_format(",mem=%" PRId64 "mb", resources->memory);
@@ -125,6 +126,15 @@ static char *cluster_set_resource_string(struct batch_queue *q, const struct rms
 			resources->cores>0 ? resources->cores : 1,
 			(resources->memory>0 && mem) ? mem : "");
 		free(mem);
+	} else if(q->type == BATCH_QUEUE_TYPE_SGE){
+		char *mem = NULL;
+		mem = string_format(" -l %s=%" PRId64 "M", (mem_type ? mem_type : "h_vmem"), resources->memory);
+		// SGE assumes shared FS, ignoring possible disk specification
+		cluster_resources = string_format(" -pe smp %" PRId64 "%s ", 
+			resources->cores>0 ? resources->cores : 1,
+			(resources->memory>0 && mem) ? mem : "");
+		free(mem);
+
 	}
 	const char *safe_mode = hash_table_lookup(q->options, "safe-submit-mode");
 	if(!strcmp("yes", safe_mode))

--- a/makeflow/example/example.categories.makeflow
+++ b/makeflow/example/example.categories.makeflow
@@ -28,15 +28,15 @@ MAKEFLOW_OUTPUTS=capitol.montage.gif
 # Resources needed for a single task in category may be included (optional).
 # MEMORY and DISK in MB.
 .MAKEFLOW CORES 1
-.MAKEFLOW MEMORY 50
+.MAKEFLOW MEMORY 100
 .MAKEFLOW DISK 100
 capitol.montage.gif: capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg
 	$CONVERT -delay 10 -loop 0 -limit thread $CORES capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.montage.gif
 
 .MAKEFLOW CATEGORY analysis
 .MAKEFLOW CORES 1
-.MAKEFLOW MEMORY 10
-.MAKEFLOW DISK 20
+.MAKEFLOW MEMORY 100
+.MAKEFLOW DISK 50
 capitol.90.jpg: capitol.jpg
 	$CONVERT -swirl 90 capitol.jpg capitol.90.jpg
 
@@ -52,7 +52,7 @@ capitol.360.jpg: capitol.jpg
 # If a rule is preceded by LOCAL, it executes at the local site.
 .MAKEFLOW CATEGORY preprocess
 .MAKEFLOW CORES 1
-.MAKEFLOW MEMORY 10
+.MAKEFLOW MEMORY 50
 .MAKEFLOW DISK 20
 capitol.jpg:
 	LOCAL $CURL -o capitol.jpg $URL

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -1183,6 +1183,7 @@ int main(int argc, char *argv[])
 	char *s;
 	int safe_submit = 0;
 	int ignore_mem_spec = 0;
+	char *batch_mem_type = NULL;
 	category_mode_t allocation_mode = CATEGORY_ALLOCATION_MODE_FIXED;
 	char *mesos_master = "127.0.0.1:5050/";
 	char *mesos_path = NULL;
@@ -1250,6 +1251,7 @@ int main(int argc, char *argv[])
 		LONG_OPT_LOCAL_CORES,
 		LONG_OPT_LOCAL_MEMORY,
 		LONG_OPT_LOCAL_DISK,
+		LONG_OPT_BATCH_MEM_TYPE,
 		LONG_OPT_MONITOR,
 		LONG_OPT_MONITOR_EXE,
 		LONG_OPT_MONITOR_INTERVAL,
@@ -1339,6 +1341,7 @@ int main(int argc, char *argv[])
 		{"gc-count", required_argument, 0, 'G'},
 		{"help", no_argument, 0, 'h'},
 		{"ignore-memory-spec", no_argument, 0, LONG_OPT_IGNORE_MEM},
+		{"batch-mem-type", required_argument, 0, LONG_OPT_BATCH_MEM_TYPE},
 		{"local-cores", required_argument, 0, LONG_OPT_LOCAL_CORES},
 		{"local-memory", required_argument, 0, LONG_OPT_LOCAL_MEMORY},
 		{"local-disk", required_argument, 0, LONG_OPT_LOCAL_DISK},
@@ -1867,6 +1870,10 @@ int main(int argc, char *argv[])
 			case LONG_OPT_IGNORE_MEM:
 				ignore_mem_spec = 1;
 				break;
+			case LONG_OPT_BATCH_MEM_TYPE:
+				free(batch_mem_type);
+				batch_mem_type = xxstrdup(optarg);
+				break;
 			case LONG_OPT_SAFE_SUBMIT:
 				safe_submit = 1;
 				break;
@@ -2125,6 +2132,7 @@ int main(int argc, char *argv[])
 	batch_queue_set_option(remote_queue, "amazon-batch-img", amazon_batch_img);
 	batch_queue_set_option(remote_queue, "safe-submit-mode", safe_submit ? "yes" : "no");
 	batch_queue_set_option(remote_queue, "ignore-mem-spec", ignore_mem_spec ? "yes" : "no");
+	batch_queue_set_option(remote_queue, "mem-type", batch_mem_type);
 
 	char *fa_multiplier = string_format("%f", wq_option_fast_abort_multiplier);
 	batch_queue_set_option(remote_queue, "fast-abort", fa_multiplier);

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -1103,6 +1103,7 @@ static void show_help_run(const char *cmd)
 	printf("    --local-disk=#              Max amount of local disk (MB) to use.\n");
 	printf("    --safe-submit-mode          Excludes resources at submission (SLURM, TORQUE, and PBS).\n");
 	printf("    --ignore-memory-spec        Excludes memory at submission (SLURM).\n");
+	printf("    --batch-mem-type            Specify memory type for resource specification (SGE).\n");
 	printf("    --working-dir=<dir|url>     Working directory for the batch system.\n");
 	        /********************************************************************************/
 	printf("\nContainers and Wrappers:\n");


### PR DESCRIPTION
Support SGE resources.

Only specifies Memory and Cores.

Assumes parallel environment `-pe smp` on SGE (single machine).

The default type of memory is `-l h_vmem=$$M`. 

Updated example to run in SGE with specified resources. Previously was failing with original resource specification.

Addresses #1978 