### PR TITLE
wq_json environment variables

### DIFF
--- a/work_queue/src/work_queue_json.c
+++ b/work_queue/src/work_queue_json.c
@@ -26,7 +26,7 @@ static const char *work_queue_properties[] = { "name", "port", "priority", "num_
 	"transactions_logfile", "keepalive_interval", "keepalive_timeout", "link_poll_end",
 	"master_preferred_connection", "monitor_mode", "monitor_file", "monitor_output_directory",
 	"monitor_summary_filename", "monitor_exe", "measured_local_resources",
-	"current_max_worker", "password", "bandwidth"
+	"current_max_worker", "password", "bandwidth", NULL
 };
 
 static const char *work_queue_task_properties[] = { "tag", "command_line", "worker_selection_algorithm", "output", "input_files", "environment",
@@ -44,7 +44,7 @@ static const char *work_queue_task_properties[] = { "tag", "command_line", "work
 	"time_execute_cmd_finish", "total_transfer_time", "cmd_execution_time",
 	"total_cmd_execution_time", "total_cmd_exhausted_execute_time",
 	"total_time_until_worker_failure", "total_bytes_received", "total_bytes_sent",
-	"total_bytes_transferred", "time_app_delay"
+	"total_bytes_transferred", "time_app_delay", NULL
 };
 
 

--- a/work_queue/src/work_queue_json.c
+++ b/work_queue/src/work_queue_json.c
@@ -101,9 +101,6 @@ static int specify_files(int input, struct jx *files, struct work_queue_task *ta
 		struct jx_pair *flag;
 		void *k = NULL;
 		void *v = NULL;
-		int cache = 1;
-		int nocache = 0;
-		int watch = 16;
 		int flags = 0;
 
 		const char *key = jx_iterate_keys(arr, &k);
@@ -121,17 +118,13 @@ static int specify_files(int input, struct jx *files, struct work_queue_task *ta
 				while(flag) {
 					char *flag_key = flag->key->u.string_value;
 					bool flag_value = flag->value->u.boolean_value;
-					if(!strcmp(flag_key, "WORK_QUEUE_NOCACHE")) {
+					if(!strcmp(flag_key, "cache")) {
 						if(flag_value) {
-							flags |= nocache;
+							flags |= WORK_QUEUE_CACHE;
 						}
-					} else if(!strcmp(flag_key, "WORK_QUEUE_CACHE")) {
+					} else if(!strcmp(flag_key, "watch")) {
 						if(flag_value) {
-							flags |= cache;
-						}
-					} else if(!strcmp(flag_key, "WORK_QUEUE_WATCH")) {
-						if(flag_value) {
-							flags |= watch;
+							flags |= WORK_QUEUE_WATCH;
 						}
 					} else {
 						printf("KEY ERROR: %s not valid", flag_key);

--- a/work_queue/src/work_queue_json.c
+++ b/work_queue/src/work_queue_json.c
@@ -328,6 +328,10 @@ char *work_queue_json_wait(struct work_queue *q, int timeout)
 
 	struct work_queue_task *t = work_queue_wait(q, timeout);
 
+    if(!t) {
+        return NULL;
+    }
+
 	command_line = jx_pair(jx_string("command_line"), jx_string(t->command_line), NULL);
 	taskid = jx_pair(jx_string("taskid"), jx_integer(t->taskid), command_line);
 	return_status = jx_pair(jx_string("return_status"), jx_integer(t->return_status), taskid);
@@ -344,7 +348,6 @@ char *work_queue_json_wait(struct work_queue *q, int timeout)
 	task = jx_print_string(j);
 
 	return task;
-
 }
 
 char *work_queue_json_remove(struct work_queue *q, int id)

--- a/work_queue/src/work_queue_json.h
+++ b/work_queue/src/work_queue_json.h
@@ -12,35 +12,55 @@ See the file COPYING for details.
  using TCP sockets, Unix applications, and files as intermediate buffers.  A
  master process uses @ref work_queue_json_create to create a queue, then @ref
  work_queue_json_submit to submit tasks. Once tasks are running, call @ref
- work_queue_json_wait to wait for completion. 
+ work_queue_json_wait to wait for completion.
 */
 
 #include "work_queue.h"
 
 /** Create a new work_queue object.
-@param port The port number to listen on. If zero is specified, then the 
-port stored in <b>WORK_QUEUE_PORT</b> is used if available. If it isn't, or 
--1 is specified, the first unused port between <b>WORK_QUEUE_LOW_PORT</b> 
+@param port The port number to listen on. If zero is specified, then the
+port stored in <b>WORK_QUEUE_PORT</b> is used if available. If it isn't, or
+-1 is specified, the first unused port between <b>WORK_QUEUE_LOW_PORT</b>
 and <b>WORK_QUEUE_HIGH_PORT</b> (1024 and 32767 by default) is chosen.
-@return A new work queue, or null if it could not be created. 
+@return A new work queue, or null if it could not be created.
  */
 struct work_queue *work_queue_json_create(const char *str);
 
 /** Submit a task to a queue.
-Once a task is submitted to a queue, it is not longer under the user's 
+Once a task is submitted to a queue, it is not longer under the user's
 control and should not be inspected until returned via @ref work_queue_wait.
-Once returned, it is safe to re-submit the same take object via 
+Once returned, it is safe to re-submit the same take object via
 @ref work_queue_submit.
 @param q A work queue object.
-@param str A JSON description of a task. 
+@param str A JSON description of a task.
 
-{ "command_line" : <i>string</i> , "output_files" : <i>array of objects with one object per output file</i> -> 
-[ { "local_name" : <i>string</i> , "remote_name" : <i>string</i> , "flags" : <i>object</i> -> { 
-"WORK_QUEUE_CACHE" : <i>boolean</i> , "WORK_QUEUE_NOCACHE" : <i>boolean</i> , "WORK_QUEUE_WATCH" : 
-<i>boolean</i> } } ] , "input _files" : <i>array of objects with one object per input file</i> -> [ { 
-"local_name" : <i>string</i> , "remote_name" : <i>string</i> , "flags" : <i>object</i> -> { "WORK_QUEUE_CACHE" : 
-<i>boolean</i> , "WORK_QUEUE_NOCACHE" : <i>boolean</i> , "WORK_QUEUE_WATCH" : <i>boolean</i> } } ] , 
-"tag" : <i>string</i> }
+task document: (only "command_line" is required.)
+{
+    "command_line" : <i>string</i>,
+    "input_files"  : <i>array of objects with one object per input file (see file document below)</i>,
+    "output_files" : <i>array of objects with one object per output file (see file document below)</i>,
+    "environment"  : <i>object with environment variables names and values (see environment document below)</i>,
+    "tag"          : <i>string</i>,  # arbitrary string to identify the task by the user.
+}
+
+file document:
+{
+    "local_name"  : <i>string</i>,   # name of the file at the machine running the master
+    "remote_name" : <i>string</i>,   # name of the file local_name is copied to/from the machine running the task.
+    "flags"       : {
+                        "cache" : <i>boolean</i>,  # whether the file should be cached at the worker. Default is false.
+                        "watch" : <i>boolean</i>,  # For output files only. Whether appends to the file should be sent
+                                                     as they occur. Default is false.
+                    }
+}
+
+environment document:
+{
+    <i>string</i> : <i>string</i>,   # name and value of an environment variable to be set for the task.
+    <i>string</i> : <i>string</i>,
+    ...
+}
+
 
 @return An integer taskid assigned to the submitted task.
 */
@@ -48,15 +68,15 @@ int work_queue_json_submit(struct work_queue *q, const char *str);
 
 /** Wait for a task to complete.
 @param q A work queue object.
-@param timeout The number of seconds to wait for a completed task before 
-returning. Use an integer time to set the timeout or the constant 
+@param timeout The number of seconds to wait for a completed task before
+returning. Use an integer time to set the timeout or the constant
 @ref WORK_QUEUE_WAITFORTASK to block until a task has completed.
 @return A JSON description of the completed task or the
- timeout was reached without a completed task, or there is completed child 
-process (call @ref process_wait to retrieve the status of the completed 
-child process). Return string should be freed using free(). 
+ timeout was reached without a completed task, or there is completed child
+process (call @ref process_wait to retrieve the status of the completed
+child process). Return string should be freed using free().
 
-{ "command_line" : <i>string</i> , "tag" : <i>string</i> , "output" : <i>string</i> , "taskid" : 
+{ "command_line" : <i>string</i> , "tag" : <i>string</i> , "output" : <i>string</i> , "taskid" :
 <i>integer</i> , "return_status" : <i>integer</i> , "result" : <i>integer</i> }
 
 */
@@ -66,7 +86,7 @@ char *work_queue_json_wait(struct work_queue *q, int timeout);
 /** Remove a task from the queue.
 @param q A work queue object.
 @param id The id of the task to be removed from the queue.
-@return A JSON description of the removed task. 
+@return A JSON description of the removed task.
 */
 char *work_queue_json_remove(struct work_queue *q, int id);
 

--- a/work_queue/src/work_queue_json.h
+++ b/work_queue/src/work_queue_json.h
@@ -61,7 +61,6 @@ environment document:
     ...
 }
 
-
 @return An integer taskid assigned to the submitted task.
 */
 int work_queue_json_submit(struct work_queue *q, const char *str);

--- a/work_queue/src/work_queue_json_example.c
+++ b/work_queue/src/work_queue_json_example.c
@@ -59,10 +59,10 @@ int main(int argc, char *argv[])
 
 	while(!work_queue_empty(q)) {
 
-		t = work_queue_json_wait(q, 20);
-
-		printf("%s\n", t);
-
+		t = work_queue_json_wait(q, 5);
+        if(t) {
+            printf("%s\n", t);
+        }
 	}
 
 	printf("all tasks complete!\n");


### PR DESCRIPTION
Adds the "environment" : { "key": "value", .... } object to the task description. Each key-value pair is fed to work_queue_task_environment_variable.

Simplifies cache and watch flags to simple boolean values (cache = true|false, watch = true|false).

Catches segfault when no task is ready after wait timeout.