### PR TITLE
bug fix: features don't take counts

### DIFF
--- a/work_queue/src/perl/Work_Queue/Task.pm
+++ b/work_queue/src/perl/Work_Queue/Task.pm
@@ -60,7 +60,7 @@ sub specify_category {
 
 sub specify_feature {
 	my ($self, $name) = @_;
-	return work_queue_task_specify_feature($self->{_task}, $name);;
+	return work_queue_task_specify_feature($self->{_task}, $name);
 }
 
 sub clone {

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4216,12 +4216,15 @@ void work_queue_task_specify_category(struct work_queue_task *t, const char *cat
 	t->category = xxstrdup(category ? category : "default");
 }
 
-void work_queue_task_specify_feature(struct work_queue_task *t, const char *name, int64_t count)
+void work_queue_task_specify_feature(struct work_queue_task *t, const char *name)
 {
-	if(!name)
+	if(!name) {
 		return;
-	if(!t->features)
+	}
+
+	if(!t->features) {
 		t->features = list_create();
+	}
 
 	list_push_tail(t->features, xxstrdup(name));
 }

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -469,10 +469,9 @@ void work_queue_task_specify_category(struct work_queue_task *t, const char *cat
 /** Label the task with a user-defined feature. The task will only run on a worker that provides (--feature option) such feature.
 @param q A work queue object.
 @param t A task object.
-@param count The number of resources consumed. If 0, the task does not consume the resource, but the worker still needs to provide it.
-@param category The name of the feature.
+@param feature The name of the feature.
 */
-void work_queue_task_specify_feature(struct work_queue_task *t, const char *name, int64_t count);
+void work_queue_task_specify_feature(struct work_queue_task *t, const char *name);
 
 /** Specify the priority of this task relative to others in the queue.
 Tasks with a higher priority value run first. If no priority is given, a task is placed at the end of the ready list, regardless of the priority.


### PR DESCRIPTION
This is a bug fix. For some reason the count argument was added to specify_feature, but never really implemented.