### PR TITLE
Remove unused os checks

### DIFF
--- a/chirp/src/chirp_alloc.c
+++ b/chirp/src/chirp_alloc.c
@@ -302,9 +302,6 @@ int chirp_alloc_init(INT64_T size)
 	} else if (cfs->lockf(-1, F_TEST, 0) == -1 && errno == ENOSYS) {
 		return -1;
 	}
-#ifdef CCTOOLS_OPSYS_CYGWIN
-	fatal("sorry, CYGWIN cannot employ space allocation because it does not support file locking.");
-#endif
 
 	alloc_enabled = 1;
 	recovery_in_progress = 1;

--- a/chirp/src/chirp_benchmark.c
+++ b/chirp/src/chirp_benchmark.c
@@ -15,9 +15,6 @@ See the file COPYING for details.
 #include <unistd.h>
 
 #include <sys/stat.h>
-#ifndef CCTOOLS_OPSYS_CYGWIN
-#include <sys/syscall.h>
-#endif
 #include <sys/time.h>
 
 #include <errno.h>

--- a/chirp/src/chirp_fs_local.c
+++ b/chirp/src/chirp_fs_local.c
@@ -53,12 +53,6 @@ See the file COPYING for details.
 #	define statfs64 statfs
 #	define fstatfs64 fstatfs
 #	define fstatat64 fstatat
-#elif defined(CCTOOLS_OPSYS_SUNOS)
-	/* Solaris has statfs, but it doesn't work! Use statvfs instead. */
-#	define statfs statvfs
-#	define fstatfs fstatvfs
-#	define statfs64 statvfs64
-#	define fstatfs64 fstatvfs64
 #endif
 
 #ifndef O_CLOEXEC
@@ -91,22 +85,7 @@ See the file COPYING for details.
 		cinfop->cst_ctime = linfop->st_ctime;\
 	} while (0)
 
-#ifdef CCTOOLS_OPSYS_SUNOS
-#	define COPY_STATFS_LOCAL_TO_CHIRP(cinfo,linfo) \
-	do {\
-		struct chirp_statfs *cinfop = &(cinfo);\
-		struct statfs64 *linfop = &(linfo);\
-		memset(cinfop, 0, sizeof(struct chirp_statfs));\
-		cinfop->f_type = linfop->f_fsid;\
-		cinfop->f_bsize = linfop->f_frsize;\
-		cinfop->f_blocks = linfop->f_blocks;\
-		cinfop->f_bavail = linfop->f_bavail;\
-		cinfop->f_bfree = linfop->f_bfree;\
-		cinfop->f_files = linfop->f_files;\
-		cinfop->f_ffree = linfop->f_ffree;\
-	} while (0)
-#else
-#	define COPY_STATFS_LOCAL_TO_CHIRP(cinfo,linfo) \
+#define COPY_STATFS_LOCAL_TO_CHIRP(cinfo,linfo) \
 	do {\
 		struct chirp_statfs *cinfop = &(cinfo);\
 		struct statfs64 *linfop = &(linfo);\
@@ -119,7 +98,6 @@ See the file COPYING for details.
 		cinfop->f_files = linfop->f_files;\
 		cinfop->f_ffree = linfop->f_ffree;\
 	} while (0)
-#endif
 
 static int rootfd = -1;
 

--- a/chirp/src/chirp_fs_local.c
+++ b/chirp/src/chirp_fs_local.c
@@ -45,8 +45,8 @@ See the file COPYING for details.
 #include <stdlib.h>
 #include <string.h>
 
-#if CCTOOLS_OPSYS_CYGWIN || CCTOOLS_OPSYS_DARWIN || CCTOOLS_OPSYS_FREEBSD || CCTOOLS_OPSYS_DRAGONFLY
-	/* Cygwin does not have 64-bit I/O, while FreeBSD/Darwin has it by default. */
+#ifdef CCTOOLS_OPSYS_DARWIN
+/* Darwin has 64-bit I/O by default */
 #	define stat64 stat
 #	define fstat64 fstat
 #	define ftruncate64 ftruncate

--- a/chirp/src/chirp_put.c
+++ b/chirp/src/chirp_put.c
@@ -26,7 +26,7 @@ See the file COPYING for details.
 #include "full_io.h"
 #include "getopt_aux.h"
 
