### PR TITLE
wq factory: add --run-factory-as-master

### DIFF
--- a/doc/man/m4/work_queue_factory.m4
+++ b/doc/man/m4/work_queue_factory.m4
@@ -82,6 +82,7 @@ OPTION_TRIPLET(-o,debug-file,file)Send debugging to this file (can also be :stde
 OPTION_TRIPLET(-O,debug-file-size,mb)Specify the size of the debug file (must use with -o option).
 OPTION_PAIR(--worker-binary,file)Specify the binary to use for the worker (relative or hard path). It should accept the same arguments as the default work_queue_worker.
 OPTION_PAIR(--runos,img)Will make a best attempt to ensure the worker will execute in the specified OS environment, regardless of the underlying OS.
+OPTION_ITEM(--run-factory-as-master)Force factory to run itself as a work queue master.
 OPTION_ITEM(`-v, --version')Show the version string.
 OPTION_ITEM(`-h, --help')Show this screen.
 OPTIONS_END

--- a/doc/man/md/work_queue_factory.md
+++ b/doc/man/md/work_queue_factory.md
@@ -104,6 +104,7 @@ remove all running workers before exiting.
 - **-O --debug-file-size <mb>** Specify the size of the debug file (must use with -o option).
 - **--worker-binary file** Specify the binary to use for the worker (relative or hard path). It should accept the same arguments as the default work_queue_worker.
 - **--runos img** Will make a best attempt to ensure the worker will execute in the specified OS environment, regardless of the underlying OS.
+- **--run-factory-as-master** Force factory to run itself as a work queue master.
 - **-v, --version** Show the version string.
 - **-h, --help** Show this screen.
 


### PR DESCRIPTION
Forces the factory to run as a work queue master when -Twq is specified.

It can only be used with -Twq.

If only one of -Twq or --run-factory-as-master is given, the factory
terminates, and the user is adviced to use -Tlocal instead.

Fix for #2190 