### PR TITLE
Install perl modules where conda wants them.

### DIFF
--- a/chirp/src/bindings/perl/Makefile
+++ b/chirp/src/bindings/perl/Makefile
@@ -1,8 +1,6 @@
 include ../../../../config.mk
 include $(CCTOOLS_HOME)/rules.mk
 
-PERL_INSTALL_DIR = $(CCTOOLS_INSTALL_DIR)/lib/perl5/site_perl/$(CCTOOLS_PERL_VERSION)
-
 # SWIG produces code that causes a lot of warnings, so use -w to turn those off.
 # Perl also defines some HAS_* stuff so we need to undefine those too.
 LOCAL_CCFLAGS = -w -UHAS_USLEEP -UHAS_ISNAN -UHAS_UTIME -fPIC -Wno-unused-value -Wno-unused-variable $(CCTOOLS_PERL_CCFLAGS)
@@ -28,11 +26,10 @@ clean:
 test: all
 
 install: all
-	mkdir -p $(PERL_INSTALL_DIR)
-	cp $(LIBRARIES)       $(PERL_INSTALL_DIR)/
-	mkdir -p              $(PERL_INSTALL_DIR)/Chirp
-	cp Chirp/Client.pm $(PERL_INSTALL_DIR)/Chirp
-	cp Chirp/Stat.pm   $(PERL_INSTALL_DIR)/Chirp
+	mkdir -p $(CCTOOLS_PERL_PATH)/Chirp
+	cp $(LIBRARIES)       $(CCTOOLS_PERL_PATH)/
+	cp Chirp/Client.pm $(CCTOOLS_PERL_PATH)/Chirp
+	cp Chirp/Stat.pm   $(CCTOOLS_PERL_PATH)/Chirp
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc
 	chmod 755 chirp_perl_example.pl
 	cp chirp_perl_example.pl $(CCTOOLS_INSTALL_DIR)/doc/

--- a/configure
+++ b/configure
@@ -1022,6 +1022,13 @@ then
 				# Remove -lperl, as it is not needed for swig, and it causes trouble if libperl is not compiled with -fPIC, as in conda.
 				perl_ldflags=`echo ${perl_ldflags} | sed 's/-lperl//g'`
 
+				if [ "${CONDA_BUILD}" = 1 ]
+				then
+					perl_install_dir="site_perl"
+				else
+					perl_install_dir="perl5/site_perl"
+				fi
+
 				swig_bindings="$swig_bindings perl"
 			else
 				perl=0
@@ -1688,6 +1695,7 @@ CCTOOLS_PERL=${perl}
 CCTOOLS_PERL_CCFLAGS=${perl_ccflags}
 CCTOOLS_PERL_LDFLAGS=${perl_ldflags}
 CCTOOLS_PERL_VERSION=${perl_version}
+CCTOOLS_PERL_PATH=\$(CCTOOLS_INSTALL_DIR)/lib/${perl_install_dir}/\$(CCTOOLS_PERL_VERSION)
 
 CCTOOLS_PYTHON=\$(CCTOOLS_PYTHON2)
 CCTOOLS_PYTHON_CCFLAGS=\$(CCTOOLS_PYTHON2_CCFLAGS)

--- a/work_queue/src/bindings/perl/Makefile
+++ b/work_queue/src/bindings/perl/Makefile
@@ -1,8 +1,6 @@
 include ../../../../config.mk
 include $(CCTOOLS_HOME)/rules.mk
 
-PERL_INSTALL_DIR = $(CCTOOLS_INSTALL_DIR)/lib/perl5/site_perl/$(CCTOOLS_PERL_VERSION)
-
 # SWIG produces code that causes a lot of warnings, so use -w to turn those off.
 # Perl also defines some HAS_* stuff so we need to undefine those too.
 LOCAL_CCFLAGS = -w -UHAS_USLEEP -UHAS_ISNAN -UHAS_UTIME -fPIC -Wno-unused-value -Wno-unused-variable $(CCTOOLS_PERL_CCFLAGS)
@@ -28,11 +26,10 @@ clean:
 test: all
 
 install: all
-	mkdir -p $(PERL_INSTALL_DIR)
-	cp $(LIBRARIES)       $(PERL_INSTALL_DIR)/
-	mkdir -p              $(PERL_INSTALL_DIR)/Work_Queue
-	cp Work_Queue.pm      $(PERL_INSTALL_DIR)
-	cp Work_Queue/Task.pm $(PERL_INSTALL_DIR)/Work_Queue
+	mkdir -p $(CCTOOLS_PERL_PATH)/Work_Queue
+	cp $(LIBRARIES)       $(CCTOOLS_PERL_PATH)/
+	cp Work_Queue.pm      $(CCTOOLS_PERL_PATH)
+	cp Work_Queue/Task.pm $(CCTOOLS_PERL_PATH)/Work_Queue
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc
 	chmod 755 work_queue_example.pl
 	cp work_queue_example.pl $(CCTOOLS_INSTALL_DIR)/doc/


### PR DESCRIPTION
This eliminates the need of setting PERL5LIB.