### PR TITLE
Check generic facility during compile time

### DIFF
--- a/configure
+++ b/configure
@@ -1309,9 +1309,25 @@ optional_include sys/statvfs.h HAS_SYS_STATVFS_H
 optional_include sys/vfs.h     HAS_SYS_VFS_H
 optional_include syslog.h      HAS_SYSLOG_H
 
-#if optional_library_function systemd/sd-journal.h sd_journal_print systemd HAS_SYSTEMD_JOURNAL_H; then
-#	external_libraries="${external_libraries} -lsystemd"
-#fi
+# Not all statfs have the f_flags field
+check_facility "statfs.f_flags" "${ccflags}" HAS_STATFS_F_FLAGS "
+#ifdef HAS_SYS_STATFS_H
+#include <sys/statfs.h>
+#endif
+
+#ifdef HAS_SYS_STATVFS_H
+#include <sys/statvfs.h>
+#endif
+
+#ifdef HAS_SYS_VFS_H
+#include <sys/vfs.h>
+#endif
+int main(int argc, char **argv) {
+	struct statfs s;
+	s.f_flags = 0;
+	return 0;
+}
+"
 
 cctools_doctargets=
 if check_path doxygen

--- a/configure.tools.sh
+++ b/configure.tools.sh
@@ -174,6 +174,40 @@ EOF
 	fi
 }
 
+check_facility()
+{
+	local name
+	local compiler_options
+	local define
+
+	name="$1"
+	shift
+
+	compiler_options="$1"
+	shift
+
+	define="$1"
+	shift
+
+	echon "checking for $name..."
+
+cat > .configure.tmp.c << EOF
+#include <stdlib.h>
+$@
+EOF
+
+	if ${CC:-gcc} .configure.tmp.c -c -o .configure.tmp.o ${compiler_options} > .configure.tmp.out 2>&1; then
+		echo yes
+		ccflags_append_define ${define}
+		rm -f .configure.tmp.c .configure.tmp.out
+		return 0
+	else
+		echo no
+		rm -f .configure.tmp.c .configure.tmp.out
+		return 1
+	fi
+}
+
 check_compiler_flag()
 {
 	echon "checking if ${ccompiler} supports $1..."

--- a/dttools/src/host_disk_info.c
+++ b/dttools/src/host_disk_info.c
@@ -53,10 +53,11 @@ int check_disk_space_for_filesize(char *path, int64_t file_size, uint64_t disk_a
 }
 
 int check_disk_flags(const char *path, unsigned int flags) {
-#ifdef CCTOOLS_OPSYS_SUNOS
-	/* for sunos assume always true. */
-	return 1;
-#else
+
+/* Some struct statfs do not include the field s.f_flags.
+ * Here we conditionally compile if one of such known flags was defined.
+ */
+#ifdef HAS_STATFS_F_FLAGS
 	int result;
 	struct statfs s;
 
@@ -67,6 +68,8 @@ int check_disk_flags(const char *path, unsigned int flags) {
 	}
 
 	return (s.f_flags & flags) == flags;
+#else
+	return 1;
 #endif
 }
 


### PR DESCRIPTION
This pr adds check_facility to check at configure time whether generic code will compile.

As an example of its use, we check whether struct statfs s; s.f_flags = 0; is valid code.

As found by Emily, some struct statfs do not have the field f_flags (e.g., the one when using the compilers included in conda).

This became an issue until we included pr #2237, which uses f_flags to check whether files can be executed from the worker's scratch directory.