### PR TITLE
Fix LOCAL in Parrot mountlist

### DIFF
--- a/parrot/src/pfs_dispatch.cc
+++ b/parrot/src/pfs_dispatch.cc
@@ -3675,6 +3675,7 @@ int pfs_dispatch_prepexe (struct pfs_process *p, char exe[PATH_MAX], const char 
 		case PFS_RESOLVE_CHANGED:
 			debug(D_DEBUG, "%s: interpreter %s resolve changed to %s", __func__, path, ldso_resolved_path);
 			break;
+		case PFS_RESOLVE_LOCAL:
 		case PFS_RESOLVE_UNCHANGED:
 			debug(D_DEBUG, "%s: interpreter %s resolve unchanged", __func__, path);
 			/* XXX This access skips mounts and other PFS redirections. */

--- a/parrot/src/pfs_resolve.c
+++ b/parrot/src/pfs_resolve.c
@@ -221,8 +221,7 @@ static pfs_resolve_t mount_entry_check( const char *logical_name, const char *pr
 		} else if(!strcmp(redirect,"ENOENT")) {
 			result = PFS_RESOLVE_ENOENT;
 		} else if(!strcmp(redirect,"LOCAL")) {
-			strcpy(physical_name,logical_name);
-			result = PFS_RESOLVE_CHANGED;
+			result = PFS_RESOLVE_LOCAL;
 		} else if(!strncmp(redirect,"resolver:",9)) {
 			result = pfs_resolve_external(logical_name,prefix,&redirect[9],physical_name);
 		} else if(!strncmp(redirect,"lcache:",7) &&
@@ -358,6 +357,7 @@ static pfs_resolve_t pfs_resolve_ns( struct pfs_mount_entry *ns, const char *log
 	}
 
 	switch(result) {
+		case PFS_RESOLVE_LOCAL:
 		case PFS_RESOLVE_UNCHANGED:
 			strcpy(physical_name,logical_name);
 			break;

--- a/parrot/src/pfs_resolve.h
+++ b/parrot/src/pfs_resolve.h
@@ -16,7 +16,8 @@ typedef enum {
 	PFS_RESOLVE_CHANGED,
 	PFS_RESOLVE_DENIED,
 	PFS_RESOLVE_ENOENT,
-	PFS_RESOLVE_FAILED
+	PFS_RESOLVE_FAILED,
+	PFS_RESOLVE_LOCAL,
 } pfs_resolve_t;
 
 struct pfs_mount_entry {

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -516,7 +516,9 @@ int pfs_table::resolve_name(int is_special_syscall, const char *cname, struct pf
 		char tmp[PFS_PATH_MAX];
 		path_split(pname->path,pname->service_name,tmp);
 		pname->service = pfs_service_lookup(pname->service_name);
-		if (result == PFS_RESOLVE_LOCAL) pname->service = NULL;
+		if (result == PFS_RESOLVE_LOCAL) {
+			pname->service = NULL;
+		}
 		if(!pname->service) {
 			pname->service = pfs_service_lookup_default();
 			strcpy(pname->service_name,"local");

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -516,6 +516,7 @@ int pfs_table::resolve_name(int is_special_syscall, const char *cname, struct pf
 		char tmp[PFS_PATH_MAX];
 		path_split(pname->path,pname->service_name,tmp);
 		pname->service = pfs_service_lookup(pname->service_name);
+		if (result == PFS_RESOLVE_LOCAL) pname->service = NULL;
 		if(!pname->service) {
 			pname->service = pfs_service_lookup_default();
 			strcpy(pname->service_name,"local");


### PR DESCRIPTION
The current path resolution code in Parrot seems to more or less ignore the `LOCAL` access control. This PR adds a new resolve outcome, `PFS_RESOLVE_LOCAL`, that causes subsequent opens to skip service lookup, forcing use of the local filesystem. Aside from that, this return code behaves almost the same as `PFS_RESOLVE_UNCHANGED`.

Fixes #2121 