### PR TITLE
allow work queue to drain workers on given host

### DIFF
--- a/work_queue/src/golang/Makefile
+++ b/work_queue/src/golang/Makefile
@@ -10,7 +10,7 @@ all: $(TARGETS)
 
 work_queue.go: work_queue.i
 	@echo "SWIG work_queue.i (golang)"
-	@$(CCTOOLS_SWIG) -go -intgosize 64 -I../../../dttools/src -I../ work_queue.i 
+	@$(CCTOOLS_SWIG) -go -cgo -intgosize 64 -I../../../dttools/src -I../ work_queue.i 
 	@mkdir -p src/work_queue
 	@mv work_queue.go work_queue_wrap.c src/work_queue
 

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -887,6 +887,12 @@ struct list * work_queue_cancel_all_tasks(struct work_queue *q);
 */
 int work_queue_shut_down_workers(struct work_queue *q, int n);
 
+/** Stop dispatching tasks to workers, which proceeds to complete running tasks, cleanup and shut down normally, on the given host  
+@param q A work queue object.
+@param worker_hashkey the hashkey that identify a worker
+*/
+void work_queue_drain_worker(struct work_queue *q, const char *hostname);
+
 /** Delete a work queue.
 This function should only be called after @ref work_queue_empty returns true.
 @param q A work queue to delete.


### PR DESCRIPTION
Implement the worker draining feature.

1. By calling `work_queue_drain_worker(struct work_queue *q, const char *hostname)`, workers on the given host will be drained (process to finish running task and disconnect from master)
2.  Add `draining_flag` to `work_queue_worker`
3. Master doesn't dispatch tasks to workers that have `draining_flag` been set to 1