### PR TITLE
Add function to canonicalize JX

### DIFF
--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -64,6 +64,7 @@ SOURCES = \
 	jx_parse.c \
 	jx_print.c \
 	jx_pretty_print.c \
+	jx_canonicalize.c \
 	jx_table.c \
 	jx_export.c \
 	jx_eval.c \

--- a/dttools/src/jx_canonicalize.c
+++ b/dttools/src/jx_canonicalize.c
@@ -1,0 +1,115 @@
+/*
+Copyright (C) 2019- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include <assert.h>
+#include <stdbool.h>
+
+#include "jx.h"
+#include "jx_print.h"
+#include "jx_canonicalize.h"
+#include "list.h"
+
+static bool jx_canonicalize_buffer(struct jx *j, buffer_t *b);
+
+static int pair_compare(const void *p1, const void *p2) {
+	assert(p1);
+	assert(p2);
+	struct jx_pair *i1 = *(struct jx_pair **) p1;
+	struct jx_pair *i2 = *(struct jx_pair **) p2;
+	assert(i1);
+	assert(i2);
+	return strcmp(i1->key->u.string_value, i2->key->u.string_value);
+}
+
+static bool jx_canonicalize_array(struct jx_item *i, buffer_t *b) {
+	assert(b);
+
+	buffer_putstring(b, "[");
+
+	const char *sep = "";
+	for (; i; i = i->next) {
+		buffer_putstring(b, sep);
+		if (!jx_canonicalize_buffer(i->value, b)) return false;
+		sep = ",";
+	}
+
+	buffer_putstring(b, "]");
+	return true;
+}
+
+static bool jx_canonicalize_object(struct jx_pair *p, buffer_t *b) {
+	assert(b);
+
+	bool rc = false;
+	struct list *pairs = list_create();
+	struct list_cursor *csr = list_cursor_create(pairs);
+
+	buffer_putstring(b, "{");
+
+	for (; p; p = p->next) {
+		if (!jx_istype(p->key, JX_STRING)) goto OUT;
+		list_push_tail(pairs, p);
+	}
+	list_sort(pairs, pair_compare);
+	
+	struct jx_pair *cur;
+	struct jx_pair *prev = NULL;
+	const char *sep = "";
+	for (list_seek(csr, 0); list_get(csr, (void **) &cur); list_next(csr)) {
+		assert(cur);
+		if (prev && !pair_compare(&cur, &prev)) goto OUT;
+		buffer_putstring(b, sep);
+		jx_canonicalize_buffer(cur->key, b); // known to be a string
+		buffer_putstring(b, ":");
+		if (!jx_canonicalize_buffer(cur->value, b)) goto OUT;
+		prev = cur;
+		sep = ",";
+	}
+
+	buffer_putstring(b, "}");
+	rc = true;
+
+OUT:
+	list_cursor_destroy(csr);
+	list_delete(pairs);
+	return rc;
+}
+
+static bool jx_canonicalize_buffer(struct jx *j, buffer_t *b) {
+	assert(j);
+	assert(b);
+
+	switch (j->type) {
+	case JX_NULL:
+	case JX_BOOLEAN:
+	case JX_INTEGER:
+	case JX_STRING:
+		jx_print_buffer(j, b);
+		return true;
+	case JX_DOUBLE:
+		buffer_printf(b,"%e",j->u.double_value);
+		return true;
+	case JX_ARRAY:
+		return jx_canonicalize_array(j->u.items, b);
+	case JX_OBJECT:
+		return jx_canonicalize_object(j->u.pairs, b);
+	default:
+		return false;
+	}
+}
+
+char *jx_canonicalize(struct jx *j) {
+	assert(j);
+
+	char *out = NULL;
+	buffer_t buffer;
+	buffer_init(&buffer);
+	if (!jx_canonicalize_buffer(j, &buffer)) goto OUT;
+	buffer_dup(&buffer, &out);
+OUT:
+	buffer_free(&buffer);
+	return out;
+}

--- a/dttools/src/jx_canonicalize.h
+++ b/dttools/src/jx_canonicalize.h
@@ -1,0 +1,31 @@
+/*
+Copyright (C) 2019- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#ifndef JX_CANONICALIZE_H
+#define JX_CANONICALIZE_H
+
+/** @file jx_canonicalize.h Print a JX structure in canonical form.
+ * Canonical form is not particularly readable, e.g. there is no added
+ * whitespace and floats are printed with fixed precision in exponential form.
+ * Only the plain JSON types are allowed.
+ * Objects must have unique string keys.
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+
+#include "jx.h"
+#include "link.h"
+#include "buffer.h"
+
+/** Canonicalize a JX expression to a string.
+ * The caller must free() the returned string.
+ * @param j A JX expression.
+ * @returns NULL With an invalid JX structure.
+ */
+char *jx_canonicalize(struct jx *j);
+
+#endif

