### PR TITLE
Python bindings style changes 

### DIFF
--- a/chirp/src/bindings/python3/chirp.binding.py
+++ b/chirp/src/bindings/python3/chirp.binding.py
@@ -151,7 +151,7 @@ class Client(object):
         result = chirp_wrap_resetacl(self.hostport, path, rights, self.__stoptime(absolute_stop_time, timeout))
 
         if result < 0:
-            raise GeneralFailure('resetacl', result, [path, subject, rights])
+            raise GeneralFailure('resetacl', result, [path, rights])
 
         return result
 
@@ -216,7 +216,7 @@ class Client(object):
         result = chirp_reli_chmod(self.hostport, path, mode, self.__stoptime(absolute_stop_time, timeout))
 
         if result < 0:
-            raise GeneralFailure('chmod', result)
+            raise GeneralFailure('chmod', result, [path, mode])
 
         return result
 

--- a/chirp/src/bindings/python3/chirp.binding.py
+++ b/chirp/src/bindings/python3/chirp.binding.py
@@ -50,7 +50,7 @@ class Client(object):
 
         self.identity = self.whoami()
 
-        if self.identity is '':
+        if self.identity == '':
             raise AuthenticationFailure(authentication)
 
     def __exit__(self):

--- a/chirp/src/bindings/python3/chirp.binding.py
+++ b/chirp/src/bindings/python3/chirp.binding.py
@@ -357,7 +357,7 @@ class Client(object):
         if job_id < 0:
             raise ChirpJobError('create', job_id, job_json)
 
-        return job_id;
+        return job_id
 
 
     ##
@@ -372,7 +372,7 @@ class Client(object):
         if result < 0:
             raise ChirpJobError('kill', result, ids_str)
 
-        return result;
+        return result
 
 
 
@@ -388,7 +388,7 @@ class Client(object):
         if result < 0:
             raise ChirpJobError('commit', result, ids_str)
 
-        return result;
+        return result
 
     ##
     # Reaps the jobs identified with the different job ids.
@@ -402,7 +402,7 @@ class Client(object):
         if result < 0:
             raise ChirpJobError('reap', result, ids_str)
 
-        return result;
+        return result
 
     ##
     # Obtains the current status for each job id. The value returned is a
@@ -417,7 +417,7 @@ class Client(object):
         if status is None:
             raise ChirpJobError('status', None, ids_str)
 
-        return json.loads(status);
+        return json.loads(status)
 
     ##
     # Waits waiting_time seconds for the job_id to terminate. Return value is
@@ -432,7 +432,7 @@ class Client(object):
         if status is None:
             raise ChirpJobError('status', None, job_id)
 
-        return json.loads(status);
+        return json.loads(status)
 
 
 ##

--- a/chirp/src/bindings/python3/chirp.binding.py
+++ b/chirp/src/bindings/python3/chirp.binding.py
@@ -239,7 +239,7 @@ class Client(object):
         result = chirp_recursive_put(self.hostport,
                                      source, destination,
                                      self.__stoptime(absolute_stop_time, timeout))
-        if(result > -1):
+        if result > -1:
             return result
 
         raise TransferFailure('put', result, source, destination)
@@ -265,7 +265,7 @@ class Client(object):
                                      source, destination,
                                      self.__stoptime(absolute_stop_time, timeout))
 
-        if(result > -1):
+        if result > -1:
             return result
 
         raise TransferFailure('get', result, source, destination)

--- a/chirp/src/bindings/python3/chirp.binding.py
+++ b/chirp/src/bindings/python3/chirp.binding.py
@@ -53,7 +53,7 @@ class Client(object):
         if self.identity == '':
             raise AuthenticationFailure(authentication)
 
-    def __exit__(self):
+    def __exit__(self, exception_type, exception_value, traceback):
         chirp_reli_disconnect(self.hostport)
 
     def __del__(self):

--- a/chirp/src/bindings/python3/chirp.binding.py
+++ b/chirp/src/bindings/python3/chirp.binding.py
@@ -616,35 +616,34 @@ class Stat(object):
         return "%s uid:%d gid:%d size:%d" % (self.path, self.uid, self.gid, self.size)
 
 class AuthenticationFailure(Exception):
