### PR TITLE
Support new HTCondor job log format containing year

### DIFF
--- a/batch_job/src/batch_job_condor.c
+++ b/batch_job/src/batch_job_condor.c
@@ -238,8 +238,22 @@ static batch_job_id_t batch_job_condor_wait (struct batch_queue * q, struct batc
 			struct batch_job_info *info;
 			int logcode, exitcode;
 
-			if(sscanf(line, "%d (%" SCNbjid ".%d.%d) %d/%d %d:%d:%d", &type, &jobid, &proc, &subproc, &tm.tm_mon, &tm.tm_mday, &tm.tm_hour, &tm.tm_min, &tm.tm_sec) == 9) {
-				tm.tm_year = 2008 - 1900;
+			/* 
+				HTCondor job log lines come in one of two flavors:
+			
+					005 (312.000.000) 2020-03-28 23:01:04
+				or
+
+					005 (312.000.000) 03/28 23:01:02 
+			*/
+			tm.tm_year = 2020;
+
+			if((sscanf(line, "%d (%" SCNbjid ".%d.%d) %d/%d %d:%d:%d", 
+					&type, &jobid, &proc, &subproc, &tm.tm_mon, &tm.tm_mday, &tm.tm_hour, &tm.tm_min, &tm.tm_sec) == 9) || 
+				(sscanf(line, "%d (%" SCNbjid ".%d.%d) %d-%d-%d %d:%d:%d", 
+					&type, &jobid, &proc, &subproc, &tm.tm_year, &tm.tm_mon, &tm.tm_mday, &tm.tm_hour, &tm.tm_min, &tm.tm_sec) == 10)) {
+
+				tm.tm_year = tm.tm_year - 1900;
 				tm.tm_isdst = 0;
 
 				current = mktime(&tm);


### PR DESCRIPTION
As of HTCondor version 8.9.3, the default userlog format puts the year
into the job log, looking like this

005 (312.000.000) 2020-03-28 23:01:04

the old format looked like

005 (312.000.000) 03/28 23:01:04

Currently, makeflow hangs forever, not seeing completed jobs when HTCondor
uses the new format.

This patch allows cctools to parse both the old and the new format. Note that
the code used to assume the year was 2008, this been updated to 2020, in the
case where we don't know.

Note that you can configure HTCondor to emit the old format by setting
DEFAULT_USERLOG_FORMAT_OPTIONS = legacy