### PR TITLE
Update install guide to include to Spack instructions.

### DIFF
--- a/doc/manuals/install/index.md
+++ b/doc/manuals/install/index.md
@@ -65,6 +65,8 @@ $ make install
 
 ## Install via Spack
 
+[Spack](https://spack.io/) is package manager that gives users the ability to build coexisting packages with multiple versions, configurations, platforms, and compilers, all on the same machine.
+
 To install the latest release of CCTools using Spack:
 
 ```sh

--- a/doc/manuals/install/index.md
+++ b/doc/manuals/install/index.md
@@ -63,6 +63,26 @@ $ make install
     Remember to export PATH, PYTHONPATH, and PERL5LIB accordingly.
 
 
+## Install via Spack
+
+To install the latest release of CCTools using Spack:
+
+```sh
+spack install cctools
+```
+
+Use the following command to locate the CCTools directory: 
+
+```sh
+spack find -p cctools 
+```
+
+Finally, update your PATH variable to point to the CCTools installation.
+
+```sh
+export PATH=$PATH:<PATH_TO_CCTOOLS>/bin
+```
+
 ## Install From Git Repository
 
 Instead of installing from the source of the current released version, you can


### PR DESCRIPTION
Updated install instructions to include steps for installing CCTools via Spack for part of Issue #2164.