### PR TITLE
WIP: Added setup.py for pip installation

### DIFF
--- a/packaging/pip/setup.py
+++ b/packaging/pip/setup.py
@@ -1,33 +1,34 @@
 import setuptools
-import setuptools.command.install
+from setuptools.command.install import install
+import os
 
 # Import code to compile
-class CustomInstall(install):
+class PostInstallCommand(install):
     def run(self):
-        command = "git clone https://github.com/cooperative-computing-lab/cctools.git"
-        process = subprocess.Popen(command, shell=True, cwd="CCTools")
-        process.wait()
+        git_clone = "git clone https://github.com/cooperative-computing-lab/ccto                                                                                        ols.git"
+        prog_configure = "./configure --without-system-{allpairs,parrot,prune,sa                                                                                        nd,umbrella,wavefront,weaver}"
+        make_command = "make && make install"
+        os.system(git_clone)
+        os.system(prog_configure)
+        os.system(make_command)
         install.run(self)
-
-# Implements C code
-ext_module = Extension(
-    
-)
 
 # Standard setup
 setuptools.setup(
     name='CCTools',
-    version='7.0.15',
+    version='7.0.16',
     author='Cooperative Computing Lab',
     author_email='dthain@nd.edu',
     packages=setuptools.find_packages(),
     url='https://github.com/cooperative-computing-lab/cctools',
-    download_url='http://ccl.cse.nd.edu/software/files/cctools-{}-source.tar.gz'.format('7.0.15'),
+    download_url='http://ccl.cse.nd.edu/software/files/cctools-{}-source.tar.gz'                                                                                        .format('7.0.16'),
     license='LICENSE.txt',
-    description='The Cooperative Computing Tools (cctools) contains Parrot, Chirp, Makeflow, Work Queue, SAND, and other software',
-    long_description='The Cooperative Computing Tools (cctools) contains Parrot, Chirp, Makeflow, Work Queue, SAND, and other software',
+    description='The Cooperative Computing Tools (cctools) contains Parrot, Chir                                                                                        p, Makeflow, Work Queue, SAND, and other software',
+    long_description='The Cooperative Computing Tools (cctools) contains Parrot,                                                                                         Chirp, Makeflow, Work Queue, SAND, and other software',
     long_description_content_type='text/markdown',
-    ext_modules = [ext_module],
-    install_requires=['swig'],
-    dependency_links=['https://github.com/swig/swig']
+    cmdclass={
+        'install': PostInstallCommand,
+    },
+    #install_requires=['swig'],
+    #dependency_links=['https://github.com/swig/swig']
 )

--- a/packaging/pip/setup.py
+++ b/packaging/pip/setup.py
@@ -1,0 +1,33 @@
+import setuptools
+import setuptools.command.install
+
+# Import code to compile
+class CustomInstall(install):
+    def run(self):
+        command = "git clone https://github.com/cooperative-computing-lab/cctools.git"
+        process = subprocess.Popen(command, shell=True, cwd="CCTools")
+        process.wait()
+        install.run(self)
+
+# Implements C code
+ext_module = Extension(
+    
+)
+
+# Standard setup
+setuptools.setup(
+    name='CCTools',
+    version='7.0.15',
+    author='Cooperative Computing Lab',
+    author_email='dthain@nd.edu',
+    packages=setuptools.find_packages(),
+    url='https://github.com/cooperative-computing-lab/cctools',
+    download_url='http://ccl.cse.nd.edu/software/files/cctools-{}-source.tar.gz'.format('7.0.15'),
+    license='LICENSE.txt',
+    description='The Cooperative Computing Tools (cctools) contains Parrot, Chirp, Makeflow, Work Queue, SAND, and other software',
+    long_description='The Cooperative Computing Tools (cctools) contains Parrot, Chirp, Makeflow, Work Queue, SAND, and other software',
+    long_description_content_type='text/markdown',
+    ext_modules = [ext_module],
+    install_requires=['swig'],
+    dependency_links=['https://github.com/swig/swig']
+)


### PR DESCRIPTION
This is a pull request for the implementation of a pip installation for CCTools. At the moment, there is a custom installation function, compilation of the C code (unfinished), and general setup function. This is untested, and the compilation of the C code is still unfinished, and should be done using the Extension instance. 

Useful links for those interested in this:
https://docs.python.org/2/extending/building.html (Extension documentation)
https://setuptools.readthedocs.io/en/latest/setuptools.html#developer-s-guide (General setuptools documentation)