### PR TITLE
Accept " when specifying file requirements

### DIFF
--- a/doc/manuals/makeflow/index.md
+++ b/doc/manuals/makeflow/index.md
@@ -58,26 +58,26 @@ into an animation. The first and the last task are marked as LOCAL to force
 them to run on the controlling machine.
 
 ```make
-CURL="/usr/bin/curl"
-CONVERT="/usr/bin/convert"
+CURL=/usr/bin/curl
+CONVERT=/usr/bin/convert
 URL="http://ccl.cse.nd.edu/images/capitol.jpg"
 
-capitol.anim.gif: capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg $(CONVERT)
+capitol.anim.gif: capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg
     LOCAL $(CONVERT) -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.anim.gif
     
-capitol.90.jpg: capitol.jpg $(CONVERT)
+capitol.90.jpg: capitol.jpg
     $(CONVERT) -swirl 90 capitol.jpg capitol.90.jpg
     
-capitol.180.jpg: capitol.jpg $(CONVERT)
+capitol.180.jpg: capitol.jpg
     $(CONVERT) -swirl 180 capitol.jpg capitol.180.jpg
     
-capitol.270.jpg: capitol.jpg $(CONVERT)
+capitol.270.jpg: capitol.jpg
     $(CONVERT) -swirl 270 capitol.jpg capitol.270.jpg
     
-capitol.360.jpg: capitol.jpg $(CONVERT)
+capitol.360.jpg: capitol.jpg
     $(CONVERT) -swirl 360 capitol.jpg capitol.360.jpg
     
-capitol.jpg: $(CURL)
+capitol.jpg:
     LOCAL $(CURL) -o capitol.jpg $(URL)
 ```
 

--- a/makeflow/example/example.makeflow
+++ b/makeflow/example/example.makeflow
@@ -7,31 +7,31 @@
 # textual substitutions:
 CURL=/usr/bin/curl
 CONVERT=/usr/bin/convert
-URL=http://ccl.cse.nd.edu/images/capitol.jpg
+URL="http://ccl.cse.nd.edu/images/capitol.jpg"
 
 # We specify the set of inputs and outputs. This is not required, but strongly
 # recommended. MAKEFLOW_INPUTS files should exist in the local filesystem, but
 # they are not copied to a remote execution site unless they appear as a rule
 # prerequisite.
 MAKEFLOW_INPUTS=
-MAKEFLOW_OUTPUTS=capitol.montage.gif
+MAKEFLOW_OUTPUTS="capitol.montage.gif"
 
 capitol.montage.gif: capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg
-	$CONVERT -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.montage.gif
+	$(CONVERT) -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.montage.gif
 
 capitol.90.jpg: capitol.jpg
-	$CONVERT -swirl 90 capitol.jpg capitol.90.jpg
+	$(CONVERT) -swirl 90 capitol.jpg capitol.90.jpg
 
 capitol.180.jpg: capitol.jpg
-	$CONVERT -swirl 180 capitol.jpg capitol.180.jpg
+	$(CONVERT) -swirl 180 capitol.jpg capitol.180.jpg
 
 capitol.270.jpg: capitol.jpg
-	$CONVERT -swirl 270 capitol.jpg capitol.270.jpg
+	$(CONVERT) -swirl 270 capitol.jpg capitol.270.jpg
 
 capitol.360.jpg: capitol.jpg
-	$CONVERT -swirl 360 capitol.jpg capitol.360.jpg
+	$(CONVERT) -swirl 360 capitol.jpg capitol.360.jpg
 
 # If a rule is preceded by LOCAL, it executes at the local site.
 capitol.jpg:
-	LOCAL $CURL -o capitol.jpg $URL
+	LOCAL $(CURL) -o capitol.jpg $(URL)
 

