### PR TITLE
give the option to just measure, but not kill tasks in workqueue

### DIFF
--- a/doc/man/resource_monitor.m4
+++ b/doc/man/resource_monitor.m4
@@ -244,7 +244,7 @@ Additionally, it can be run automatically from Work Queue:
 
 LONGCODE_BEGIN
 q = work_queue_create_monitoring(port);
-work_queue_enable_monitoring(q, some-log-dir);
+work_queue_enable_monitoring(q, some-log-dir, /*kill tasks on exhaustion*/ 1);
 LONGCODE_END
 
 wraps every task with the monitor and writes the resulting summaries in

--- a/doc/resource_monitor.html
+++ b/doc/resource_monitor.html
@@ -236,7 +236,7 @@ Snapshots are included in the output summary file as an array of JSON objects un
       From Work Queue:
 
 <code>q = work_queue_create(port);
-work_queue_enable_monitoring(q, some-log-file);
+work_queue_enable_monitoring(q, some-log-file, /* kill tasks on exhaustion */ 1);
 </code>
 
       wraps every task with the monitor, and appends all generated

--- a/dttools/src/rmonitor.c
+++ b/dttools/src/rmonitor.c
@@ -106,7 +106,11 @@ char *resource_monitor_write_command(const char *monitor_path, const char *templ
 	if(!monitor_path)
 		fatal("Monitor path should be specified.");
 
+	//useful when debugging (uncomment):
+	//buffer_printf(&cmd_builder, "valgrind  --leak-check=full -- ");
+	
 	buffer_printf(&cmd_builder, "%s --no-pprint", monitor_path);
+
 	buffer_printf(&cmd_builder, " --with-output-files=%s", template_filename);
 
 	if(debug_output)

--- a/dttools/src/rmonitor_poll.c
+++ b/dttools/src/rmonitor_poll.c
@@ -261,16 +261,17 @@ int rmonitor_get_children(pid_t pid, uint64_t **children)
 
 	while(fscanf(fstat, "%" PRIu64, &child) == 1) {
 		count++;
-
-		if(count > max) {
+		if(count >= max) {
 			max = 2*count;
-			child_list = realloc(child_list, sizeof(pid_t) * max);
+			child_list = realloc(child_list, max*sizeof(uint64_t));
 		}
 
 		child_list[count - 1] = child;
 	}
 
 	*children = child_list;
+
+	fclose(fstat);
 
 	return count;
 }

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -2164,8 +2164,6 @@ int main(int argc, char **argv) {
 	snapshot_labels = list_create();
 	snapshot_watch_pids = itable_create(0);
 
-    rmsummary_read_env_vars(resources_limits);
-
     processes = itable_create(0);
     wdirs     = hash_table_create(0,0);
     filesysms = itable_create(0);

--- a/work_queue/src/perl/Work_Queue.pm
+++ b/work_queue/src/perl/Work_Queue.pm
@@ -112,13 +112,17 @@ sub task_state {
 }
 
 sub enable_monitoring {
-	my ($self, $summary_file) = @_;
-	return work_queue_enable_monitoring($self->{_work_queue}, $summary_file);
+	my ($self, $dir_name, $watchdog) = @_;
+
+    $watchdog = defined $watchdog ? $watchdog : 1;
+	return work_queue_enable_monitoring($self->{_work_queue}, $dir_name, $watchdog);
 }
 
 sub enable_monitoring_full {
-	my ($self, $dir_name) = @_;
-	return work_queue_enable_monitoring_full($self->{_work_queue}, $dir_name);
+	my ($self, $dir_name, $watchdog) = @_;
+
+    $watchdog = defined $watchdog ? $watchdog : 1;
+	return work_queue_enable_monitoring_full($self->{_work_queue}, $dir_name, $watchdog);
 }
 
 
@@ -485,7 +489,7 @@ A resource name.
 =back
 
 
-=head3 C<enable_monitoring($dir_name)>
+=head3 C<enable_monitoring($dir_name, $watchdog)>
 
 Enables resource monitoring of tasks in the queue, and writes a summary per
 task to the directory given. Additionally, all summaries are consolidate into
@@ -497,9 +501,11 @@ Returns 1 on success, 0 on failure (i.e., monitoring was not enabled).
 
 =item dirname    Directory name for the monitor output.
 
+=item watchdog   If non-zero, kill tasks that exhaust their declared resources. (if not given, defaults to 1)
+
 =back
 
-=head3 C<enable_monitoring_full($dir_name)>
+=head3 C<enable_monitoring_full($dir_name, $watchdog)>
 
 As @ref enable_monitoring, but it also generates a time series and a debug
 file.  WARNING: Such files may reach gigabyte sizes for long running tasks.
@@ -509,6 +515,8 @@ Returns 1 on success, 0 on failure (i.e., monitoring was not enabled).
 =over 12
 
 =item dirname    Directory name for the monitor output.
+
+=item watchdog   If non-zero, kill tasks that exhaust their declared resources. (if not given, defaults to 1)
 
 =back
 

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -941,8 +941,9 @@ class WorkQueue(_object):
     #
     # @param self 	Reference to the current work queue object.
     # @param dirname    Directory name for the monitor output.
-    def enable_monitoring(self, dirname):
-        return work_queue_enable_monitoring(self._work_queue, dirname)
+    # @param watchdog   If True (default), kill tasks that exhaust their declared resources.
+    def enable_monitoring(self, dirname = None, watchdog = True):
+        return work_queue_enable_monitoring(self._work_queue, dirname, watchdog)
 
     ## As @ref enable_monitoring, but it also generates a time series and a debug file.
     #  WARNING: Such files may reach gigabyte sizes for long running tasks.
@@ -951,8 +952,9 @@ class WorkQueue(_object):
     #
     # @param self 	Reference to the current work queue object.
     # @param dirname    Directory name for the monitor output.
-    def enable_monitoring_full(self, dirname):
-        return work_queue_enable_monitoring_full(self._work_queue, dirname)
+    # @param watchdog   If True (default), kill tasks that exhaust their declared resources.
+    def enable_monitoring_full(self, dirname = None, watchdog = True):
+        return work_queue_enable_monitoring_full(self._work_queue, dirname, watchdog)
 
     ##
     # Turn on or off fast abort functionality for a given queue for tasks in

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1446,7 +1446,7 @@ void resource_monitor_append_report(struct work_queue *q, struct work_queue_task
 	if(t->monitor_output_directory)
 		keep = 1;
 
-	if(q->monitor_mode | MON_FULL && q->monitor_output_directory)
+	if(q->monitor_mode & MON_FULL && q->monitor_output_directory)
 		keep = 1;
 				
 	if(!keep)
@@ -1514,7 +1514,7 @@ static void fetch_output_from_worker(struct work_queue *q, struct work_queue_wor
 		read_measured_resources(q, t);
 
 		/* Further, if we got debug and series files, gzip them. */
-		if(q->monitor_mode | MON_FULL)
+		if(q->monitor_mode & MON_FULL)
 			resource_monitor_compress_logs(q, t);
 	}
 
@@ -5255,7 +5255,7 @@ void work_queue_monitor_add_files(struct work_queue *q, struct work_queue_task *
 	work_queue_task_specify_file(t, summary, RESOURCE_MONITOR_REMOTE_NAME ".summary", WORK_QUEUE_OUTPUT, WORK_QUEUE_NOCACHE);
 	free(summary);
 
-	if(q->monitor_mode | MON_FULL && (q->monitor_output_directory || t->monitor_output_directory)) {
+	if(q->monitor_mode & MON_FULL && (q->monitor_output_directory || t->monitor_output_directory)) {
 		char *debug  = monitor_file_name(q, t, ".debug");
 		char *series = monitor_file_name(q, t, ".series");
 
@@ -5283,9 +5283,9 @@ char *work_queue_monitor_wrap(struct work_queue *q, struct work_queue_worker *w,
 		free(tmp);
 	}
 
-	int extra_files = (q->monitor_mode | MON_FULL);
+	int extra_files = (q->monitor_mode & MON_FULL);
 
-	struct rmsummary *watch_limits = (q->monitor_mode | MON_WATCHDOG) ? limits : NULL;
+	struct rmsummary *watch_limits = (q->monitor_mode & MON_WATCHDOG) ? limits : NULL;
 
 	char *monitor_cmd = resource_monitor_write_command("./" RESOURCE_MONITOR_REMOTE_NAME, RESOURCE_MONITOR_REMOTE_NAME, watch_limits, extra_options, /* debug */ extra_files, /* series */ extra_files, /* inotify */ 0, /* measure_dir */ NULL);
 	char *wrap_cmd  = string_wrap_command(t->command_line, monitor_cmd);

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -598,9 +598,10 @@ explicitely given by work_queue_task's monitor_output_file.
 @param monitor_output_dirname The name of the output directory. If NULL,
 summaries are kept only when monitor_output_directory is specify per task, but
 resources_measured from work_queue_task is updated.  @return 1 on success, 0 if
+@param watchdog if not 0, kill tasks that exhaust declared resources.
 monitoring was not enabled.
 */
-int work_queue_enable_monitoring(struct work_queue *q, char *monitor_output_directory);
+int work_queue_enable_monitoring(struct work_queue *q, char *monitor_output_directory, int watchdog);
 
 /** Enables resource monitoring on the give work queue.
 As @ref work_queue_enable_monitoring, but it generates a time series and a
@@ -608,9 +609,10 @@ monitor debug file (WARNING: for long running tasks these files may reach
 gigabyte sizes. This function is mostly used for debugging.) @param q A work
 queue object.
 @param monitor_output_dirname The name of the output directory.
+@param watchdog if not 0, kill tasks that exhaust declared resources.
 @return 1 on success, 0 if monitoring was not enabled.
 */
-int work_queue_enable_monitoring_full(struct work_queue *q, char *monitor_output_directory);
+int work_queue_enable_monitoring_full(struct work_queue *q, char *monitor_output_directory, int watchdog);
 
 /** Submit a task to a queue.
 Once a task is submitted to a queue, it is not longer under the user's

--- a/work_queue/src/work_queue_test_main.c
+++ b/work_queue/src/work_queue_test_main.c
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
 
 	if(monitor_flag) {
 		unlink_recursive("work-queue-test-monitor");
-		work_queue_enable_monitoring(q, "work-queue-test-monitor");
+		work_queue_enable_monitoring(q, "work-queue-test-monitor", 1);
 		work_queue_specify_category_mode(q, NULL, WORK_QUEUE_ALLOCATION_MODE_MAX_THROUGHPUT);
 
 		work_queue_specify_transactions_log(q, "work-queue-test-monitor/transactions.log");


### PR DESCRIPTION
Measure but don't kill tasks that exhaust resources.

(To help with debugging in shadho.)