### PR TITLE
wq_bwa: fixed off by two error when submitting tasks

### DIFF
--- a/apps/wq_bwa/wq_bwa
+++ b/apps/wq_bwa/wq_bwa
@@ -128,10 +128,12 @@ sub split_query {
 		$line_count++;
 	}
 
+    $num_outputs++;
+
 	close(infile);
 
 	print localtime(). " Number of splits of $query_file is $num_outputs.\n";
-	return $num_outputs-1;
+	return $num_outputs;
 }
 
 sub partition_tasks {


### PR DESCRIPTION
There was an error where two of the splits were not being created/submitted as tasks. A simple fix is proposed here.