-    def __init__(self, value):
-        self.value = value
-    def __str__(self):
-        return repr(self.value)
+    pass
 
 class GeneralFailure(Exception):
     def __init__(self, action, status, value):
+        message = "Error with %s(%s) %s" % (action, status, value)
+        super(GeneralFailure, self).__init__(message)
+
         self.action = action
         self.status = status
-        self.value  = value
-    def __str__(self):
-        return "%s(%s) %s" % (self.action, self.status, self.value)
+        self.value = value
 
 class TransferFailure(Exception):
     def __init__(self, action, status, source, dest):
+        message = "Error with %s(%s) %s %s" % (action, status, source, dest)
+        super(TransferFailure, self).__init__(message)
+
         self.action = action
         self.status = status
         self.source = source
-        self.dest   = dest
-    def __str__(self):
-        return "Error with %s(%s) %s %s" % (self.action, self.status, self.source, self.dest)
+        self.dest = dest
 
 class ChirpJobError(Exception):
     def __init__(self, action, status, value):
+        message = "Error with %s(%s) %s" % (action, status, value)
+        super(ChirpJobError, self).__init__(message)
+
         self.action = action
         self.status = status
-        self.value  = value
-    def __str__(self):
-        return "%s(%s) %s" % (self.action, self.status, self.value)
-
+        self.value = value
 
 # @endcode

--- a/chirp/src/bindings/python3/chirp.binding.py
+++ b/chirp/src/bindings/python3/chirp.binding.py
@@ -10,12 +10,9 @@
 #
 # - @ref Chirp.Client
 # - @ref Chirp.Stat
-
 import os
 import time
 import json
-import binascii
-
 
 ##
 # Python Client object

--- a/chirp/src/bindings/python3/chirp.binding.py
+++ b/chirp/src/bindings/python3/chirp.binding.py
@@ -29,7 +29,7 @@ class Client(object):
     # @param authentication    A list of prefered authentications. E.g., ['tickets', 'unix']
     # @param debug             Generate client debug output.
     def __init__(self, hostport, timeout=60, authentication=None, tickets=None, debug=False):
-        self.hostport    = hostport
+        self.hostport = hostport
         self.timeout = timeout
 
         if debug:
@@ -167,14 +167,14 @@ class Client(object):
     # @param timeout             If given, maximum number of seconds to
     #                            wait for a server response.
     def ls(self, path, absolute_stop_time=None, timeout=None):
-        dr    = chirp_reli_opendir(self.hostport, path, self.__stoptime(absolute_stop_time, timeout))
+        dr = chirp_reli_opendir(self.hostport, path, self.__stoptime(absolute_stop_time, timeout))
         files = []
 
         if dir is None:
             raise IOError(path)
 
         while True:
-            d =  chirp_reli_readdir(dr)
+            d = chirp_reli_readdir(dr)
             if d is None: break
             files.append(Stat(d.name, d.info))
 
@@ -352,7 +352,7 @@ class Client(object):
     # @endcode
     def job_create(self, job_description):
         job_json = json.dumps(job_description)
-        job_id   = chirp_wrap_job_create(self.hostport, job_json, self.__stoptime())
+        job_id = chirp_wrap_job_create(self.hostport, job_json, self.__stoptime())
 
         if job_id < 0:
             raise ChirpJobError('create', job_id, job_json)
@@ -367,7 +367,7 @@ class Client(object):
     #
     def job_kill(self, *job_ids):
         ids_str = json.dumps(job_ids)
-        result  = chirp_wrap_job_kill(self.hostport, ids_str, self.__stoptime())
+        result = chirp_wrap_job_kill(self.hostport, ids_str, self.__stoptime())
 
         if result < 0:
             raise ChirpJobError('kill', result, ids_str)
@@ -383,7 +383,7 @@ class Client(object):
     #
     def job_commit(self, *job_ids):
         ids_str = json.dumps(job_ids)
-        result  = chirp_wrap_job_commit(self.hostport, ids_str, self.__stoptime())
+        result = chirp_wrap_job_commit(self.hostport, ids_str, self.__stoptime())
 
         if result < 0:
             raise ChirpJobError('commit', result, ids_str)
@@ -397,7 +397,7 @@ class Client(object):
     #
     def job_reap(self, *job_ids):
         ids_str = json.dumps(job_ids)
