### PR TITLE
Always remove temporary jx args files

### DIFF
--- a/makeflow/src/dag_node.c
+++ b/makeflow/src/dag_node.c
@@ -60,6 +60,10 @@ struct dag_node *dag_node_create(struct dag *d, int linenum)
 
 	n->resource_request = CATEGORY_ALLOCATION_FIRST;
 
+	// arguments for subworkflow nodes
+	n->workflow_args = NULL;
+	n->workflow_args_file = NULL;
+
 	return n;
 }
 
@@ -83,6 +87,10 @@ void dag_node_delete(struct dag_node *n)
 	if(n->resources_measured)
 		rmsummary_delete(n->resources_measured);
 
+
+	jx_delete(n->workflow_args);
+	free(n->workflow_args_file);
+
 	free(n);
 }
 
@@ -104,8 +112,16 @@ void dag_node_set_workflow(struct dag_node *n, const char *dag, struct jx * args
 
 	n->type = DAG_NODE_TYPE_WORKFLOW;
 	n->workflow_file = xxstrdup(dag);
-	n->workflow_args = jx_copy(args);
 	n->workflow_is_jx = is_jx;
+
+	n->workflow_args = jx_copy(args);
+	if(n->workflow_args) {
+		n->workflow_args_file = string_format("makeflow.jx.args.XXXXXX");
+		int fd = mkstemp(n->workflow_args_file);
+		FILE *argsfile = fdopen(fd,"w");
+		jx_print_stream(n->workflow_args,argsfile);
+		fclose(argsfile);
+	}
 
 	/* Record a placeholder in the command field */
 	/* A usable command will be created at submit time. */

--- a/makeflow/src/dag_node.h
+++ b/makeflow/src/dag_node.h
@@ -53,6 +53,7 @@ struct dag_node {
 
 	const char *workflow_file;  /* Name of the sub-makeflow to run, if type is WORKFLOW */
 	struct jx *workflow_args;   /* Arguments to pass to the workflow. */
+	char *workflow_args_file;   /* Automatically generated temporary file to write workflow_args to disc. */
 	int workflow_is_jx;	    /* True is sub-workflow is jx, false otherwise. */
 
 	struct itable *remote_names;        /* Mapping from struct *dag_files to remotenames (char *) */

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -213,18 +213,12 @@ struct batch_task *makeflow_node_to_task(struct dag_node *n, struct batch_queue 
 		/* Generate the workflow arguments file */
 
 		if(n->workflow_args) {
-			char args[] = "makeflow.jx.args.XXXXXX";
-			int fd = mkstemp(args);
-			FILE *argsfile = fdopen(fd,"w");
-			jx_print_stream(n->workflow_args,argsfile);
-			fclose(argsfile);
-
 			oldcmd = cmd;
-			cmd = string_format("%s --jx-args %s",cmd,args);
+			cmd = string_format("%s --jx-args %s",cmd,n->workflow_args_file);
 			free(oldcmd);
 
 			/* Define this file as a temp so it is removed on completion. */
-			makeflow_hook_add_input_file(n->d,task,args,args,DAG_FILE_TYPE_TEMP);
+			makeflow_hook_add_input_file(n->d,task,n->workflow_args_file,n->workflow_args_file,DAG_FILE_TYPE_TEMP);
 		}
 
 		/* Add resource controls to the sub-workflow, if known. */

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -2427,6 +2427,19 @@ EXIT_WITH_FAILURE:
 		exit_value = EXIT_SUCCESS;
 	}
 
+	/* delete all jx args files. We do this here are some of these files may be created in clean mode. */
+	{
+		struct dag_node *n;
+		uint64_t key;
+		itable_firstkey(d->node_table);
+		while(itable_nextkey(d->node_table, &key, (void **) &n)) {
+			if(n->workflow_args_file) {
+				debug(D_MAKEFLOW_RUN, "deleting tmp file: %s\n", n->workflow_args_file);
+				unlink(n->workflow_args_file);
+			}
+		}
+	}
+
 	makeflow_hook_destroy(d);
 
 	/* Batch queues are removed after hooks are destroyed to allow for file clean up on related files. */


### PR DESCRIPTION
Fix for #2185. Ensure that the files created while parsing are always deleted.