### PR TITLE
Python work_queue library that allows for asynchronous wait

### DIFF
--- a/work_queue/src/bindings/python/Makefile
+++ b/work_queue/src/bindings/python/Makefile
@@ -33,6 +33,6 @@ test:
 install: all
 	mkdir -p $(CCTOOLS_PYTHON_PATH)
 	chmod 755 work_queue_example.py
-	cp work_queue.py $(WQPYTHONSO) $(CCTOOLS_PYTHON_PATH)/
+	cp work_queue.py work_queue_async.py $(WQPYTHONSO) $(CCTOOLS_PYTHON_PATH)/
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc
 	cp work_queue_example.py $(CCTOOLS_INSTALL_DIR)/doc/

--- a/work_queue/src/bindings/python/Makefile
+++ b/work_queue/src/bindings/python/Makefile
@@ -35,4 +35,4 @@ install: all
 	chmod 755 work_queue_example.py
 	cp work_queue.py work_queue_async.py $(WQPYTHONSO) $(CCTOOLS_PYTHON_PATH)/
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc
-	cp work_queue_example.py $(CCTOOLS_INSTALL_DIR)/doc/
+

--- a/work_queue/src/bindings/python/work_queue.binding.py
+++ b/work_queue/src/bindings/python/work_queue.binding.py
@@ -1140,13 +1140,11 @@ class WorkQueue(object):
     def specify_transactions_log(self, logfile):
         work_queue_specify_transactions_log(self._work_queue, logfile)
 
-
     ##
     # Add a mandatory password that each worker must present.
     #
     # @param self      Reference to the current work queue object.
     # @param password  The password.
-
     def specify_password(self, password):
         return work_queue_specify_password(self._work_queue, password)
 

--- a/work_queue/src/bindings/python/work_queue_async.py
+++ b/work_queue/src/bindings/python/work_queue_async.py
@@ -1,0 +1,136 @@
+## @package WorkQueuePythonAsync
+# Python Work Queue bindings.
+#
+# This is a library on top of work_queue which allows for asynchronous wait.
+# It should work as drop-in replacement for the classic work_queue module.
+#
+# EXPERIMENTAL CODE, IT MAY NOT WORK AT ALL
+#
+# BEHAVIOUR DIFFERENCE: queue sends/receives tasks even when wait() is not called.
+#
+# INTERFACE DIFFERENCE: q.wait(0) returns immediately if no task to return is
+# available. Also, q.receive() is the same as q.wait(0)
+# 
+#
+# - @ref work_queue_async::WorkQueue
+# - @ref work_queue::Task
+
+import work_queue
+from work_queue import Task, set_debug_flag
+import threading
+import Queue as ThreadQueue
+
+##
+# Python Work Queue object
+#
+# Implements an asynchronous WorkQueue object.
+# @ref work_queue_async::WorkQueue.
+class WorkQueue(object):
+    def __init__(self, *args, **kwargs):
+        self._queue = work_queue.WorkQueue(*args, **kwargs)
+        self._thread = threading.Thread(target = self._sync_loop)
+
+        self._stop_queue_event = threading.Event()
+
+        self._tasks_to_return = ThreadQueue.Queue()
+        self._tasks_to_submit = ThreadQueue.Queue()
+
+        # calls to synchronous WorkQueue are coordinated with _queue_lock
+        self._queue_lock     = threading.Lock()
+
+        self._thread.daemon  = True
+        self._thread.start()
+
+    # methods not explicitly defined we route to synchronous WorkQueue, using a lock.
+    def __getattr__(self, name):
+        attr = getattr(self._queue, name)
+
+        if callable(attr):
+            def method_wrapped(*args, **kwargs):
+                result = None
+                with self._queue_lock:
+                    result = attr(*args, **kwargs)
+                return result
+            return method_wrapped
+        else:
+            return attr
+
+    ##
+    # Submit a task to the queue.
+    #
+    # @param self   Reference to the current work queue object.
+    # @param task   A task description created from @ref work_queue::Task.
+    def submit(self, task):
+        if isinstance(task, Task):
+            self._tasks_to_submit.put(task, False)
+        else:
+            raise TypeError("{} is not a WorkQueue.Task")
+
+    ##
+    # Waits for timeout for a task to complete. Return such task if it exists.
+    # If timeout = 0 and no task is completed, return immediately.
+    #
+    # @param self       Reference to the current work queue object.
+    # @param timeout    The number of seconds to wait for a completed task
+    #                   before returning.  Use an integer to set the timeout or the constant @ref
+    #                   WORK_QUEUE_WAITFORTASK to block until a task has completed.
+    def wait(self, timeout=0):
+        try:
+            task = self._tasks_to_return.get(True, timeout)
+            self._tasks_to_return.task_done()
+            return task
+        except ThreadQueue.Empty:
+            return None
+
+    ##
+    # Returns. a completed task. If there are no completed tasks, returns None.
+    #
+    # @param self       Reference to the current work queue object.
+    def receive(self):
+        return self.wait(0)
+
+    ##
+    # Determine whether there are any known tasks queued, running, or waiting to be collected.
+    #
+    # Returns 0 if there are tasks remaining in the system, 1 if the system is "empty".
+    #
+    # @param self       Reference to the current work queue object.
+    def empty(self):
+        if self._tasks_to_submit.empty() and self._tasks_to_return.empty():
+            return self._queue.empty()
+        else:
+            return 0
+
+    def _sync_loop(self):
+        while True:
+            if self._stop_queue_event.is_set():
+                return
+
+            # do the submits, if any
+            while not self._tasks_to_submit.empty():
+                try:
+                    task = self._tasks_to_submit.get(False)
+                    with self._queue_lock:
+                        self._queue.submit(task)
+                    self._tasks_to_submit.task_done()
+                except ThreadQueue.Empty:
+                    pass
+
+            # wait for any task
+            task = None
+            if not self._queue.empty():
+                with self._queue_lock:
+                    task = self._queue.wait(1)
+                if task:
+                    self._tasks_to_return.put(task, False)
+
+    def _terminate(self):
+        self._stop_queue_event.set()
+        self._thread.join()
+
+    def __exit__(self):
+        self._terminate()
+
+    def __del__(self):
+        self._terminate()
+