--- a/dttools/test/TR_jx_canonicalize.sh
+++ b/dttools/test/TR_jx_canonicalize.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+
+. ../../dttools/test/test_runner_common.sh
+
+exe="canonical.test"
+
+prepare()
+{
+	gcc -g -o "$exe" -I ../src/ -x c - -x none ../src/libdttools.a -lm <<EOF
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jx.h"
+#include "jx_canonicalize.h"
+
+
+int main(int argc, char **argv) {
+	char *s;
+
+	struct jx *x_null = jx_null();
+	struct jx *x_true = jx_boolean(1);
+	struct jx *x_false = jx_boolean(0);
+	struct jx *x_integer = jx_integer(42);
+	struct jx *x_double = jx_double(42);
+	struct jx *x_string = jx_string("s");
+	struct jx *x_string2 = jx_string("t");
+	struct jx *x_symbol = jx_symbol("sym");
+	struct jx *x_array = jx_array(NULL);
+	struct jx *x_object = jx_object(NULL);
+
+	s = jx_canonicalize(x_null);
+	assert(s);
+	assert(!strcmp(s, "null"));
+
+	s = jx_canonicalize(x_true);
+	assert(s);
+	assert(!strcmp(s, "true"));
+
+	s = jx_canonicalize(x_false);
+	assert(s);
+	assert(!strcmp(s, "false"));
+
+	s = jx_canonicalize(x_integer);
+	assert(s);
+	assert(!strcmp(s, "42"));
+
+	s = jx_canonicalize(x_double);
+	assert(s);
+	assert(!strcmp(s, "4.200000e+01"));
+
+	s = jx_canonicalize(x_string);
+	assert(s);
+	assert(!strcmp(s, "\"s\""));
+
+	s = jx_canonicalize(x_symbol);
+	assert(!s);
+
+	s = jx_canonicalize(x_array);
+	assert(s);
+	assert(!strcmp(s, "[]"));
+
+	jx_array_append(x_array, x_null);
+	jx_array_append(x_array, x_string);
+	jx_array_append(x_array, x_string2);
+	jx_array_append(x_array, x_integer);
+	jx_array_append(x_array, x_string);
+	s = jx_canonicalize(x_array);
+	assert(s);
+	assert(!strcmp(s, "[null,\"s\",\"t\",42,\"s\"]"));
+
+	jx_array_append(x_array, x_symbol);
+	s = jx_canonicalize(x_array);
+	assert(!s);
+
+	s = jx_canonicalize(x_object);
+	assert(s);
+	assert(!strcmp(s, "{}"));
+
+	jx_insert(x_object, x_string, x_integer);
+	jx_insert(x_object, x_string2, x_null);
+	s = jx_canonicalize(x_object);
+	assert(s);
+	assert(!strcmp(s, "{\"s\":42,\"t\":null}"));
+
+	x_object = jx_object(NULL);
+	jx_insert(x_object, x_string2, x_null);
+	jx_insert(x_object, x_string, x_integer);
+	s = jx_canonicalize(x_object);
+	assert(s);
+	assert(!strcmp(s, "{\"s\":42,\"t\":null}"));
+
+	jx_insert(x_object, x_string, x_true);
+	s = jx_canonicalize(x_object);
+	assert(!s);
+
+	x_object = jx_object(NULL);
+	jx_insert(x_object, x_integer, x_false);
+	s = jx_canonicalize(x_object);
+	assert(!s);
+
+	x_object = jx_object(NULL);
+	jx_insert(x_object, x_string, x_symbol);
+	s = jx_canonicalize(x_object);
+	assert(!s);
+
+	return 0;
+}
+EOF
+	return $?
+}
+
+run()
+{
+	./"$exe"
+	return $?
+}
+
+clean()
+{
+	rm -f "$exe"
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:


### PR DESCRIPTION
Picking up from #1942, this PR introduces a `jx_canonicalize` function for rendering a JX object as a string in canonical form. This is intended for both generating a hash of some JX or for producing a stable representation. I allowed a conservative subset of JX:
- Only plain JSON types
- Object keys must be strings
- Object keys must be unique

This is to ensure that it's straightforward to decide how things should canonicalize without saying anything about future language changes. This canonical form is not great for general printing because of the aforementioned restrictions, lack of support for whitespace padding, and weird formatting of floats. It should, however, produce a stable JSON representation suitable for hashing or use as a dictionary key or what have you. For hashing uses like in #1893, the intended procedure is
1. Make a JX object and populate it with the fields identifying whatever you're hashing.
2. Call `jx_canonicalize` to get a string in canonical form.
3. Take the SHA1 or whatever hash.

For archive mode uses, the procedure is similar, but the canonical string itself is written to a file, which can then be hashed or viewed. The hash should remain the same across both uses.