### PR TITLE
Pedantic warnings makeflow

### DIFF
--- a/makeflow/src/makeflow_linker.c
+++ b/makeflow/src/makeflow_linker.c
@@ -216,7 +216,7 @@ struct list *find_dependencies_for(struct dependency *dep){
 		close(pipefd[1]);
 		char next;
 		char *buffer = (char *) malloc(sizeof(char));
-		char *original_name;
+		char *original_name = NULL;
 		int size = 0;
 		int depth = dep->depth  + 1;
 		struct list *new_deps = list_create();

--- a/makeflow/src/makeflow_summary.c
+++ b/makeflow/src/makeflow_summary.c
@@ -71,7 +71,7 @@ void makeflow_summary_create(struct dag *d, const char *filename, const char *em
 
 	struct dag_node *n;
 	struct dag_file *f;
-	const char *fn;
+	const char *fn = NULL;
 	dag_node_state_t state;
 	struct list *output_files;
 	output_files = list_create();

--- a/makeflow/src/parser_make.c
+++ b/makeflow/src/parser_make.c
@@ -729,7 +729,7 @@ static int dag_parse_make_export(struct lexer *bk)
 {
 	struct token *t, *vtoken, *vname;
 
-	const char *name;
+	const char *name = NULL;
 
 	int count = 0;
 	while((t = lexer_peek_next_token(bk)) && t->type != TOKEN_NEWLINE)

--- a/work_queue/src/work_queue_json.c
+++ b/work_queue/src/work_queue_json.c
@@ -230,7 +230,7 @@ struct work_queue *work_queue_json_create(const char *str)
 
 
 	int port = 0, priority = 0;
-	char *name;
+	char *name = NULL;
 
 	struct jx *json = jx_parse_string(str);
 	if(!json) {


### PR DESCRIPTION
Warnings found with 7.3.0.

The uninitialized values never came into play. Adding initial values to make the compiler happy.