### PR TITLE
JX f-strings

### DIFF
--- a/doc/jx-quick.html
+++ b/doc/jx-quick.html
@@ -127,7 +127,7 @@ true | false
 <h2>Operators</h2>
 <pre>
 a["b"]   func(x)
-* % /
+* % /    f"{x}.dat"
 + -
 == != < <= > >=
 not

--- a/doc/jx-tutorial.html
+++ b/doc/jx-tutorial.html
@@ -202,16 +202,15 @@ instance of the job:
 
 Note that the value of <tt>N</tt> is substituted into both the commands
 string and the output list by using the plus sign to indicate string
-concatenation.  If you prefer a more <tt>printf</tt> style, you can
-use the <tt>format()</tt> function to insert values into strings
-into places indicate by percent codes:
+concatenation.  If you prefer a more compact style, you can
+use Python-style f-strings to insert values into strings:
 
 <code>{
    "rules": [
       {
-         "command" : <b>format("./simulate.py -n %d > output.%d.txt",N,N)</b>
+         "command" : <b>f"./simulate.py -n {N} > output.{N}.txt"</b>
          "inputs" : [ "simulate.py" ],
-         "outputs" : [ "output."+N+".txt" ],
+         "outputs" : [ <b>f"output.{N}.txt"</b> ],
       } for N in [ 1, 2, 3 ]
    ]
 }
@@ -250,7 +249,7 @@ Of course, it would be better to generate the list automatically.
 The list of output files is easy: just generate them using
 a list comprehension.  For example, this expression:
 
-<code>[ "output."+N+".txt" for N in [1,2,3] ]
+<code>[ f"output.{N}.txt" for N in [1,2,3] ]
 </code>
 
 Would evaluate to this array:
@@ -273,8 +272,8 @@ Evaluates to this string:
 We can put all of those bits into a single job, like this:
 
 <code>{
-   "command" : "cat "+join(["output."+N+".txt" for N in [1,2,3]])+" >output.all.txt",
-   "inputs" : [ "output."+N+".txt" for N in [ 1, 2, 3 ] ],
+   "command" : "cat "+join([f"output.{N}.txt" for N in [1,2,3]])+" >output.all.txt",
+   "inputs" : [ f"output.{N}.txt" for N in [ 1, 2, 3 ] ],
    "outputs" : [ "output.all.txt" ],
 }
 </code>
