### PR TITLE
Unary minus in JX

### DIFF
--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -621,27 +621,6 @@ static int jx_pair_is_constant(struct jx_pair *p) {
 		&& jx_pair_is_constant(p->next);
 }
 
-//hot fix for unary + and - with numbers
-static int jx_operator_is_constant(struct jx *j) {
-    if(j->u.oper.type != JX_OP_ADD && j->u.oper.type != JX_OP_SUB) {
-        return 0;
-    }
-
-    if(j->u.oper.left) {
-        return 0;
-    }
-
-    if(!j->u.oper.right) {
-        return 0;
-    }
-
-    if(j->u.oper.right->type != JX_INTEGER && j->u.oper.right->type != JX_DOUBLE) {
-        return 0;
-    }
-
-    return 1;
-}
-
 static int jx_item_is_constant(struct jx_item *i) {
 	if(!i) return 1;
 	if (i->comp) return 0;
@@ -666,9 +645,8 @@ int jx_is_constant( struct jx *j )
 			return jx_pair_is_constant(j->u.pairs);
 		case JX_ERROR:
 		case JX_FUNCTION:
-            return 0;
 		case JX_OPERATOR:
-			return jx_operator_is_constant(j);
+			return 0;
 	}
 
 	/* not reachable, but some compilers complain. */

--- a/dttools/src/jx_parse.c
+++ b/dttools/src/jx_parse.c
@@ -833,9 +833,15 @@ static struct jx * jx_parse_unary( struct jx_parser *s )
 				// error set by deeper level
 				return NULL;
 			}
-			j = jx_operator(jx_token_to_operator(t), NULL, j);
+			if (t == JX_TOKEN_SUB && jx_istype(j, JX_INTEGER)) {
+				j->u.integer_value *= -1;
+			} else if (t == JX_TOKEN_SUB && jx_istype(j, JX_DOUBLE)) {
+				j->u.double_value *= -1;
+			} else {
+				j = jx_operator(jx_token_to_operator(t), NULL, j);
+				j->u.oper.line = line;
+			}
 			j->line = line;
-			j->u.oper.line = line;
 			return j;
 		}
 		case JX_TOKEN_ERROR: {

--- a/dttools/src/jx_parse.c
+++ b/dttools/src/jx_parse.c
@@ -833,10 +833,19 @@ static struct jx * jx_parse_unary( struct jx_parser *s )
 				// error set by deeper level
 				return NULL;
 			}
+
+			// For the special case of + or - followed by a numeric literal,
+			// don't create an operator in the AST. This plain-JSON syntax
+			// should result in a constant, so we negate as necessary here
+			// and return just a number.
 			if (t == JX_TOKEN_SUB && jx_istype(j, JX_INTEGER)) {
 				j->u.integer_value *= -1;
 			} else if (t == JX_TOKEN_SUB && jx_istype(j, JX_DOUBLE)) {
 				j->u.double_value *= -1;
+			} else if (t == JX_TOKEN_ADD && jx_istype(j, JX_INTEGER)) {
+				// don't need to do anything here
+			} else if (t == JX_TOKEN_ADD && jx_istype(j, JX_DOUBLE)) {
+				// don't need to do anything here
 			} else {
 				j = jx_operator(jx_token_to_operator(t), NULL, j);
 				j->u.oper.line = line;

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -336,14 +336,14 @@ value:      [[0,0,0,true],[0,0,0,false],[0,0,1,true],[0,0,1,false],[0,0,2,true],
 expression: list[2]
 value:      300
 
-expression: list[(-1)]
+expression: list[-1]
 value:      300
 
-expression: list[(-3)]
+expression: list[-3]
 value:      100
 
-expression: list[(-10)]
-value:      error("array reference on line 0: index out of range")
+expression: list[-10]
+value:      error("array reference on line 146: index out of range")
 
 expression: list[1:]
 value:      [200,300]
@@ -360,16 +360,16 @@ value:      [100,200,300]
 expression: list[3:2]
 value:      []
 
-expression: list[(-11):3]
+expression: list[-11:3]
 value:      [100,200,300]
 
-expression: list[3:(-11)]
+expression: list[3:-11]
 value:      []
 
-expression: list[1:(-1)]
+expression: list[1:-1]
 value:      [200]
 
-expression: list[(-1):1]
+expression: list[-1:1]
 value:      []
 
 expression: list[0:100]


### PR DESCRIPTION
Fixes #2007 

This reverts the hotfix in #2006 and makes the changes in the parser. For the specific case of a unary minus preceding a numeric constant, we carry out the evaluation at parse time. JSON doesn't allow a preceding plus, but we could allow that if someone wants it.