### PR TITLE
Perl Chirp test path update (Fix #2134)

### DIFF
--- a/chirp/test/TR_chirp_perl.sh
+++ b/chirp/test/TR_chirp_perl.sh
@@ -11,7 +11,7 @@ ticket=my.ticket
 
 check_needed()
 {
-	test -f ../src/perl/CChirp.so
+	test -f ../src/bindings/perl/CChirp.so
 	command -v openssl >/dev/null 2>&1
 }
 
@@ -31,7 +31,7 @@ run()
 
 	chirp -d all -a unix "$hostport" ticket_create -output "$ticket" -bits 1024 -duration 86400 -subject unix:`whoami` / write
 
-	../src/perl/chirp_perl_example.pl $hostport $ticket
+	../src/bindings/perl/chirp_perl_example.pl $hostport $ticket
 
 	return 0
 }


### PR DESCRIPTION
Changed paths in chirp/test/TR_chirp_perl.sh from `src/perl/` to `src/bindings/perl` as referenced in issue #2134.