### PR TITLE
Hotfix for Catalog Server

### DIFF
--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -603,16 +603,15 @@ struct jx  *jx_copy( struct jx *j )
 struct jx *jx_merge(struct jx *j, ...) {
 	va_list ap;
 	va_start (ap, j);
-	struct jx_pair *result = NULL;
+	struct jx *result = jx_object(NULL);
 	for (struct jx *next = j; jx_istype(next, JX_OBJECT); next = va_arg(ap, struct jx *)) {
-		struct jx_pair *tmp = result;
-		result = jx_pair_copy(next->u.pairs);
-		struct jx_pair **last = &result;
-		while (*last) last = &(*last)->next;
-		*last = tmp;
+		for (struct jx_pair *p = next->u.pairs; p; p = p->next) {
+			jx_delete(jx_remove(result, p->key));
+			jx_insert(result, jx_copy(p->key), jx_copy(p->value));
+		}
 	}
 	va_end(ap);
-	return jx_object(result);
+	return result;
 }
 
 static int jx_pair_is_constant(struct jx_pair *p) {

--- a/dttools/src/jx_database.c
+++ b/dttools/src/jx_database.c
@@ -286,7 +286,7 @@ static void corrupt_data( const char *filename, const char *line )
 static void handle_merge( struct jx_database *db, const char *key, struct jx *update )
 {
 	struct jx *current = hash_table_remove(db->table,key);
-	struct jx *merged = jx_merge(update,current,0);
+	struct jx *merged = jx_merge(current, update, NULL);
 
 	hash_table_insert(db->table,key,merged);
 

--- a/dttools/src/jx_parse.c
+++ b/dttools/src/jx_parse.c
@@ -1026,6 +1026,7 @@ int jx_parse_cmd_define(struct jx *jx_args, char *define_stmt) {
 	char *s;
     struct jx *jx_expr = NULL;
 	struct jx *jx_tmp = NULL;
+	struct jx *key = NULL;
 
 	s = strchr(define_stmt, '=');
     if (!s){
@@ -1049,7 +1050,9 @@ int jx_parse_cmd_define(struct jx *jx_args, char *define_stmt) {
 		return 0;
 	}
 
-	jx_insert(jx_args, jx_string(optarg), jx_tmp);
+	key = jx_string(optarg);
+	for (struct jx *r; (r = jx_remove(jx_args, key)); jx_delete(r));
+	jx_insert(jx_args, key, jx_tmp);
 
 	return 1;
 }

--- a/dttools/test/TR_jx_merge.sh
+++ b/dttools/test/TR_jx_merge.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+
+. ../../dttools/test/test_runner_common.sh
+
+exe="merge.test"
+
+prepare()
+{
+	gcc -g -o "$exe" -I ../src/ -x c - -x none ../src/libdttools.a -lm <<EOF
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jx.h"
+#include "jx_parse.h"
+
+int main(int argc, char **argv) {
+	struct jx *a;
+	struct jx *b;
+	struct jx *c;
+	struct jx *r;
+	struct jx *s;
+	struct jx *t;
+
+	a = jx_object(NULL);
+	jx_insert(a, jx_string("k"), jx_integer(5));
+	jx_insert(a, jx_string("e"), jx_integer(6));
+	jx_insert(a, jx_string("y"), jx_integer(7));
+
+	b = jx_object(NULL);
+
+	c = jx_object(NULL);
+	jx_insert(c, jx_string("x"), jx_integer(2));
+	jx_insert(c, jx_string("x"), jx_integer(3));
+
+
+	t = jx_parse_string("{\"k\": 5, \"e\": 6, \"y\": 7}");
+
+	s = jx_merge(a, NULL);
+	assert(jx_equals(s, t));
+	jx_delete(s);
+
+	s = jx_merge(a, b, NULL);
+	assert(jx_equals(s, t));
+	jx_delete(s);
+
+	s = jx_merge(b, a, NULL);
+	assert(jx_equals(s, t));
+	jx_delete(s);
+
+	jx_delete(t);
+
+	t = jx_integer(3);
+	s = jx_lookup(c, "x");
+	assert(jx_equals(s, t));
+	jx_delete(t);
+
+	r = jx_merge(c, NULL);
+	s = jx_lookup(r, "x");
+	t = jx_integer(2);
+	// probably not desirable...
+	assert(jx_equals(s, t));
+	jx_delete(r);
+	jx_delete(t);
+
+	s = jx_merge(a, b, c, NULL);
+	t = jx_parse_string("{\"x\":2,\"k\":5,\"e\":6,\"y\":7}");
+	assert(jx_equals(s, t));
+	jx_delete(s);
+	jx_delete(t);
+
+	s = jx_merge(a, c, a, NULL);
+	t = jx_parse_string("{\"k\":5,\"e\":6,\"y\":7,\"x\":2}");
+	assert(jx_equals(s, t));
+	jx_delete(s);
+	jx_delete(t);
+
+	jx_delete(a);
+	jx_delete(b);
+	jx_delete(c);
+
+	return 0;
+}
+EOF
+	return $?
+}
+
+run()
+{
+	./"$exe"
+	return $?
+}
+
+clean()
+{
+	rm -f "$exe"
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:


### PR DESCRIPTION
This is a fix for #2094 

Putting aside any changes to JX objects for the moment, I simply reverted to the original `jx_merge()` implementation and added a workaround for the motivating problem. I tested against the minimal case in the linked issue and didn't observe any corruption.