### PR TITLE
Mpi tutorial reference

### DIFF
--- a/doc/makeflow.html
+++ b/doc/makeflow.html
@@ -59,10 +59,10 @@
 <li><a href=#wrapper>Wrapper Commands</a>
 </ul>
 
-<li><a href=#mpi>MPI</a>
+<li><a href=#mpi>Running in an MPI Environment</a>
 <ul>
-<li><a href=#makeflow-mpi>Makeflow as an MPI process</a>
-<li><a href=#mpi-starter>Makeflow MPI Starter</a>
+<li><a href=#makeflow-mpi>Running Makeflow as an MPI Job</a>
+<li><a href=#mpi-starter>Running Makeflow and WorkQueue as an MPI Job</a>
 </ul>
 
 <li><a href=#advanced>Advanced Features</a>
@@ -886,20 +886,27 @@ exec "$@"
 
 <code>makeflow --wrapper ./setupjava.sh --wrapper-input setupjava.sh example.makeflow</code>
 
-<a name=mpi><h2>Running as MPI</h2></a>
+<a name=mpi><h2>Running in an MPI Environment</h2></a>
 
-<a name=makeflow-mpi><h3>Makeflow as MPI program</h3></a>
-If cctools and Makeflow has been configured and built with <tt>mpicc</tt>, then Makeflow can be ran as an MPI program by passing Makeflow and all of its arguments as arguments to <tt>mpirun</tt> or <tt>mpiexec</tt>. An example of using it as such looks like <code>mpirun -np 120 makeflow -T mpi example.makeflow</code> As the example shows, <tt>-T mpi</tt> is necessary to inform Makeflow that is is being ran as an mpi program. When doing so, Makeflow will count how many processes report back to the master/RANK0 process on each node, and use that as how many cores exist on each node. A single process on each node is then ran as the worker process, with RANK0 acting as the master process, dispatching jobs and acting as Makeflow usually does. Each worker will then share its memory fairly amongst all logical cores and the number of cores Makeflow measures that it gets to use on each node. This is done by following the equation <tt> worker_memory = (total_memory / total_logical_cores) * cores_for_worker</tt>. To overrite these options, use the commands <tt>--mpi-cores=NUM --mpi-memory=NUM</tt> to set the number of cores each worker should use, and how much memory each worker gets to use.
+If you have access to an MPI cluster, Makeflow and CCTools can also take advantage of these systems. First, CCTools needs to be configured and built with <tt>mpicc</tt>. Once done, there are two methods
+for employing Makeflow and CCTools with MPI: directly running Makeflow as and MPI Job, and Makeflow+WorkQueue as an MPI Job.
 
-<a name=mpi-starter><h3>Makeflow MPI Starter</h3></a>
+<a name=makeflow-mpi><h3>Running Makeflow as an MPI Job</h3></a>
+If cctools and Makeflow has been configured and built with <tt>mpicc</tt>, then Makeflow can be ran as an MPI program by passing Makeflow and all of its arguments as arguments to <tt>mpirun</tt> or <tt>mpiexec</tt>. An example of using it as such looks like 
+<code>mpirun -np 120 makeflow -T mpi example.makeflow</code> 
+As the example shows, <tt>-T mpi</tt> is necessary to inform Makeflow that is is being ran as an mpi program. When doing so, Makeflow will count how many processes report back to the master/RANK0 process on each node, and use that as how many cores exist on each node. A single process on each node is then ran as the worker process, with RANK0 acting as the master process, dispatching jobs and acting as Makeflow usually does. Each worker will then share its memory fairly amongst all logical cores and the number of cores Makeflow measures that it gets to use on each node. This is done by following the equation <tt> worker_memory = (total_memory / total_logical_cores) * cores_for_worker</tt>. To overrite these options, use the commands <tt>--mpi-cores=NUM --mpi-memory=NUM</tt> to set the number of cores each worker should use, and how much memory each worker gets to use.
+Calling <tt>mpirun makeflow -T mpi</tt> can also be done in your batch system's submission script, or other methods of submitting an MPI job.
+
+<a name=mpi-starter><h3>Running Makeflow and WorkQueue as an MPI Job</h3></a>
 An alternative way of using Makeflow with MPI is to couple it with WorkQueue and submit both as an MPI job. You can do this by using <tt>makeflow_mpi_starter</tt>. This allows the user to submit a single program which will start Makeflow on the Rank0 process, and WorkQueue workers on all of the nodes. It behaves the same way as using Makeflow as an MPI program does in partitioning cores and memory on the workers. using it is very simple, as seen here:
 
 <code>
 mpiexec -np 120 makeflow_mpi_starter -m "-r 10 example.makeflow" -q "" -p 9000
 </code>
 
-In the above code, we turn on retries for failed jobs for makeflow, setting the maximum number of retries to 10. We don't pass anything to workqueue, and we set the port for makeflow to 9000. This method can be a helpful way to take advantage of both WorkQueue while using an MPI partition, when using Makeflow.
+In the above code, we turn on retries for failed jobs for Makeflow, setting the maximum number of retries to 10. We don't pass anything to WorkQueue, and we set the port for Makeflow to 9000. This method can be a helpful way to take advantage of both WorkQueue while using an MPI partition, when using Makeflow. Because we are passing the arguments of <tt>-m</tt> and <tt>-q</tt> directly to Makeflow and WorkQueue respectively, you can overwrite the core and memory partitioning by using the normal commands for Makeflow and WorkQueue (e.g. <tt>--local-cores=1</tt> and <tt>--cores=10</tt>).
 
