### PR TITLE
WIP: External Test Setup

### DIFF
--- a/test/TR_jx.sh
+++ b/test/TR_jx.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+. test_runner_common.sh
+
+prepare()
+{
+	$CCTOOLS_COMPILE jx_test.c -o jx_test -ldttools -lm
+}
+
+run()
+{
+	./jx_test < jx.input > jx.output
+	diff jx.output jx.expected
+	return $?
+}
+
+clean()
+{
+	rm -f jx.output jx_test
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/test/TR_jx_canonicalize.sh
+++ b/test/TR_jx_canonicalize.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+
+. test_runner_common.sh
+
+prepare()
+{
+$CCTOOLS_COMPILE_STDIN -o jx_canonicalize -ldttools -lm <<EOF
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jx.h"
+#include "jx_canonicalize.h"
+
+int main(int argc, char **argv) {
+	char *s;
+
+	struct jx *x_null = jx_null();
+	struct jx *x_true = jx_boolean(1);
+	struct jx *x_false = jx_boolean(0);
+	struct jx *x_integer = jx_integer(42);
+	struct jx *x_double = jx_double(42);
+	struct jx *x_string = jx_string("s");
+	struct jx *x_string2 = jx_string("t");
+	struct jx *x_symbol = jx_symbol("sym");
+	struct jx *x_array = jx_array(NULL);
+	struct jx *x_object = jx_object(NULL);
+
+	s = jx_canonicalize(x_null);
+	assert(s);
+	assert(!strcmp(s, "null"));
+
+	s = jx_canonicalize(x_true);
+	assert(s);
+	assert(!strcmp(s, "true"));
+
+	s = jx_canonicalize(x_false);
+	assert(s);
+	assert(!strcmp(s, "false"));
+
+	s = jx_canonicalize(x_integer);
+	assert(s);
+	assert(!strcmp(s, "42"));
+
+	s = jx_canonicalize(x_double);
+	assert(s);
+	assert(!strcmp(s, "4.200000e+01"));
+
+	s = jx_canonicalize(x_string);
+	assert(s);
+	assert(!strcmp(s, "\"s\""));
+
+	s = jx_canonicalize(x_symbol);
+	assert(!s);
+
+	s = jx_canonicalize(x_array);
+	assert(s);
+	assert(!strcmp(s, "[]"));
+
+	jx_array_append(x_array, x_null);
+	jx_array_append(x_array, x_string);
+	jx_array_append(x_array, x_string2);
+	jx_array_append(x_array, x_integer);
+	jx_array_append(x_array, x_string);
+	s = jx_canonicalize(x_array);
+	assert(s);
+	assert(!strcmp(s, "[null,\"s\",\"t\",42,\"s\"]"));
+
+	jx_array_append(x_array, x_symbol);
+	s = jx_canonicalize(x_array);
+	assert(!s);
+
+	s = jx_canonicalize(x_object);
+	assert(s);
+	assert(!strcmp(s, "{}"));
+
+	jx_insert(x_object, x_string, x_integer);
+	jx_insert(x_object, x_string2, x_null);
+	s = jx_canonicalize(x_object);
+	assert(s);
+	assert(!strcmp(s, "{\"s\":42,\"t\":null}"));
+
+	x_object = jx_object(NULL);
+	jx_insert(x_object, x_string2, x_null);
+	jx_insert(x_object, x_string, x_integer);
+	s = jx_canonicalize(x_object);
+	assert(s);
+	assert(!strcmp(s, "{\"s\":42,\"t\":null}"));
+
+	jx_insert(x_object, x_string, x_true);
+	s = jx_canonicalize(x_object);
+	assert(!s);
+
+	x_object = jx_object(NULL);
+	jx_insert(x_object, x_integer, x_false);
+	s = jx_canonicalize(x_object);
+	assert(!s);
+
+	x_object = jx_object(NULL);
+	jx_insert(x_object, x_string, x_symbol);
+	s = jx_canonicalize(x_object);
+	assert(!s);
+
+	return 0;
+}
+EOF
+	return $?
+}
+
+run()
+{
+	./jx_canonicalize
+	return $?
+}
+
+clean()
+{
+	rm -f jx_canonicalize
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/test/TR_jx_count.sh
+++ b/test/TR_jx_count.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+. test_runner_common.sh
+
+prepare()
+{
+	$CCTOOLS_COMPILE jx_count.c -o jx_count -ldttools -lm
+}
+
+run()
+{
+	./jx_count 4 jx_count.input
+}
+
+clean()
+{
+	rm -f jx_count
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/test/TR_jx_env.sh
+++ b/test/TR_jx_env.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+. test_runner_common.sh
+
+prepare()
+{
+cat << EOF > jx_env.input
+{
+    "hello":"goodbye",
+    "plate": { "fork" : { "knife" : { "spoon" : "tea spoon" } } },
+	"tag"  : "it"
+}
+EOF
+
+	return 0
+}
+
+run()
+{
+	eval $(jx2env jx_env.input varname=hello othervarname=plate.fork.knife.spoon)
+
+	[ "${varname}" = "goodbye" ] || exit 1
+	[ "${othervarname}" = "tea spoon" ] || exit 1
+	[ -z ${tag} ] || exit 1
+}
+
+clean()
+{
+	rm -f jx_env.input
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/test/TR_jx_match.sh
+++ b/test/TR_jx_match.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+. test_runner_common.sh
+
+exe="match.test"
+
+prepare()
+{
+$CCTOOLS_COMPILE_STDIN -o "$exe" -ldttools -lm <<EOF
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jx.h"
+#include "jx_match.h"
+
+
+int main(int argc, char **argv)
+{
+	char *ee;
+
+	struct jx *a = jx_boolean(10);
+	int aa = 42;
+	assert(jx_match_boolean(a, &aa));
+	assert(!jx_match_symbol(a, &ee));
+	assert(aa == 1);
+	jx_delete(a);
+
+	struct jx *b = jx_double(2.71);
+	double bb = 100.0;
+	assert(jx_match_double(b, &bb));
+	assert(!jx_match_boolean(b, &aa));
+	assert(bb == 2.71);
+	jx_delete(b);
+
+	struct jx *c = jx_integer(17);
+	jx_int_t cc = -10;
+	assert(jx_match_integer(c, &cc));
+	assert(!jx_match_double(c, &bb));
+	assert(cc == 17);
+	jx_delete(c);
+
+	struct jx *d = jx_string("d");
+	char *dd = NULL;
+	assert(jx_match_string(d, &dd));
+	assert(!jx_match_integer(d, &cc));
+	jx_delete(d);
+	assert(strlen(dd) == 1);
+	free(dd);
+
+	struct jx *e = jx_symbol("e");
+	assert(jx_match_symbol(e, &ee));
+	assert(!jx_match_string(e, &ee));
+	jx_delete(e);
+	assert(strlen(ee) == 1);
+	free(ee);
+
+	int f1;
+	char *f2;
+	double f3;
+	struct jx *f4 = jx_null();
+	struct jx *f = jx_array(NULL);
+	jx_array_insert(f, jx_double(3.14));
+	jx_array_insert(f, jx_string("pi"));
+	jx_array_insert(f, jx_boolean(0));
+	assert(!jx_match_boolean(f, &f1));
+	assert(!jx_match_array(f, NULL));
+	assert(!jx_match_array(f4, &f1, JX_BOOLEAN, NULL));
+	jx_delete(f4);
+	assert(jx_match_array(f, &f1, JX_BOOLEAN, &f3, JX_DOUBLE, NULL) == 1);
+	assert(jx_match_array(f, &f1, JX_BOOLEAN, &f2, JX_STRING, &f3, JX_DOUBLE, NULL) == 3);
+	assert(f1 == 0);
+	assert(strlen(f2) == 2);
+	assert(f3 == 3.14);
+	free(f2);
+	assert(jx_match_array(f, &f4, JX_ANY, NULL) == 1);
+	assert(jx_match_boolean(f4, &f1));
+	assert(f1 == 0);
+
+	return 0;
+}
+EOF
+	return $?
+}
+
+run()
+{
+	./"$exe"
+	return $?
+}
+
+clean()
+{
+	rm -f "$exe"
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/test/TR_jx_merge.sh
+++ b/test/TR_jx_merge.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+. test_runner_common.sh
+
+prepare()
+{
+$CCTOOLS_COMPILE_STDIN -o jx_merge -ldttools -lm <<EOF
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jx.h"
+#include "jx_parse.h"
+
+int main(int argc, char **argv) {
+	struct jx *a;
+	struct jx *b;
+	struct jx *c;
+	struct jx *r;
+	struct jx *s;
+	struct jx *t;
+
+	a = jx_object(NULL);
+	jx_insert(a, jx_string("k"), jx_integer(5));
+	jx_insert(a, jx_string("e"), jx_integer(6));
+	jx_insert(a, jx_string("y"), jx_integer(7));
+
+	b = jx_object(NULL);
+
+	c = jx_object(NULL);
+	jx_insert(c, jx_string("x"), jx_integer(2));
+	jx_insert(c, jx_string("x"), jx_integer(3));
+
+
+	t = jx_parse_string("{\"k\": 5, \"e\": 6, \"y\": 7}");
+
+	s = jx_merge(a, NULL);
+	assert(jx_equals(s, t));
+	jx_delete(s);
+
+	s = jx_merge(a, b, NULL);
+	assert(jx_equals(s, t));
+	jx_delete(s);
+
+	s = jx_merge(b, a, NULL);
+	assert(jx_equals(s, t));
+	jx_delete(s);
+
+	jx_delete(t);
+
+	t = jx_integer(3);
+	s = jx_lookup(c, "x");
+	assert(jx_equals(s, t));
+	jx_delete(t);
+
+	r = jx_merge(c, NULL);
+	s = jx_lookup(r, "x");
+	t = jx_integer(2);
+	// probably not desirable...
+	assert(jx_equals(s, t));
+	jx_delete(r);
+	jx_delete(t);
+
+	s = jx_merge(a, b, c, NULL);
+	t = jx_parse_string("{\"x\":2,\"k\":5,\"e\":6,\"y\":7}");
+	assert(jx_equals(s, t));
+	jx_delete(s);
+	jx_delete(t);
+
+	s = jx_merge(a, c, a, NULL);
+	t = jx_parse_string("{\"k\":5,\"e\":6,\"y\":7,\"x\":2}");
+	assert(jx_equals(s, t));
+	jx_delete(s);
+	jx_delete(t);
+
+	jx_delete(a);
+	jx_delete(b);
+	jx_delete(c);
+
+	return 0;
+}
+EOF
+	return $?
+}
+
+run()
+{
+	./jx_merge
+	return $?
+}
+
+clean()
+{
+	rm -f jx_merge
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/test/jx.expected
+++ b/test/jx.expected
@@ -1,0 +1,638 @@
+Enter context expression (or {} for an empty context):
+Now enter expressions:
+expression: 10
+value:      10
+
+expression: 3847.576
+value:      3847.576
+
+expression: 0.5
+value:      0.5
+
+expression: 10
+value:      10
+
+expression: 987
+value:      987
+
+expression: 12347812309487
+value:      12347812309487
+
+expression: "hello"
+value:      "hello"
+
+expression: "goodbye\n"
+value:      "goodbye\n"
+
+expression: "\"quotes\""
+value:      "\"quotes\""
+
+expression: "tab\ttab\ttab\rreturn\nnewline\n"
+value:      "tab\ttab\ttab\rreturn\nnewline\n"
+
+expression: "\\\\\\\\"
+value:      "\\\\\\\\"
+
+expression: true
+value:      true
+
+expression: false
+value:      false
+
+expression: null
+value:      null
+
+expression: true and true
+value:      true
+
+expression: true and true
+value:      true
+
+expression: true and false
+value:      false
+
+expression: true and false
+value:      false
+
+expression: false and true
+value:      false
+
+expression: false and true
+value:      false
+
+expression: false and false
+value:      false
+
+expression: false and false
+value:      false
+
+expression: true or true
+value:      true
+
+expression: true or true
+value:      true
+
+expression: true or false
+value:      true
+
+expression: true or false
+value:      true
+
+expression: false or true
+value:      true
+
+expression: false or true
+value:      true
+
+expression: false or false
+value:      false
+
+expression: false or false
+value:      false
+
+expression:  not true
+value:      false
+
+expression:  not true
+value:      false
+
+expression:  not false
+value:      true
+
+expression: 10==20
+value:      false
+
+expression: 10!=20
+value:      true
+
+expression: 10<20
+value:      true
+
+expression: 10<=20
+value:      true
+
+expression: 10>20
+value:      false
+
+expression: 10>=20
+value:      false
+
+expression: 10.5==20.5
+value:      false
+
+expression: 10.5!=20.5
+value:      true
+
+expression: 10.5<20.5
+value:      true
+
+expression: 10.5<=20.5
+value:      true
+
+expression: 10.5>20.5
+value:      false
+
+expression: 10.5>=20.5
+value:      false
+
+expression: "hello"=="goodbye"
+value:      false
+
+expression: "hello"!="goodbye"
+value:      true
+
+expression: "hello"<="goodbye"
+value:      false
+
+expression: "hello"<"goodbye"
+value:      false
+
+expression: "hello">"goodbye"
+value:      true
+
+expression: "hello">="goodbye"
+value:      true
+
+expression: "hello"=="hello"
+value:      true
+
+expression: "hello"!="hello"
+value:      false
+
+expression: "hello"<="hello"
+value:      true
+
+expression: "hello"<"hello"
+value:      false
+
+expression: "hello">"hello"
+value:      false
+
+expression: "hello">="hello"
+value:      true
+
+expression: a==b
+value:      false
+
+expression: a!=b
+value:      true
+
+expression: a<b
+value:      error("on line 82, true<false: unsupported operator on boolean")
+
+expression: a>b
+value:      error("on line 83, true>false: unsupported operator on boolean")
+
+expression: a<=b
+value:      error("on line 84, true<=false: unsupported operator on boolean")
+
+expression: a>=b
+value:      error("on line 85, true>=false: unsupported operator on boolean")
+
+expression: f==g
+value:      false
+
+expression: f!=g
+value:      true
+
+expression: f<g
+value:      true
+
+expression: f>g
+value:      false
+
+expression: f<=g
+value:      true
+
+expression: f>=g
+value:      false
+
+expression: x==y
+value:      false
+
+expression: x!=y
+value:      true
+
+expression: x<y
+value:      true
+
+expression: x>y
+value:      false
+
+expression: x<=y
+value:      true
+
+expression: x>=y
+value:      false
+
+expression: a+b
+value:      error("on line 101, true+false: unsupported operator on boolean")
+
+expression: a-b
+value:      error("on line 102, true-false: unsupported operator on boolean")
+
+expression: a*b
+value:      error("on line 103, true*false: unsupported operator on boolean")
+
+expression: a/b
+value:      error("on line 104, true/false: unsupported operator on boolean")
+
+expression: a%b
+value:      error("on line 105, true%false: unsupported operator on boolean")
+
+expression: f+g
+value:      3.641592654
+
+expression: f-g
+value:      -2.641592654
+
+expression: f*g
+value:      1.570796327
+
+expression: f/g
+value:      0.159154943071114
+
+expression: f%g
+value:      0
+
+expression: x+y
+value:      30
+
+expression: x-y
+value:      -10
+
+expression: x*y
+value:      200
+
+expression: x/y
+value:      0
+
+expression: x%y
+value:      10
+
+expression: x and y
+value:      error("on line 118, 10 and 20: unsupported operator on integer")
+
+expression: x or y
+value:      error("on line 119, 10 or 20: unsupported operator on integer")
+
+expression: x and y
+value:      error("on line 120, 10 and 20: unsupported operator on integer")
+
+expression: x or y
+value:      error("on line 121, 10 or 20: unsupported operator on integer")
+
+expression: (x+y)*(f+g)
+value:      109.24777962
+
+expression: 10+20*30
+value:      610
+
+expression: 10*(20+30)
+value:      500
+
+expression: a==b or (f>g and x<y)
+value:      false
+
+expression: a==b or (f>g and x<y)
+value:      false
+
+expression: [[0,i] for i in [1,2,x],10,-90.5,true for i in range(5),false,null,[-1,-2,-3]]
+value:      [[0,1],[0,2],[0,10],10,-90.5,true,true,true,true,true,false,null,[-1,-2,-3]]
+
+expression: [format(":%d",2*i) for i in range(10)]
+value:      [":0",":2",":4",":6",":8",":10",":12",":14",":16",":18"]
+
+expression: [i+1 for i in [10-i for i in range(10)]]
+value:      [11,10,9,8,7,6,5,4,3,2]
+
+expression: [[[i,j] for j in range(3)] for i in [10-i for i in range(4)]]
+value:      [[[10,0],[10,1],[10,2]],[[9,0],[9,1],[9,2]],[[8,0],[8,1],[8,2]],[[7,0],[7,1],[7,2]]]
+
+expression: [null for i in 7]
+value:      error("on line 134: list comprehension takes an array")
+
+expression: [i for i in range(10) if i%3==0]
+value:      [0,3,6,9]
+
+expression: [[i,j] for i in range(4) for j in range(3)]
+value:      [[0,0],[0,1],[0,2],[1,0],[1,1],[1,2],[2,0],[2,1],[2,2],[3,0],[3,1],[3,2]]
+
+expression: [[i,j] for i in range(5) for j in range(4) if (i+j)%2==0]
+value:      [[0,0],[0,2],[1,1],[1,3],[2,0],[2,2],[3,1],[3,3],[4,0],[4,2]]
+
+expression: [[i,j] for i in range(5) for j in range(4) if j%2==1]
+value:      [[0,1],[0,3],[1,1],[1,3],[2,1],[2,3],[3,1],[3,3],[4,1],[4,3]]
+
+expression: [[i,j] for i in range(5) if i%2==0 for j in range(4) if j%2==1]
+value:      [[0,1],[0,3],[2,1],[2,3],[4,1],[4,3]]
+
+expression: [[i,j] for i in range(5) if j%2==0 for j in range(4) if i%2==1]
+value:      error("on line 140, j: undefined symbol")
+
+expression: [[i,j,k,l] for i in range(4) for j in range(3) for k in range(3) for l in [true,false]]
+value:      [[0,0,0,true],[0,0,0,false],[0,0,1,true],[0,0,1,false],[0,0,2,true],[0,0,2,false],[0,1,0,true],[0,1,0,false],[0,1,1,true],[0,1,1,false],[0,1,2,true],[0,1,2,false],[0,2,0,true],[0,2,0,false],[0,2,1,true],[0,2,1,false],[0,2,2,true],[0,2,2,false],[1,0,0,true],[1,0,0,false],[1,0,1,true],[1,0,1,false],[1,0,2,true],[1,0,2,false],[1,1,0,true],[1,1,0,false],[1,1,1,true],[1,1,1,false],[1,1,2,true],[1,1,2,false],[1,2,0,true],[1,2,0,false],[1,2,1,true],[1,2,1,false],[1,2,2,true],[1,2,2,false],[2,0,0,true],[2,0,0,false],[2,0,1,true],[2,0,1,false],[2,0,2,true],[2,0,2,false],[2,1,0,true],[2,1,0,false],[2,1,1,true],[2,1,1,false],[2,1,2,true],[2,1,2,false],[2,2,0,true],[2,2,0,false],[2,2,1,true],[2,2,1,false],[2,2,2,true],[2,2,2,false],[3,0,0,true],[3,0,0,false],[3,0,1,true],[3,0,1,false],[3,0,2,true],[3,0,2,false],[3,1,0,true],[3,1,0,false],[3,1,1,true],[3,1,1,false],[3,1,2,true],[3,1,2,false],[3,2,0,true],[3,2,0,false],[3,2,1,true],[3,2,1,false],[3,2,2,true],[3,2,2,false]]
+
+expression: list[2]
+value:      300
+
+expression: list[-1]
+value:      300
+
+expression: list[-3]
+value:      100
+
+expression: list[-10]
+value:      error("array reference on line 146: index out of range")
+
+expression: list[1:]
+value:      [200,300]
+
+expression: list[:2]
+value:      [100,200]
+
+expression: list[1:2]
+value:      [200]
+
+expression: list[:]
+value:      [100,200,300]
+
+expression: list[3:2]
+value:      []
+
+expression: list[-11:3]
+value:      [100,200,300]
+
+expression: list[3:-11]
+value:      []
+
+expression: list[1:-1]
+value:      [200]
+
+expression: list[-1:1]
+value:      []
+
+expression: list[0:100]
+value:      [100,200,300]
+
+expression: list[true:4]
+value:      error("on line 0, true:4: slice indices must be integers")
+
+expression: list[4:null]
+value:      error("on line 0, 4:null: slice indices must be integers")
+
+expression: list[true:false]
+value:      error("on line 0, true:false: slice indices must be integers")
+
+expression: object["house"]
+value:      "home"
+
+expression: {"command":"grep English "+infile+" > "+outfile,"inputs":["/usr/bin/grep",infile],"outputs":[outfile],"environment":{"PATH":"/usr/bin"},"cores":1,"memory":16,"disk":1}
+value:      {"command":"grep English mydata > results","inputs":["/usr/bin/grep","mydata"],"outputs":["results"],"environment":{"PATH":"/usr/bin"},"cores":1,"memory":16,"disk":1}
+
+expression: range(5)
+value:      [0,1,2,3,4]
+
+expression: range(3,7)
+value:      [3,4,5,6]
+
+expression: range(7,3)
+value:      []
+
+expression: range(-1,10,2)
+value:      [-1,1,3,5,7,9]
+
+expression: range(1,10,0)
+value:      error("function range on line 0: step must be nonzero")
+
+expression: range(0,5,-1)
+value:      []
+
+expression: range(5,0,1)
+value:      []
+
+expression: range(5,0,-1)
+value:      [5,4,3,2,1]
+
+expression: format()
+value:      error("function format on line 0: invalid/missing format string")
+
+expression: format("%%")
+value:      "%"
+
+expression: format("value: %i!!",x+y)
+value:      "value: 30!!"
+
+expression: format("%i",x,y)
+value:      error("function format on line 0: too many arguments for format specifier")
+
+expression: format("(%d, %i)",x,y)
+value:      "(10, 20)"
+
+expression: format("%i")
+value:      error("function format on line 0: mismatched format specifier")
+
+expression: format("%e",1.2e-22)
+value:      "1.200000e-22"
+
+expression: format("%E",6.02e+23)
+value:      "6.020000E+23"
+
+expression: format("%f",2.5)
+value:      "2.500000"
+
+expression: format("%F",3.14)
+value:      "3.140000"
+
+expression: format("%g",9900000000)
+value:      "9.9e+09"
+
+expression: format("%G",2.11111e-12)
+value:      "2.11111E-12"
+
+expression: format("%s","foo")
+value:      "foo"
+
+expression: 10+[1]
+value:      error("on line 195, 10+[1]: mismatched types for operator")
+
+expression: "abc"+[2]
+value:      error("on line 196, \"abc\"+[2]: mismatched types for operator")
+
+expression: []+[]
+value:      []
+
+expression: []+[1]
+value:      [1]
+
+expression: [1]+[]
+value:      [1]
+
+expression: [1,2]+[3]
+value:      [1,2,3]
+
+expression: [1,2]+[]+[4,[5,6]]
+value:      [1,2,4,[5,6]]
+
+expression: [10]==[10]
+value:      true
+
+expression: [10]!=[10]
+value:      false
+
+expression: [1,2,3]==[1,3,2]
+value:      false
+
+expression: [1,2,[3,4]]==[1,2,[3,4]]
+value:      true
+
+expression: ceil(f)
+value:      1
+
+expression: ceil()
+value:      error("function ceil on line 0: too few arguments")
+
+expression: ceil([])
+value:      error("function ceil on line 0: arg of invalid type")
+
+expression: ceil(x)
+value:      10
+
+expression: ceil(g)
+value:      4
+
+expression: ceil(x,f)
+value:      error("function ceil on line 0: too many arguments")
+
+expression: ceil("foo")
+value:      error("function ceil on line 0: arg of invalid type")
+
+expression: floor(f)
+value:      0
+
+expression: floor()
+value:      error("function floor on line 0: too few arguments")
+
+expression: floor([])
+value:      error("function floor on line 0: arg of invalid type")
+
+expression: floor(x)
+value:      10
+
+expression: floor(g)
+value:      3
+
+expression: floor(x,f)
+value:      error("function floor on line 0: too many arguments")
+
+expression: floor("foo")
+value:      error("function floor on line 0: arg of invalid type")
+
+expression: join([])
+value:      ""
+
+expression: join([],"")
+value:      ""
+
+expression: join(["a","b","c","d"]," ")
+value:      "a b c d"
+
+expression: join()
+value:      error("function join on line 0: too few arguments to join")
+
+expression: join([a,b,c])
+value:      error("on line 227, c: undefined symbol")
+
+expression: join(["a","b","c","d"])
+value:      "a b c d"
+
+expression: join(",",["a","b"])
+value:      error("function join on line 0: A list must be the first argument in join")
+
+expression: join(["a","b"],",")
+value:      "a,b"
+
+expression: join(["a","b"])
+value:      "a b"
+
+expression: basename("/usr/lib")
+value:      "lib"
+
+expression: basename("/usr/")
+value:      "usr"
+
+expression: basename("usr")
+value:      "usr"
+
+expression: basename("file.txt")
+value:      "file.txt"
+
+expression: basename("file.txt",".txt")
+value:      "file"
+
+expression: basename("file.txt",".csv")
+value:      "file.txt"
+
+expression: basename("/")
+value:      "/"
+
+expression: basename(".")
+value:      "."
+
+expression: basename("..")
+value:      ".."
+
+expression: dirname("/usr/lib")
+value:      "/usr"
+
+expression: dirname("/usr/")
+value:      "/"
+
+expression: dirname("usr")
+value:      "."
+
+expression: dirname("/")
+value:      "/"
+
+expression: dirname(".")
+value:      "."
+
+expression: dirname("..")
+value:      "."
+
+expression: listdir()
+value:      error("function listdir on line 0 takes one argument, 0 given")
+
+expression: listdir(7)
+value:      error("function listdir on line 0 takes a string path")
+
+expression: listdir("-")
+value:      error("function listdir on line 0: -, No such file or directory")
+
+expression: listdir("dir")
+value:      ["a"]
+
+expression: escape("test")
+value:      "\"test\""
+
+expression: escape("echo $PATH")
+value:      "\"echo \\$PATH\""
+
+expression: escape("$(pwd)/\"test program\" -x `date`")
+value:      "\"\\$(pwd)/\\\"test program\\\" -x \\`date\\`\""
+
+expression: escape("y\\x")
+value:      "\"y\\\\x\""
+
+expression: "hello "+1+" world"
+value:      "hello 1 world"
+
+expression: true+" maybe "+false
+value:      "true maybe false"
+
+expression: "pi is "+3.141592654
+value:      "pi is 3.141592654"
+
+expression: error({"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"})
+value:      error({"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"})
+

--- a/test/jx.input
+++ b/test/jx.input
@@ -1,0 +1,266 @@
+#!/bin/false
+{
+"outfile":"results",
+"infile":"mydata",
+"a": true,
+"b": false,
+"f": 0.5,
+"g": 3.141592654,
+"x": 10,
+"y": 20,
+"list": [100,200,300],
+"object": { "house": "home" }
+}
+
+#comment
+10;
+3847.576;
+.5;
+10.;
+987;
+12347812309487;
+
+"hello";
+"goodbye\n";
+"\"quotes\"";
+"tab\ttab\ttab\rreturn\nnewline\n";
+"\\\\\\\\";
+
+true;
+false;
+null;
+true and true;
+true && true;
+true and false;
+true && false;
+false and true;
+false && true;
+false and false;
+false && false;
+true or true;
+true || true;
+true or false;
+true || false;
+false or true;
+false || true;
+false or false;
+false || false;
+!true;
+not true;
+not false;
+
+10 == 20;
+10 != 20;
+10 < 20;
+10 <= 20;
+10 > 20;
+10 >= 20;
+
+10.5 == 20.5;
+10.5 != 20.5;
+10.5 < 20.5;
+10.5 <= 20.5;
+10.5 > 20.5;
+10.5 >= 20.5;
+
+"hello" == "goodbye";
+"hello" != "goodbye";
+"hello" <= "goodbye";
+"hello" < "goodbye";
+"hello" > "goodbye";
+"hello" >= "goodbye";
+
+"hello" == "hello";
+"hello" != "hello";
+"hello" <= "hello";
+"hello" < "hello";
+"hello" > "hello";
+"hello" >= "hello";
+
+a==b;
+a!=b;
+a<b;
+a>b;
+a<=b;
+a>=b;
+
+f==g;
+f!=g;
+f<g;
+f>g;
+f<=g;
+f>=g;
+
+x==y;
+x!=y;
+x<y;
+x>y;
+x<=y;
+x>=y;
+
+a+b;
+a-b;
+a*b;
+a/b;
+a%b;
+
+f+g;
+f-g;
+f*g;
+f/g;
+f%g;
+
+x+y;
+x-y;
+x*y;
+x/y;
+x%y;
+x && y;
+x || y;
+x and y;
+x or y;
+
+(x+y)*(f+g);
+(10 + (20 * 30));
+(10*(20+30));
+(a==b) or ((f>g) and x<y);
+(a==b) || ((f>g) && x<y);
+
+#[10,-90.5,true,false,null,[-1,-2,-3]];
+[[0, i] for i in [1,2,x], 10,-90.5,true for i in range(5),false,null,[-1,-2,-3]];
+[format(":%d", 2*i) for i in range(10)];
+[i + 1 for i in [10 - i for i in range(10)]];
+[[[i, j] for j in range(3)] for i in [10 - i for i in range(4)]];
+[null for i in 7];
+[i for i in range(10) if i % 3 == 0];
+[[i, j] for i in range(4) for j in range(3)];
+[[i, j] for i in range(5) for j in range(4) if (i + j) % 2 == 0];
+[[i, j] for i in range(5) for j in range(4) if j % 2 == 1];
+[[i, j] for i in range(5) if i % 2 == 0 for j in range(4) if j % 2 == 1];
+[[i, j] for i in range(5) if j % 2 == 0 for j in range(4) if i % 2 == 1];
+[[i, j, k, l] for i in range(4) for j in range(3) for k in range(3) for l in [true, false]];
+
+list[2];
+list[-1];
+list[-3];
+list[-10];
+list[1:];
+list[:2];
+list[1:2];
+list[:];
+list[3:2];
+list[-11:3];
+list[3:-11];
+list[1:-1];
+list[-1:1];
+list[0:100];
+list[true:4];
+list[4:null];
+list[true:false];
+object["house"];
+
+{
+"command":"grep English "+infile+" > "+outfile,
+"inputs":["/usr/bin/grep",infile],
+"outputs":[outfile],
+"environment":{"PATH":"/usr/bin"},
+"cores":1,
+"memory":16,
+"disk":1,
+};
+
+range(5);
+range(3, 7);
+range (7, 3);
+range(-1, 10, 2);
+range(1, 10, 0);
+range(0, 5, -1);
+range(5, 0, 1);
+range(5, 0, -1);
+
+format();
+format("%%");
+format("value: %i!!", x + y);
+format("%i", x, y);
+format("(%d, %i)", x, y);
+format("%i");
+format("%e", 1.2e-22);
+format("%E", 6.02e23);
+format("%f", 2.5);
+format("%F", 3.14);
+format("%g", 9.9e9);
+format("%G", 2.11111e-12);
+format("%s", "foo");
+
+10 + [1];
+"abc" + [2];
+[] + [];
+[] + [1];
+[1] + [];
+[1, 2] + [3];
+[1, 2] + [] + [4, [5, 6]];
+[10] == [10];
+[10] != [10];
+[1,2, 3] == [1,3,2];
+[1,2,[3,4]] == [1,2,[3,4]];
+
+ceil(f);
+ceil();
+ceil([]);
+ceil(x);
+ceil(g);
+ceil(x, f);
+ceil("foo");
+
+floor(f);
+floor();
+floor([]);
+floor(x);
+floor(g);
+floor(x, f);
+floor("foo");
+
+join([]);
+join([], "");
+join(["a", "b", "c", "d"], " ");
+join();
+join([a, b, c]);
+join(["a", "b", "c", "d"]);
+join(",", ["a", "b"]);
+join(["a", "b"], ",");
+join(["a", "b"]);
+
+basename("/usr/lib");
+basename("/usr/");
+basename("usr");
+basename("file.txt");
+basename("file.txt", ".txt");
+basename("file.txt", ".csv");
+basename("/");
+basename(".");
+basename("..");
+
+dirname("/usr/lib");
+dirname("/usr/");
+dirname("usr");
+dirname("/");
+dirname(".");
+dirname("..");
+
+listdir();
+listdir(7);
+listdir("-");
+listdir("dir");
+
+escape("test");
+escape("echo $PATH")
+escape("$(pwd)/\"test program\" -x `date`");
+escape("y\\x");
+
+"hello " + 1 + " world"
+true + " maybe " + false
+"pi is " + 3.141592654
+
+error({"source":"jx_eval","op":10+[1],"line":409,"file":"jx_eval.c","message":"mismatched types for operator","name":"TypeError"});
+
+#end

--- a/test/jx_count.c
+++ b/test/jx_count.c
@@ -1,0 +1,63 @@
+/*
+  Copyright (C) 2016- The University of Notre Dame This software is
+  distributed under the GNU General Public License.  See the file
+  COPYING for details.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include "jx.h"
+#include "jx_parse.h"
+#include "jx_print.h"
+
+int main(int argc, char **argv) {
+	if(argc < 3) {
+		fprintf(stderr, "Usage:\n%s expected-number-of-objects input-file\n", argv[0]);
+		exit(1);
+	}
+
+	int n = atoi(argv[1]);
+	const char *filename = argv[2];
+
+	FILE *stream = fopen(filename, "r");
+
+	if(!stream) {
+		fprintf(stderr, "%s: Could not open file '%s' (%s)\n", argv[0], filename, strerror(errno));
+		exit(1);
+	}
+
+	int count = 0;
+
+	struct jx *j;
+	struct jx_parser *p = jx_parser_create(0);
+	jx_parser_read_stream(p, stream);
+	while((j = jx_parser_yield(p))) {
+		char *str = jx_print_string(j);
+		fprintf(stdout, "%s\n", str);
+		
+		fprintf(stdout, "%d\n", j->type);
+
+		jx_delete(j);
+		free(str);
+
+		count++;
+	}
+
+	if(jx_parser_errors(p)) {
+		fprintf(stderr, "%s error: %s\n", argv[0], jx_parser_error_string(p));
+	}
+
+	jx_parser_delete(p);
+
+	if(count == n) {
+		exit(0);
+	} else {
+		fprintf(stderr, "%s: Expected %d objects, got %d.\n", argv[0], n, count);
+		exit(2);
+	}
+}
+
+/* vim: set noexpandtab tabstop=4: */

--- a/test/jx_count.input
+++ b/test/jx_count.input
@@ -1,0 +1,5 @@
+{"tag": "one"} {"tag": "two"}
+
+{"tag": "three", "other": {"tag": "not-four"}}
+{"tag": "four"}
+

--- a/test/jx_test.c
+++ b/test/jx_test.c
@@ -1,0 +1,67 @@
+/*
+Copyright (C) 2015- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+/*
+This is a test program for the jx library.
+It first reads in one JX expression which is used as the evaluation context.
+Then, each successive expression is parsed and then evaluated.
+The program exits on the first failure or EOF.
+*/
+
+#include "jx.h"
+#include "jx_parse.h"
+#include "jx_print.h"
+#include "jx_eval.h"
+
+#include <stdio.h>
+#include <errno.h>
+
+int main( int argc, char *argv[] )
+{
+	printf("Enter context expression (or {} for an empty context):\n");
+
+	struct jx_parser *p = jx_parser_create(0);
+	jx_parser_read_stream(p,stdin);
+
+	struct jx *context = jx_parse(p);
+	if(!context) return 1;
+	if(jx_parser_errors(p)) {
+		fprintf(stderr,"invalid context expression: %s\n",jx_parser_error_string(p));
+		return 1;
+	}
+
+	printf("Now enter expressions:\n");
+
+	while(1) {
+		struct jx *j = jx_parse(p);
+
+		if(!j && !jx_parser_errors(p)) {
+			// end of file
+			break;
+		} else if(!jx_parser_errors(p)) {
+			// successful parse
+			printf("expression: ");
+			jx_print_stream(j,stdout);
+			printf("\n");
+
+			struct jx *k = jx_eval(j,context);
+			printf("value:      ");
+			jx_print_stream(k,stdout);
+			printf("\n\n");
+
+			jx_delete(j);
+			jx_delete(k);
+		} else {
+			// failed parse
+			printf("\"jx parse error: %s\"\n",jx_parser_error_string(p));
+			jx_delete(j);
+			jx_parser_delete(p);
+			return 1;
+		}
+	}
+	jx_parser_delete(p);
+	return 0;
+}

--- a/test/test_runner_common.sh
+++ b/test/test_runner_common.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+
+export CCTOOLS_COMPILE="gcc -g -I${CCTOOLS_INSTALL_DIR}/include/cctools -L${CCTOOLS_INSTALL_DIR}/lib"
+export CCTOOLS_COMPILE_STDIN="${CCTOOLS_COMPILE} -x c - -x none"
+
+export PATH=${CCTOOLS_INSTALL_DIR}/bin:`pwd`:${PATH}
+export PYTHONPATH=${CCTOOLS_INSTALL_DIR}/lib/python${CCTOOLS_PYTHON_VERSION}/site-packages:${PYTHONPATH}
+export PERL5LIB=${CCTOOLS_INSTALL_DIR}/lib/perl5/site-perl:${PERL5LIB}
+
+dispatch()
+{
+	case "$1" in
+		check_needed)
+			check_needed $@
+			;;
+		prepare)
+			prepare $@
+			;;
+		run)
+			run $@
+			;;
+		clean)
+			clean $@
+			;;
+		*)
+			echo "unknown command: $1"
+			echo "use: $0 [check_needed|prepare|run|clean]"
+			exit 1
+			;;
+	esac
+	exit $?
+}
+
+# wait_for_file_creation(filename, timeout)
+# Waits at most timeout seconds (default 5) for filename to be created.
+# Returns 0 if filename created before timeout, otherwise terminates the script.
+wait_for_file_creation()
+{
+	filename=$1
+	timeout=${2:-5}
+	counter_seconds=0
+
+	[ -z $filename ] && exit 1
+
+	while [ $counter_seconds -lt $timeout ];
+	do
+		[ -f $filename ] && return 0
+		counter_seconds=$(($counter_seconds + 1))
+		sleep 1
+	done
+
+	exit 1
+}
+
+# wait_for_file_modification(filename, timeout)
+# returns until the last modification to filename is timeout seconds (default 5) in the past.
+wait_for_file_modification()
+{
+	filename=$1
+	timeout=${2:-5}
+
+	case `uname -s` in
+		Darwin)
+			args="-f %m $filename"
+		;;
+		*)
+			args="-c %Y $filename"
+		;;
+	esac
+
+	while true; do
+		sleep 1
+		[ ! -f $filename ] && exit 1
+		mtime=`stat $args`
+		now=`date +"%s"`
+		delta=$(($now-$mtime))
+		[  $delta -gt 3 ] && break
+	done
+}
+
+run_local_worker()
+{
+	local port_file=$1
+	local log=$2
+	local timeout=15
+
+	if [ -z "$log" ]; then
+		log=worker.log
+	fi
+
+	echo "Waiting for master to be ready."
+	if wait_for_file_creation $port_file $timeout
+	then
+		echo "Master is ready on port `cat $port_file` "
+	else
+		echo "ERROR: Master failed to respond in $timeout seconds."
+		exit 1
+	fi
+	echo "Running worker."
+	if ! work_queue_worker --single-shot --timeout=10s --cores 1 --memory 250 --disk 250 --debug=all --debug-file="$log" localhost $(cat "$port_file"); then
+		echo "ERROR: could not start worker"
+		exit 1
+	fi
+	echo "Worker completed."
+	return 0
+}
+
+require_identical_files()
+{
+	echo "Comparing output $1 and $2"
+	if diff $1 $2
+	then
+		echo "$1 and $2 are the same."
+		return 0
+	else
+		echo "ERROR: $1 and $2 differ!"
+		exit 1
+	fi
+}
+
+check_needed()
+{
+# to be implemented by individual tests that are optional.
+# For an example, see chirp/test/TR_chirp_python.sh
+	return 0
+}
+
+# For OS X
+if ! echo $PATH | grep /sbin > /dev/null 2>&1; then
+	export PATH=$PATH:/usr/sbin:/sbin
+fi
+
+# vim: set noexpandtab tabstop=4:

