### PR TITLE
add measure of master load

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -472,6 +472,7 @@ static void log_queue_stats(struct work_queue *q)
 	buffer_printf(&B, " %d", s.capacity_disk);
 	buffer_printf(&B, " %d", s.capacity_instantaneous);
 	buffer_printf(&B, " %d", s.capacity_weighted);
+	buffer_printf(&B, " %f", s.master_load);
 
 	buffer_printf(&B, " %" PRId64, s.total_cores);
 	buffer_printf(&B, " %" PRId64, s.total_memory);
@@ -2294,6 +2295,7 @@ static struct jx * queue_to_jx( struct work_queue *q, struct link *foreman_uplin
 	jx_insert_integer(j,"capacity_disk",info.capacity_disk);
 	jx_insert_integer(j,"capacity_instantaneous",info.capacity_instantaneous);
 	jx_insert_integer(j,"capacity_weighted",info.capacity_weighted);
+	jx_insert_integer(j,"master_load",info.master_load);
 
 	// Add the resources computed from tributary workers.
 	struct work_queue_resources r;
@@ -2382,6 +2384,7 @@ static struct jx * queue_lean_to_jx( struct work_queue *q, struct link *foreman_
 	jx_insert_integer(j,"capacity_memory",info.capacity_memory);
 	jx_insert_integer(j,"capacity_disk",info.capacity_disk);
 	jx_insert_integer(j,"capacity_weighted",info.capacity_weighted);
+	jx_insert_double(j,"master_load",info.master_load);
 
 	//resources information the factory needs
 	struct rmsummary *total = total_resources_needed(q);
@@ -3341,6 +3344,21 @@ static void compute_capacity(const struct work_queue *q, struct work_queue_stats
 	q->stats->capacity_memory = DIV_INT_ROUND_UP(capacity.resources->memory * ratio, count);
 	q->stats->capacity_disk   = DIV_INT_ROUND_UP(capacity.resources->disk   * ratio, count);
 	q->stats->capacity_instantaneous = DIV_INT_ROUND_UP(capacity_instantaneous, 1);
+}
+
+void compute_master_load(struct work_queue *q, int task_activity) {
+
+	double alpha = 0.05;
+
+	double load = q->stats->master_load;
+
+	if(task_activity) {
+		load = load * (1 - alpha) + 1 * alpha;
+	} else {
+		load = load * (1 - alpha) + 0 * alpha;
+	}
+
+	q->stats->master_load = load;
 }
 
 static int check_hand_against_task(struct work_queue *q, struct work_queue_worker *w, struct work_queue_task *t) {
@@ -5799,8 +5817,6 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 		if(t) {
 			change_task_state(q, t, WORK_QUEUE_TASK_DONE);
 
-
-
 			if( t->result != WORK_QUEUE_RESULT_SUCCESS )
 			{
 				q->stats->tasks_failed++;
@@ -5813,7 +5829,6 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 			END_ACCUM_TIME(q, time_internal);
 			break;
 		}
-
 
 		 // update catalog if appropriate
 		if(q->name) {
@@ -5834,6 +5849,7 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 			// returning and retrieving tasks.
 		}
 
+
 		q->busy_waiting_flag = 0;
 
 		// tasks waiting to be retrieved?
@@ -5843,6 +5859,7 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 		if(result) {
 			// retrieved at least one task
 			events++;
+			compute_master_load(q, 1);
 			continue;
 		}
 
@@ -5853,8 +5870,12 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 		if(result) {
 			// expired at least one task
 			events++;
+			compute_master_load(q, 1);
 			continue;
 		}
+
+		// record that there was not task activity for this iteration
+		compute_master_load(q, 0);
 
 		// tasks waiting to be dispatched?
 		BEGIN_ACCUM_TIME(q, time_send);
@@ -5865,6 +5886,9 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 			events++;
 			continue;
 		}
+
+		//we reach here only if no task was neither sent nor received. 
+		compute_master_load(q, 1);
 
 		// send keepalives to appropriate workers
 		BEGIN_ACCUM_TIME(q, time_status_msgs);
@@ -6440,7 +6464,7 @@ int work_queue_specify_log(struct work_queue *q, const char *logfile)
 			// bandwidth:
 			" bytes_sent bytes_received bandwidth"
 			// resources:
-			" capacity_tasks capacity_cores capacity_memory capacity_disk capacity_instantaneous capacity_weighted"
+			" capacity_tasks capacity_cores capacity_memory capacity_disk capacity_instantaneous capacity_weighte master_load"
 			" total_cores total_memory total_disk"
 			" committed_cores committed_memory committed_disk"
 			" max_cores max_memory max_disk"

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -264,6 +264,13 @@ struct work_queue_stats {
 	int64_t min_memory;       /**< The smallest memory size in MB observed among the connected workers. */
 	int64_t min_disk;         /**< The smallest disk space in MB observed among the connected workers. */
 
+    double master_load;       /**< In the range of [0,1]. If close to 1, then
+                                the master is at full load and spends most
+                                of its time sending and receiving taks, and
+                                thus cannot accept connections from new
+                                workers. If close to 0, the master is spending
+                                most of its time waiting for something to happen. */
+
 	/**< deprecated fields: */
 	int total_workers_connected;    /**< @deprecated Use workers_connected instead. */
 	int total_workers_joined;       /**< @deprecated Use workers_joined instead. */


### PR DESCRIPTION
Adds q->stats->master_load

When close to 1, the master is at full load dealing with the transfer of tasks, and cannot accept connections of new workers.
When close to 0, the master is mostly waiting for something to happen.

It can be seen as a measure of capacity taken from the behavior of the master, independent of any time measures.