-        result  = chirp_wrap_job_reap(self.hostport, ids_str, self.__stoptime())
+        result = chirp_wrap_job_reap(self.hostport, ids_str, self.__stoptime())
 
         if result < 0:
             raise ChirpJobError('reap', result, ids_str)
@@ -412,7 +412,7 @@ class Client(object):
     #
     def job_status(self, *job_ids):
         ids_str = json.dumps(job_ids)
-        status  = chirp_wrap_job_status(self.hostport, ids_str, self.__stoptime())
+        status = chirp_wrap_job_status(self.hostport, ids_str, self.__stoptime())
 
         if status is None:
             raise ChirpJobError('status', None, ids_str)
@@ -426,8 +426,8 @@ class Client(object):
     #
     # @param waiting_time maximum number of seconds to wait for a job to finish.
     # @param job_id id of the job to wait.
-    def job_wait(self, waiting_time, job_id = 0):
-        status  = chirp_wrap_job_wait(self.hostport, job_id, waiting_time, self.__stoptime())
+    def job_wait(self, waiting_time, job_id=0):
+        status = chirp_wrap_job_wait(self.hostport, job_id, waiting_time, self.__stoptime())
 
         if status is None:
             raise ChirpJobError('status', None, job_id)

--- a/resource_monitor/src/bindings/python3/resource_monitor.bindings.py
+++ b/resource_monitor/src/bindings/python3/resource_monitor.bindings.py
@@ -148,9 +148,9 @@ def __measure_update_to_peak(pid, old_summary=None):
 
     if old_summary is None:
         return new_summary
-    else:
-        rmsummary_merge_max(old_summary, new_summary)
-        return old_summary
+
+    rmsummary_merge_max(old_summary, new_summary)
+    return old_summary
 
 def __child_handler(child_finished, signum, frame):
     child_finished.set()
