### PR TITLE
expand newlines, etc. in batch-options for condor/wq-factory

### DIFF
--- a/batch_job/src/batch_job_condor.c
+++ b/batch_job/src/batch_job_condor.c
@@ -176,8 +176,12 @@ static batch_job_id_t batch_job_condor_submit (struct batch_queue *q, const char
 			fprintf(file, "request_disk = %" PRId64 "\n", disk);
 	}
 
-	if(options)
-		fprintf(file, "%s\n", options);
+	if(options) {
+		char *opt_expanded = malloc(2 * strlen(options) + 1);
+		string_replace_backslash_codes(options, opt_expanded);
+		fprintf(file, "%s\n", opt_expanded);
+		free(opt_expanded);
+	}
 
 	fprintf(file, "queue\n");
 	fclose(file);


### PR DESCRIPTION
This allows to easily modify the condor submit file the factory uses.
E.g., as needed by mfrayer at Wisconsin:

work_queue_factory -T condor --batch-options="universe=docker\ndocker_image=debian" ...etc...