### PR TITLE
Change pydoc search.

### DIFF
--- a/configure
+++ b/configure
@@ -1057,6 +1057,7 @@ then
 	fi
 fi
 
+PYDOC=""
 python=0    #to be set to the python path
 if [ $config_python_path != no ]
 then
@@ -1064,12 +1065,39 @@ then
 	if [ -n "$PYTHON" ] && check_file ${PYTHON}
 	then
 		python=${PYTHON}
+		python_dir=`dirname ${PYTHON}`
+		python_cmd=`basename ${PYTHON}`
+		pydoc_cmd=`echo $python_cmd | sed s/python/pydoc/`
+		pydoc2_cmd=`echo $python_cmd | sed s/python/pydoc2/`
+		pydoc=${python_dir}/${pydoc_cmd}
+		pydoc2=${python_dir}/${pydoc2_cmd}
+		if check_file $pydoc
+		then
+		    PYDOC=$pydoc
+		elif check_file $pydoc2
+		then
+		    PYDOC=$pydoc2
+		fi
 	elif check_file ${python_path}/bin/python2
 	then
 		python=${python_path}/bin/python2
+		if check_file ${python_path}/bin/pydoc
+		then
+		    PYDOC=${python_path}/bin/pydoc
+		elif check_file ${python_path}/bin/pydoc2
+		then
+		    PYDOC=${python_path}/bin/pydoc2
+		fi
 	elif check_file ${python_path}/bin/python
 	then
 		python=${python_path}/bin/python
+		if check_file ${python_path}/bin/pydoc
+		then
+		    PYDOC=${python_path}/bin/pydoc
+		elif check_file ${python_path}/bin/pydoc2
+		then
+		    PYDOC=${python_path}/bin/pydoc2
+		fi
 	else
 		python=0
 	fi
@@ -1159,12 +1187,48 @@ then
 	if [ -n "$PYTHON3" ] && check_file ${PYTHON3}
 	then
 		python3=${PYTHON3}
+		if [ "$PYDOC" = "" ]
+		then
+			python_dir=`dirname ${PYTHON3}`
+			python_cmd=`basename ${PYTHON3}`
+			pydoc_cmd=`echo $python_cmd | sed s/python/pydoc/`
+			pydoc3_cmd=`echo $python_cmd | sed s/python/pydoc3/`
+			pydoc=${python_dir}/${pydoc_cmd}
+			pydoc3=${python_dir}/${pydoc3_cmd}
+		    if check_file $pydoc
+		    then
+		        PYDOC=$pydoc
+		    elif heck_file $pydoc3
+		    then
+		        PYDOC=$pydoc3
+		    fi
+	    fi
 	elif check_file ${python3_path}/bin/python3
 	then
 		python3=${python3_path}/bin/python3
+		if [ "$PYDOC" = "" ]
+		then
+			if check_file ${python3_path}/bin/pydoc
+			then
+				PYDOC=${python3_path}/bin/pydoc
+			elif check_file ${python3_path}/bin/pydoc3
+			then
+				PYDOC=${python3_path}/bin/pydoc3
+			fi
+		fi
 	elif check_file ${python3_path}/bin/python
 	then
 		python3=${python3_path}/bin/python
+		if [ "$PYDOC" = "" ]
+		then
+			if check_file ${python3_path}/bin/pydoc
+			then
+				PYDOC=${python3_path}/bin/pydoc
+			elif check_file ${python3_path}/bin/pydoc3
+			then
+				PYDOC=${python3_path}/bin/pydoc3
+			fi
+		fi
 	else
 		python3=0
 	fi
@@ -1722,7 +1786,7 @@ CCTOOLS_PYTHON3_VERSION=${python3_major_version}.${python3_minor_version}
 CCTOOLS_PYTHON3_2TO3=${python3_2to3}
 CCTOOLS_PYTHON3_PATH=\$(CCTOOLS_INSTALL_DIR)/lib/python\$(CCTOOLS_PYTHON3_VERSION)/site-packages
 
-CCTOOLS_PYDOC=$(which pydoc 2> /dev/null || which pydoc2 2> /dev/null || which pydoc3 > /dev/null)
+CCTOOLS_PYDOC=${PYDOC}
 
 CCTOOLS_SGE_PARAMETERS=$(echo ${sge_parameters} | sed -e 's/\$/\\\$\$/g')
 


### PR DESCRIPTION
pydoc is faiied when wrong PYTHONHOME environment variable is found.
```
$ PYTHONHOME=/tmp pydoc -w umbrella
ImportError: No module named site
```
This PR search pydoc in python install directory (expected to match PYTHONHOME ).