@@ -287,14 +286,14 @@ Putting it all together, we have this:
 <code>{
    "define": {
       "RANGE" : range(1,3),
-      "FILELIST" : ["output."+N+".txt for N in RANGE],
+      "FILELIST" : [f"output.{N}.txt for N in RANGE],
    },
 
    "rules": [
       {
-        "command" : "./simulate.py -n "+N+" > output."+N+".txt",
+        "command" : f"./simulate.py -n {N} > output.{N}.txt",
         "inputs" : [ "simulate.py" ],
-        "outputs" : [ "output."+N+".txt" ],
+        "outputs" : [ f"output.{N}.txt" ],
       } for N in RANGE,
       {
         "command" : "cat "+join(FILELIST," ")+" >output.all.txt",
@@ -315,7 +314,7 @@ JX allows you to specify the number of cores, and the memory and disk sizes a ru
 <code>{
    "define": {
       "RANGE" : range(1,3),
-      "FILELIST" : ["output."+N+".txt for N in RANGE],
+      "FILELIST" : [f"output.{N}.txt for N in RANGE],
    },
 
    "categories": {
@@ -329,9 +328,9 @@ JX allows you to specify the number of cores, and the memory and disk sizes a ru
 
    "rules": [
       {
-        "command" : "./simulate.py -n "+N+" > output."+N+".txt",
+        "command" : f"./simulate.py -n {N} > output.{N}.txt",
         "inputs" : [ "simulate.py" ],
-        "outputs" : [ "output."+N+".txt" ],
+        "outputs" : [ f"output.{N}.txt" ],
         "category" : "simulate"
       } for N in RANGE,
       {

--- a/doc/jx.html
+++ b/doc/jx.html
@@ -561,6 +561,28 @@ they are evaluated from left to right.
 </code></pre>
 </p>
 
+<h2 id="fstrings">F-strings<a class="sectionlink" href="#fstrings" title="Link to this section.">&#x21d7;</a></h2>
+
+<p>
+Python-style f-strings offer a concise way to build strings based on variables.
+F-strings are represented as string literals prefixed with <tt>f</tt>.
+Curly braces <tt>{ }</tt> indicate points where variables should be substituted.
+For exmaple,
+<pre><code>f"./process.py -n {N} -o {OUTPUT}.{N}.dat"</code></pre>
+</p>
+Here the variables <tt>N</tt> and <tt>OUTPUT</tt> are substituted in where they appear.
+Unlike in Python, f-strings in JX may not substitute arbitrary expressions;
+only variable names are allowed.
+For more powerful string formatting, see the <a href="#functions"><tt>format()</tt> function</a>.
+To include a literal <tt>{</tt> or <tt>}</tt> in an f-string, quote by doubling it.
+For example, suppose <tt>OUTPUT</tt> is a JX variable containing <tt>"file.dat"</tt>.
+<pre><code>f"./run -m ${{MODE}} > {OUTPUT}"
+=> "./run -m ${MODE} file.dat" </code></pre>
+The JX variable <tt>OUTPUT</tt> is substituted in, while the double braces are not evaluated as expressions.
+Thus they will be interpreted by the shell to insert sh variable <tt>$MODE</tt> at runtime.
+</p>
+
+
 <h2 id="errors">Errors<a class="sectionlink" href="#errors" title="Link to this section.">&#x21d7;</a></h2>
 
 <p>

--- a/dttools/src/.gitignore
+++ b/dttools/src/.gitignore
@@ -30,3 +30,4 @@ worker_condor_submit
 libforce_halt_enospc.so
 jx_count_obj_test
 jx2env
+jx_binary_test

--- a/dttools/src/jx.h
+++ b/dttools/src/jx.h
@@ -99,6 +99,7 @@ typedef enum {
 	JX_OP_LOOKUP,
 	JX_OP_CALL,
 	JX_OP_SLICE,
+	JX_OP_F,
 	JX_OP_INVALID,
 } jx_operator_t;
 

--- a/dttools/src/jx_print.c
+++ b/dttools/src/jx_print.c
@@ -72,6 +72,7 @@ const char * jx_operator_string( jx_operator_t type )
 		case JX_OP_LOOKUP: return "[";
 		case JX_OP_CALL: return "(";
 		case JX_OP_SLICE: return ":";
+		case JX_OP_F: return "f";
 		default:        return "???";
 	}
 }

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -636,3 +636,27 @@ value:      "pi is 3.141592654"
 expression: error({"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"})
 value:      error({"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"})
 
+expression: f"str"
+value:      "str"
+
+expression: f""
+value:      ""
+
+expression: f"{infile}"
+value:      "mydata"
+
+expression: f" {x}"
+value:      " 10"
+
+expression: f"{f}"
+value:      "0.5"
+
+expression: f"test { g} and {y\t} "
+value:      "test 3.141592654 and 20 "
+
+expression: f"{{{f}}}"
+value:      "{0.5}"
+
+expression: f"{zzzzzzzzzzzzzzzzzzzzzz}"
+value:      error("on line 273: undefined symbol zzzzzzzzzzzzzzzzzzzzzz in template")
+

--- a/dttools/test/jx.expected
+++ b/dttools/test/jx.expected
@@ -660,3 +660,27 @@ value:      "{0.5}"
 expression: f"{zzzzzzzzzzzzzzzzzzzzzz}"
 value:      error("on line 273: undefined symbol zzzzzzzzzzzzzzzzzzzzzz in template")
 
+expression: f"{"
+value:      error("on line 274: unterminated expression in fstring")
+
+expression: f"}"
+value:      error("on line 275: unmatched } in template")
+
+expression: f"{}"
+value:      error("on line 276: invalid f-string; each expression must be a single identifier")
+
+expression: f"{x y}"
+value:      error("on line 277: invalid f-string; each expression must be a single identifier")
+
+expression: f"{x+y}"
+value:      error("on line 278: invalid f-string; each expression must be a single identifier")
+
+expression: f"{12}"
+value:      error("on line 279: invalid f-string; each expression must be a single identifier")
+
+expression: f"f}"
+value:      error("on line 280: unmatched } in template")
+
+expression: f"{f"
+value:      error("on line 281: unterminated expression in fstring")
+

--- a/dttools/test/jx.input
+++ b/dttools/test/jx.input
@@ -271,5 +271,13 @@ f"{f}";
 f"test { g} and {y	} ";
 f"{{{f}}}";
 f"{zzzzzzzzzzzzzzzzzzzzzz}";
+f"{";
+f"}";
+f"{}";
+f"{x y}";
+f"{x+y}";
+f"{12}";
+f"f}";
+f"{f";
 
 #end

--- a/dttools/test/jx.input
+++ b/dttools/test/jx.input
@@ -263,4 +263,13 @@ true + " maybe " + false
 
 error({"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"});
 
+f"str";
+f"";
+f"{infile}";
+f" {x}";
+f"{f}";
+f"test { g} and {y	} ";
+f"{{{f}}}";
+f"{zzzzzzzzzzzzzzzzzzzzzz}";
+
 #end


### PR DESCRIPTION
This PR adds limited f-strings to JX. I also added a number of test cases and updated the docs.

Rather than allowing arbitrary expressions, this PR only allows variable names. I implemented f-strings as a unary prefix operator that the parser only allows on string literals. At evaluation time, invalid f-strings produce helpful error messages. I had considered adding a new fundamental type `JX_FSTRING` rather than doing an operator. The former is more flexible but requires more cross-cutting changes. Since I don't see much interest in generalizing this feature to arbitrary expressions, I did the latter.

Resolves #2107 