### PR TITLE
Write out info on Makeflow failures

### DIFF
--- a/makeflow/src/dag_node.c
+++ b/makeflow/src/dag_node.c
@@ -434,16 +434,11 @@ struct jx * dag_node_to_jx( struct dag *d, struct dag_node *n, int send_all_loca
 {
 	struct jx *task = jx_object(0);
 
-	jx_insert(task, jx_string("command"), jx_string(n->command));
+	jx_insert(task, jx_string("resources"), rmsummary_to_json(dag_node_dynamic_label(n), 1));
+	jx_insert(task, jx_string("category"), jx_string(n->category->name));
+	jx_insert(task, jx_string("environment"), dag_node_env_create(d, n, send_all_local_env));
 
 	struct dag_file *f = NULL;
-
-	struct jx *inputs = jx_array(0);
-	list_first_item(n->source_files);
-	while((f = list_next_item(n->source_files))) {
-		jx_array_insert(inputs, dag_file_to_jx(f, n));
-	}
-	jx_insert(task, jx_string("inputs"), inputs);
 
 	struct jx *outputs = jx_array(0);
 	list_first_item(n->target_files);
@@ -452,9 +447,14 @@ struct jx * dag_node_to_jx( struct dag *d, struct dag_node *n, int send_all_loca
 	}
 	jx_insert(task, jx_string("outputs"), outputs);
 
-	jx_insert(task, jx_string("environment"), dag_node_env_create(d, n, send_all_local_env));
+	struct jx *inputs = jx_array(0);
+	list_first_item(n->source_files);
+	while((f = list_next_item(n->source_files))) {
+		jx_array_insert(inputs, dag_file_to_jx(f, n));
+	}
+	jx_insert(task, jx_string("inputs"), inputs);
 
-	jx_insert(task, jx_string("resources"), rmsummary_to_json(dag_node_dynamic_label(n), 1));
+	jx_insert(task, jx_string("command"), jx_string(n->command));
 
 	return task;
 }


### PR DESCRIPTION
This PR has Makeflow write out a file called `INFO.json` in the `makeflow.failed.%d` directories that get created on rule failure. This consists of the fields from `dag_node_to_jx()`, plus the exit code/signal. An example of the info for the usual `example.makeflow` (where I modified one of the rules to fail):

    {
      "exit_code":1,
      "command":"/usr/bin/convert -swirl 90 capitol.jpg capitol.90.jpg; exit 1",
      "inputs":
        [
          {
            "size":51274,
            "dag_name":"capitol.jpg"
          }
        ],
      "outputs":
        [  
          {
            "size":1073741824,
            "dag_name":"capitol.90.jpg"
          }
        ],
      "environment":
        {
          "CORES":"1",
          "OMP_NUM_THREADS":"1"
        },
      "category":"default",
      "resources":
        {
        }
    }