### PR TITLE
Pedantic warnings confuga

### DIFF
--- a/chirp/src/chirp_fs_local.c
+++ b/chirp/src/chirp_fs_local.c
@@ -236,7 +236,7 @@ int chirp_fs_local_resolve (const char *path, int *dirfd, char basename[CHIRP_PA
 {
 	int i;
 	int rc;
-	int fd;
+	int fd=0;
 	char working[CHIRP_PATH_MAX] = "";
 	struct stat rootinfo;
 

--- a/chirp/src/chirp_fs_local.c
+++ b/chirp/src/chirp_fs_local.c
@@ -236,7 +236,7 @@ int chirp_fs_local_resolve (const char *path, int *dirfd, char basename[CHIRP_PA
 {
 	int i;
 	int rc;
-	int fd=0;
+	int fd=-1;
 	char working[CHIRP_PATH_MAX] = "";
 	struct stat rootinfo;
 

--- a/chirp/src/confuga_job.c
+++ b/chirp/src/confuga_job.c
@@ -539,7 +539,7 @@ static int dispatch (confuga *C, chirp_jobid_t id, const char *tag)
 	sqlite3 *db = C->db;
 	sqlite3_stmt *stmt = NULL;
 	const char *current = SQL;
-	confuga_sid_t sid;
+	confuga_sid_t sid=-1;
 	struct job_stats stats;
 	memset(&stats, 0, sizeof(stats));
 

--- a/chirp/src/confuga_namespace.c
+++ b/chirp/src/confuga_namespace.c
@@ -100,7 +100,7 @@ static int resolve (confuga *C, const char *path, int *dirfd, char basename[CONF
 {
 	int i;
 	int rc;
-	int fd;
+	int fd=-1;
 	char working[CONFUGA_PATH_MAX] = "";
 	struct stat rootinfo;
 

--- a/chirp/src/confuga_replica.c
+++ b/chirp/src/confuga_replica.c
@@ -199,9 +199,9 @@ CONFUGA_IAPI int confugaR_replicate (confuga *C, confuga_fid_t fid, confuga_sid_
 	struct confuga_host host_to;
 	char replica_open[CONFUGA_PATH_MAX];
 	char replica_closed[CONFUGA_PATH_MAX];
-	time_t start;
+	time_t start=0;
 	confuga_sid_t fsid = 0;
-	confuga_off_t size;
+	confuga_off_t size=0;
 
 	debug(D_DEBUG, "synchronously replicating " CONFUGA_FID_DEBFMT " to " CONFUGA_SID_DEBFMT, CONFUGA_FID_PRIARGS(fid), sid);
 
@@ -1112,7 +1112,7 @@ static int waitall (confuga *C, confuga_sid_t fsid, const char *fhostport)
 	for (i = 0; i < J->u.array.length; i++) {
 		json_value *job = J->u.array.values[i];
 		assert(jistype(job, json_object));
-		chirp_jobid_t id;
+		chirp_jobid_t id=-1;
 
 		json_value *cid = jsonA_getname(job, "id", json_integer);
 		CATCH(lookuptjid(C, fsid, cid->u.integer, &id));

--- a/chirp/src/json.c
+++ b/chirp/src/json.c
@@ -100,6 +100,14 @@ static void * json_alloc (json_state * state, unsigned long size, int zero)
    return state->settings.mem_alloc (size, zero, state->settings.user_data);
 }
 
+#ifdef __GNUC__
+#if __GNUC__ >= 7
+/* Temporary fix for warning strict-aliasing.
+ * This file should be replace with dttools/src/jx */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
+#endif
 static int new_value
    (json_state * state, json_value ** top, json_value ** root, json_value ** alloc, json_type type)
 {
@@ -178,6 +186,11 @@ static int new_value
 
    return 1;
 }
+#ifdef __GNUC__
+#if __GNUC__ >= 7
+#pragma GCC diagnostic pop
+#endif
+#endif
 
 #define e_off \
    ((int) (i - cur_line_begin))
@@ -189,6 +202,15 @@ static int new_value
 #define string_add(b)  \
    do { if (!state.first_pass) string [string_length] = b;  ++ string_length; } while (0);
 
+
+#ifdef __GNUC__
+#if __GNUC__ >= 7
+/* Temporary fix for warning strict-aliasing.
+ * This file should be replace with dttools/src/jx */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
+#endif
 static const long
    flag_next             = 1 << 0,
    flag_reproc           = 1 << 1,
@@ -364,8 +386,9 @@ json_value * json_parse_ex (json_settings * settings,
 
                   case json_object:
 
-                     if (state.first_pass)
+                     if (state.first_pass) {
                         (*(json_char **) &top->u.object.values) += string_length + 1;
+                     }
                      else
                      {  
                         top->u.object.values [top->u.object.length].name
@@ -809,6 +832,11 @@ e_failed:
 
    return 0;
 }
+#ifdef __GNUC__
+#if __GNUC__ >= 7
+#pragma GCC diagnostic pop
+#endif
+#endif
 
 json_value * json_parse (const json_char * json, size_t length)
 {

--- a/chirp/src/json.c
+++ b/chirp/src/json.c
@@ -216,8 +216,8 @@ json_value * json_parse_ex (json_settings * settings,
    static const json_state _state;
    json_state state = _state;
    long flags;
-   long num_digits, num_e;
-   json_int_t num_fraction;
+   long num_digits=0, num_e=0;
+   json_int_t num_fraction=0;
 
    error[0] = '\0';
    end = (json + length);

--- a/chirp/src/json.c
+++ b/chirp/src/json.c
@@ -240,8 +240,8 @@ json_value * json_parse_ex (json_settings * settings,
    {
       json_uchar uchar;
       unsigned char uc_b1, uc_b2, uc_b3, uc_b4;
-      json_char * string;
-      unsigned int string_length;
+      json_char * string=0;
+      unsigned int string_length=0;
 
       top = root = 0;
       flags = flag_seek_value;


### PR DESCRIPTION
Warnings found with gcc 7.3.0.

I simply silenced the strict aliasing one, as I am not sure what those are lines are doing, and we should be replacing json.h and json.c with jx anyway.