### PR TITLE
guard uninitialized struct in jx_copy (pedantic compiler fix)

### DIFF
--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -540,7 +540,7 @@ struct jx_item * jx_item_copy( struct jx_item *i )
 struct jx  *jx_copy( struct jx *j )
 {
 	if(!j) return 0;
-	struct jx *c;
+	struct jx *c = 0;
 
 	switch(j->type) {
 		case JX_NULL:
@@ -575,7 +575,10 @@ struct jx  *jx_copy( struct jx *j )
 			break;
 	}
 
-	c->line = j->line;
+    if(c) {
+        c->line = j->line;
+    }
+
 	return c;
 }
 


### PR DESCRIPTION
Warning found with gcc 7.3.0.

The uninitialized value never comes into play, as initialization is covered by the switch statement. Adding an initial value to make the compiles happy.