### PR TITLE
Fix typo in makeflow manual on line 282

### DIFF
--- a/doc/makeflow.html
+++ b/doc/makeflow.html
@@ -279,7 +279,7 @@ running, complete, and so forth.  These tools can read the transaction
 log and summarize the workflow:
 
 <ol>
-<li> <tt>makeflow_monitor</tt> reads the transaction log and produceds a continuous
+<li> <tt>makeflow_monitor</tt> reads the transaction log and produces a continuous
 display that shows the overall time and progress through the workflow:
 <code>makeflow example.makeflow & makeflow_monitor example.makeflow.makeflowlog
 </code>


### PR DESCRIPTION
Corrected Typo in makeflow manual #2142: In /cctools/doc/makeflow.html on line 282, "produceds" should be "produces"