-#if CCTOOLS_OPSYS_CYGWIN || CCTOOLS_OPSYS_DARWIN || CCTOOLS_OPSYS_FREEBSD
+#ifdef CCTOOLS_OPSYS_DARWIN
 #define fopen64 fopen
 #define open64 open
 #define lseek64 lseek

--- a/chirp/src/chirp_recursive.c
+++ b/chirp/src/chirp_recursive.c
@@ -18,7 +18,7 @@ See the file COPYING for details.
 #include <sys/stat.h>
 #include <dirent.h>
 
-#if CCTOOLS_OPSYS_CYGWIN || CCTOOLS_OPSYS_DARWIN || CCTOOLS_OPSYS_FREEBSD || CCTOOLS_OPSYS_DRAGONFLY
+#ifdef CCTOOLS_OPSYS_DARWIN
 #define fopen64 fopen
 #define open64 open
 #define lseek64 lseek

--- a/chirp/src/chirp_tool.c
+++ b/chirp/src/chirp_tool.c
@@ -43,7 +43,7 @@ See the file COPYING for details.
 #include <stdlib.h>
 #include <string.h>
 
-#if CCTOOLS_OPSYS_CYGWIN || CCTOOLS_OPSYS_DARWIN || CCTOOLS_OPSYS_FREEBSD
+#ifdef CCTOOLS_OPSYS_DARWIN
 #define fopen64 fopen
 #define open64 open
 #define lseek64 lseek

--- a/chirp/src/confuga.c
+++ b/chirp/src/confuga.c
@@ -44,9 +44,6 @@ See the file COPYING for details.
 #	include <sys/mount.h>
 #	include <sys/param.h>
 #	define statfs64 statfs
-#elif CCTOOLS_OPSYS_SUNOS
-#	define statfs statvfs
-#	define statfs64 statvfs64
 #endif
 
 #include <assert.h>
@@ -63,12 +60,6 @@ See the file COPYING for details.
 #	define statfs64 statfs
 #	define fstatfs64 fstatfs
 #	define fstatat64 fstatat
-#elif defined(CCTOOLS_OPSYS_SUNOS)
-	/* Solaris has statfs, but it doesn't work! Use statvfs instead. */
-#	define statfs statvfs
-#	define fstatfs fstatvfs
-#	define statfs64 statvfs64
-#	define fstatfs64 fstatvfs64
 #endif
 
 #define TICKET_REFRESH (6*60*60)

--- a/chirp/src/confuga.c
+++ b/chirp/src/confuga.c
@@ -40,7 +40,7 @@ See the file COPYING for details.
 #ifdef HAS_SYS_STATVFS_H
 #	include <sys/statvfs.h>
 #endif
-#if CCTOOLS_OPSYS_CYGWIN || CCTOOLS_OPSYS_DARWIN || CCTOOLS_OPSYS_FREEBSD
+#ifdef CCTOOLS_OPSYS_DARWIN
 #	include <sys/mount.h>
 #	include <sys/param.h>
 #	define statfs64 statfs
@@ -52,7 +52,7 @@ See the file COPYING for details.
 #include <string.h>
 #include <time.h>
 
-#if CCTOOLS_OPSYS_CYGWIN || CCTOOLS_OPSYS_DARWIN || CCTOOLS_OPSYS_FREEBSD || CCTOOLS_OPSYS_DRAGONFLY
+#ifdef CCTOOLS_OPSYS_DARWIN
 	/* Cygwin does not have 64-bit I/O, while FreeBSD/Darwin has it by default. */
 #	define stat64 stat
 #	define fstat64 fstat

--- a/chirp/src/confuga_namespace.c
+++ b/chirp/src/confuga_namespace.c
@@ -40,12 +40,6 @@ See the file COPYING for details.
 #	define statfs64 statfs
 #	define fstatfs64 fstatfs
 #	define fstatat64 fstatat
-#elif defined(CCTOOLS_OPSYS_SUNOS)
-	/* Solaris has statfs, but it doesn't work! Use statvfs instead. */
-#	define statfs statvfs
-#	define fstatfs fstatvfs
-#	define statfs64 statvfs64
-#	define fstatfs64 fstatvfs64
 #endif
 
 #ifdef CCTOOLS_OPSYS_DARWIN

