### PR TITLE
Adds runos to CCTools

### DIFF
--- a/batch_job/src/Makefile
+++ b/batch_job/src/Makefile
@@ -53,6 +53,8 @@ install:
 	cp $(PROGRAMS) $(SCRIPTS) $(CCTOOLS_INSTALL_DIR)/bin
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib
 	cp $(LIBRARIES) $(CCTOOLS_INSTALL_DIR)/lib
+	mkdir -p $(CCTOOLS_INSTALL_DIR)/etc/cctools
+	cp cctools-runos.json $(CCTOOLS_INSTALL_DIR)/etc/cctools
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/include/cctools
 	cp $(PUBLIC_HEADERS) $(CCTOOLS_INSTALL_DIR)/include/cctools
 

--- a/batch_job/src/Makefile
+++ b/batch_job/src/Makefile
@@ -4,6 +4,7 @@ include ../../rules.mk
 LIBRARIES = libbatch_job.a
 
 PROGRAMS = work_queue_factory work_queue_pool
+SCRIPTS  = cctools-runos
 
 ifeq ($(CCTOOLS_CHIRP),chirp)
 CHIRP_LIB=../../chirp/src/libchirp.a
@@ -49,7 +50,7 @@ work_queue_pool: work_queue_factory
 
 install:
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/bin
-	cp $(PROGRAMS) $(CCTOOLS_INSTALL_DIR)/bin
+	cp $(PROGRAMS) $(SCRIPTS) $(CCTOOLS_INSTALL_DIR)/bin
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib
 	cp $(LIBRARIES) $(CCTOOLS_INSTALL_DIR)/lib
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/include/cctools

--- a/batch_job/src/cctools-runos
+++ b/batch_job/src/cctools-runos
@@ -8,6 +8,7 @@ import sys
 import os
 import subprocess
 import shlex
+import shutil
 import uuid
 import platform
 import threading
@@ -130,6 +131,14 @@ def parse_command_line_argumets(argv):
         show_help()
         sys.exit(1)
 
+def find_worker_executable(worker_repository, target, worker_version):
+    worker_executable = os.path.join(worker_repository, 'x86_64', target, 'cctools', worker_version, 'bin', 'work_queue_worker')
+
+    if not (os.path.isfile(worker_executable) and os.access(worker_executable, os.X_OK)):
+        sys.stderr.write("could not find worker executable at '{}'\n".format(worker_executable))
+        exit(1)
+
+    return worker_executable
 
 
 if __name__ == "__main__":
@@ -140,15 +149,17 @@ if __name__ == "__main__":
     if(debug_output):
         logfile = open(debug_output, 'a+')
 
-    switch=True
-
     # osused is the path to the image for target
     try:
         osused = os.path.join(image_repository, image_of[target])
     except KeyError:
         sys.stderr.write("could not find an image for target os '{}'\n".format(target))
         exit(1)
+
+    # worker_executable is the path to the correct work_queue_worker
+    worker_executable = find_worker_executable(worker_repository, target, worker_version)
     
+    switch=True
     #ensure singularity on computer
     run_native=False
     try:
@@ -162,7 +173,8 @@ if __name__ == "__main__":
                 run_native = True
             else:
                 sys.stderr.write("The System doesn't have Singularity Installed, and the target is unrecognized!\n")
-                exit(17)
+                exit(2)
+
         #can assume singularity
         proc2 = subprocess.Popen('singularity exec %s python -c "import platform; print platform.dist()"'%osused,stdout=subprocess.PIPE,shell=True)
         (imgbase,err2) = proc2.communicate() 
@@ -172,7 +184,11 @@ if __name__ == "__main__":
             run_native = True
     except Exception, e:
         print e
-        exit(88)
+        exit(2)
+
+
+    cmd = ['./work_queue_worker'] + worker_opts
+
     
     #calling process
     mid = uuid.uuid4()
@@ -182,11 +198,13 @@ if __name__ == "__main__":
     else:
         tmphome = "/tmp/runos_singularity_home-%d"%mid
         if not (os.path.isdir(tmphome)):
-            os.mkdir(tmphome,0777)
+            os.mkdir(tmphome,0755)
 
-        cmdwrap = "'cd /disk; %s'" % (arr_to_str(cmd))
-        #newcmd  = ["exec","--bind","%s:/disk"%os.getcwd(),"--home","%s:%s"%(tmphome,tmphome),"--bind","/var:/var","--bind","/afs/crc.nd.edu/group/ccl/software:/cclsoftware",osused,"sh","-c",cmdwrap]
-        newcmd  = ["exec","--bind","%s:/disk"%os.getcwd(),"--home","%s:%s"%(tmphome,tmphome),"--bind","/var:/var","--bind","/afs/:/afs",osused,"sh","-c",cmdwrap]
+        shutil.copy(worker_executable, tmphome)
+
+
+        cmdwrap = "'cd /worker-home; %s'" % (arr_to_str(cmd))
+        newcmd  = ["exec", "--home", "{}:/worker-home".format(tmphome), "--bind","/var:/var", osused, "sh", "-c", cmdwrap]
 
         if os.path.isfile("/usr/local/bin/singularity"):
             newcmd.insert(0, "/usr/local/bin/singularity")

--- a/batch_job/src/cctools-runos
+++ b/batch_job/src/cctools-runos
@@ -84,10 +84,6 @@ def parse_command_line_argumets(argv):
         opts_dict = dict(opts)
         command_opts = args_left
 
-        print(sys.argv)
-        print(args_left)
-        print(opts)
-
         if not ('--os' in opts_dict.keys()):
             sys.stderr.write("command line option '--os' is required")
             show_help()
@@ -157,7 +153,7 @@ def find_sigularity_executable(path_from_opt):
 
 if __name__ == "__main__":
 
-    target, worker_opts, run_worker, singularity_opt, worker_version, debug_output = parse_command_line_argumets(sys.argv)
+    target, run_worker, command_opts, singularity_opt, worker_version, debug_output = parse_command_line_argumets(sys.argv)
 
     logfile = sys.stderr
     if(debug_output):
@@ -170,8 +166,13 @@ if __name__ == "__main__":
         sys.stderr.write("could not find an image for target os '{}'\n".format(target))
         exit(1)
 
-    # worker_executable is the path to the correct work_queue_worker
-    worker_executable = find_worker_executable(worker_repository, target, worker_version)
+    # executable is the path to the correct work_queue_worker if --run-worker is given
+    executable = None
+    if run_worker:
+        executable = find_worker_executable(worker_repository, target, worker_version)
+    else:
+        executable = command_opts.pop(0)
+
 
     # singularity_executable is the absolute path to singularity
     singularity_executable = find_sigularity_executable(singularity_opt)
@@ -198,25 +199,26 @@ if __name__ == "__main__":
         sys.stderr.write("could not create temporary directory {}: {}".format(tmphome), e)
         sys.exit(3)
 
-    try:
-        shutil.copy(worker_executable, tmphome)
-    except Exception as e:
-        sys.stderr.write("could not copy worker executable {} to temporary directory {}: {}".format(worker_executable, tmphome), e)
-        sys.exit(3)
+    if run_worker:
+        try:
+            shutil.copy(executable, tmphome)
+            executable = os.path.join(tmphome, os.path.basename(executable))   # execute with a path from inside singularity
+        except Exception as e:
+            sys.stderr.write("could not copy worker executable {} to temporary directory {}: {}".format(executable, tmphome), e)
+            sys.exit(3)
 
