### PR TITLE
Batch local /bin/sh

### DIFF
--- a/batch_job/src/batch_job_k8s.c
+++ b/batch_job/src/batch_job_k8s.c
@@ -311,7 +311,7 @@ static batch_job_id_t batch_job_k8s_submit (struct batch_queue *q, const char *c
 
 		char *job_id_str = string_format("%d", job_id);
 
-		execlp("/bin/bash", "bash", k8s_script_file_name, "create", pod_id, job_id_str, 
+		execlp("/bin/sh", "sh", k8s_script_file_name, "create", pod_id, job_id_str, 
 				extra_input_files, cmd, extra_output_files, (char *) NULL);
 		_exit(127);
 
@@ -359,7 +359,7 @@ static int batch_job_k8s_remove (struct batch_queue *q, batch_job_id_t jobid)
 
 		char *cmd = string_format("kubectl delete pods %s", pod_id);
 
-		execlp("/bin/bash", "bash", "-c", cmd, (char *) 0);
+		execlp("/bin/sh", "sh", "-c", cmd, (char *) 0);
 		_exit(errno);
 
     }
@@ -624,7 +624,7 @@ static batch_job_id_t batch_job_k8s_wait (struct batch_queue * q,
 
 					} else if (pid == 0) {
 
-						execlp("/bin/bash", "bash", k8s_script_file_name, "exec", curr_pod_id, curr_job_id, 
+						execlp("/bin/sh", "sh", k8s_script_file_name, "exec", curr_pod_id, curr_job_id, 
 								curr_k8s_job_info->extra_input_files, curr_k8s_job_info->cmd, 
 								curr_k8s_job_info->extra_output_files, (char *) NULL);
 						_exit(127);

--- a/batch_job/src/batch_job_local.c
+++ b/batch_job/src/batch_job_local.c
@@ -58,7 +58,7 @@ static batch_job_id_t batch_job_local_submit (struct batch_queue *q, const char 
 		 * bash which does not do this when invoked as sh.)
 		 */
 
-		execlp("sh", "sh", "-c", cmd, (char *) 0);
+		execlp("/bin/sh", "sh", "-c", cmd, (char *) 0);
 		_exit(127);	// Failed to execute the cmd.
 	}
 	return -1;

--- a/batch_job/src/batch_job_mpi.c
+++ b/batch_job/src/batch_job_mpi.c
@@ -486,7 +486,7 @@ void mpi_worker_handle_execute( struct jx *job )
 
 		const char *cmd = jx_lookup_string(job,"CMD");
 
-		execlp("sh", "sh", "-c", cmd, (char *) 0);
+		execlp("/bin/sh", "sh", "-c", cmd, (char *) 0);
 		debug(D_BATCH,"failed to execute: %s",strerror(errno));
 		_exit(127);
 	}

--- a/dttools/src/shell.c
+++ b/dttools/src/shell.c
@@ -39,7 +39,7 @@ static int execute (const char *cmd, const char * const env[], int in[2], int ou
 		CATCHUNIX(putenv((char *)env[i]));
 	}
 
-	CATCHUNIX(execlp("sh", "sh", "-c", cmd, NULL));
+	CATCHUNIX(execlp("/bin/sh", "sh", "-c", cmd, NULL));
 
 	rc = 0;
 	goto out;


### PR DESCRIPTION
Fixes a bug in which if PATH does not include /bin, batch_job_local cannot execute the job.

This may occur when a workflow sets the PATH variable in JX.