### PR TITLE
do not require c++ in configure

### DIFF
--- a/configure
+++ b/configure
@@ -387,8 +387,14 @@ export HOST_MULTIARCH=$(check_multiarch)
 rm -f config.mk
 
 require_path ${ccompiler}
-require_path ${cxxcompiler}
 require_gnu_make
+
+if ! optional_path ${cxxcompiler}
+then
+	echo "*** could not find a C++ compiler, skipping parrot support"
+	include_package_parrot=""
+fi
+
 
 # Lots of warnings are enabled by default, but several are too strict
 # and crop up in third-party code, so we disable those checks.

--- a/configure.tools.sh
+++ b/configure.tools.sh
@@ -178,9 +178,19 @@ require_file ()
 	fi
 }
 
-require_path ()
+optional_path ()
 {
 	if check_path $1
+	then
+		return 0
+	else
+		return 1
+	fi
+}
+
+require_path ()
+{
+	if optional_path $1
 	then
 		return 0
 	else


### PR DESCRIPTION
Instead of requiring c++, parrot is disabled.