-
-    worker_cmdlst  = [os.path.join(tmphome, 'work_queue_worker')] + worker_opts
-    worker_command = ' '.join(worker_cmdlst)
+    cmdlst  = [executable] + command_opts
+    command = ' '.join(cmdlst)
 
     proc = None
     
     if run_native:
         logfile.write('[runos-{}]: STARTING with native execution\n'.format(unique_id))
         logfile.write('[runos-{}] cmd: {}\n'.format(unique_id, worker_command))
-        proc = subprocess.Popen(worker_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)  
+        proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)  
     else:
-        sing_cmdlst = [singularity_executable, "exec", "--home", "{}:/worker-home".format(tmphome), "--bind","/var:/var", osused, "sh", "-c", "'" + " ".join(worker_cmdlst) + "'"]
-        sing_cmdlst.append("'" + worker_command + "'")
+        sing_cmdlst = [singularity_executable, "exec", "--home", "{}:/worker-home".format(tmphome), "--bind","/var:/var", osused, "sh", "-c"]
+        sing_cmdlst.append("'" + command + "'")
         sing_cmd = ' '.join(sing_cmdlst)
 
         proc = subprocess.Popen(sing_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)  

--- a/batch_job/src/cctools-runos
+++ b/batch_job/src/cctools-runos
@@ -59,14 +59,7 @@ def write_stderr(lefile, proc, mid, lelock):
 
 
 def clean_and_remove(path):
-    allthings = os.listdir(path)
-    for x in allthings:
-        if os.path.isdir(x):
-            clean_and_remove(x)
-            os.rmdir(x)
-        else:
-            os.remove(x)
-    return 1
+    return shutil.rmtree(path)
 
 def show_help():
     sys.stderr.write("""

--- a/batch_job/src/cctools-runos
+++ b/batch_job/src/cctools-runos
@@ -12,7 +12,34 @@ import shlex
 import uuid
 import platform
 import threading
-import threading
+
+######## Configuration
+
+#### Directory where images reside. All workers should have reading access to this directory.
+
+image_repository = '/afs/crc.nd.edu/group/ccl/software/runos'
+
+#### Mapping 'Name of OS' to 'image'. 'image' is expected to be a singularity
+#### image in the image_repository directory.
+
+image_of = {
+    'redhat6'  : 'rhel6.img',
+    'redhat7'  : 'rhel7.img',
+}
+
+#### Directory where the workers reside. 
+#### The hierarchy expected is worker_repository/ARCHITECTURE/OS/cctools/CCTOOLS_VERSION/bin/work_queue_worker
+#### ARCHITECTURE will eventually be found automatically. Now it's fixed to x86_64
+#### OS is a reguired command line argument (e.g., redhat7)
+#### CCTOOLS_VERSION is set by the command line argument --worker-version (defaults to 'stable')
+
+worker_repository = '/afs/crc.nd.edu/group/ccl/software'
+
+###### END OF CONFIGURATION
+
+
+
+
 
 def write_stdout(lefile, proc, mid, lelock):
     with proc.stdout:
@@ -69,22 +96,13 @@ if __name__ == "__main__":
         cmd = sys.argv[3:]
         output = sys.argv[1][len('--output='):]
 
-    #finding config file
-    mydir = os.path.dirname(os.path.realpath(__file__))
+
+    # osused is the path to the image for target
     try:
-        cfg = open(mydir+"/"+"runos.cfg","r")
-    except IOError:
-        sys.stderr.write("config file not found at: "+mydir+"/runos.cfg\n")
-        exit(16)
-    oslocs = json.loads(cfg.read())
-    cfg.close()
-    #getting image path
-    try:
-        osused = oslocs[target]
-        osused=osused.replace("$CONFIG_PATH",mydir)
+        osused = os.path.join(image_repository, image_of[target])
     except KeyError:
-        sys.stderr.write("target OS not found in config file\n")
-        exit(18)
+        sys.stderr.write("could not find an image for target os '{}'\n".format(target))
+        exit(1)
     
     #ensure singularity on computer
     run_native=False

--- a/batch_job/src/cctools-runos
+++ b/batch_job/src/cctools-runos
@@ -4,40 +4,39 @@
 # This software is distributed under the GNU General Public License.
 # See the file COPYING for details.
 
-import sys
+import distutils
+import getopt
+import json
 import os
-import subprocess
+import platform
+import re
 import shlex
 import shutil
-import distutils
+import subprocess
+import sys
 import uuid
-import platform
-import getopt
-import re
 
-######## Configuration
+#### All the following variables are set by reading the configuration file cctools-runos.json
 
 #### Directory where images reside. All workers should have reading access to this directory.
-
-image_repository = '/afs/crc.nd.edu/group/ccl/software/runos'
-
-#### Mapping 'Name of OS' to 'image'. 'image' is expected to be a singularity
-#### image in the image_repository directory.
-
-image_of = {
-    'redhat6'  : 'rhel6.img',
-    'redhat7'  : 'rhel7.img',
-}
+image_repository = None
 
 #### Directory where the workers reside. 
 #### The hierarchy expected is worker_repository/ARCHITECTURE/OS/cctools/CCTOOLS_VERSION/bin/work_queue_worker
 #### ARCHITECTURE will eventually be found automatically. Now it's fixed to x86_64
 #### OS is a reguired command line argument (e.g., redhat7)
 #### CCTOOLS_VERSION is set by the command line argument --worker-version (defaults to 'stable')
+worker_repository = None
 
-worker_repository = '/afs/crc.nd.edu/group/ccl/software'
+#### Mapping 'Name of OS' to 'image'. 'image' is expected to be a singularity
+#### image in the image_repository directory.
+image_of = {}
 
-###### END OF CONFIGURATION
+####
+
+
+#### Original contents of configuration file
+conf_contents = None
 
 
 def clean_and_remove(path):
@@ -46,39 +45,40 @@ def clean_and_remove(path):
 def show_help():
     sys.stderr.write("""
     Usage:
-        runos [--worker-version VERSION] [--debug-file OUTPUT] [--singularity SINGULARITY-EXEC] --os TARGET_OS --run-worker -- WORKER-ARGUMENTS ...
+        runos [--conf CONF] [--debug-file OUTPUT] [--singularity SINGULARITY-EXEC] --os TARGET_OS --worker-version VERSION --run-worker -- WORKER-ARGUMENTS ...
 
         or 
 
-        runos [--worker-version VERSION] [--debug-file OUTPUT] [--singularity SINGULARITY-EXEC] --os TARGET_OS COMMAND_TO_RUN COMMAND_ARGUMENTS ...
-
-        where TARGET_OS is one of: {}
-    """.format(', '.join(image_of.keys())))
+        runos [--conf CONF] [--debug-file OUTPUT] [--singularity SINGULARITY-EXEC] --os TARGET_OS COMMAND_TO_RUN COMMAND_ARGUMENTS ...
+    """)
 
 def parse_command_line_argumets(argv):
     try:
