### PR TITLE
make umbrella and its documentation really optional

### DIFF
--- a/configure
+++ b/configure
@@ -1260,7 +1260,6 @@ then
 	echo "python version is suitable for prune"
 	echo "python version is suitable for weaver"
 else
-	packages=`echo ${packages} | sed 's/umbrella//g'`
 	echo "prune requires python >= 2.6"
 	packages=`echo ${packages} | sed 's/prune//g'`
 	echo "weaver requires python >= 2.6"
@@ -1271,6 +1270,7 @@ if [ "$python" = 0 -o "$python3" = 0 ]
 then
 	echo "python version is suitable for umbrella"
 else
+	packages=`echo ${packages} | sed 's/umbrella//g'`
 	echo "umbrella requires python >= 2.6"
 fi
 

--- a/umbrella/src/Makefile
+++ b/umbrella/src/Makefile
@@ -15,9 +15,7 @@ umbrella: umbrella.py
 	chmod 755 umbrella
 
 umbrella_helper.html: umbrella.py
-	# pydoc creates a html file, umbrella.html.
-	if [ -x "${CCTOOLS_PYDOC}" ]; then ${CCTOOLS_PYDOC} -w umbrella; fi
-	if [ -f umbrella.html ]; then mv umbrella.html umbrella_helper.html; fi
+	@if $(CCTOOLS_PYDOC) -w umbrella > /dev/null 2>&1; then mv umbrella.html umbrella_helper.html; else echo Could not create $@; fi
 
 clean:
 	rm -f $(OBJECTS) $(TARGETS)


### PR DESCRIPTION
The pr #2211 brought attention to the fact that the umbrella documentation was not optional.  This pr makes it so that if the documentation for umbrella cannot be build, then the installation does not fail.

In the very near future we should do something in the spirit of #2211, and detect the pydoc corresponding to the correct python environment. I would like to this using python itself, rather than what we currently do, which is manipulating names for a command line which will eventually break.