--- a/makeflow/src/lexer.c
+++ b/makeflow/src/lexer.c
@@ -461,7 +461,7 @@ int lexer_read_literal(struct lexer * lx)
 
 struct token *lexer_read_literal_in_expandable_until(struct lexer *lx, char end_marker)
 {
-	const char end_markers[8] = { end_marker, '$', '\\', '"', '\'', '#', CHAR_EOF ,0};
+	const char end_markers[8] = { end_marker, '$', '\\', '"', '\'', '#', 0};
 
 	int count = 0;
 	do {

--- a/makeflow/src/lexer.c
+++ b/makeflow/src/lexer.c
@@ -820,6 +820,12 @@ void lexer_concatenate_consecutive_literals(struct list *tokens)
 			continue;
 		}
 
+		//drop empty strings
+		if(t->lexeme[0] == '\0') {
+			lexer_free_token(t);
+			continue;
+		}
+
 		prev = list_pop_tail(tmp);
 
 		if(!prev) {

--- a/makeflow/src/lexer.c
+++ b/makeflow/src/lexer.c
@@ -785,6 +785,12 @@ struct token *lexer_read_file(struct lexer *lx)
 		lx->keep_quotes = 1;
 		return lexer_pack_token(lx, TOKEN_LITERAL);
 		break;
+	case '"':
+		lx->keep_quotes = 0;
+		struct token *q = lexer_read_expandable(lx, '"');
+		lx->keep_quotes = 1;
+		return q;
+		break;
 	case '-':
 		if(lexer_peek_remote_rename_syntax(lx)) {
 			lexer_next_char(lx);	/* Jump -> */

--- a/makeflow/src/lexer.c
+++ b/makeflow/src/lexer.c
@@ -25,7 +25,7 @@
 #define CHAR_EOF 26		// ASCII for EOF
 
 #define LITERAL_LIMITS  "\\\"'$#\n\t \032"
-#define SYNTAX_LIMITS  LITERAL_LIMITS  ",.-(){},[]<>=+!?/"
+#define SYNTAX_LIMITS  LITERAL_LIMITS  ",.-(){},[]<>=+!?/:"
 #define FILENAME_LIMITS LITERAL_LIMITS  ":-"
 
 #define WHITE_SPACE          " \t"

--- a/makeflow/src/lexer.h
+++ b/makeflow/src/lexer.h
@@ -108,6 +108,8 @@ struct lexer
 
 	char *linetext;   //This member will be removed once the new lexer is integrated.
 
+    int keep_quotes;  //When reading commands, do not drop " or '.
+
 	int depth;        //Levels of substitutions. Only depth=0 has stream != NULL.
 };
 

--- a/makeflow/test/TR_makeflow_025_quoting.sh
+++ b/makeflow/test/TR_makeflow_025_quoting.sh
@@ -10,17 +10,24 @@ prepare()
 	cd $test_dir
 	ln -sf ../../src/makeflow .
 	ln -sf ../syntax/quotes.01.makeflow
-cat > A.expected <<'EOF'
-A
+
+for letter in A B C D E F G 
+do
+	/bin/echo ${letter} > ${letter}.expected
+done
+
+cat > C\ D.expected <<'EOF'
+C D 'C D' "C D"
 EOF
 
-cat > B.expected <<'EOF'
-B
+cat > H\ I.expected <<'EOF'
+H I
 EOF
 
-cat > A\ B.expected <<'EOF'
-A B 'A B' $(FILES)
+cat > J\ K.expected <<'EOF'
+J K
 EOF
+
 	exit 0
 }
 
@@ -30,12 +37,13 @@ run()
 	./makeflow -j 1 quotes.01.makeflow
 
 	if [ $? -eq 0 ]; then
-		diff -w A.expected A  || exit 1
-		diff -w B.expected B  || exit 1
-		diff -w A\ B.expected A\ B || exit 1
-	else
-		exit 1
+		for file in A B C D E F G "C D" "H I" "J K"
+		do
+			diff -w "${file}".expected "${file}" || exit 1
+		done
 	fi
+
+	exit 0
 }
 
 clean()