--- a/work_queue/src/bindings/python/work_queue_async_example.py
+++ b/work_queue/src/bindings/python/work_queue_async_example.py
@@ -1,0 +1,18 @@
+import work_queue_async
+from time import sleep
+
+q = work_queue_async.WorkQueue(9123)
+
+for i in range(0,5):
+    t = work_queue_async.Task('sleep 2; /bin/date > out.{}'.format(i))
+    t.specify_output_file('out.{}'.format(i))
+    q.submit(t)
+
+while not q.empty():
+    t = q.receive()    # same as t.wait(0)
+    if t:
+        print('task {} done. status: {}'.format(t.id, t.return_status))
+    else:
+        print('doing some work at the master...')
+        sleep(1)
+

--- a/work_queue/src/bindings/python3/Makefile
+++ b/work_queue/src/bindings/python3/Makefile
@@ -11,7 +11,7 @@ EXTERNAL_DEPENDENCIES = $(CCTOOLS_HOME)/work_queue/src/libwork_queue.a $(CCTOOLS
 WQPYTHONSO = _work_queue.$(CCTOOLS_DYNAMIC_SUFFIX)
 LIBRARIES = $(WQPYTHONSO) work_queue.py work_queue_async.py
 OBJECTS = work_queue_wrap.o
-TARGETS = $(LIBRARIES) work_queue_example.py 
+TARGETS = $(LIBRARIES) work_queue_example.py  work_queue_async_example.py
 
 all: $(TARGETS)
 
@@ -25,19 +25,19 @@ work_queue_wrap.c work_queue.py: work_queue.i work_queue.binding.py
 
 $(WQPYTHONSO): work_queue_wrap.o $(EXTERNAL_DEPENDENCIES)
 
-work_queue.binding.py work_queue_async.py work_queue_example.py: %.py: ../python/%.py
+work_queue.binding.py work_queue_async.py work_queue_example.py work_queue_async_example.py: %.py: ../python/%.py
 	cp $< $@
 	$(CCTOOLS_PYTHON3_2TO3) --nobackups --no-diffs --write $@
 
 test:
 
 clean:
-	rm -f $(OBJECTS) $(TARGETS) Python.framework work_queue.binding.py work_queue_async.py work_queue_example.py work_queue.py work_queue_wrap.c *.pyc
+	rm -f $(OBJECTS) $(TARGETS) Python.framework work_queue.binding.py work_queue_async.py work_queue_example.py  work_queue_async_example.py work_queue.py work_queue_wrap.c *.pyc
 
 install: all
 	mkdir -p $(CCTOOLS_PYTHON3_PATH)
 	chmod 755 work_queue.py
 	cp work_queue.py work_queue_async.py _work_queue.$(CCTOOLS_DYNAMIC_SUFFIX) $(CCTOOLS_PYTHON3_PATH)/
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc
-	cp work_queue_example.py $(CCTOOLS_INSTALL_DIR)/doc/
+	cp work_queue_example.py work_queue_async_example.py $(CCTOOLS_INSTALL_DIR)/doc/
 

--- a/work_queue/src/bindings/python3/Makefile
+++ b/work_queue/src/bindings/python3/Makefile
@@ -9,9 +9,9 @@ LOCAL_LINKAGE = $(CCTOOLS_PYTHON3_LDFLAGS) -lz
 
 EXTERNAL_DEPENDENCIES = $(CCTOOLS_HOME)/work_queue/src/libwork_queue.a $(CCTOOLS_HOME)/dttools/src/libdttools.a
 WQPYTHONSO = _work_queue.$(CCTOOLS_DYNAMIC_SUFFIX)
-LIBRARIES = $(WQPYTHONSO) work_queue.py
+LIBRARIES = $(WQPYTHONSO) work_queue.py work_queue_async.py
 OBJECTS = work_queue_wrap.o
-TARGETS = $(LIBRARIES) work_queue_example.py
+TARGETS = $(LIBRARIES) work_queue_example.py 
 
 all: $(TARGETS)
 
@@ -25,19 +25,19 @@ work_queue_wrap.c work_queue.py: work_queue.i work_queue.binding.py
 
 $(WQPYTHONSO): work_queue_wrap.o $(EXTERNAL_DEPENDENCIES)
 
-work_queue.binding.py work_queue_example.py: %.py: ../python/%.py
+work_queue.binding.py work_queue_async.py work_queue_example.py: %.py: ../python/%.py
 	cp $< $@
 	$(CCTOOLS_PYTHON3_2TO3) --nobackups --no-diffs --write $@
 
 test:
 
 clean:
-	rm -f $(OBJECTS) $(TARGETS) Python.framework work_queue.binding.py work_queue_example.py work_queue.py work_queue_wrap.c *.pyc
+	rm -f $(OBJECTS) $(TARGETS) Python.framework work_queue.binding.py work_queue_async.py work_queue_example.py work_queue.py work_queue_wrap.c *.pyc
 
 install: all
 	mkdir -p $(CCTOOLS_PYTHON3_PATH)
 	chmod 755 work_queue.py
-	cp work_queue.py _work_queue.$(CCTOOLS_DYNAMIC_SUFFIX) $(CCTOOLS_PYTHON3_PATH)/
+	cp work_queue.py work_queue_async.py _work_queue.$(CCTOOLS_DYNAMIC_SUFFIX) $(CCTOOLS_PYTHON3_PATH)/
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc
 	cp work_queue_example.py $(CCTOOLS_INSTALL_DIR)/doc/
 


### PR DESCRIPTION
It should work as drop-in replacement for the classic work_queue
module.

HIGHLY EXPERIMENTAL CODE, IT MAY NOT WORK AT ALL

BEHAVIOUR DIFFERENCE: queue transfers/receives tasks even when wait() is not called.

INTERFACE DIFFERENCE: q.wait(0) returns immediately if no task to return is ready. Also, the new method q.receive() is the same as q.wait(0)

It mainly captures submit and wait calls. Tasks submitted get added to a
queue for later real submission. Returned tasks are put into a queue to
be retrieved at the client's convenience. Any other call is made with a
lock (that is, no two work queue calls can be made at the same time.)