-        opts, args_left = getopt.getopt(sys.argv[1:], '', ['os=','run-worker', 'worker-version=','debug-file=','singularity='])
+        opts, args_left = getopt.getopt(sys.argv[1:], '', ['os=', 'conf=', 'dump-conf', 'run-worker', 'worker-version=','debug-file=','singularity='])
 
         opts_dict = dict(opts)
         command_opts = args_left
 
-        if not ('--os' in opts_dict.keys()):
-            sys.stderr.write("command line option '--os' is required")
-            show_help()
-            sys.exit(1)
+        target          = opts_dict.get('--os', None)
+        worker_version  = opts_dict.get('--worker-version', 'stable')
+        debug_output    = opts_dict.get('--debug-file',  None)
+        singularity_opt = opts_dict.get('--singularity', None)
+        conf            = find_conf_file(opts_dict.get('--conf', None))
+        run_worker      = True if '--run-worker' in opts_dict.keys() else False
+        dump_conf       = True if '--dump-conf' in opts_dict.keys() else False
 
-        target           = opts_dict['--os']
-        worker_version   = opts_dict.get('--worker-version', 'stable')
-        debug_output     = opts_dict.get('--debug-file',  None)
-        singularity_opt  = opts_dict.get('--singularity', None)
-        run_worker       = True if '--run-worker' in opts_dict.keys() else False
+        if not dump_conf:
+            if target is None:
+                sys.stderr.write("command line option '--os' is required")
+                show_help()
+                sys.exit(1)
 
-        if run_worker is False and not command_opts:
-            sys.stderr.write("Either COMMAND_TO_RUN or --run-worker are needed.")
-            show_help()
-            sys.exit(1)
+            if run_worker is False and not command_opts:
+                sys.stderr.write("Either COMMAND_TO_RUN or --run-worker are needed.")
+                show_help()
+                sys.exit(1)
 
-        return (target, run_worker, command_opts, singularity_opt, worker_version, debug_output)
+        return (target, conf, dump_conf, run_worker, command_opts, singularity_opt, worker_version, debug_output)
 
     except Exception:
         raise
@@ -93,6 +93,42 @@ def find_worker_executable(worker_repository, target, worker_version):
         exit(1)
 
     return worker_executable
+
+def find_conf_file(conf_path):
+    base = os.path.dirname(os.path.abspath(__file__))
+
+    if conf_path:
+        return conf_path
+
+    for location in [ '', '../etc/cctools', '../etc' ]:
+        candidate = os.path.join(base, location, 'cctools-runos.json')
+
+        if os.path.isfile(candidate):
+            return candidate
+
+    sys.stderr.write("could not find a configuration file\n")
+    exit(1)
+
+
+def read_configuration(conf_path):
+
+    try:
+        with open(conf_path) as f:
+            raw = f.read()
+            conf_dict = json.loads(raw)
+
+            image_repository  = conf_dict['image-repository']
+            worker_repository = conf_dict['worker-repository']
+            image_of          = conf_dict['images']
+            conf_contents     = raw
+
+            return (image_repository, worker_repository, image_of, conf_contents)
+    except KeyError as e:
+        sys.stderr.write("configuration file {} does not have key {}".format(conf_path, e))
+        exit(1)
+    except Exception as e:
+        sys.stderr.write("error reading configuration file {}: {}".format(conf_path, e))
+        exit(1)
 
 
 def find_executable(executable, paths = os.environ['PATH']):
@@ -131,11 +167,18 @@ def find_sigularity_executable(path_from_opt):
 
 if __name__ == "__main__":
 
-    target, run_worker, command_opts, singularity_opt, worker_version, debug_output = parse_command_line_argumets(sys.argv)
+    target, conf, dump_conf, run_worker, command_opts, singularity_opt, worker_version, debug_output = parse_command_line_argumets(sys.argv)
+
+    image_repository, worker_repository, image_of, conf_contents = read_configuration(conf)
+
+    if(dump_conf):
+        sys.stdout.write(conf_contents)
+        sys.exit(0)
 
     logfile = sys.stderr
     if(debug_output):
         logfile = open(debug_output, 'a+')
+
 
     # osused is the path to the image for target
     try:

--- a/batch_job/src/cctools-runos
+++ b/batch_job/src/cctools-runos
@@ -43,10 +43,11 @@ worker_repository = '/afs/crc.nd.edu/group/ccl/software'
 
 def write_stdout(lefile, proc, unique_id, lelock):
     with proc.stdout:
-        for line in iter(proc.stdout.readline,b''):
+        for line in iter(proc.stdout.readline, b''):
             lelock.acquire()
             try:
-                logfile.write('[runos-{}] stdout: {}'.format(unique_id,line))
+                line = bytearray(line).decode('utf-8') #compat between py2 and py3
+                logfile.write('[runos-{}] stdout: {}\n'.format(unique_id,str(line)))
             finally:
                 lelock.release()
 
@@ -55,7 +56,8 @@ def write_stderr(lefile, proc, unique_id, lelock):
         for line in iter(proc.stderr.readline,b''):
             lelock.acquire()
             try:
-                logfile.write('[runos-{}] stderr: {}'.format(unique_id,line))
+                line = bytearray(line).decode('utf-8') #compat between py2 and py3
+                logfile.write('[runos-{}] stderr: {}\n'.format(unique_id,str(line)))
             finally:
                 lelock.release()
 
@@ -191,14 +193,14 @@ if __name__ == "__main__":
     try:
         tmphome = "/tmp/runos_singularity_home-{}".format(unique_id)
         if not (os.path.isdir(tmphome)):
-            os.mkdir(tmphome,0755)
-    except Exception, e:
+            os.mkdir(tmphome, 0o755)
+    except Exception as e:
         sys.stderr.write("could not create temporary directory {}: {}".format(tmphome), e)
         sys.exit(3)
 
     try:
         shutil.copy(worker_executable, tmphome)
-    except Exception, e:
+    except Exception as e:
         sys.stderr.write("could not copy worker executable {} to temporary directory {}: {}".format(worker_executable, tmphome), e)
         sys.exit(3)
 

--- a/batch_job/src/cctools-runos
+++ b/batch_job/src/cctools-runos
@@ -12,7 +12,6 @@ import shutil
 import distutils
 import uuid
 import platform
-import threading
 import getopt
 import re
 
@@ -39,27 +38,6 @@ image_of = {
 worker_repository = '/afs/crc.nd.edu/group/ccl/software'
 
 ###### END OF CONFIGURATION
-
-
-def write_stdout(lefile, proc, unique_id, lelock):
-    with proc.stdout:
-        for line in iter(proc.stdout.readline, b''):
-            lelock.acquire()
-            try:
-                line = bytearray(line).decode('utf-8') #compat between py2 and py3
-                logfile.write('[runos-{}] stdout: {}\n'.format(unique_id,str(line)))
-            finally:
-                lelock.release()
-
-def write_stderr(lefile, proc, unique_id, lelock):
-    with proc.stderr:
-        for line in iter(proc.stderr.readline,b''):
-            lelock.acquire()
-            try:
-                line = bytearray(line).decode('utf-8') #compat between py2 and py3
-                logfile.write('[runos-{}] stderr: {}\n'.format(unique_id,str(line)))
-            finally:
-                lelock.release()
 
 
 def clean_and_remove(path):
@@ -208,35 +186,22 @@ if __name__ == "__main__":
             sys.exit(3)
 
     cmdlst  = [executable] + command_opts
-    command = ' '.join(cmdlst)
 
-    proc = None
-    
-    if run_native:
+    if run_native or True:
         logfile.write('[runos-{}]: STARTING with native execution\n'.format(unique_id))
-        logfile.write('[runos-{}] cmd: {}\n'.format(unique_id, worker_command))
-        proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)  
     else:
