### PR TITLE
fix linking for conda on darwin

### DIFF
--- a/configure
+++ b/configure
@@ -1056,7 +1056,12 @@ then
 
 			if [ $BUILD_SYS = DARWIN ]
 			then
-				python2_ldflags="$python2_ldflags -undefined dynamic_lookup"
+				if [ "${CONDA_BUILD}" = 1 ]
+				then
+					python2_ldflags="-undefined dynamic_lookup"
+				else
+					python2_ldflags="$python2_ldflags -undefined dynamic_lookup"
+				fi
 			fi
 
 			if ! check_function Py_MATH_PI Python.h ${python2_ccflags} ${python2_ldflags}
@@ -1131,7 +1136,12 @@ then
 
 			if [ $BUILD_SYS = DARWIN ]
 			then
-				python3_ldflags="$python3_ldflags -undefined dynamic_lookup"
+				if [ "${CONDA_BUILD}" = 1 ]
+				then
+					python3_ldflags="-undefined dynamic_lookup"
+				else
+					python3_ldflags="$python3_ldflags -undefined dynamic_lookup"
+				fi
 			fi
 
 			if ! check_function Py_MATH_PI Python.h ${python3_ccflags} ${python3_ldflags}


### PR DESCRIPTION
conda adds some python flags that clash with swig. These flags are not needed for linking anyway, as the python libraries from conda in OSX are compiled statically.