### PR TITLE
fix uninitialized value in deltadb_reduction_value

### DIFF
--- a/deltadb/src/deltadb_reduction.c
+++ b/deltadb/src/deltadb_reduction.c
@@ -61,7 +61,7 @@ void deltadb_reduction_update( struct deltadb_reduction *r, double val )
 
 double deltadb_reduction_value( struct deltadb_reduction *r )
 {
-	double value;
+	double value = 0;
 	switch(r->type) {
 		case COUNT:
 			value = r->count;

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -731,7 +731,7 @@ int rmonitor_handle_inotify(void)
 
 #if defined(RESOURCE_MONITOR_USE_INOTIFY)
 	struct inotify_event *evdata = NULL;
-	struct rmonitor_file_info *finfo;
+	struct rmonitor_file_info *finfo = NULL;
 	struct stat fst;
 	char *fname;
 	int nbytes, evc, i;


### PR DESCRIPTION
Found with gcc version 7.3.0.

Initial value is provided by the switch statement, but the compiler is missing that.