-        sing_cmdlst = [singularity_executable, "exec", "--home", "{}:/worker-home".format(tmphome), "--bind","/var:/var", osused, "sh", "-c"]
-        sing_cmdlst.append("'" + command + "'")
-        sing_cmd = ' '.join(sing_cmdlst)
-
-        proc = subprocess.Popen(sing_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)  
         logfile.write('[runos-{}]: STARTING with singularity image {}\n'.format(unique_id,osused))
-        logfile.write('[runos-{}] cmd: {}\n'.format(unique_id, sing_cmd))
+        sing_cmdlst = [singularity_executable, "exec", "--home", "{}:/worker-home".format(tmphome), osused]
+        cmdlst = sing_cmdlst + cmdlst
 
-    lelock = threading.Lock()
-    out_t = threading.Thread(target = write_stdout, args=(logfile, proc, unique_id, lelock,))
-    err_t = threading.Thread(target = write_stderr, args=(logfile, proc, unique_id, lelock,))
-    out_t.start()
-    err_t.start()
-    out_t.join()
-    err_t.join()
-    proc.wait()
-    exitcode = proc.returncode
+    logfile.write('[runos-{}]: {}\n'.format(unique_id, cmdlst))
+
+    exitcode = subprocess.call(cmdlst, stdout=logfile, stderr=subprocess.STDOUT)
+
     clean_and_remove(tmphome)
     logfile.write('[runos-{}] ret: {}\n'.format(unique_id,exitcode))
     logfile.close()
+
     exit(exitcode)  
 
 #vim: set sts=4 sw=4 ts=4 expandtab ft=python:

--- a/batch_job/src/cctools-runos
+++ b/batch_job/src/cctools-runos
@@ -203,34 +203,37 @@ if __name__ == "__main__":
         sys.exit(3)
 
 
-    worker_cmdlst = [os.path.join(tmphome, 'work_queue_worker')] + worker_opts
+    worker_cmdlst  = [os.path.join(tmphome, 'work_queue_worker')] + worker_opts
+    worker_command = ' '.join(worker_cmdlst)
+
+    proc = None
     
     if run_native:
-        proc = subprocess.Popen(' '.join(worker_cmdlst), shell=True)
-        proc.wait()
-        exitcode = proc.returncode
-        clean_and_remove(tmphome)
-        exit(exitcode)
+        logfile.write('[runos-{}]: STARTING with native execution\n'.format(unique_id))
+        logfile.write('[runos-{}] cmd: {}\n'.format(unique_id, worker_command))
+        proc = subprocess.Popen(worker_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)  
     else:
-        sing_cmd = [singularity_executable, "exec", "--home", "{}:/worker-home".format(tmphome), "--bind","/var:/var", osused, "sh", "-c", "'" + " ".join(worker_cmdlst) + "'"]
+        sing_cmdlst = [singularity_executable, "exec", "--home", "{}:/worker-home".format(tmphome), "--bind","/var:/var", osused, "sh", "-c", "'" + " ".join(worker_cmdlst) + "'"]
+        sing_cmdlst.append("'" + worker_command + "'")
+        sing_cmd = ' '.join(sing_cmdlst)
 
-        logfile.write('[runos-{}]: {}\n'.format(unique_id,'STARTING'))
-        logfile.write('[runos-{}] cmd: {}\n'.format(unique_id,' '.join(sing_cmd)))
+        proc = subprocess.Popen(sing_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)  
+        logfile.write('[runos-{}]: STARTING with singularity image {}\n'.format(unique_id,osused))
+        logfile.write('[runos-{}] cmd: {}\n'.format(unique_id, sing_cmd))
 
-        proc = subprocess.Popen(' '.join(sing_cmd),stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=True)  
-        lelock = threading.Lock()
-        out_t = threading.Thread(target = write_stdout, args=(logfile, proc, unique_id, lelock,))
-        err_t = threading.Thread(target = write_stderr, args=(logfile, proc, unique_id, lelock,))
-        out_t.start()
-        err_t.start()
-        out_t.join()
-        err_t.join()
-        proc.wait()
-        exitcode = proc.returncode
-        clean_and_remove(tmphome)
-        logfile.write('[runos-{}] ret: {}\n'.format(unique_id,exitcode))
-        logfile.close()
-        exit(exitcode)  
+    lelock = threading.Lock()
+    out_t = threading.Thread(target = write_stdout, args=(logfile, proc, unique_id, lelock,))
+    err_t = threading.Thread(target = write_stderr, args=(logfile, proc, unique_id, lelock,))
+    out_t.start()
+    err_t.start()
+    out_t.join()
+    err_t.join()
+    proc.wait()
+    exitcode = proc.returncode
+    clean_and_remove(tmphome)
+    logfile.write('[runos-{}] ret: {}\n'.format(unique_id,exitcode))
+    logfile.close()
+    exit(exitcode)  
 
 #vim: set sts=4 sw=4 ts=4 expandtab ft=python:
 

--- a/batch_job/src/cctools-runos
+++ b/batch_job/src/cctools-runos
@@ -9,10 +9,12 @@ import os
 import subprocess
 import shlex
 import shutil
+import distutils
 import uuid
 import platform
 import threading
 import getopt
+import re
 
 ######## Configuration
 
@@ -39,21 +41,21 @@ worker_repository = '/afs/crc.nd.edu/group/ccl/software'
 ###### END OF CONFIGURATION
 
 
-def write_stdout(lefile, proc, mid, lelock):
+def write_stdout(lefile, proc, unique_id, lelock):
     with proc.stdout:
         for line in iter(proc.stdout.readline,b''):
             lelock.acquire()
             try:
-                logfile.write('[runos-{}] out: {}\n'.format(mid,line))
+                logfile.write('[runos-{}] stdout: {}'.format(unique_id,line))
             finally:
                 lelock.release()
 
-def write_stderr(lefile, proc, mid, lelock):
+def write_stderr(lefile, proc, unique_id, lelock):
     with proc.stderr:
         for line in iter(proc.stderr.readline,b''):
             lelock.acquire()
             try:
-                logfile.write('[runos-{}] err: {}\n'.format(mid,line))
+                logfile.write('[runos-{}] stderr: {}'.format(unique_id,line))
             finally:
                 lelock.release()
 
@@ -117,6 +119,40 @@ def find_worker_executable(worker_repository, target, worker_version):
     return worker_executable
 
 