--- a/chirp/src/confuga_namespace.c
+++ b/chirp/src/confuga_namespace.c
@@ -32,7 +32,7 @@ See the file COPYING for details.
 #include <stdio.h>
 #include <stdlib.h>
 
-#if CCTOOLS_OPSYS_CYGWIN || CCTOOLS_OPSYS_DARWIN || CCTOOLS_OPSYS_FREEBSD || CCTOOLS_OPSYS_DRAGONFLY
+#ifdef CCTOOLS_OPSYS_DARWIN
 	/* Cygwin does not have 64-bit I/O, while FreeBSD/Darwin has it by default. */
 #	define stat64 stat
 #	define fstat64 fstat

--- a/configure
+++ b/configure
@@ -93,7 +93,7 @@ ccompiler=${CC:-gcc}
 cxxcompiler=${CXX:-g++}
 linker="${ccompiler}"
 
-ccflags="${CFLAGS} -D__EXTENSIONS__ -D_LARGEFILE64_SOURCE -D__LARGE64_FILES -Wall -Wextra"
+ccflags="${CFLAGS} -D__EXTENSIONS__ -D_LARGEFILE64_SOURCE -D__LARGE64_FILES -Wall -Wextra -fPIC"
 c_only_flags="-std=c99"
 
 config_zlib_path=yes
@@ -406,18 +406,6 @@ do
 		ccflags="${ccflags} -W$flag"
 	fi
 done
-
-# Cygwin has some compiler oddities.
-# 1 - Sloppy definitions of the ctype.h functions cause spurious warnings
-# about char -> int conversions.
-# 2 - All code is PIC by default, and adding the flag causes more warnings.
-
-if [ ${BUILD_SYS} = CYGWIN ]
-then
-	ccflags="${ccflags} -Wno-char-subscripts"
-else
-	ccflags="${ccflags} -fPIC"
-fi
 
 #
 # Currently, we rely on the linker --as-needed flag to sort out
@@ -1278,11 +1266,8 @@ fi
 if [ "$optstatic" = 1 ]
 then
 	static_libraries="../../dttools/src/libdttools.a ${zlib_path}/lib/libz.a"
-elif [ ${BUILD_SYS} != CYGWIN ]
-then
-	external_libraries="${external_libraries} -lstdc++ -lpthread -lz -lc -lm"
 else
-	external_libraries="${external_libraries} -lstdc++ -lpthread -lz -lm"
+	external_libraries="${external_libraries} -lstdc++ -lpthread -lz -lc -lm"
 fi
 
 if [ $BUILD_SYS = DARWIN ]

--- a/configure
+++ b/configure
@@ -62,9 +62,6 @@ case "$BUILD_CPU" in
 	POWER\ MACINTOSH)
 	BUILD_CPU=POWERPC
 	;;
-	SUN4V)
-	BUILD_CPU=SPARC
-	;;
 esac
 
 include_package_apps="apps"
@@ -1442,18 +1439,6 @@ do
 	fi
 done
 
-
-# We always compile with debugging enabled,
-# however on Solaris, the -g option results in a different
-# debugging format that causes linking errors in getopt code.
-
-if [ $BUILD_SYS = SUNOS ]
-then
-	debug_flag="-gstabs+"
-else
-	debug_flag="-g"
-fi
-
 ccflags_append_define \
 	"BUILD_DATE='\"$BUILD_DATE\"'" \
 	"BUILD_HOST='\"$BUILD_HOST\"'" \
@@ -1474,8 +1459,9 @@ ccflags_append_define \
 	"_GNU_SOURCE" \
 	"_REENTRANT"
 
-ccflags_append "$debug_flag"
-ldflags="${ldflags} ${debug_flag}"
+debug_flags="-g"
+ccflags_append "$debug_flags"
+ldflags="${ldflags} ${debug_flags}"
 
 if [ X$include_package_parrot = "Xparrot" ]
 then

--- a/configure
+++ b/configure
@@ -1241,10 +1241,7 @@ then
 	external_libraries="${external_libraries} -lrt"
 fi
 