@@ -294,8 +294,8 @@ def __monitor_function(limits, callback, interval, return_resources, function, *
 
     if not results['resources']:
         raise results['result']
-    else:
-        results['resources'] = _resources_to_dict(results['resources'])
+
+    results['resources'] = _resources_to_dict(results['resources'])
 
     if results['resource_exhaustion']:
         raise ResourceExhaustion(results['resources'], function, args, kwargs)
@@ -553,10 +553,9 @@ class Category:
 
         if mode == 'fixed':
             return self.maximum_seen()
-        else:
-            category_update_first_allocation(self._cat, None)
-            return resource_monitor.to_dict(self._cat.first_allocation)
+
+        category_update_first_allocation(self._cat, None)
+        return resource_monitor.to_dict(self._cat.first_allocation)
 
     def maximum_seen(self):
         return resource_monitor.to_dict(self._cat.max_resources_seen)
-

--- a/resource_monitor/src/bindings/python3/resource_monitor.bindings.py
+++ b/resource_monitor/src/bindings/python3/resource_monitor.bindings.py
@@ -128,22 +128,20 @@ class ResourceExhaustion(Exception):
     # @param function            Function that caused the exhaustion.
     # @param args                List of positional arguments to function that caused the exhaustion.
     # @param kwargs              Dictionary of keyword arguments to function that caused the exhaustion.
-    def __init__(self, resources, function, args = None, kwargs = None):
-        self.resources = resources
-        self.function  = function
-        self.args      = args
-        self.kwargs    = kwargs
-
-    def __str__(self):
-        r = self.resources
-        l = r['limits_exceeded']
+    def __init__(self, resources, function, args=None, kwargs=None):
+        r = resources
+        l = resources['limits_exceeded']
         ls = ["{limit}: {value}".format(limit=k, value=l[k]) for k in list(l.keys()) if (l[k] > -1 and l[k] < r[k])]
+        message = 'Limits broken: {limits}'.format(limits=','.join(ls))
+        super(ResourceExhaustion, self).__init__(message)
 
-        return 'Limits broken: {limits}'.format(limits=','.join(ls))
+        self.resources = resources
+        self.function = function
+        self.args = args
+        self.kwargs = kwargs
 
 class ResourceInternalError(Exception):
-    def __init__(self, *args, **kwargs):
-        super(ResourceInternalError, self).__init__(*args, **kwargs)
+    pass
 
 def __measure_update_to_peak(pid, old_summary=None):
     new_summary = rmonitor_measure_process(pid)

--- a/resource_monitor/src/bindings/python3/resource_monitor.bindings.py
+++ b/resource_monitor/src/bindings/python3/resource_monitor.bindings.py
@@ -19,14 +19,12 @@
 import fcntl
 import functools
 import json
-import math
 import multiprocessing
 import os
 import signal
 import struct
 import tempfile
 import threading
-import time
 
 def set_debug_flag(*flags):
     for flag in flags:

--- a/resource_monitor/src/bindings/python3/resource_monitor.bindings.py
+++ b/resource_monitor/src/bindings/python3/resource_monitor.bindings.py
@@ -75,12 +75,12 @@ cctools_debug_config('resource_monitor')
 # >>> (result_a, resources) = my_sum_a([1,2,3])
 # >>> print(result, resources['memory'])
 # 6, 66
-# 
-# >>> result_b = my_sum_b([1,2,3]) 
+#
+# >>> result_b = my_sum_b([1,2,3])
 # memory used: 66
 #
 # >>> assert(result_a == result_b)
-# 
+#
 #
 # # Wrapping the already defined function 'sum', adding limits:
 # my_sum_monitored = monitored(limits = {'memory': 1024})(sum)
@@ -90,7 +90,7 @@ cctools_debug_config('resource_monitor')
 # except ResourceExhaustion as e:
 #   print(e)
 #   ...
-# 
+#
 # # Defining a function with a callback and a decorator.
 # # In this example, we record the time series of resources used:
 # import multiprocessing
@@ -104,7 +104,7 @@ cctools_debug_config('resource_monitor')
 #   ...
 #
 # result = my_function(...)
-# 
+#
 # # print the time series
 # while not results_series.empty():
 #     try:
@@ -113,7 +113,7 @@ cctools_debug_config('resource_monitor')
 #     except multiprocessing.Empty:
 #         pass
 # @endcode
-def monitored(limits = None, callback = None, interval = 1, return_resources = True):
+def monitored(limits=None, callback=None, interval=1, return_resources=True):
     def monitored_inner(function):
         return functools.partial(__monitor_function, limits, callback, interval, return_resources, function)
     return monitored_inner
@@ -145,7 +145,7 @@ class ResourceInternalError(Exception):
     def __init__(self, *args, **kwargs):
         super(ResourceInternalError, self).__init__(*args, **kwargs)
 
-def __measure_update_to_peak(pid, old_summary = None):
+def __measure_update_to_peak(pid, old_summary=None):
     new_summary = rmonitor_measure_process(pid)
 
     if old_summary is None:
@@ -211,12 +211,12 @@ def _watchman(results_queue, limits, callback, interval, function, args, kwargs)
         pids_file = None
         try:
             # try python3 version first, which gets the 'buffering' keyword argument
-            pids_file=tempfile.NamedTemporaryFile(mode='rb+', prefix='p_mon-', buffering=0)
+            pids_file = tempfile.NamedTemporaryFile(mode='rb+', prefix='p_mon-', buffering=0)
         except TypeError:
             # on error try python2, which gets the 'bufsize' keyword argument
-            pids_file=tempfile.NamedTemporaryFile(mode='rb+', prefix='p_mon-', bufsize=0)
+            pids_file = tempfile.NamedTemporaryFile(mode='rb+', prefix='p_mon-', bufsize=0)
 
-        os.environ['CCTOOLS_RESOURCE_MONITOR_PIDS_FILE']=pids_file.name
+        os.environ['CCTOOLS_RESOURCE_MONITOR_PIDS_FILE'] = pids_file.name
 
         cctools_debug(D_RMON, "starting function process")
         fun_proc.start()
@@ -237,13 +237,13 @@ def _watchman(results_queue, limits, callback, interval, function, args, kwargs)
                 resources_now = rmonitor_minimonitor(MINIMONITOR_MEASURE, 0)
                 rmsummary_merge_max(resources_max, resources_now)
 
-                rmsummary_check_limits(resources_max, limits);
+                rmsummary_check_limits(resources_max, limits)
                 if resources_max.limits_exceeded is not None:
                     child_finished.set()
                 else:
                     if callback:
                         callback(fun_id, function.__name__, step, _resources_to_dict(resources_now))
-                child_finished.wait(timeout = interval)
+                child_finished.wait(timeout=interval)
         except Exception as e:
             fun_proc.terminate()
             fun_proc.join()
@@ -252,7 +252,7 @@ def _watchman(results_queue, limits, callback, interval, function, args, kwargs)
         if resources_max.limits_exceeded is not None:
             fun_proc.terminate()
             fun_proc.join()
-            results_queue.put({ 'result': None, 'resources': resources_max, 'resource_exhaustion': True})
+            results_queue.put({'result': None, 'resources': resources_max, 'resource_exhaustion': True})
         else:
             fun_proc.join()
             try:
@@ -266,7 +266,7 @@ def _watchman(results_queue, limits, callback, interval, function, args, kwargs)
                 raise fun_result
 
             rmsummary_merge_max(resources_max, resources_measured_end)
-            results_queue.put({ 'result': fun_result, 'resources': resources_max, 'resource_exhaustion': False})
+            results_queue.put({'result': fun_result, 'resources': resources_max, 'resource_exhaustion': False})
 
         if callback:
             callback(fun_id, function.__name__, -1, _resources_to_dict(resources_max))
@@ -282,9 +282,8 @@ def _resources_to_dict(resources):
         if d['wall_time'] > 0:
             d['cores_avg'] = float(d['cpu_time']) / float(d['wall_time'])
     except KeyError:
-            d['cores_avg'] = -1
+        d['cores_avg'] = -1
     return d
-
 
 def __monitor_function(limits, callback, interval, return_resources, function, *args, **kwargs):
     result_queue = multiprocessing.Queue()
@@ -323,8 +322,8 @@ class Categories:
     # Create an empty set of categories.
     # @param self                Reference to the current object.
     # @param all_categories_name Name of the general category that holds all of the summaries.
-    def __init__(self, all_categories_name = '(all)'):
-        self.categories          = {}
+    def __init__(self, all_categories_name='(all)'):
+        self.categories = {}
         self.all_categories_name = all_categories_name
         category_tune_bucket_size('category-steady-n-tasks', -1)
 
@@ -379,7 +378,7 @@ class Categories:
 
     ##
     # Add the summary (a dictionary) to the respective category.
-    # At least both the 'category' and 'wall_time' keys should be defined. 
+    # At least both the 'category' and 'wall_time' keys should be defined.
     #
     # @code
     # cs = Categories()
@@ -387,7 +386,7 @@ class Categories:
     # @endcode
     #
     def accumulate_summary(self, summary):
-        category      = summary['category']
+        category = summary['category']
         wall_time = summary['wall_time']
 
         if category == self.all_categories_name:
@@ -509,9 +508,9 @@ class Category:
     def usage(self, field):
         usage = 0
         for r in self.summaries:
-            resource  = r[field]
+            resource = r[field]
             wall_time = r['wall_time']
-            usage    += wall_time * resource
+            usage += wall_time * resource
         return usage
 
     def waste(self, field, allocation):
@@ -519,7 +518,7 @@ class Category:
 
         waste = 0
         for r in self.summaries:
-            resource  = r[field]
+            resource = r[field]
             wall_time = r['wall_time']
             if resource > allocation:
                 waste += wall_time * (allocation + maximum - resource)
@@ -537,17 +536,17 @@ class Category:
         maximum = self.maximum_seen()[field]
         maximum = float(maximum)
 
-        tasks      = 0
+        tasks = 0
         total_time = 0
         for r in self.summaries:
-            resource  = r[field]
+            resource = r[field]
             wall_time = r['wall_time']
 
             if resource > allocation:
-                tasks      += 1
+                tasks += 1
                 total_time += 2*wall_time
             else:
-                tasks      += maximum/allocation
+                tasks += maximum/allocation
                 total_time += wall_time
         return tasks/total_time
 

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -1278,8 +1278,8 @@ class WorkQueue(object):
     def blacklist_clear(self, host=None):
         if host is None:
             return work_queue_blacklist_clear(self._work_queue)
-        else:
-            return work_queue_blacklist_remove(self._work_queue, host)
+
+        return work_queue_blacklist_remove(self._work_queue, host)
 
     ##
     # Delete file from workers's caches.

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -1224,7 +1224,7 @@ class WorkQueue(object):
     # @param rm       Dictionary indicating maximum values. See @resources_measured for possible fields.
     # @param filename JSON file with resource summaries.
 
-    def initialize_categories(filename, rm):
+    def initialize_categories(self, filename, rm):
         return work_queue_initialize_categories(self._work_queue, rm, filename)
 
     ##

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -49,7 +49,7 @@ class Task(object):
         try:
             self._task = work_queue_task_create(command)
             if not self._task:
-                raise
+                raise Exception('Unable to create internal Task structure')
         except:
             raise Exception('Unable to create internal Task structure')
 

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -27,7 +27,7 @@ def specify_port_range(low_port, high_port):
     if low_port >= high_port:
         raise TypeError('low_port {} should be smaller than high_port {}'.format(low_port, high_port))
 
-    os.environ['TCP_LOW_PORT']  = str(low_port)
+    os.environ['TCP_LOW_PORT'] = str(low_port)
     os.environ['TCP_HIGH_PORT'] = str(high_port)
 
 cctools_debug_config('work_queue_python')
@@ -276,7 +276,7 @@ class Task(object):
     #
     #   events:
     #   label        Name that identifies the snapshot. Only alphanumeric, -,
-    #                and _ characters are allowed. 
+    #                and _ characters are allowed.
     #   on-create    Take a snapshot every time the file is created. Default: false
     #   on-truncate  Take a snapshot when the file is truncated.    Default: false
     #   on-pattern   Take a snapshot when a line matches the regexp pattern.    Default: none
@@ -297,51 +297,51 @@ class Task(object):
     # default), the task is tried indefinitely. A task that did not succeed
     # after the given number of retries is returned with result
     # WORK_QUEUE_RESULT_MAX_RETRIES.
-    def specify_max_retries( self, max_retries ):
-        return work_queue_task_specify_max_retries(self._task,max_retries)
+    def specify_max_retries(self, max_retries):
+        return work_queue_task_specify_max_retries(self._task, max_retries)
 
     ##
     # Indicate the number of cores required by this task.
-    def specify_cores( self, cores ):
-        return work_queue_task_specify_cores(self._task,cores)
+    def specify_cores(self, cores):
+        return work_queue_task_specify_cores(self._task, cores)
 
     ##
     # Indicate the memory (in MB) required by this task.
-    def specify_memory( self, memory ):
-        return work_queue_task_specify_memory(self._task,memory)
+    def specify_memory(self, memory):
+        return work_queue_task_specify_memory(self._task, memory)
 
     ##
     # Indicate the disk space (in MB) required by this task.
-    def specify_disk( self, disk ):
-        return work_queue_task_specify_disk(self._task,disk)
+    def specify_disk(self, disk):
+        return work_queue_task_specify_disk(self._task, disk)
 
     ##
     # Indicate the the priority of this task (larger means better priority, default is 0).
-    def specify_priority( self, priority ):
-        return work_queue_task_specify_priority(self._task,priority)
+    def specify_priority(self, priority):
+        return work_queue_task_specify_priority(self._task, priority)
 
     # Indicate the maximum end time (absolute, in microseconds from the Epoch) of this task.
     # This is useful, for example, when the task uses certificates that expire.
     # If less than 1, or not specified, no limit is imposed.
-    def specify_end_time( self, useconds ):
-        return work_queue_task_specify_end_time(self._task,useconds)
+    def specify_end_time(self, useconds):
+        return work_queue_task_specify_end_time(self._task, useconds)
 
     # Indicate the maximum running time for a task in a worker (relative to
     # when the task starts to run).  If less than 1, or not specified, no limit
     # is imposed.
-    def specify_running_time( self, useconds ):
-        return work_queue_task_specify_running_time(self._task,useconds)
+    def specify_running_time(self, useconds):
+        return work_queue_task_specify_running_time(self._task, useconds)
 
     ##
     # Set this environment variable before running the task.
     # If value is None, then variable is unset.
-    def specify_environment_variable( self, name, value = None ):
-        return work_queue_task_specify_enviroment_variable(self._task,name,value)
+    def specify_environment_variable(self, name, value=None):
+        return work_queue_task_specify_enviroment_variable(self._task, name, value)
 
     ##
     # Set a name for the resource summary output directory from the monitor.
-    def specify_monitor_output( self, directory ):
-        return work_queue_task_specify_monitor_output(self._task,directory)
+    def specify_monitor_output(self, directory):
+        return work_queue_task_specify_monitor_output(self._task, directory)
 
     ##
     # Get the user-defined logical name for the task.
@@ -793,9 +793,9 @@ class WorkQueue(object):
     #
     # @see work_queue_create    - For more information about environmental variables that affect the behavior this method.
     def __init__(self, port=WORK_QUEUE_DEFAULT_PORT, name=None, shutdown=False, stats_log=None, transactions_log=None, debug_log=None):
-        self._shutdown   = shutdown
+        self._shutdown = shutdown
         self._work_queue = None
-        self._stats      = None
+        self._stats = None
         self._stats_hierarchy = None
         self._task_table = {}
 
@@ -814,7 +814,7 @@ class WorkQueue(object):
         try:
             if debug_log:
                 specify_debug_log(debug_log)
-            self._stats      = work_queue_stats()
+            self._stats = work_queue_stats()
             self._stats_hierarchy = work_queue_stats()
             self._work_queue = work_queue_create(port)
             if not self._work_queue:
@@ -973,7 +973,7 @@ class WorkQueue(object):
     # @param self 	Reference to the current work queue object.
     # @param dirname    Directory name for the monitor output.
     # @param watchdog   If True (default), kill tasks that exhaust their declared resources.
-    def enable_monitoring(self, dirname = None, watchdog = True):
+    def enable_monitoring(self, dirname=None, watchdog=True):
         return work_queue_enable_monitoring(self._work_queue, dirname, watchdog)
 
     ## As @ref enable_monitoring, but it also generates a time series and a debug file.
@@ -984,7 +984,7 @@ class WorkQueue(object):
     # @param self 	Reference to the current work queue object.
     # @param dirname    Directory name for the monitor output.
     # @param watchdog   If True (default), kill tasks that exhaust their declared resources.
-    def enable_monitoring_full(self, dirname = None, watchdog = True):
+    def enable_monitoring_full(self, dirname=None, watchdog=True):
         return work_queue_enable_monitoring_full(self._work_queue, dirname, watchdog)
 
     ##
@@ -1012,8 +1012,8 @@ class WorkQueue(object):
     # @param self       Reference to the current work queue object.
     # @param host       The hostname the host running the workers.
     # @param drain_mode If True, no new tasks are dispatched to workers at hostname, and empty workers are shutdown. Else, workers works as usual.
-    def specify_draining_by_hostname(self, hostname, drain_mode = True):
-        return work_queue_specify_draining_by_hostname (self._work_queue, hostname, drain_mode)
+    def specify_draining_by_hostname(self, hostname, drain_mode=True):
+        return work_queue_specify_draining_by_hostname(self._work_queue, hostname, drain_mode)
 
     ##
     # Determine whether there are any known tasks queued, running, or waiting to be collected.
@@ -1363,7 +1363,7 @@ class WorkQueue(object):
         task_pointer = work_queue_wait(self._work_queue, timeout)
         if task_pointer:
             task = self._task_table[int(task_pointer.taskid)]
-            del(self._task_table[task_pointer.taskid])
+            del self._task_table[task_pointer.taskid]
             return task
         return None
 
@@ -1373,7 +1373,7 @@ def rmsummary_snapshots(self):
 
     snapshots = []
     for i in range(0, self.snapshots_count):
-        snapshot = rmsummary_get_snapshot(self, i);
+        snapshot = rmsummary_get_snapshot(self, i)
         snapshots.append(snapshot)
     return snapshots
 

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -63,13 +63,13 @@ class Task(object):
         # asked explicitely.
 
         if flags is None:
-            flags = WORK_QUEUE_NOCACHE;
+            flags = WORK_QUEUE_NOCACHE
 
         if cache is not None:
             if cache:
-                flags = flags | WORK_QUEUE_CACHE;
+                flags = flags | WORK_QUEUE_CACHE
             else:
-                flags = flags & ~(WORK_QUEUE_CACHE);
+                flags = flags & ~(WORK_QUEUE_CACHE)
 
         return flags
 


### PR DESCRIPTION
conda-forge CI failed for python3.8/osx with a SyntaxWarning (using 'is' instead of ==).

This pr comes from using a python linter to pickup other such warnings.