### PR TITLE
Fix compilation for Chirp SWIG bindings for Python 3.7

### DIFF
--- a/chirp/src/bindings/python3/Makefile
+++ b/chirp/src/bindings/python3/Makefile
@@ -4,7 +4,7 @@ include $(CCTOOLS_HOME)/rules.mk
 # Python always uses 'so' for its modules (even on Darwin)
 CCTOOLS_DYNAMIC_SUFFIX = so
 # SWIG produces code that causes a lot of warnings, so use -w to turn those off.
-LOCAL_CCFLAGS = -fPIC -w $(CCTOOLS_PYTHON3_CCFLAGS)
+LOCAL_CCFLAGS = -fPIC -w -DNDEBUG $(CCTOOLS_PYTHON3_CCFLAGS)
 LOCAL_LINKAGE = $(CCTOOLS_PYTHON3_LDFLAGS) $(CCTOOLS_GLOBUS_LDFLAGS) $(CCTOOLS_EXTERNAL_LINKAGE)
 
 EXTERNAL_DEPENDENCIES = $(CCTOOLS_HOME)/chirp/src/libchirp.a $(CCTOOLS_HOME)/dttools/src/libdttools.a

--- a/configure.tools.sh
+++ b/configure.tools.sh
@@ -258,6 +258,12 @@ library_search_normal()
 			else
 				library_search_result="-l$1"
 			fi
+
+			if [ $BUILD_SYS = DARWIN ]
+			then
+				library_search_result="${library_search_result} -rpath $libdir"
+			fi
+
 			return 0
 		fi
 	fi


### PR DESCRIPTION
From a [thread](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/cctools-nd/lwt9A_EZJK4) on the mailing list, there are compilation errors on Python 3.7 using conda. I grabbed the fix in 3fd3826554c0c4dbc3a1a2425175c541ff07baab and put it on the Chirp bindings, and things seem to work.