--- a/test/work_queue_common.sh
+++ b/test/work_queue_common.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+. test_runner_common.sh
+
+prepare()
+{
+	echo "nothing to do"
+}
+
+run()
+{
+	cat > master.script << EOF
+submit 1 0 1 $TASKS
+wait
+quit
+EOF
+
+	echo "starting master"
+	work_queue_test -d all -o master.log -Z master.port < master.script &
+
+	echo "waiting for master to get ready"
+	wait_for_file_creation master.port 5
+
+	port=`cat master.port`
+
+	echo "starting worker"
+	work_queue_worker -d all -o worker.log localhost $port -b 1 --timeout 20 --cores $CORES --memory-threshold 10 --memory 50 --single-shot
+
+	echo "checking for output"
+	i=0
+	while [ $i -lt $TASKS ]
+	do
+		file=output.$i
+		if [ ! -f $file ]
+		then
+			echo "$file is missing!"
+
+			if [ -f master.log  ]
+			then
+				echo "master log:"
+				cat master.log
+			fi
+
+			if [ -f worker.log  ]
+			then
+				echo "worker log:"
+				cat worker.log
+			fi
+
+			return 1
+		fi
+		i=$((i+1))
+	done
+
+	echo "all output present"
+	return 0
+}
+
+clean()
+{
+	rm -f master.script master.log master.port worker.log output.* input.*
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:


### PR DESCRIPTION
This is a first pass at cleaning up the test suite to operate external to the build system.  I didn't convert all the tests in one pass, but did a handful to test the idea.  I'm attempting to minimize what each component knows about the whole system, so it ought to be possible to run the test suite on a build that came via pip, conda, spack, etc without knowing the config.mk that came out of that build.

Here is the idea:

1 - Each test operates independently and expects that the appropriate `PATH`, `PYTHONPATH`, etc has already been set to point to the target test installation.  The test only uses assets in the cwd and relies on binaries, etc already being in the path. If it needs to compile something, it uses `CCTOOLS_COMPILE` or `CCTOOLS_COMPILE_STDIN` to invoke the compiler appropriately.

2 - `test_runner_common.sh` expects only `CCTOOLS_INSTALL_DIR` to be set, and uses that to construct an appropriate `PATH`, `PYTHONPATH`, etc for each test.  `CCTOOLS_COMPILE` is defined to use `CCTOOLS_INSTALL_DIR` to find `include`, `lib`, etc.

3 - `run_all_tests.sh` does not attempt to parse `config.mk` but just relies on `CCTOOLS_INSTALL_DIR` being set, and then invokes all of the tests.  (Still need to pass in what subset of tests to run somehow.)

@btovar @trshaffer  does this seem like a sensible approach?
Anything missing here?
