### PR TITLE
Pedantic warnings parrot

### DIFF
--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -1159,7 +1159,7 @@ int main( int argc, char *argv[] )
 
 	if(optind>=argc) show_help(argv[0]);
 
-	FILE *stats_out;
+	FILE *stats_out = NULL;
 	if (stats_file) {
 		stats_enable();
 		stats_out = fopen(stats_file, "w");

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -557,7 +557,9 @@ int pfs_table::resolve_name(int is_special_syscall, const char *cname, struct pf
 				} else {
 					pname->port = pname->service->get_default_port();
 				}
-				sprintf(pname->hostport,"%s:%d",pname->host,pname->port);
+				char *hostport=string_format("%s:%d", pname->host, pname->port);
+				strncpy(pname->hostport, hostport, sizeof(pname->hostport));
+				free(hostport);
 			}
 
 			if(!strcmp(pname->service_name,"multi")) {


### PR DESCRIPTION
Warnings found with 7.3.0.

The uninitialized value never came into play. Adding an initial value to make the compiler happy.

The other commit eliminates the use of sprintf.