### PR TITLE
Correct work queue status of task when monitor summary not available

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1414,6 +1414,10 @@ void read_measured_resources(struct work_queue *q, struct work_queue_task *t) {
 	if(t->resources_measured) {
 		rmsummary_assign_char_field(t->resources_measured, "category", t->category);
 		t->return_status = t->resources_measured->exit_status;
+	} else {
+		/* if no resources were measured, then we don't overwrite the return
+		 * status, and mark the task as with error from monitoring. */
+			update_task_result(t, WORK_QUEUE_RESULT_RMONITOR_ERROR);
 	}
 
 	free(summary);

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -67,7 +67,8 @@ typedef enum {
 	WORK_QUEUE_RESULT_FORSAKEN            = 5 << 3, /**< The task failed, but it was not a task error **/
 	WORK_QUEUE_RESULT_MAX_RETRIES         = 6 << 3, /**< The task could not be completed successfully in the given number of retries. **/
 	WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME   = 7 << 3, /**< The task ran for more than the specified time (relative since running in a worker). **/
-	WORK_QUEUE_RESULT_DISK_ALLOC_FULL     = 8 << 3  /**< The task filled its loop device allocation but needed more space. **/
+	WORK_QUEUE_RESULT_DISK_ALLOC_FULL     = 8 << 3, /**< The task filled its loop device allocation but needed more space. **/
+	WORK_QUEUE_RESULT_RMONITOR_ERROR      = 9 << 3  /**< The task failed because the monitor did not produce a summary report. **/
 } work_queue_result_t;
 
 typedef enum {


### PR DESCRIPTION
Related to #2229.

When the resource monitor failed to execute, the task was marked with return status 0. This should be really considered as an internal work queue error.