+def find_executable(executable, paths = os.environ['PATH']):
+    for path in paths.split(':'):
+        candidate = os.path.join(path, executable)
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def get_redhat_release():
+    try:
+        with open('/etc/redhat-release') as f:
+            match = re.search('.*release (?P<major>[0-9])+.*', f.read())
+            if match:
+                return 'redhat' + match.groupdict()['major']
+    except Exception:
+        raise
+        pass
+
+    return 'unknown'
+
+
+def find_sigularity_executable(path_from_opt):
+
+    singularity = path_from_opt
+    if singularity is None:
+        singularity = find_executable('singularity', os.environ.get('PATH', '') + ':/usr/bin:/usr/local/bin') 
+
+    if singularity is None or not (os.path.isfile(singularity) and os.access(singularity, os.X_OK)):
+        sys.stderr.write("could not find a working singularity executable\n")
+        return None
+
+    return singularity
+
+
 if __name__ == "__main__":
 
     target, worker_opts, run_worker, singularity_opt, worker_version, debug_output = parse_command_line_argumets(sys.argv)
@@ -134,84 +170,67 @@ if __name__ == "__main__":
 
     # worker_executable is the path to the correct work_queue_worker
     worker_executable = find_worker_executable(worker_repository, target, worker_version)
-    
-    switch=True
+
+    # singularity_executable is the absolute path to singularity
+    singularity_executable = find_sigularity_executable(singularity_opt)
+
+    # runos instance id to create tmp directory, label log lines, etc.
+    unique_id = str(uuid.uuid4())[:8]
+
     #ensure singularity on computer
     run_native=False
+    if singularity_executable is None:
+        redhat_release = get_redhat_release()
+
+        if redhat_release == target:
+            run_native = True
+        else:
+            sys.stderr.write("singularity is not installed, and the host system '{}' does not match taget '{}'\n".format(redhat_release, target))
+            exit(2)
+
     try:
-        proc = subprocess.Popen('~condor/software/config/get_system_info.sh',stdout=subprocess.PIPE,shell=True)
-        (out, err) = proc.communicate()
-        base = str(platform.dist())
-        if not "has_singularity = true" in out: #no singularity
-            if ('redhat' in base and '6' in base) and ('rhel6' == target or 'osg_el6' == target):
-                run_native = True
-            elif ('redhat' in base and '7' in base) and ('rhel7' == target):
-                run_native = True
-            else:
-                sys.stderr.write("The System doesn't have Singularity Installed, and the target is unrecognized!\n")
-                exit(2)
-
-        #can assume singularity
-        proc2 = subprocess.Popen('singularity exec %s python -c "import platform; print platform.dist()"'%osused,stdout=subprocess.PIPE,shell=True)
-        (imgbase,err2) = proc2.communicate() 
-        if   ('redhat' in base and '6' in base) and (('redhat' in imgbase or 'centos' in imgbase) and '6' in imgbase):
-            run_native = True
-        elif ('redhat' in base and '7' in base) and (('redhat' in imgbase or 'centos' in imgbase) and '7' in imgbase):
-            run_native = True
-    except Exception, e:
-        print e
-        exit(2)
-
-
-    cmd = ['./work_queue_worker'] + worker_opts
-
-    
-    #calling process
-    mid = str(uuid.uuid4())[:8]
-    if run_native and not run_native:
-        exitcode = subprocess.call(cmd)
-        exit(exitcode)
-    else:
-        tmphome = "/tmp/runos_singularity_home-{}".format(mid)
+        tmphome = "/tmp/runos_singularity_home-{}".format(unique_id)
         if not (os.path.isdir(tmphome)):
             os.mkdir(tmphome,0755)
+    except Exception, e:
+        sys.stderr.write("could not create temporary directory {}: {}".format(tmphome), e)
+        sys.exit(3)
 
+    try:
         shutil.copy(worker_executable, tmphome)
+    except Exception, e:
+        sys.stderr.write("could not copy worker executable {} to temporary directory {}: {}".format(worker_executable, tmphome), e)
+        sys.exit(3)
 
 
-        cmdwrap = "'cd /worker-home; " + ' '.join(cmd) + "'"
-        newcmd  = ["exec", "--home", "{}:/worker-home".format(tmphome), "--bind","/var:/var", osused, "sh", "-c", cmdwrap]
+    worker_cmdlst = [os.path.join(tmphome, 'work_queue_worker')] + worker_opts
+    
+    if run_native:
+        proc = subprocess.Popen(' '.join(worker_cmdlst), shell=True)
+        proc.wait()
+        exitcode = proc.returncode
+        clean_and_remove(tmphome)
+        exit(exitcode)
+    else:
+        sing_cmd = [singularity_executable, "exec", "--home", "{}:/worker-home".format(tmphome), "--bind","/var:/var", osused, "sh", "-c", "'" + " ".join(worker_cmdlst) + "'"]
 
-        if os.path.isfile("/usr/local/bin/singularity"):
-            newcmd.insert(0, "/usr/local/bin/singularity")
-        elif os.path.isfile("/usr/bin/singularity"):
-            newcmd.insert(0, "/usr/bin/singularity")
-        else:
-            newcmd.insert(0, "singularity")
+        logfile.write('[runos-{}]: {}\n'.format(unique_id,'STARTING'))
+        logfile.write('[runos-{}] cmd: {}\n'.format(unique_id,' '.join(sing_cmd)))
 
-        if switch == False:
-            proc = subprocess.Popen(' '.join(newcmd),shell=True)
-            proc.wait()
-            exitcode = proc.returncode
-            clean_and_remove(tmphome)
-            exit(exitcode)
-        else:   
-            logfile.write('[runos-{}]: {}\n'.format(mid,'STARTING'))
-            logfile.write('[runos-{}] cmd: {}\n'.format(mid,' '.join(newcmd)))
-            proc = subprocess.Popen(' '.join(newcmd),stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=True)  
-            lelock = threading.Lock()
-            out_t = threading.Thread(target = write_stdout, args=(logfile, proc, mid, lelock,))
-            err_t = threading.Thread(target = write_stderr, args=(logfile, proc, mid, lelock,))
-            out_t.start()
-            err_t.start()
-            out_t.join()
-            err_t.join()
-            proc.wait()
-            exitcode = proc.returncode
-            clean_and_remove(tmphome)
-            logfile.write('[runos-{}] ret: {}\n'.format(mid,exitcode))
-            logfile.close()
-            exit(exitcode)  
+        proc = subprocess.Popen(' '.join(sing_cmd),stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=True)  
+        lelock = threading.Lock()
+        out_t = threading.Thread(target = write_stdout, args=(logfile, proc, unique_id, lelock,))
+        err_t = threading.Thread(target = write_stderr, args=(logfile, proc, unique_id, lelock,))
+        out_t.start()
+        err_t.start()
+        out_t.join()
+        err_t.join()
+        proc.wait()
+        exitcode = proc.returncode
+        clean_and_remove(tmphome)
+        logfile.write('[runos-{}] ret: {}\n'.format(unique_id,exitcode))
+        logfile.close()
+        exit(exitcode)  
 
 #vim: set sts=4 sw=4 ts=4 expandtab ft=python:
 

--- a/batch_job/src/cctools-runos
+++ b/batch_job/src/cctools-runos
@@ -58,7 +58,6 @@ def write_stderr(lefile, proc, mid, lelock):
                 lelock.release()
 
 
-
 def clean_and_remove(path):
     allthings = os.listdir(path)
     for x in allthings:
@@ -68,19 +67,6 @@ def clean_and_remove(path):
         else:
             os.remove(x)
     return 1