-if [ $BUILD_SYS != FREEBSD ] || [ $BUILD_SYS != DRAGONFLY ]
-then
-	external_libraries="${external_libraries} -ldl"
-fi
+external_libraries="${external_libraries} -ldl"
 
 zlib_path=${zlib_path:-${base_root}}
 if library_search z ${zlib_path}

--- a/dttools/src/address.h
+++ b/dttools/src/address.h
@@ -7,7 +7,7 @@
 #include <netdb.h>
 
 #ifndef SOCKLEN_T
-#if defined(__GLIBC__) || defined(CCTOOLS_OPSYS_DARWIN) || defined(CCTOOLS_OPSYS_AIX) || defined(__MUSL__)
+#if defined(__GLIBC__) || defined(CCTOOLS_OPSYS_DARWIN) || defined(__MUSL__)
 #define SOCKLEN_T socklen_t
 #else
 #define SOCKLEN_T int

--- a/dttools/src/auth_kerberos.c
+++ b/dttools/src/auth_kerberos.c
@@ -5,7 +5,7 @@ This software is distributed under the GNU General Public License.
 See the file COPYING for details.
 */
 
-#if defined(HAS_KRB5) && !defined(CCTOOLS_OPSYS_FREEBSD)
+#if defined(HAS_KRB5)
 
 #include "krb5.h"
 

--- a/dttools/src/auth_unix.c
+++ b/dttools/src/auth_unix.c
@@ -96,7 +96,7 @@ static void make_challenge_path(char *path)
 	debug(D_AUTH, "unix: challenge path is %s", path);
 }
 
-#if CCTOOLS_OPSYS_DARWIN || CCTOOLS_OPSYS_FREEBSD || CCTOOLS_OPSYS_CYGWIN
+#ifdef CCTOOLS_OPSYS_DARWIN
 
 /*
 Darwin does not have fgetpwent in libc,

--- a/dttools/src/auth_unix.c
+++ b/dttools/src/auth_unix.c
@@ -131,10 +131,6 @@ struct passwd *fgetpwent(FILE * file)
 static struct passwd *auth_get_passwd_from_uid(uid_t uid)
 {
 	if(alternate_passwd_file[0]) {
-#ifdef CCTOOLS_OPSYS_DRAGONFLY
-		debug(D_AUTH, "unix: couldn't open %s: %s", alternate_passwd_file, strerror(errno));
-		return 0;
-#else
 		struct passwd *p;
 		FILE *file;
 
@@ -156,7 +152,6 @@ static struct passwd *auth_get_passwd_from_uid(uid_t uid)
 			debug(D_AUTH, "unix: couldn't open %s: %s", alternate_passwd_file, strerror(errno));
 			return 0;
 		}
-#endif
 	} else {
 		return getpwuid(uid);
 	}

--- a/dttools/src/file_cache.c
+++ b/dttools/src/file_cache.c
@@ -26,7 +26,7 @@ See the file COPYING for details.
 
 /* Cygwin does not have 64-bit I/O, while Darwin has it by default. */
 
-#if CCTOOLS_OPSYS_CYGWIN || CCTOOLS_OPSYS_DARWIN || CCTOOLS_OPSYS_FREEBSD || CCTOOLS_OPSYS_DRAGONFLY
+#ifdef CCTOOLS_OPSYS_DARWIN
 #define fstat64 fstat
 #define stat64 stat
 #define open64 open

