### PR TITLE
Fix parrot linking

### DIFF
--- a/parrot/src/Makefile
+++ b/parrot/src/Makefile
@@ -3,6 +3,8 @@ include ../../rules.mk
 
 EXTERNAL_DEPENDENCIES = ../../ftp_lite/src/libftp_lite.a ../../chirp/src/libchirp.a ../../grow/src/grow.o ../../dttools/src/libdttools.a
 LIBRARIES = libparrot_helper.$(CCTOOLS_DYNAMIC_SUFFIX) libparrot_client.a
+LOCAL_CXXFLAGS=$(CCTOOLS_IRODS_CCFLAGS) $(CCTOOLS_MYSQL_CCFLAGS) $(CCTOOLS_XROOTD_CCFLAGS) $(CCTOOLS_CVMFS_CCFLAGS) $(CCTOOLS_EXT2FS_CCFLAGS) $(CCTOOLS_GLOBUS_CCFLAGS) $(CCTOOLS_GLOBUS_CCFLAGS)
+LOCAL_LDFLAGS=$(CCTOOLS_IRODS_LDFLAGS) $(CCTOOLS_MYSQL_LDFLAGS) $(CCTOOLS_XROOTD_LDFLAGS) $(CCTOOLS_CVMFS_LDFLAGS) $(CCTOOLS_EXT2FS_LDFLAGS) $(CCTOOLS_GLOBUS_LDFLAGS) $(CCTOOLS_GLOBUS_LDFLAGS)
 OBJECTS = $(OBJECTS_PARROT_RUN) parrot_client.o pfs_resolve_mount.o
 OBJECTS_PARROT_RUN = pfs_main.o tracer.o pfs_paranoia.o pfs_dispatch.o pfs_dispatch64.o pfs_process.o pfs_channel.o pfs_sys.o pfs_time.o pfs_table.o pfs_resolve.o pfs_mountfile.o pfs_service.o pfs_file.o pfs_file_cache.o pfs_dir.o pfs_dircache.o pfs_pointer.o pfs_location.o ibox_acl.o pfs_service_local.o pfs_service_http.o pfs_service_grow.o pfs_service_chirp.o pfs_service_multi.o pfs_service_nest.o pfs_service_ftp.o pfs_service_irods.o irods_reli.o pfs_service_hdfs.o pfs_service_bxgrid.o pfs_service_xrootd.o pfs_service_cvmfs.o pfs_service_ext.o
 PROGRAMS = parrot_run $(UTILITIES)

--- a/parrot/test/TR_parrot_cvmfs_access.sh
+++ b/parrot/test/TR_parrot_cvmfs_access.sh
@@ -3,10 +3,6 @@
 . ../../dttools/test/test_runner_common.sh
 . ./parrot-test.sh
 
-export PARROT_ALLOW_SWITCHING_CVMFS_REPOSITORIES="yes"
-export HTTP_PROXY=http://cache01.hep.wisc.edu:3128
-export PARROT_CVMFS_REPO='*.cern.ch:pubkey=<BUILTIN-cern.ch.pub>,url=http://cvmfs-stratum-one.cern.ch/cvmfs/*.cern.ch'
-
 tmp_dir=${PWD}/parrot_temp_dir
 
 prepare()

--- a/parrot/test/TR_parrot_cvmfs_alien_cache.sh
+++ b/parrot/test/TR_parrot_cvmfs_alien_cache.sh
@@ -3,10 +3,6 @@
 . ../../dttools/test/test_runner_common.sh
 . ./parrot-test.sh
 
-export PARROT_ALLOW_SWITCHING_CVMFS_REPOSITORIES="yes"
-export HTTP_PROXY=http://cache01.hep.wisc.edu:3128
-export PARROT_CVMFS_REPO='*.cern.ch:pubkey=<BUILTIN-cern.ch.pub>,url=http://cvmfs-stratum-one.cern.ch/cvmfs/*.cern.ch'
-
 tmp_dir_master=${PWD}/parrot_temp_dir
 tmp_dir_hitcher=${PWD}/parrot_temp_dir_hitcher
 


### PR DESCRIPTION
Ensures that  the correct libraries, such as for cvmfs, are linked when building parrot.