### PR TITLE
Disable perl bindings in OSX

### DIFF
--- a/packaging/scripts/configure-from-image
+++ b/packaging/scripts/configure-from-image
@@ -38,8 +38,15 @@ then
     STATIC_WORKER=1
 fi
 
+# disable perl bindings in osx (to compile as we do in conda)
+perl_option=''
+if [[ "${TRAVIS_OS_NAME}" = osx ]]
+then
+    perl_option='--with-perl-path no'
+fi
+
 # compile everything
-./configure --strict $DEP_ARGS "$@"
+./configure --strict $DEP_ARGS ${perl_option} "$@"
 [[ -f config.mk ]] && make clean
 make
 


### PR DESCRIPTION
This matches how we compile things for conda. In conda we disabled it because in OSX libperl is needed for produce the bindings, but the libperl provided cannot be linked against. Recent changes to the osx travis images also have this issue.