### PR TITLE
adds work_queue_specify_draining_by_hostname

### DIFF
--- a/work_queue/src/bindings/perl/Work_Queue.pm
+++ b/work_queue/src/bindings/perl/Work_Queue.pm
@@ -188,6 +188,17 @@ sub activate_fast_abort_category {
 	return work_queue_activate_fast_abort_category($self->{_work_queue}, $name, $multiplier);
 }
 
+
+sub specify_draining_by_hostname {
+    my ($self, $hostname, $drain_mode) = @_;
+
+    unless(defined $drain_mode) { 
+        $drain_mode ||= 1;
+    }
+
+    return work_queue_specify_draining($self->{_work_queue}, $hostname, $drain_mode);
+}
+
 sub empty {
 	my ($self) = @_;
 	return work_queue_empty($self->{_work_queue});
@@ -643,6 +654,21 @@ fast_abort is deactivated. If less than zero (default), use the fast abort of
 the "default" category.
 
 =back
+
+
+
+=head3 C<specify_draining_by_hostname>
+
+Set draining mode for workers at hostname.
+
+=over12
+
+=item The hostname the host running the workers.
+
+=item If 0, workers at hostname work as usual, else no new tasks are dispatched, and empty workers are shutdown.
+
+=back
+
 
 
 =head3 C<empty>

--- a/work_queue/src/bindings/python/work_queue.binding.py
+++ b/work_queue/src/bindings/python/work_queue.binding.py
@@ -1009,6 +1009,15 @@ class WorkQueue(object):
         return work_queue_activate_fast_abort_category(self._work_queue, name, multiplier)
 
     ##
+    # Turn on or off draining mode for workers at hostname.
+    #
+    # @param self       Reference to the current work queue object.
+    # @param host       The hostname the host running the workers.
+    # @param drain_mode If True, no new tasks are dispatched to workers at hostname, and empty workers are shutdown. Else, workers works as usual.
+    def specify_draining_by_hostname(self, hostname, drain_mode = True):
+        return work_queue_specify_draining_by_hostname (self._work_queue, hostname, drain_mode)
+
+    ##
     # Determine whether there are any known tasks queued, running, or waiting to be collected.
     #
     # Returns 0 if there are tasks remaining in the system, 1 if the system is "empty".

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -212,7 +212,11 @@ struct work_queue_worker {
 	char *version;
 	char addrport[WORKER_ADDRPORT_MAX];
 	char hashkey[WORKER_HASHKEY_MAX];
+
 	int  foreman;                             // 0 if regular worker, 1 if foreman
+
+	int  draining;                            // if 1, worker does not accept anymore tasks. It is shutdown if no task running.
+
 	struct work_queue_stats     *stats;
 	struct work_queue_resources *resources;
 	struct hash_table           *features;
@@ -976,7 +980,8 @@ static void add_worker(struct work_queue *q)
 	w->os = strdup("unknown");
 	w->arch = strdup("unknown");
 	w->version = strdup("unknown");
-	w->foreman = 0;
+	w->foreman  = 0;
+	w->draining = 0;
 	w->link = link;
 	w->current_files = hash_table_create(0, 0);
 	w->current_tasks = itable_create(0);
@@ -3353,6 +3358,10 @@ static int check_hand_against_task(struct work_queue *q, struct work_queue_worke
 		return 0;
 	}
 
+	if(w->draining) {
+		return 0;
+	}
+
 	if(!w->foreman) {
 		struct blacklist_host_info *info = hash_table_lookup(q->worker_blacklist, w->hostname);
 		if (info && info->blacklisted) {
@@ -3895,6 +3904,24 @@ static int shut_down_worker(struct work_queue *q, struct work_queue_worker *w)
 
 	return 1;
 }
+
+static int abort_drained_workers(struct work_queue *q) {
+	char *worker_hashkey = NULL;
+	struct work_queue_worker *w = NULL;
+
+	int removed = 0;
+
+	hash_table_firstkey(q->worker_table);
+	while(hash_table_nextkey(q->worker_table, &worker_hashkey, (void **) &w)) {
+		if(w->draining && itable_size(w->current_tasks) == 0) {
+			removed++;
+			shut_down_worker(q, w);
+		}
+	}
+
+	return removed;
+}
+
 
 //comparator function for checking if a task matches given tag.
 static int tasktag_comparator(void *t, const void *r) {
@@ -5899,9 +5926,10 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 		ask_for_workers_updates(q);
 		END_ACCUM_TIME(q, time_status_msgs);
 
-		// If fast abort is enabled, kill off slow workers.
+		// Kill off slow/drained workers.
 		BEGIN_ACCUM_TIME(q, time_internal);
-		result = abort_slow_workers(q);
+		result  = abort_slow_workers(q);
+		result += abort_drained_workers(q);
 		work_queue_blacklist_clear_by_time(q, time(0));
 		END_ACCUM_TIME(q, time_internal);
 		if(result) {
@@ -6000,6 +6028,26 @@ int work_queue_shut_down_workers(struct work_queue *q, int n)
 	}
 
 	return i;
+}
+
+int work_queue_specify_draining_by_hostname(struct work_queue *q, const char *hostname, int drain_flag)
+{
+	char *worker_hashkey = NULL;
+	struct work_queue_worker *w = NULL;
+
+	drain_flag = !!(drain_flag);
+
+	int workers_updated = 0;
+
+	hash_table_firstkey(q->worker_table);
+	while(hash_table_nextkey(q->worker_table, &worker_hashkey, (void *) w)) {
+		if (!strcmp(w->hostname, hostname)) {
+			w->draining = drain_flag;
+			workers_updated++;
+		}
+	}
+
+	return workers_updated;
 }
 
 /**

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -796,6 +796,16 @@ multiplier.  The value specified here applies only to tasks in the given categor
 */
 int work_queue_activate_fast_abort_category(struct work_queue *q, const char *category, double multiplier);
 
+
+/** Set the draining mode per worker hostname.
+	If drain_flag is 0, workers at hostname receive tasks as usual.
+    If drain_flag is not 1, no new tasks are dispatched to workers at hostname,
+    and if empty they are shutdown.
+  @param q A work queue object.
+  @param drain_flag Draining mode.
+  */
+int work_queue_specify_draining_by_hostname(struct work_queue *q, const char *hostname, int drain_flag);
+
 /** Turn on or off first-allocation labeling for a given category. By default, only cores, memory, and disk are labeled. Turn on/off other specific resources use @ref work_queue_specify_category_autolabel_resource.
 @param q A work queue object.
 @param category A category name.


### PR DESCRIPTION
Supersedes #2048 without the need to modify work_queues communication protocol. It also adds perl and python bindings.