### PR TITLE
Return the number of physical CPUs from load_average_get_cpus()

### DIFF
--- a/doc/man/.gitignore
+++ b/doc/man/.gitignore
@@ -1,2 +1,3 @@
 *.html
 *.gz
+man/

--- a/dttools/src/load_average.c
+++ b/dttools/src/load_average.c
@@ -68,7 +68,10 @@ int load_average_get_cpus()
 
 	int cpus = string_set_size(cores);
 	string_set_delete(cores);
-	if (cpus < 1) cpus = 1;
+	if (cpus < 1) {
+		cpus = 1;
+		fprintf(stderr, "Unable to detect CPUs, falling back to 1\n");
+	}
 	return cpus;
 }
 

--- a/dttools/src/load_average.c
+++ b/dttools/src/load_average.c
@@ -21,7 +21,7 @@ int load_average_get_cpus()
 {
 	int n;
 	size_t size = sizeof(n);
-	if(sysctlbyname("hw.ncpu", &n, &size, 0, 0) == 0) {
+	if(sysctlbyname("hw.physicalcpu", &n, &size, 0, 0) == 0) {
 		return n;
 	} else {
 		return 1;

--- a/makeflow/test/TR_makeflow_alloc_output.sh
+++ b/makeflow/test/TR_makeflow_alloc_output.sh
@@ -10,7 +10,7 @@ prepare()
 run()
 {
 	cd alloc
-	../../src/makeflow alloc.mf --storage-type 2 --storage-limit 5 
+	../../src/makeflow alloc.mf --local-cores 2 --storage-type 2 --storage-limit 5 
 	# This should fail as the output only tracking doesn't do an adequate job
 	if [ $? -eq 1 ]; then
 		exit 0

--- a/resource_monitor/src/.gitignore
+++ b/resource_monitor/src/.gitignore
@@ -2,3 +2,4 @@ resource_monitor_cluster
 resource_monitor_histograms
 rmonitor_poll_example
 rmonitor_snapshot
+librminimonitor_helper.so

--- a/work_queue/src/.gitignore
+++ b/work_queue/src/.gitignore
@@ -7,3 +7,4 @@ work_queue_test
 work_queue_test_watch
 work_queue_worker
 work_queue_workload_simulator
+work_queue_json_example


### PR DESCRIPTION
Currently, we count *logical* cores when examining the host system. On systems that make use of hyper-threading (especially extreme cases like Xeon Phi), this can lead to accidental over-subscription issues.

This PR changes `load_average_get_cpus()` to return the number of *physical* cores on the machine. For Macs, this is a simple change. For Linux, it requires some digging into `/sys`. I've tested a number of CPU configurations:
- Single-socket, no HT (cclws20)
- Single socket, HT (cclws19)
- Multi-socket, no HT (crcfe02)
- Multi-socket, HT (earth)

From what I could find online, the Xeon Phi registers as a normal CPU with HT, but I don't think I have access to any real machines to test on.

Resolves #2262