### PR TITLE
Warn when worker workspace on noexec filesystem

### DIFF
--- a/dttools/src/host_disk_info.c
+++ b/dttools/src/host_disk_info.c
@@ -16,18 +16,6 @@ See the file COPYING for details.
 #include <sys/param.h>
 #include <sys/mount.h>
 
-#ifdef HAS_SYS_STATFS_H
-#include <sys/statfs.h>
-#endif
-
-#ifdef HAS_SYS_STATVFS_H
-#include <sys/statvfs.h>
-#endif
-
-#ifdef HAS_SYS_VFS_H
-#include <sys/vfs.h>
-#endif
-
 int host_disk_info_get(const char *path, UINT64_T * avail, UINT64_T * total)
 {
 #ifdef CCTOOLS_OPSYS_SUNOS

--- a/dttools/src/host_disk_info.c
+++ b/dttools/src/host_disk_info.c
@@ -78,6 +78,24 @@ int check_disk_space_for_filesize(char *path, int64_t file_size, uint64_t disk_a
 	return 1;
 }
 
+int check_disk_flags(const char *path, unsigned int flags) {
+#ifdef CCTOOLS_OPSYS_SUNOS
+	/* for sunos assume always true. */
+	return 1;
+#else
+	int result;
+	struct statfs s;
+
+	result = statfs(path, &s);
+	if(result < 0) {
+		/* on error, assume false */
+		return 0;
+	}
+
+	return (s.f_flags & flags) == flags;
+#endif
+}
+
 
 
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/host_disk_info.h
+++ b/dttools/src/host_disk_info.h
@@ -8,6 +8,19 @@ See the file COPYING for details.
 #ifndef DISK_INFO_H
 #define DISK_INFO_H
 
+#ifdef HAS_SYS_STATFS_H
+#include <sys/statfs.h>
+#endif
+
+#ifdef HAS_SYS_STATVFS_H
+#include <sys/statvfs.h>
+#endif
+
+#ifdef HAS_SYS_VFS_H
+#include <sys/vfs.h>
+#endif
+
+
 #include "int_sizes.h"
 #include <time.h>
 

--- a/dttools/src/host_disk_info.h
+++ b/dttools/src/host_disk_info.h
@@ -31,4 +31,13 @@ int host_disk_info_get(const char *path, UINT64_T * avail, UINT64_T * total);
 */
 int check_disk_space_for_filesize(char *path, INT64_T file_size, UINT64_T disk_avail_threshold);
 
+
+/** Return whether the file system where path resides was mounted with particular flags.
+@param path A filename of the disk to be measured.
+@param flags Mount flags to test, such as (ST_NOEXEC | ST_RDONLY). For valid flags see statfs(2).
+@return 0 if at least one mount flag is not set, otherwise 1.
+*/
+
+int check_disk_flags(const char *path, unsigned int flags);
+
 #endif

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1580,6 +1580,31 @@ static void fetch_output_from_worker(struct work_queue *q, struct work_queue_wor
 		}
 	}
 
+	/* print warnings if the task ran for a very short time (1s) and exited with common non-zero status */
+	if(t->result == WORK_QUEUE_RESULT_SUCCESS && t->time_workers_execute_last < 1000000) {
+		switch(t->return_status) {
+			case(126):
+				warn(D_WQ, "Task %d ran for a very short time and exited with code %d.\n", t->taskid, t->return_status);
+				warn(D_WQ, "This usually means that the task's command is not an executable,\n");
+				warn(D_WQ, "or that the worker's scratch directory is on a no-exec partition.\n");
+				break;
+			case(127):
+				warn(D_WQ, "Task %d ran for a very short time and exited with code %d.\n", t->taskid, t->return_status);
+				warn(D_WQ, "This usually means that the task's command could not be found, or that\n");
+				warn(D_WQ, "it uses a shared library not available at the worker, or that\n");
+				warn(D_WQ, "it uses a version of the glibc different than the one at the worker.\n");
+				break;
+			case(139):
+				warn(D_WQ, "Task %d ran for a very short time and exited with code %d.\n", t->taskid, t->return_status);
+				warn(D_WQ, "This usually means that the task's command had a segmentation fault,\n");
+				warn(D_WQ, "either because it has a memory access error (segfault), or because\n");
+				warn(D_WQ, "it uses a version of a shared library different from the one at the worker.\n");
+				break;
+			default:
+				break;
+		}
+	}
+
 	add_task_report(q, t);
 	debug(D_WQ, "%s (%s) done in %.02lfs total tasks %lld average %.02lfs",
 			w->hostname,

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1814,6 +1814,15 @@ static int workspace_create() {
 	}
 
 	printf( "work_queue_worker: creating workspace %s\n", workspace);
+
+#ifdef ST_NOEXEC
+	if(check_disk_flags(workdir, ST_NOEXEC)) {
+		warn(D_NOTICE, "Workspace directory '%s' is on a filesystem mounted as 'noexec'.\n", workspace);
+		warn(D_NOTICE, "Unless the task command is an absolute path, the task will fail with exit status 126.\n");
+		warn(D_NOTICE, "Use the --workdir command line switch to change where the workspace is created.\n");
+	}
+#endif
+
 	if(!create_dir(workspace,0777)) {
 		return 0;
 	}


### PR DESCRIPTION
Related to issue #2229.

I opted for simply warn rather than terminating the worker as command absolute paths would work when workspace is on a noexec filesystem.

@annawoodard, thanks again for debugging this issue for us!