+Just like the previous use case, this can also be used as the command in your batch system's submission script, or other method of submitting an MPI job.
 <a name=advanced><h2>Advanced Features</h2></a>
 
 <a name=shared><h3>Shared File Systems</h3></a>

--- a/doc/man/makeflow.m4
+++ b/doc/man/makeflow.m4
@@ -197,6 +197,8 @@ has, and use that as the core count for the worker on that node. Makeflow will t
 on the node, following the following equation BOLD(worker_memory) = (BOLD(total_memory) / BOLD(total_logical_cores)) * BOLD(num_cores_for_worker).
 To override Makeflow sharing memory equally, or setting per-worker cores value, use OPTION_ITEM('--mpi-cores') and OPTION_ITEM('--mpi-memory').
 
+Tasks can also have their own sandbox. To specify the directory for tasks to create their sandbox subdirectory in, use OPTION_ITEM('--mpi-task-working-dir').
+
 SECTION(ENVIRONMENT VARIABLES)
 
 The following environment variables will affect the execution of your

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -1235,6 +1235,7 @@ static void show_help_run(const char *cmd)
 	printf("\nMPI Options:\n");
 	printf(" --mpi-cores=<val>              Set Number of cores each worker should use.\n");
 	printf(" --mpi-memory=<val>             Set amount of memory each worker has to use.\n");
+    printf(" --mpi-task-working-dir=<val>   Set the path where all tasks will create sandbox directory and execute in.\n");
 }
 
 int main(int argc, char *argv[])
@@ -1310,6 +1311,7 @@ int main(int argc, char *argv[])
         int mpi_cores_per = 0;
         int mpi_mem_per = 0;
         char* debug_base_path = NULL;
+        char* mpi_working_dir = NULL;
 #endif
 
 	random_init();
@@ -1421,6 +1423,7 @@ int main(int argc, char *argv[])
 #ifdef CCTOOLS_WITH_MPI
                 LONG_OPT_MPI_CORES,
                 LONG_OPT_MPI_MEM,
+                LONG_OPT_MPI_WORKDIR,
 #endif
 	};
 
@@ -1538,6 +1541,7 @@ int main(int argc, char *argv[])
 #ifdef CCTOOLS_WITH_MPI
         {"mpi-cores", required_argument,0, LONG_OPT_MPI_CORES},
         {"mpi-memory", required_argument,0, LONG_OPT_MPI_MEM},
+        {"mpi-task-working-dir",required_argument,0,LONG_OPT_MPI_WORKDIR},
 #endif
 		{0, 0, 0, 0}
 	};
@@ -2039,12 +2043,15 @@ int main(int argc, char *argv[])
 				break;
 			}
 #ifdef CCTOOLS_WITH_MPI
-                    case LONG_OPT_MPI_CORES:
-                        mpi_cores_per = atoi(optarg);
-                        break;
-                    case LONG_OPT_MPI_MEM:
-                        mpi_mem_per = atoi(optarg);
-                        break;
+            case LONG_OPT_MPI_CORES:
+                mpi_cores_per = atoi(optarg);
+                break;
+            case LONG_OPT_MPI_MEM:
+                mpi_mem_per = atoi(optarg);
+                break;
+            case LONG_OPT_MPI_WORKDIR:
+                mpi_working_dir = xxstrdup(optarg);
+                break;
 #endif
 			default:
 				show_help_run(argv[0]);
@@ -2076,7 +2083,7 @@ int main(int argc, char *argv[])
                 }
                 need_mpi_finalize = 1;
                 
-                makeflow_mpi_master_setup(mpi_world_size,mpi_cores_per,mpi_mem_per,working_dir);
+                makeflow_mpi_master_setup(mpi_world_size,mpi_cores_per,mpi_mem_per,mpi_working_dir);
 				int cores_total = load_average_get_cpus();
 		        uint64_t memtotal;
        			uint64_t memavail;

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -2065,6 +2065,7 @@ int main(int argc, char *argv[])
         //the code assumes sizeof(void*) == uint64_t
         int need_mpi_finalize = 0;
         if (batch_queue_type == BATCH_QUEUE_TYPE_MPI) {
+			//mpi boilerplate code modified from tutorial at www.mpitutorial.com
             MPI_Init(NULL, NULL);
             int mpi_world_size;
             MPI_Comm_size(MPI_COMM_WORLD, &mpi_world_size);

--- a/makeflow/src/makeflow_mpi_starter.c
+++ b/makeflow/src/makeflow_mpi_starter.c
@@ -79,6 +79,7 @@ int main(int argc, char** argv) {
     }
     c = 0;
 
+	//mpi boilerplate code modified from tutorial at www.mpitutorial.com
     MPI_Init(NULL, NULL);
     int mpi_world_size;
     MPI_Comm_size(MPI_COMM_WORLD, &mpi_world_size);

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -2546,6 +2546,7 @@ int main(int argc, char *argv[])
 	//to move into an init function
 	
 	if (using_mpi == 1) {
+		//mpi boilerplate code modified from tutorial at www.mpitutorial.com
 		MPI_Init(NULL, NULL);
 		int mpi_world_size;
 		MPI_Comm_size(MPI_COMM_WORLD, &mpi_world_size);


### PR DESCRIPTION
@dthain @btovar 

Probably not necessary, but before the mpi boilerplate code I added a link in a comment to the tutorials where I learned how to use MPI. Ben said it wasn't necessary, especially because it's not an exact copy paste, but it's pretty similar in the variable naming. At the very least, whoever comes after me and needs to maintain it will have a link to a good tutorial on MPI.

Also included are some of the other changes that haven't been merged in yet, namely updating the commandline reference for task sandboxing in `-T mpi` mode and updated wording in the manpages/webpages.