### PR TITLE
Fix segfault in makeflow_{viz,analyze} with --jx-args

### DIFF
--- a/makeflow/src/makeflow_analyze.c
+++ b/makeflow/src/makeflow_analyze.c
@@ -285,7 +285,8 @@ int main(int argc, char *argv[])
 				break;
 			case LONG_OPT_JX_ARGS:
 				dag_syntax = DAG_SYNTAX_JX;
-				if(!jx_parse_cmd_args(jx_args, optarg))
+				jx_args = jx_parse_cmd_args(jx_args, optarg);
+				if(!jx_args)
 					fatal("Failed to parse in JX Args File.\n");
 				break;
 			case LONG_OPT_JX_DEFINE:

--- a/makeflow/src/makeflow_viz.c
+++ b/makeflow/src/makeflow_viz.c
@@ -238,7 +238,8 @@ int main(int argc, char *argv[])
 				break;
 			case LONG_OPT_JX_ARGS:
 				dag_syntax = DAG_SYNTAX_JX;
-				if(!jx_parse_cmd_args(jx_args, optarg))
+				jx_args = jx_parse_cmd_args(jx_args, optarg);
+				if(!jx_args)
 					fatal("Failed to parse in JX Args File.\n");
 				break;
 			case LONG_OPT_JX_DEFINE:


### PR DESCRIPTION
The problem was that the result of jx_parse_cmd_args was not being
reassigned to jx_args. Eventually this would lead to a double free.