### PR TITLE
Add flag to use previous logic for job names

### DIFF
--- a/doc/man/makeflow.m4
+++ b/doc/man/makeflow.m4
@@ -73,6 +73,7 @@ OPTION_ITEM(`--ignore-memory-spec')Excludes memory at submission. (SLURM)
 OPTION_PAIR(--batch-mem-type, type)Specify memory resource type. (SGE)
 OPTION_PAIR(--working-dir, dir|url)Working directory for batch system.
 OPTION_ITEM(`--sandbox')Run task in sandbox using bash script and task directory.
+OPTION_ITEM(`--verbose-jobnames')Set the job name based on the command.
 OPTIONS_END
 
 SUBSECTION(JSON/JX Options)

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -100,6 +100,8 @@ an example.
 
 #define MAX_REMOTE_JOBS_DEFAULT 100
 
+extern int batch_job_verbose_jobnames;
+
 static sig_atomic_t makeflow_abort_flag = 0;
 static int makeflow_failed_flag = 1; // Makeflow fails by default. This is changed at dag start to indicate correct start.
 static int makeflow_submit_timeout = 3600;
@@ -1198,6 +1200,7 @@ static void show_help_run(const char *cmd)
 	printf("    --local-disk=#              Max amount of local disk (MB) to use.\n");
 	printf("    --safe-submit-mode          Excludes resources at submission.\n");
 	printf("                                  (SLURM, TORQUE, and PBS)\n");
+	printf("    --verbose-jobnames          Set the job name based on the command.\n");
 	printf("    --ignore-memory-spec        Excludes memory at submission (SLURM).\n");
 	printf("    --batch-mem-type=<type>     Specify memory resource type (SGE).\n");
 	printf("    --working-dir=<dir|url>     Working directory for the batch system.\n");
@@ -1427,6 +1430,7 @@ int main(int argc, char *argv[])
 		LONG_OPT_MESOS_PRELOAD,
 		LONG_OPT_SEND_ENVIRONMENT,
 		LONG_OPT_K8S_IMG,
+		LONG_OPT_VERBOSE_JOBNAMES,
 #ifdef CCTOOLS_WITH_MPI
                 LONG_OPT_MPI_CORES,
                 LONG_OPT_MPI_MEM,
@@ -1546,6 +1550,7 @@ int main(int argc, char *argv[])
 		{"mesos-path", required_argument, 0, LONG_OPT_MESOS_PATH},
 		{"mesos-preload", required_argument, 0, LONG_OPT_MESOS_PRELOAD},
 		{"k8s-image", required_argument, 0, LONG_OPT_K8S_IMG},
+		{"verbose-jobnames", no_argument, 0, LONG_OPT_VERBOSE_JOBNAMES},
 #ifdef CCTOOLS_WITH_MPI
         {"mpi-cores", required_argument,0, LONG_OPT_MPI_CORES},
         {"mpi-memory", required_argument,0, LONG_OPT_MPI_MEM},
@@ -2052,6 +2057,9 @@ int main(int argc, char *argv[])
 				jx_delete(j);
 				break;
 			}
+			case LONG_OPT_VERBOSE_JOBNAMES:
+				batch_job_verbose_jobnames = 1;
+				break;
 #ifdef CCTOOLS_WITH_MPI
             case LONG_OPT_MPI_CORES:
                 mpi_cores_per = atoi(optarg);


### PR DESCRIPTION
This PR adds a flag to switch to pre f892d75f behavior. This is helpful for figuring out which job/command is running. This is not the default, as we shouldn't assume that the batch system will handle it.