### PR TITLE
catalog reporting to the resource monitor

### DIFF
--- a/doc/man/resource_monitor.m4
+++ b/doc/man/resource_monitor.m4
@@ -115,7 +115,10 @@ OPTION_ITEM(--follow-chdir)Follow processes' current working directories.
 OPTION_ITEM(--without-disk-footprint)Do not measure working directory footprint. Overrides --measure-dir.
 OPTION_ITEM(--no-pprint)Do not pretty-print summaries.
 OPTION_ITEM(--snapshot-events=file)Configuration file for snapshots on file patterns. See below.
-
+OPTION_ITEM(--catalog-record-id=<record-id>)Report measurements to catalog server as <record-id>.
+OPTION_ITEM(--catalog=<catalog>)Use catalog server <catalog>. (default=catalog.cse.nd.edu:9097).\n", "--catalog=<catalog>");
+OPTION_ITEM(--catalog-project=<project>)Set project name of catalog update to <project> (default=<record-id>).
+OPTION_ITEM(--catalog-interval=<interval>)Send update to catalog every <interval> seconds. (default=30).
 
 OPTIONS_END
 

--- a/dttools/src/catalog_query.h
+++ b/dttools/src/catalog_query.h
@@ -20,6 +20,8 @@ Query the global catalog server for server descriptions.
 #define CATALOG_HOST (getenv("CATALOG_HOST") ? getenv("CATALOG_HOST") : CATALOG_HOST_DEFAULT )
 #define CATALOG_PORT (getenv("CATALOG_PORT") ? atoi(getenv("CATALOG_PORT")) : CATALOG_PORT_DEFAULT )
 
+#define CATALOG_RECORD_ID_FIELD "record-id"
+
 /** Create a catalog query.
 Connects to a catalog server, issues a query, and waits for the results.
 The caller may specify a specific catalog host and port.


### PR DESCRIPTION
works in conjuction with #2113.

Records are tagged with --catalog-record-id.
Additionally, they can be tagged with a project name --catalog-project.

--catalog indicates which catalog to use (usual defaults).
--catalog-interval how often in seconds an update is done (30s default).

Fix for #2090 