--- a/dttools/src/full_io.c
+++ b/dttools/src/full_io.c
@@ -61,7 +61,7 @@ ssize_t full_write(int fd, const void *buf, size_t count)
 
 ssize_t full_pread64(int fd, void *buf, size_t count, int64_t offset)
 {
-#if CCTOOLS_OPSYS_CYGWIN || CCTOOLS_OPSYS_DARWIN || CCTOOLS_OPSYS_FREEBSD || CCTOOLS_OPSYS_DRAGONFLY
+#ifdef CCTOOLS_OPSYS_DARWIN
 	FULL_PIO(pread(fd, buf, count, offset));
 #else
 	FULL_PIO(pread64(fd, buf, count, offset));
@@ -70,7 +70,7 @@ ssize_t full_pread64(int fd, void *buf, size_t count, int64_t offset)
 
 ssize_t full_pwrite64(int fd, const void *buf, size_t count, int64_t offset)
 {
-#if CCTOOLS_OPSYS_CYGWIN || CCTOOLS_OPSYS_DARWIN || CCTOOLS_OPSYS_FREEBSD || CCTOOLS_OPSYS_DRAGONFLY
+#ifdef CCTOOLS_OPSYS_DARWIN
 	FULL_PIO(pwrite(fd, buf, count, offset));
 #else
 	FULL_PIO(pwrite64(fd, buf, count, offset));

--- a/dttools/src/host_disk_info.c
+++ b/dttools/src/host_disk_info.c
@@ -30,19 +30,6 @@ See the file COPYING for details.
 
 int host_disk_info_get(const char *path, UINT64_T * avail, UINT64_T * total)
 {
-#ifdef CCTOOLS_OPSYS_SUNOS
-	int result;
-	struct statvfs s;
-
-	result = statvfs(path, &s);
-	if(result < 0)
-		return result;
-
-	*total = ((UINT64_T) s.f_bsize) * s.f_blocks;
-	*avail = ((UINT64_T) s.f_bsize) * s.f_bfree;
-
-	return 0;
-#else
 	int result;
 	struct statfs s;
 
@@ -54,7 +41,6 @@ int host_disk_info_get(const char *path, UINT64_T * avail, UINT64_T * total)
 	*avail = ((UINT64_T) s.f_bsize) * s.f_bavail;
 
 	return 0;
-#endif
 }
 
 int check_disk_space_for_filesize(char *path, int64_t file_size, uint64_t disk_avail_threshold) {

--- a/dttools/src/host_memory_info.c
+++ b/dttools/src/host_memory_info.c
@@ -6,7 +6,7 @@ See the file COPYING for details.
 
 #include "host_memory_info.h"
 
-#if defined(CCTOOLS_OPSYS_LINUX) || defined(CCTOOLS_OPSYS_SUNOS)
+#if defined(CCTOOLS_OPSYS_LINUX)
 
 #include <unistd.h>
 

--- a/dttools/src/link.c
+++ b/dttools/src/link.c
@@ -491,14 +491,9 @@ struct link *link_connect(const char *addr, int port, time_t stoptime)
 
 	link_window_configure(link);
 
-	/* sadly, cygwin does not do non-blocking connect correctly */
-#ifdef CCTOOLS_OPSYS_CYGWIN
-	if(!link_nonblocking(link, 0))
+	if(!link_nonblocking(link, 1)) {
 		goto failure;
-#else
-	if(!link_nonblocking(link, 1))
-		goto failure;
-#endif
+	}
 
 	debug(D_TCP, "connecting to %s port %d", addr, port);
 
@@ -521,9 +516,6 @@ struct link *link_connect(const char *addr, int port, time_t stoptime)
 		// If the remote address is valid, we are connected no matter what.
 		if(link_address_remote(link, link->raddr, &link->rport)) {
 			debug(D_TCP, "made connection to %s port %d", link->raddr, link->rport);
-#ifdef CCTOOLS_OPSYS_CYGWIN
-			link_nonblocking(link, 1);
-#endif
 			return link;
 		}
 

--- a/dttools/src/load_average.c
+++ b/dttools/src/load_average.c
@@ -4,28 +4,7 @@ This software is distributed under the GNU General Public License.
 See the file COPYING for details.
 */
 
-#if defined(CCTOOLS_OPSYS_SUNOS)
-
-#include <sys/loadavg.h>
-#include <unistd.h>
-
-void load_average_get(double *avg)
-{
-	avg[0] = avg[1] = avg[2] = 0;
-	getloadavg(avg, 3);
-}
-
-int load_average_get_cpus()
-{
-	long n = sysconf(_SC_NPROCESSORS_ONLN);
-	if(n >= 1) {
-		return n;
-	} else {
-		return 1;
-	}
-}
-
-#elif defined(CCTOOLS_OPSYS_DARWIN)
+#if defined(CCTOOLS_OPSYS_DARWIN)
 
 #include <unistd.h>
 #include <stdlib.h>

--- a/dttools/src/md5.c
+++ b/dttools/src/md5.c
@@ -315,7 +315,7 @@ void md5_buffer(const void *buffer, size_t length, unsigned char digest[16])
 	md5_final(digest, &context);
 }
 
-#if defined(CCTOOLS_OPSYS_DARWIN) || defined(CCTOOLS_OPSYS_CYGWIN) || defined (CCTOOLS_OPSYS_FREEBSD)
+#if defined(CCTOOLS_OPSYS_DARWIN)
 #define stat64 stat
 #endif
 

--- a/dttools/src/rmonitor_poll_internal.h
+++ b/dttools/src/rmonitor_poll_internal.h
@@ -11,7 +11,7 @@ See the file COPYING for details.
 #include "hash_table.h"
 
 #include "rmonitor_types.h"
-#if defined(CCTOOLS_OPSYS_DARWIN) || defined(CCTOOLS_OPSYS_FREEBSD)
+#if defined(CCTOOLS_OPSYS_DARWIN)
   #include <sys/param.h>
   #include <sys/mount.h>
   #include <sys/resource.h>

--- a/dttools/src/rmonitor_types.h
+++ b/dttools/src/rmonitor_types.h
@@ -1,4 +1,4 @@
-#if defined(CCTOOLS_OPSYS_DARWIN) || defined(CCTOOLS_OPSYS_FREEBSD)
+#if defined(CCTOOLS_OPSYS_DARWIN)
   #include <sys/param.h>
   #include <sys/mount.h>
   #include <sys/resource.h>

--- a/dttools/src/uptime.c
+++ b/dttools/src/uptime.c
@@ -7,7 +7,7 @@ See the file COPYING for details.
 #include "uptime.h"
 #include "debug.h"
 
-#if defined(CCTOOLS_OPSYS_DARWIN) || defined(CCTOOLS_OPSYS_FREEBSD)
+#if defined(CCTOOLS_OPSYS_DARWIN)
 #include <sys/sysctl.h>
 #include <time.h>
 #elif defined(CCTOOLS_OPSYS_LINUX)
@@ -18,7 +18,7 @@ int uptime_get()
 {
 	int uptime;
 
-#if defined(CCTOOLS_OPSYS_DARWIN) || defined(CCTOOLS_OPSYS_FREEBSD)
+#if defined(CCTOOLS_OPSYS_DARWIN)
 	struct timeval boottime;
 	size_t len = sizeof(boottime);
 	int mib[2] = { CTL_KERN, KERN_BOOTTIME };

--- a/resource_monitor/src/rminimonitor_helper.c
+++ b/resource_monitor/src/rminimonitor_helper.c
@@ -31,14 +31,6 @@
 
 #define BUFFER_MAX 1024
 
-// XXX This is a quick hack to get through the build on Cygwin.
-// It appears thaqt RTLD_NEXT does not exist on Cygwin.
-// Can this module work on that operating system?
-
-#if defined(CCTOOLS_OPSYS_CYGWIN) && !defined(RTLD_NEXT)
-#define RTLD_NEXT 0
-#endif
-
 #define RESOURCE_MONITOR_PIDS_FILE "CCTOOLS_RESOURCE_MONITOR_PIDS_FILE"
 
 #define declare_original_dlsym(name) __typeof__(name) *original_ ## name;

--- a/resource_monitor/src/rmonitor_helper.c
+++ b/resource_monitor/src/rmonitor_helper.c
@@ -48,15 +48,6 @@
 
 #define BUFFER_MAX 1024
 
-// XXX This is a quick hack to get through the build on Cygwin.
-// It appears thaqt RTLD_NEXT does not exist on Cygwin.
-// Can this module work on that operating system?
-
-#if defined(CCTOOLS_OPSYS_CYGWIN) && !defined(RTLD_NEXT)
-#define RTLD_NEXT 0
-#endif
-
-
 #define PUSH_ERRNO { int last_errno = errno; errno = 0;
 #define POP_ERRNO(msg) msg.error = errno; if(!errno){ errno = last_errno; } }
 


### PR DESCRIPTION
Removes compile options and #ifdef's for cygwin, sunos, aix, and bsd's that are not darwin.