### PR TITLE
Pedantic warnings wq json

### DIFF
--- a/work_queue/src/work_queue_json.c
+++ b/work_queue/src/work_queue_json.c
@@ -96,7 +96,8 @@ static int specify_files(int input, struct jx *files, struct work_queue_task *ta
 
 	while(arr != NULL) {
 
-		char *local, *remote;
+		char *local = NULL;
+        char *remote = NULL;
 		struct jx_pair *flag;
 		void *k = NULL;
 		void *v = NULL;

--- a/work_queue/src/work_queue_json.c
+++ b/work_queue/src/work_queue_json.c
@@ -166,8 +166,9 @@ static int specify_files(int input, struct jx *files, struct work_queue_task *ta
 static struct work_queue_task *create_task(const char *str)
 {
 
-	char *command_line;
-	struct jx *input_files, *output_files;
+	char *command_line = NULL;
+	struct jx *input_files = NULL;
+    struct jx *output_files = NULL;
 
 	struct jx *json = jx_parse_string(str);
 	if(!json) {


### PR DESCRIPTION
Found with gcc 7.3.0.

As far as I can tell, the logic of the function prevents the uninitialized values from being used.