-
-def arr_to_str(arr):
-    s = ""
-    for x in arr:
-        s += ("%s " % x)
-    return s[:-1]
-
-def convert(shlex_list):
-    a = []
-    for x in shlex_list:
-        a.append(str(x))
-    return a
-
 
 def show_help():
     sys.stderr.write("""
@@ -200,7 +186,7 @@ if __name__ == "__main__":
         shutil.copy(worker_executable, tmphome)
 
 
-        cmdwrap = "'cd /worker-home; %s'" % (arr_to_str(cmd))
+        cmdwrap = "'cd /worker-home; " + ' '.join(cmd) + "'"
         newcmd  = ["exec", "--home", "{}:/worker-home".format(tmphome), "--bind","/var:/var", osused, "sh", "-c", cmdwrap]
 
         if os.path.isfile("/usr/local/bin/singularity"):
@@ -209,15 +195,12 @@ if __name__ == "__main__":
             newcmd.insert(0, "/usr/bin/singularity")
         else:
             newcmd.insert(0, "singularity")
-        #exitcode = subprocess.call(cmd)
-        #proc = subprocess.Popen(' '.join(newcmd),stdout=subprocess.STDOUT,stderr=subprocess.STDOUT,shell=True)
+
         if switch == False:
             proc = subprocess.Popen(' '.join(newcmd),shell=True)
             proc.wait()
             exitcode = proc.returncode
             clean_and_remove(tmphome)
-            #logfile.write('[runos-%d]ret: %i\n'%(mid,exitcode))
-            #logfile.close()
             exit(exitcode)
         else:   
             logfile.write('[runos-{}]: {}\n'.format(mid,'STARTING'))
@@ -230,18 +213,9 @@ if __name__ == "__main__":
             err_t.start()
             out_t.join()
             err_t.join()
-            #with proc.stdout:
-            #   for line in iter(proc.stdout.readline,b''):
-            #       print(line)
-            #       logfile.write('[runos-%d]out: %s\n'%(mid,line))
-            #(out) = proc.communicate()
             proc.wait()
             exitcode = proc.returncode
             clean_and_remove(tmphome)
-            #print(out)
-            #print(err)
-            #logfile.write('[runos-%d]out: %s\n'%(mid,out))
-            #logfile.write('[runos-%d]err: %s\n'%(mid,err))
             logfile.write('[runos-{}] ret: {}\n'.format(mid,exitcode))
             logfile.close()
             exit(exitcode)  

--- a/batch_job/src/cctools-runos
+++ b/batch_job/src/cctools-runos
@@ -7,11 +7,11 @@
 import sys
 import os
 import subprocess
-import json
 import shlex
 import uuid
 import platform
 import threading
+import getopt
 
 ######## Configuration
 
@@ -76,26 +76,71 @@ def arr_to_str(arr):
     for x in arr:
         s += ("%s " % x)
     return s[:-1]
+
 def convert(shlex_list):
     a = []
     for x in shlex_list:
         a.append(str(x))
     return a
 
-if __name__ == "__main__":
-    if len(sys.argv) < 3:
-        sys.stderr.write("Usage: runos (rhel6|rhel7) [arguments ...]\n")
-        exit(2)
-    target = sys.argv[1]
-    cmd = sys.argv[2:]
-    output = 'runos-output.txt'
-    switch=False
-    if '--output=' in sys.argv[1]:
-        switch=True
-        target = sys.argv[2]
-        cmd = sys.argv[3:]
-        output = sys.argv[1][len('--output='):]
 
+def show_help():
+    sys.stderr.write("""
+    Usage:
+        runos [--worker-version VERSION] [--debug-file OUTPUT] [--singularity SINGULARITY-EXEC] --os TARGET_OS --run-worker -- WORKER-ARGUMENTS ...
+
+        or 
+
+        runos [--worker-version VERSION] [--debug-file OUTPUT] [--singularity SINGULARITY-EXEC] --os TARGET_OS COMMAND_TO_RUN COMMAND_ARGUMENTS ...
+
+        where TARGET_OS is one of: {}
+    """.format(', '.join(image_of.keys())))
+
+def parse_command_line_argumets(argv):
+    try:
+        opts, args_left = getopt.getopt(sys.argv[1:], '', ['os=','run-worker', 'worker-version=','debug-file=','singularity='])
+
+        opts_dict = dict(opts)
+        command_opts = args_left
+
+        print(sys.argv)
+        print(args_left)
+        print(opts)
+
+        if not ('--os' in opts_dict.keys()):
+            sys.stderr.write("command line option '--os' is required")
+            show_help()
+            sys.exit(1)
+
+        target           = opts_dict['--os']
+        worker_version   = opts_dict.get('--worker-version', 'stable')
+        debug_output     = opts_dict.get('--debug-file',  None)
+        singularity_opt  = opts_dict.get('--singularity', None)
+        run_worker       = True if '--run-worker' in opts_dict.keys() else False
+
+        if run_worker is False and not command_opts:
+            sys.stderr.write("Either COMMAND_TO_RUN or --run-worker are needed.")
+            show_help()
+            sys.exit(1)
+
+        return (target, run_worker, command_opts, singularity_opt, worker_version, debug_output)
+
+    except Exception:
+        raise
+        show_help()
+        sys.exit(1)
+
+
+
+if __name__ == "__main__":
+
+    target, worker_opts, run_worker, singularity_opt, worker_version, debug_output = parse_command_line_argumets(sys.argv)
+
+    logfile = sys.stderr
+    if(debug_output):
+        logfile = open(debug_output, 'a+')
+
+    switch=True
 
     # osused is the path to the image for target
     try:
@@ -131,8 +176,6 @@ if __name__ == "__main__":
     
     #calling process
     mid = uuid.uuid4()
-    if switch:
-        logfile = open(output,'a+')
     if run_native and not run_native:
         exitcode = subprocess.call(cmd)
         exit(exitcode)

--- a/batch_job/src/cctools-runos
+++ b/batch_job/src/cctools-runos
@@ -39,15 +39,12 @@ worker_repository = '/afs/crc.nd.edu/group/ccl/software'
 ###### END OF CONFIGURATION
 
 
-
-
-
 def write_stdout(lefile, proc, mid, lelock):
     with proc.stdout:
         for line in iter(proc.stdout.readline,b''):
             lelock.acquire()
             try:
-                logfile.write('[runos-%d]out: %s\n'%(mid,line))
+                logfile.write('[runos-{}] out: {}\n'.format(mid,line))
             finally:
                 lelock.release()
 
@@ -56,7 +53,7 @@ def write_stderr(lefile, proc, mid, lelock):
         for line in iter(proc.stderr.readline,b''):
             lelock.acquire()
             try:
-                logfile.write('[runos-%d]err: %s\n'%(mid,line))
+                logfile.write('[runos-{}] err: {}\n'.format(mid,line))
             finally:
                 lelock.release()
 
@@ -191,12 +188,12 @@ if __name__ == "__main__":
 
     
     #calling process
-    mid = uuid.uuid4()
+    mid = str(uuid.uuid4())[:8]
     if run_native and not run_native:
         exitcode = subprocess.call(cmd)
         exit(exitcode)
     else:
-        tmphome = "/tmp/runos_singularity_home-%d"%mid
+        tmphome = "/tmp/runos_singularity_home-{}".format(mid)
         if not (os.path.isdir(tmphome)):
             os.mkdir(tmphome,0755)
 
@@ -223,8 +220,8 @@ if __name__ == "__main__":
             #logfile.close()
             exit(exitcode)
         else:   
-            logfile.write('[runos-%d]: %s\n'%(mid,'STARTING'))
-            logfile.write('[runos-%d]cmd: %s\n'%(mid,' '.join(newcmd)))
+            logfile.write('[runos-{}]: {}\n'.format(mid,'STARTING'))
+            logfile.write('[runos-{}] cmd: {}\n'.format(mid,' '.join(newcmd)))
             proc = subprocess.Popen(' '.join(newcmd),stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=True)  
             lelock = threading.Lock()
             out_t = threading.Thread(target = write_stdout, args=(logfile, proc, mid, lelock,))
@@ -245,7 +242,7 @@ if __name__ == "__main__":
             #print(err)
             #logfile.write('[runos-%d]out: %s\n'%(mid,out))
             #logfile.write('[runos-%d]err: %s\n'%(mid,err))
-            logfile.write('[runos-%d]ret: %i\n'%(mid,exitcode))
+            logfile.write('[runos-{}] ret: {}\n'.format(mid,exitcode))
             logfile.close()
             exit(exitcode)  
 

--- a/batch_job/src/cctools-runos
+++ b/batch_job/src/cctools-runos
@@ -1,0 +1,174 @@
+#! /usr/bin/env python
+
+# Copyright (C) 2018- The University of Notre Dame
+# This software is distributed under the GNU General Public License.
+# See the file COPYING for details.
+
+import sys
+import os
+import subprocess
+import json
+import shlex
+import uuid
+import platform
+import threading
+import threading
+
+def write_stdout(lefile, proc, mid, lelock):
+    with proc.stdout:
+        for line in iter(proc.stdout.readline,b''):
+            lelock.acquire()
+            try:
+                logfile.write('[runos-%d]out: %s\n'%(mid,line))
+            finally:
+                lelock.release()
+
+def write_stderr(lefile, proc, mid, lelock):
+    with proc.stderr:
+        for line in iter(proc.stderr.readline,b''):
+            lelock.acquire()
+            try:
+                logfile.write('[runos-%d]err: %s\n'%(mid,line))
+            finally:
+                lelock.release()
+
+
+
+def clean_and_remove(path):
+    allthings = os.listdir(path)
+    for x in allthings:
+        if os.path.isdir(x):
+            clean_and_remove(x)
+            os.rmdir(x)
+        else:
+            os.remove(x)
+    return 1
+
+def arr_to_str(arr):
+    s = ""
+    for x in arr:
+        s += ("%s " % x)
+    return s[:-1]
+def convert(shlex_list):
+    a = []
+    for x in shlex_list:
+        a.append(str(x))
+    return a
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        sys.stderr.write("Usage: runos (rhel6|rhel7) [arguments ...]\n")
+        exit(2)
+    target = sys.argv[1]
+    cmd = sys.argv[2:]
+    output = 'runos-output.txt'
+    switch=False
+    if '--output=' in sys.argv[1]:
+        switch=True
+        target = sys.argv[2]
+        cmd = sys.argv[3:]
+        output = sys.argv[1][len('--output='):]
+
+    #finding config file
+    mydir = os.path.dirname(os.path.realpath(__file__))
+    try:
+        cfg = open(mydir+"/"+"runos.cfg","r")
+    except IOError:
+        sys.stderr.write("config file not found at: "+mydir+"/runos.cfg\n")
+        exit(16)
+    oslocs = json.loads(cfg.read())
+    cfg.close()
+    #getting image path
+    try:
+        osused = oslocs[target]
+        osused=osused.replace("$CONFIG_PATH",mydir)
+    except KeyError:
+        sys.stderr.write("target OS not found in config file\n")
+        exit(18)
+    
+    #ensure singularity on computer
+    run_native=False
+    try:
+        proc = subprocess.Popen('~condor/software/config/get_system_info.sh',stdout=subprocess.PIPE,shell=True)
+        (out, err) = proc.communicate()
+        base = str(platform.dist())
+        if not "has_singularity = true" in out: #no singularity
+            if ('redhat' in base and '6' in base) and ('rhel6' == target or 'osg_el6' == target):
+                run_native = True
+            elif ('redhat' in base and '7' in base) and ('rhel7' == target):
+                run_native = True
+            else:
+                sys.stderr.write("The System doesn't have Singularity Installed, and the target is unrecognized!\n")
+                exit(17)
+        #can assume singularity
+        proc2 = subprocess.Popen('singularity exec %s python -c "import platform; print platform.dist()"'%osused,stdout=subprocess.PIPE,shell=True)
+        (imgbase,err2) = proc2.communicate() 
+        if   ('redhat' in base and '6' in base) and (('redhat' in imgbase or 'centos' in imgbase) and '6' in imgbase):
+            run_native = True
+        elif ('redhat' in base and '7' in base) and (('redhat' in imgbase or 'centos' in imgbase) and '7' in imgbase):
+            run_native = True
+    except Exception, e:
+        print e
+        exit(88)
+    
+    #calling process
+    mid = uuid.uuid4()
+    if switch:
+        logfile = open(output,'a+')
+    if run_native and not run_native:
+        exitcode = subprocess.call(cmd)
+        exit(exitcode)
+    else:
+        tmphome = "/tmp/runos_singularity_home-%d"%mid
+        if not (os.path.isdir(tmphome)):
+            os.mkdir(tmphome,0777)
+
+        cmdwrap = "'cd /disk; %s'" % (arr_to_str(cmd))
+        #newcmd  = ["exec","--bind","%s:/disk"%os.getcwd(),"--home","%s:%s"%(tmphome,tmphome),"--bind","/var:/var","--bind","/afs/crc.nd.edu/group/ccl/software:/cclsoftware",osused,"sh","-c",cmdwrap]
+        newcmd  = ["exec","--bind","%s:/disk"%os.getcwd(),"--home","%s:%s"%(tmphome,tmphome),"--bind","/var:/var","--bind","/afs/:/afs",osused,"sh","-c",cmdwrap]
+
+        if os.path.isfile("/usr/local/bin/singularity"):
+            newcmd.insert(0, "/usr/local/bin/singularity")
+        elif os.path.isfile("/usr/bin/singularity"):
+            newcmd.insert(0, "/usr/bin/singularity")
+        else:
+            newcmd.insert(0, "singularity")
+        #exitcode = subprocess.call(cmd)
+        #proc = subprocess.Popen(' '.join(newcmd),stdout=subprocess.STDOUT,stderr=subprocess.STDOUT,shell=True)
+        if switch == False:
+            proc = subprocess.Popen(' '.join(newcmd),shell=True)
+            proc.wait()
+            exitcode = proc.returncode
+            clean_and_remove(tmphome)
+            #logfile.write('[runos-%d]ret: %i\n'%(mid,exitcode))
+            #logfile.close()
+            exit(exitcode)
+        else:   
+            logfile.write('[runos-%d]: %s\n'%(mid,'STARTING'))
+            logfile.write('[runos-%d]cmd: %s\n'%(mid,' '.join(newcmd)))
+            proc = subprocess.Popen(' '.join(newcmd),stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=True)  
+            lelock = threading.Lock()
+            out_t = threading.Thread(target = write_stdout, args=(logfile, proc, mid, lelock,))
+            err_t = threading.Thread(target = write_stderr, args=(logfile, proc, mid, lelock,))
+            out_t.start()
+            err_t.start()
+            out_t.join()
+            err_t.join()
+            #with proc.stdout:
+            #   for line in iter(proc.stdout.readline,b''):
+            #       print(line)
+            #       logfile.write('[runos-%d]out: %s\n'%(mid,line))
+            #(out) = proc.communicate()
+            proc.wait()
+            exitcode = proc.returncode
+            clean_and_remove(tmphome)
+            #print(out)
+            #print(err)
+            #logfile.write('[runos-%d]out: %s\n'%(mid,out))
+            #logfile.write('[runos-%d]err: %s\n'%(mid,err))
+            logfile.write('[runos-%d]ret: %i\n'%(mid,exitcode))
+            logfile.close()
+            exit(exitcode)  
+
+#vim: set sts=4 sw=4 ts=4 expandtab ft=python:
+

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -45,7 +45,7 @@ See the file COPYING for details.
 #include <unistd.h>
 #include <signal.h>
 
-#define CCTOOLS_RUNOS_PATH "/afs/crc.nd.edu/group/ccl/software/runos/runos.py"
+#define CCTOOLS_RUNOS_PATH "/afs/crc.nd.edu/group/ccl/software/runos/cctools-runos"
 #define CCTOOLS_VC3_BUILDER_PATH "/afs/crc.nd.edu/group/ccl/software/vc3-builder-src/vc3-builder"
 
 typedef enum {

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -404,7 +404,7 @@ static int submit_worker( struct batch_queue *queue )
 	}
 	
 	if(runos_os){
-		char* temp = string_format("%s --worker-version %s %s %s", CCTOOLS_RUNOS_PATH, runos_worker_version, runos_os, cmd);
+		char* temp = string_format("%s --os %s --worker-version %s --run-worker -- %s", CCTOOLS_RUNOS_PATH, runos_worker_version, runos_os, cmd);
 		free(cmd);
 		cmd = temp;
 	}else{

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -46,7 +46,6 @@ See the file COPYING for details.
 #include <signal.h>
 
 #define CCTOOLS_RUNOS_PATH "/afs/crc.nd.edu/group/ccl/software/runos/cctools-runos"
-#define CCTOOLS_VC3_BUILDER_PATH "/afs/crc.nd.edu/group/ccl/software/vc3-builder-src/vc3-builder"
 
 typedef enum {
 	FORMAT_TABLE,
@@ -102,7 +101,7 @@ static char *wrapper_input = 0;
 static char *worker_command = 0;
 
 static char *runos_os = 0;
-static char *runos_cctools_nd = "cctools-stable";
+static char *runos_worker_version = "stable";
 
 /* -1 means 'not specified' */
 static struct rmsummary *resources = NULL;
@@ -405,14 +404,9 @@ static int submit_worker( struct batch_queue *queue )
 	}
 	
 	if(runos_os){
-		char* vc3_cmd = string_format("./vc3-builder --var CCTOOLS_ND=\"%s\" --require cctools-wq-worker -- %s",runos_cctools_nd,cmd);
-		char* temp = string_format("python %s %s %s",CCTOOLS_RUNOS_PATH,runos_os,vc3_cmd);
-		free(vc3_cmd);
+		char* temp = string_format("%s --worker-version %s %s %s", CCTOOLS_RUNOS_PATH, runos_worker_version, runos_os, cmd);
 		free(cmd);
 		cmd = temp;
-		temp = string_format("%s,%s",files,"vc3-builder");
-		free(files);
-		files = temp;
 	}else{
 		char* temp = string_format("%s,%s",files,worker);
 		free(files);
@@ -1240,7 +1234,7 @@ int main(int argc, char *argv[])
 				runos_os = xxstrdup(optarg);
 				break;
 			case LONG_OPT_RUN_OS_WORKER_VERSION:
-				runos_cctools_nd = xxstrdup(optarg);
+				runos_worker_version = xxstrdup(optarg);
 				break;
 			default:
 				show_help(argv[0]);
@@ -1345,16 +1339,6 @@ int main(int argc, char *argv[])
 		free(cmd);
 	}
 	
-	
-	if(runos_os) {
-		cmd = string_format("cp '%s' '%s'",  CCTOOLS_VC3_BUILDER_PATH, scratch_dir);
-		int k = system(cmd);
-		if (k) {
-			fprintf(stderr, "can't copy vc3-builder! Please make sure it's at `%s`. Error code: %i\n",  CCTOOLS_VC3_BUILDER_PATH, k);
-			exit(EXIT_FAILURE);
-		}
-	}
-
 	if(password_file) {
 		cmd = string_format("cp %s %s/pwfile",password_file,scratch_dir);
 		system(cmd);

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -102,6 +102,7 @@ static char *wrapper_input = 0;
 static char *worker_command = 0;
 
 static char *runos_os = 0;
+static char *runos_cctools_nd = "cctools-stable";
 
 /* -1 means 'not specified' */
 static struct rmsummary *resources = NULL;
@@ -404,7 +405,7 @@ static int submit_worker( struct batch_queue *queue )
 	}
 	
 	if(runos_os){
-		char* vc3_cmd = string_format("./vc3-builder --require cctools-statics -- %s",cmd);
+		char* vc3_cmd = string_format("./vc3-builder --var CCTOOLS_ND=\"%s\" --require cctools-wq-worker -- %s",runos_cctools_nd,cmd);
 		char* temp = string_format("python %s %s %s",CCTOOLS_RUNOS_PATH,runos_os,vc3_cmd);
 		free(vc3_cmd);
 		free(cmd);
@@ -1021,6 +1022,7 @@ enum{   LONG_OPT_CORES = 255,
 		LONG_OPT_CATALOG,
 		LONG_OPT_ENVIRONMENT_VARIABLE,
 		LONG_OPT_RUN_OS,
+		LONG_OPT_RUN_OS_WORKER_VERSION,
 	};
 
 static const struct option long_options[] = {
@@ -1061,6 +1063,7 @@ static const struct option long_options[] = {
 	{"k8s-image", required_argument, 0, LONG_OPT_K8S_IMAGE},
 	{"k8s-worker-image", required_argument, 0, LONG_OPT_K8S_WORKER_IMAGE},
 	{"runos", required_argument, 0, LONG_OPT_RUN_OS},
+	{"runos-worker-version", required_argument, 0, LONG_OPT_RUN_OS_WORKER_VERSION},
 	{0,0,0,0}
 };
 
@@ -1235,6 +1238,9 @@ int main(int argc, char *argv[])
 				break;
 			case LONG_OPT_RUN_OS:
 				runos_os = xxstrdup(optarg);
+				break;
+			case LONG_OPT_RUN_OS_WORKER_VERSION:
+				runos_cctools_nd = xxstrdup(optarg);
 				break;
 			default:
 				show_help(argv[0]);


### PR DESCRIPTION
Originally written by @Nekel-Seyew.

This version removes the dependency on the vc3-builder, and  sends the runos executable along the batch job (no fixed path dependency anymore).

The example configuration file (which is found automatically) works for Notre Dame path for images and workers.
