### PR TITLE
Compile work_queue_worker statically with travis

### DIFF
--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -160,7 +160,11 @@ HEADERS_PUBLIC = \
 	xxmalloc.h \
 
 LIBRARIES = libdttools.a
+
+ifneq ($(CCTOOLS_STATIC),1)
 PRELOAD_LIBRARIES = libforce_halt_enospc.so
+endif
+
 ifeq ($(CCTOOLS_CURL_AVAILABLE),yes)
 CCTOOLS_EXTERNAL_LINKAGE += $(CCTOOLS_CURL_LDFLAGS) -lssl -lcrypto
 SOURCES += s3_file_io.c

--- a/packaging/scripts/configure-from-image
+++ b/packaging/scripts/configure-from-image
@@ -27,7 +27,29 @@ done
 
 cd ${CCTOOLS_SRC}
 
+if [[ -d /opt/vc3/cctools-deps ]]
+then
+    # compile work_queue binaries statically
+    [[ -f config.mk ]] && make clean
+    CFLAGS=-D__MUSL__ CC=/opt/vc3/cctools-deps/musl/bin/musl-gcc LD=/opt/vc3/cctools-deps/musl/bin/musl-gcc ./configure --without-system-{doc,apps,chirp} --with-readline-path=no --static  --with-zlib-path=/opt/vc3/cctools-deps/musl-zlib "$@"
+    (cd dttools/src && make)
+    (cd work_queue/src && make)
+    (cp work_queue/src/work_queue_{worker,status,example} .)
+    STATIC_WORKER=1
+fi
+
+# compile everything
 ./configure --strict $DEP_ARGS "$@"
+[[ -f config.mk ]] && make clean
+make
+
+if [[ "${STATIC_WORKER}" = 1 ]]
+then
+    # set the static binaries for test and installation
+    mv work_queue_{worker,status,example} work_queue/src
+    touch work_queue/src/work_queue_{worker,status,example}
+fi
+
 make install
 make test
 

--- a/packaging/scripts/generate-images
+++ b/packaging/scripts/generate-images
@@ -62,6 +62,12 @@ my $builder = [
 	'chmod 755 ./vc3-builder',
 ];
 
+my $musl = [
+	'cd /opt/vc3/utils',
+	'./vc3-builder --make-jobs=4 --require musl -- ln -s \$VC3_ROOT_MUSL /opt/vc3/cctools-deps/musl',
+	'./vc3-builder --make-jobs=4 --require musl-zlib -- ln -s \$VC3_ROOT_MUSL_ZLIB /opt/vc3/cctools-deps/musl-zlib',
+];
+
 my $cvmfs = [
 	'cd /opt/vc3/utils',
 	'./vc3-builder --make-jobs=4 --require uuid -- ln -s \$VC3_ROOT_UUID /opt/vc3/cctools-deps/uuid',
@@ -163,6 +169,7 @@ libattr                  => 'libattr-devel',
 libffi                   => 'libffi',
 lsb_release              => 'lsb-release',
 m4                       => 'm4',
+musl					 => [],             # from builder
 mysql                    => [],             # from builder
 ncurses                  => 'ncurses-devel',
 openssl                  => ['openssl', 'openssl-devel'],
@@ -199,7 +206,7 @@ $preinstall_for{centos}{default} = [
 $postinstall_for{centos}{default} = [
 	'yum -y clean all',
 	@{$builder},
-	@{$swig},
+	@{$musl},
 	@{$fuse},
 	@{$e2fsprogs},
 	@{$cvmfs},
@@ -231,6 +238,7 @@ $preinstall_for{fedora}{default}  = [ ];
 
 $postinstall_for{fedora}{default} = [
 	@{$builder},
+	@{$musl},
 ];
 
 ########## debian ########## 
@@ -288,10 +296,10 @@ $postinstall_for{debian}{default} = [
 	'apt-get clean',
 
 	@{$builder},
+	@{$musl},
 	@{$fuse},
 	@{$cvmfs},
 	# do not compile with g++6:
-	# @{$swig},
 	# @{$irods},
 	# @{$xrootd}
 ];

--- a/packaging/scripts/generate-images
+++ b/packaging/scripts/generate-images
@@ -85,13 +85,6 @@ my $e2fsprogs = [
 ];
 
 
-# using builder to provide at least version 3.
-my $swig = [
-	'cd /opt/vc3/utils',
-	'./vc3-builder --make-jobs=4 --require swig -- ln -s \$VC3_ROOT_SWIG /opt/vc3/cctools-deps/swig',
-];
-
-
 # using builder to provide .a library
 my $mysql = [
 	'cd /opt/vc3/utils',
@@ -180,7 +173,7 @@ python                   => ['python-devel', 'python-setuptools', 'python-tools'
 python3					 => [],				# from epel
 readline                 => 'readline-devel',
 strace                   => 'strace',
-swig                     => [],  # version >= 3, from builder
+swig                     => 'swig',
 troff                    => 'groff',
 unzip                    => 'unzip',
 vim                      => 'vim',
@@ -273,7 +266,7 @@ pkg_config               => 'pkg-config',
 python                   => ['python-dev', 'python-setuptools'],
 python3                  => ['python3-dev', 'python3-setuptools'],
 readline                 => 'libreadline-dev',
-swig                     => ['swig'],  # not from builder, pcre does not compile with g++6
+swig                     => 'swig',
 strace                   => 'strace',
 troff                    => 'groff',
 unzip                    => 'unzip',


### PR DESCRIPTION
This pr modifies `packaging/scripts/configure-from-image` such that the `work_queue_worker` binary is compiled statically. This eases the deployment of workers across machines with the same architecture.

If this works as intended, we can follow a similar approach for compiling cctools with conda, such that workers do not depend on the conda environment's shared libraries.