### PR TITLE
Catalog/DeltaDB Merge Event

### DIFF
--- a/deltadb/src/Makefile
+++ b/deltadb/src/Makefile
@@ -4,7 +4,7 @@ include ../../rules.mk
 EXTERNAL_DEPENDENCIES = ../../dttools/src/libdttools.a
 LIBRARIES = libdeltadb.a
 OBJECTS = $(SOURCES:%.c=%.o)
-PROGRAMS = deltadb_query
+PROGRAMS = deltadb_query deltadb_upgrade_log
 SCRIPTS =
 SOURCES = deltadb_stream.c deltadb_reduction.c
 TARGETS = $(LIBRARIES) $(PROGRAMS)

--- a/deltadb/src/deltadb_query.c
+++ b/deltadb/src/deltadb_query.c
@@ -279,18 +279,40 @@ int deltadb_delete_event( struct deltadb *db, const char *key )
 	return 1;
 }
 
+/*
+Merge all the values of the update object into the current object,
+replacing where they exist.  We previously used jx_merge here,
+but the O(n^2) nature of the function and the heavy reliance on
+malloc/free resulted in poor performance.  This function avoids
+many malloc/frees by popping pairs off of the update in order,
+finding matches in current, if needed, and then pushing the pair
+on to the head of the current list.
+*/
+
+static void jx_merge_into( struct jx *current, struct jx *update )
+{
+	while(1) {
+		struct jx_pair *p = update->u.pairs;
+		if(!p) break;
+
+		update->u.pairs = p->next;
+
+		struct jx *oldvalue = jx_remove(current,p->key);
+		if(oldvalue) jx_delete(oldvalue);
+
+		p->next = current->u.pairs;
+		current->u.pairs = p;
+	}
+}
+
 int deltadb_merge_event( struct deltadb *db, const char *key, struct jx *update )
 {
-	struct jx *current = hash_table_remove(db->table,key);
+	struct jx *current = hash_table_lookup(db->table,key);
 	if(!current) {
 		/* If the key is not found, it was filtered out; skip the update. */
 		jx_delete(update);
 		return 1;
 	}
-
-	struct jx * merged = jx_merge(update,current,0);
-
-	hash_table_insert(db->table,key,merged);
 
 	if(display_mode==MODE_STREAM) {
 		display_deferred_time(db);
@@ -299,8 +321,9 @@ int deltadb_merge_event( struct deltadb *db, const char *key, struct jx *update 
 		free(str);
 	}
 
+	jx_merge_into(current,update);
+
 	jx_delete(update);
-	jx_delete(current);
 
 	return 1;
 }

--- a/deltadb/src/deltadb_query.c
+++ b/deltadb/src/deltadb_query.c
@@ -288,7 +288,7 @@ int deltadb_merge_event( struct deltadb *db, const char *key, struct jx *update 
 		return 1;
 	}
 
-	struct jx * merged = jx_merge(update,current);
+	struct jx * merged = jx_merge(update,current,0);
 
 	hash_table_insert(db->table,key,merged);
 

--- a/deltadb/src/deltadb_stream.c
+++ b/deltadb/src/deltadb_stream.c
@@ -39,7 +39,8 @@ int deltadb_process_stream( struct deltadb *db, FILE *stream, time_t starttime, 
 		if(line[0]=='C') {
 			n = sscanf(line,"C %s %[^\n]",key,value);
 			if(n==1) {
-				/* backwards compatibility with old log format */				struct nvpair *nv = nvpair_create();
+				/* backwards compatibility with old log format */
+				struct nvpair *nv = nvpair_create();
 				nvpair_parse_stream(nv,stream);
 				jvalue = nvpair_to_jx(nv);
 				nvpair_delete(nv);

--- a/deltadb/src/deltadb_stream.c
+++ b/deltadb/src/deltadb_stream.c
@@ -63,6 +63,21 @@ int deltadb_process_stream( struct deltadb *db, FILE *stream, time_t starttime, 
 
 			if(!deltadb_delete_event(db,key)) break;
 
+		} else if(line[0]=='M') {
+			n = sscanf(line,"M %s %[^\n]",key,value);
+			if(n==2) {
+				jvalue = jx_parse_string(value);
+				if(!jvalue) {
+					corrupt_data(filename,line);
+					continue;
+				}
+			} else {
+				corrupt_data(filename,line);
+				continue;
+			}
+
+			if(!deltadb_merge_event(db,key,jvalue)) break;
+
 		} else if(line[0]=='U') {
 			n=sscanf(line,"U %s %s %[^\n],",key,name,value);
 			if(n!=3) {

--- a/deltadb/src/deltadb_stream.h
+++ b/deltadb/src/deltadb_stream.h
@@ -17,6 +17,7 @@ struct deltadb;
 int deltadb_create_event( struct deltadb *db, const char *key, struct jx *jobject );
 int deltadb_delete_event( struct deltadb *db, const char *key );
 int deltadb_update_event( struct deltadb *db, const char *key, const char *name, struct jx *jvalue );
+int deltadb_merge_event( struct deltadb *db, const char *key, struct jx *jobject );
 int deltadb_remove_event( struct deltadb *db, const char *key, const char *name );
 int deltadb_time_event( struct deltadb *db, time_t starttime, time_t stoptime, time_t current );
 int deltadb_post_event( struct deltadb *db, const char *line );

--- a/deltadb/src/deltadb_upgrade_log.c
+++ b/deltadb/src/deltadb_upgrade_log.c
@@ -1,0 +1,116 @@
+/*
+Copyright (C) 2015- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+/*
+A limited-use program to upgrade (still-valid) log files
+in two ways that save space:
+1 - Adjacent U records are combined into one M record.
+2 - T records are reduced to one per minute.
+*/
+
+
+#include "jx.h"
+#include "jx_print.h"
+#include "jx_parse.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#define LOG_LINE_MAX 4096
+
+void corrupt_data( const char *line, int lineno )
+{
+	fprintf(stderr,"ABORT: corrupt data line %d: %s\n",lineno,line);
+	exit(1);
+}
+
+
+int main( int argc, char *argv[] )
+{
+	if(argc!=3) {
+		fprintf(stderr,"use: %s <infile> <outfile>\n",argv[0]);
+		return 1;
+	}
+
+	FILE *input = fopen(argv[1],"r");
+	if(!input) {
+		fprintf(stderr,"couldn't open %s: %s\n",argv[1],strerror(errno));
+		return 1;
+	}
+
+	FILE *output = fopen(argv[2],"w");
+	if(!input) {
+		fprintf(stderr,"couldn't open %s: %s\n",argv[2],strerror(errno));
+		return 1;
+	}
+
+	char line[LOG_LINE_MAX] = "";
+	char key[LOG_LINE_MAX] = "";
+	char name[LOG_LINE_MAX] = "";
+	char value[LOG_LINE_MAX] = "";
+
+	char lastop = 0;
+	char lastkey[LOG_LINE_MAX] = "";
+
+	struct jx *merge = 0;
+	int lineno = 0;
+	long time;
+	long lasttime = 0;
+	long time_granularity = 60;
+
+	while(fgets(line,sizeof(line),input)) {
+		lineno++;
+		int emit_merge = 0;
+
+		if(line[0]=='U') {
+			if(sscanf(line,"U %s %s %[^\n]",key,name,value)==3) {
+				if(lastop=='U' && !strcmp(key,lastkey)) {
+					struct jx *jvalue = jx_parse_string(value);
+					if(!merge) merge = jx_object(0);
+					jx_insert(merge,jx_string(name),jvalue);
+				} else {
+					emit_merge = 1;
+				}
+				strcpy(lastkey,key);
+			} else {
+				corrupt_data(line,lineno);
+			}
+		} else {
+			emit_merge = 1;
+		}
+
+		if(emit_merge && merge) {
+			char *str = jx_print_string(merge);
+			fprintf(output,"M %s %s\n",key,str);
+			free(str);
+			jx_delete(merge);
+			merge = 0;
+		}
+
+		if(line[0]=='T') {
+			if(sscanf(line,"T %ld",&time)) {
+				if((time-lasttime)>time_granularity) {
+					fputs(line,output);
+					lasttime = time;
+				}
+			} else {
+				corrupt_data(line,lineno);
+			}
+		} else if(line[0]!='U') {
+			fputs(line,output);
+		}
+
+		lastop = line[0];
+	}
+
+	fclose(input);
+	fclose(output);
+
+	return 0;
+}
+

--- a/deltadb/src/deltadb_upgrade_log.c
+++ b/deltadb/src/deltadb_upgrade_log.c
@@ -54,7 +54,6 @@ int main( int argc, char *argv[] )
 	char name[LOG_LINE_MAX] = "";
 	char value[LOG_LINE_MAX] = "";
 
-	char lastop = 0;
 	char lastkey[LOG_LINE_MAX] = "";
 
 	struct jx *merge = 0;
@@ -71,7 +70,7 @@ int main( int argc, char *argv[] )
 				// If a merge for a different key is pending, emit it.
 				if(merge && strcmp(key,lastkey) ) {
 					char *str = jx_print_string(merge);
-					fprintf(output,"M %s %s\n",key,str);
+					fprintf(output,"M %s %s\n",lastkey,str);
 					free(str);
 					jx_delete(merge);
 					merge = 0;
@@ -90,7 +89,7 @@ int main( int argc, char *argv[] )
 		} else if(merge) {
 			// Emit the pending merge on any other op.
 			char *str = jx_print_string(merge);
-			fprintf(output,"M %s %s\n",key,str);
+			fprintf(output,"M %s %s\n",lastkey,str);
 			free(str);
 			jx_delete(merge);
 			merge = 0;
@@ -108,8 +107,6 @@ int main( int argc, char *argv[] )
 		} else if(line[0]!='U') {
 			fputs(line,output);
 		}
-
-		lastop = line[0];
 	}
 
 	fclose(input);

--- a/dttools/src/catalog_server.c
+++ b/dttools/src/catalog_server.c
@@ -290,7 +290,20 @@ static void handle_update( const char *addr, int port, const char *raw_data, int
 
 		char name[DOMAIN_NAME_MAX];
 		if(domain_name_cache_lookup_reverse(addr, name)) {
-			jx_insert_string(j, "name", name);
+			/*
+			Special case: Prior bug resulted in multiple name
+			entries in logged data.  When removing the name property,
+			keep looking until all items are removed.
+			*/
+			struct jx *jname = jx_string("name");
+			struct jx *n;
+			while((n=jx_remove(j,jname))) {
+				jx_delete(n);
+			}
+			jx_delete(jname);
+
+			jx_insert_string(j,"name",name);
+	
 		} else if (jx_lookup_string(j, "name") == NULL) {
 			/* If rDNS is unsuccessful, then we use the name reported if given.
 			 * This allows for hostnames that are only valid in the subnet of

--- a/dttools/src/jx_database.c
+++ b/dttools/src/jx_database.c
@@ -283,7 +283,7 @@ static void corrupt_data( const char *filename, const char *line )
 static void handle_merge( struct jx_database *db, const char *key, struct jx *update )
 {
 	struct jx *current = hash_table_remove(db->table,key);
-	struct jx *merged = jx_merge(update,current);
+	struct jx *merged = jx_merge(update,current,0);
 
 	hash_table_insert(db->table,key,merged);
 

--- a/dttools/src/jx_database.c
+++ b/dttools/src/jx_database.c
@@ -248,9 +248,12 @@ static void log_updates( struct jx_database *db, const char *key, struct jx *a, 
 		}
 	}
 
-	char *str = jx_print_string(u);
-	log_message(db,"M %s %s\n",key,str);
-	free(str);
+	// If the update is not empty, log it.
+	if(u->u.pairs) {
+		char *str = jx_print_string(u);
+		log_message(db,"M %s %s\n",key,str);
+		free(str);
+	}
 
 	jx_delete(u);
 }


### PR DESCRIPTION
In an effort to reduce the size of catalog logs, this PR introduces a new event type "M" (merge) which captures multiple changes in a single merge event.  (In short, each UDP update now corresponds to a single log event.)