### PR TITLE
Updated conda build recipe

### DIFF
--- a/packaging/conda/build.sh
+++ b/packaging/conda/build.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-DISABLED=$(echo --without-system-{allpairs,parrot,prune,sand,umbrella,wavefront})
+DISABLED=$(echo --without-system-{allpairs,parrot,prune,sand,umbrella,wavefront,weaver})
 
 if [[ $PY3K == 1 ]]; then
     ./configure --prefix ${PREFIX} --with-python3-path ${CONDA_PREFIX} ${DISABLED}
@@ -9,4 +9,3 @@ else
 fi
 
 make && make install
-

--- a/packaging/conda/meta.yaml
+++ b/packaging/conda/meta.yaml
@@ -18,8 +18,14 @@ requirements:
   run:
     - python
 
+test:
+  import:
+    - work_queue
+  commands:
+    - resource_monitor -h
+    - makeflow -h
+
 about:
   home: http://ccl.cse.nd.edu
   license: GNU GPL version 2
-  summary: The Cooperative Computing Tools contains Chirp, Makeflow, JX, and Work Queue (base).
-
+  summary: The Cooperative Computing Tools contains Chirp, Makeflow, JX, and Work Queue.


### PR DESCRIPTION
I've added support for tests in the meta.yaml, and changed the build script to exclude weaver when installing with Python 3 as the python version. 