### PR TITLE
use object instead of _object

### DIFF
--- a/chirp/src/python/chirp.binding.py
+++ b/chirp/src/python/chirp.binding.py
@@ -21,7 +21,7 @@ import binascii
 # Python Client object
 #
 # This class is used to create a chirp client
-class Client:
+class Client(object):
 
     ##
     # Create a new chirp client
@@ -442,7 +442,7 @@ class Client:
 # Python Stat object
 #
 # This class is used to record stat information for files/directories of a chirp server.
-class Stat:
+class Stat(object):
     def __init__(self, path, cstat):
         self._path = path
         self._info = cstat

--- a/work_queue/src/python/work_queue.binding.py
+++ b/work_queue/src/python/work_queue.binding.py
@@ -36,7 +36,7 @@ cctools_debug_config('work_queue_python')
 # Python Task object
 #
 # This class is used to create a task specification.
-class Task(_object):
+class Task(object):
 
     ##
     # Create a new task specification.
@@ -779,7 +779,7 @@ class Task(_object):
 #
 # This class uses a dictionary to map between the task pointer objects and the
 # @ref work_queue::Task.
-class WorkQueue(_object):
+class WorkQueue(object):
     ##
     # Create a new work queue.
     #


### PR DESCRIPTION
This change is necessary for swig4 usage.

swig pre version 4 defined _object as a fallback in case object was not
defined. Since we require at least python2.7 which does define object,
we can drop the use of _object.

Fix for #2054 