--- a/makeflow/test/TR_makeflow_025_quoting.sh
+++ b/makeflow/test/TR_makeflow_025_quoting.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+. ../../dttools/test/test_runner_common.sh
+
+test_dir=`basename $0 .sh`.dir
+
+prepare()
+{
+	mkdir $test_dir
+	cd $test_dir
+	ln -sf ../../src/makeflow .
+	ln -sf ../syntax/quotes.01.makeflow
+cat > A.expected <<'EOF'
+A
+EOF
+
+cat > B.expected <<'EOF'
+B
+EOF
+
+cat > A\ B.expected <<'EOF'
+A B 'A B' $(FILES)
+EOF
+	exit 0
+}
+
+run()
+{
+	cd $test_dir
+	./makeflow -j 1 quotes.01.makeflow
+
+	if [ $? -eq 0 ]; then
+		diff -w A.expected A  || exit 1
+		diff -w B.expected B  || exit 1
+		diff -w A\ B.expected A\ B || exit 1
+	else
+		exit 1
+	fi
+}
+
+clean()
+{
+	rm -fr $test_dir
+	exit 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/makeflow/test/TR_makeflow_025_quoting_open.sh
+++ b/makeflow/test/TR_makeflow_025_quoting_open.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+. ../../dttools/test/test_runner_common.sh
+
+test_dir=`basename $0 .sh`.dir
+
+prepare()
+{
+	exit 0
+}
+
+run()
+{
+    cd syntax
+    if ../../src/makeflow_analyze -k quotes.02.makeflow
+    then
+        echo "Open double quotes should have failed syntax check."
+        exit 1
+    fi
+
+    cd syntax
+    if ../../src/makeflow_analyze -k quotes.03.makeflow
+    then
+        echo "Open single quotes should have failed syntax check."
+        exit 1
+    fi
+
+	exit 0
+}
+
+clean()
+{
+	exit 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/makeflow/test/syntax/quotes.01.makeflow
+++ b/makeflow/test/syntax/quotes.01.makeflow
@@ -1,0 +1,10 @@
+
+MAKEFLOW_INPUTS=input/hello
+MAKEFLOW_OUTPUTS=mydir
+
+FILES=A B
+
+# This rule should generate files A, B, A B, C, D, and E.
+# Contents of file A B should be: A B 'A B' $(FILES)
+$(FILES) "$(FILES)" "C" 'D' E:
+    /bin/echo A > A; /bin/echo B > B; /bin/echo C > C; /bin/echo D > D; /bin/echo E > E; /bin/echo $(FILES) \\\'$(FILES)\\\' '$(FILES)' > "$(FILES)"

--- a/makeflow/test/syntax/quotes.01.makeflow
+++ b/makeflow/test/syntax/quotes.01.makeflow
@@ -2,9 +2,25 @@
 MAKEFLOW_INPUTS=input/hello
 MAKEFLOW_OUTPUTS=mydir
 
-FILES=A B
+# Generate file A with contents A
+"A":
+	/bin/echo A > A
 
-# This rule should generate files A, B, A B, C, D, and E.
-# Contents of file A B should be: A B 'A B' $(FILES)
-$(FILES) "$(FILES)" "C" 'D' E:
-    /bin/echo A > A; /bin/echo B > B; /bin/echo C > C; /bin/echo D > D; /bin/echo E > E; /bin/echo $(FILES) \\\'$(FILES)\\\' '$(FILES)' > "$(FILES)"
+# Generate file B with contents B
+'B':
+	/bin/echo B > B
+
+# Generate file C, D and E with contents C, D and E, respectively
+VAR_CD=C D
+$(VAR_CD) E:
+	/bin/echo C > C; /bin/echo D > D; /bin/echo E > E
+
+# Generate file "C D" with contents C D 'C D' "C D", and files F and G, with contents F and G respectively
+F "$(VAR_CD)" G:
+	/bin/echo "$(VAR_CD) \'$(VAR_CD)\' \\\"$(VAR_CD)\\\"" > "$(VAR_CD)"; /bin/echo F > F; /bin/echo G > G 
+
+# Generate files "H I" and "J K"
+VAR_HK="H I" "J K"
+$(VAR_HK):
+    /bin/echo H I > "H I"; /bin/echo J K > "J K"
+

--- a/makeflow/test/syntax/quotes.02.makeflow
+++ b/makeflow/test/syntax/quotes.02.makeflow
@@ -1,0 +1,3 @@
+:"unbalanced
+    nothing
+

--- a/makeflow/test/syntax/quotes.03.makeflow
+++ b/makeflow/test/syntax/quotes.03.makeflow
@@ -1,0 +1,3 @@
+:'unbalanced
+    nothing
+


### PR DESCRIPTION
With a recent change, using "a": "b" would fail with a syntax error.

This pr also adds two tests to check " and ' syntax, and makes the example in the manual the same as example.makeflow with respect to the use of quotes.