### PR TITLE
Portably check worker exec

### DIFF
--- a/dttools/src/host_disk_info.c
+++ b/dttools/src/host_disk_info.c
@@ -52,24 +52,4 @@ int check_disk_space_for_filesize(char *path, int64_t file_size, uint64_t disk_a
 	return 1;
 }
 
-int check_disk_flags(const char *path, unsigned int flags) {
-#ifdef CCTOOLS_OPSYS_SUNOS
-	/* for sunos assume always true. */
-	return 1;
-#else
-	int result;
-	struct statfs s;
-
-	result = statfs(path, &s);
-	if(result < 0) {
-		/* on error, assume false */
-		return 0;
-	}
-
-	return (s.f_flags & flags) == flags;
-#endif
-}
-
-
-
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/host_disk_info.h
+++ b/dttools/src/host_disk_info.h
@@ -44,13 +44,4 @@ int host_disk_info_get(const char *path, UINT64_T * avail, UINT64_T * total);
 */
 int check_disk_space_for_filesize(char *path, INT64_T file_size, UINT64_T disk_avail_threshold);
 
-
-/** Return whether the file system where path resides was mounted with particular flags.
-@param path A filename of the disk to be measured.
-@param flags Mount flags to test, such as (ST_NOEXEC | ST_RDONLY). For valid flags see statfs(2).
-@return 0 if at least one mount flag is not set, otherwise 1.
-*/
-
-int check_disk_flags(const char *path, unsigned int flags);
-
 #endif


### PR DESCRIPTION
Create a test script to check whether we can execute files from the worker's scratch directory.

The previous method of checking filesystem flags was removed, as it was not portable.