### PR TITLE
WQ Recursive Put

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4,12 +4,6 @@ This software is distributed under the GNU General Public License.
 See the file COPYING for details.
 */
 
-/*
-The following major problems must be fixed:
-- The capacity code assumes one task per worker.
-- The log specification need to be updated.
-*/
-
 #include "work_queue.h"
 #include "work_queue_protocol.h"
 #include "work_queue_internal.h"

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -2887,24 +2887,22 @@ static work_queue_result_code_t send_directory( struct work_queue *q, struct wor
 
 	work_queue_result_code_t result = SUCCESS;
 
-	send_worker_msg(q,w,"dir %s",remotedirname);
+	send_worker_msg(q,w,"dir %s\n",remotedirname);
 
 	struct dirent *d;
 	while((d = readdir(dir))) {
 		if(!strcmp(d->d_name, ".") || !strcmp(d->d_name, "..")) continue;
 
 		char *localpath = string_format("%s/%s",dirname,d->d_name);
-		char *remotepath = string_format("%s/%s",remotedirname,d->d_name);
 
-		result = send_item( q, w, t, localpath, remotepath, total_bytes, flags );
+		result = send_item( q, w, t, localpath, d->d_name, total_bytes, flags );
 
 		free(localpath);
-		free(remotepath);
 
 		if(result != SUCCESS) break;
 	}
 
-	send_worker_msg(q,w,"end");
+	send_worker_msg(q,w,"end\n");
 
 	closedir(dir);
 	return result;
@@ -3306,7 +3304,7 @@ static work_queue_result_code_t start_one_task(struct work_queue *q, struct work
 	// send_worker_msg returns the number of bytes sent, or a number less than
 	// zero to indicate errors. We are lazy here, we only check the last
 	// message we sent to the worker (other messages may have failed above).
-	int result_msg = send_worker_msg(q,w, "end\n");
+	int result_msg = send_worker_msg(q,w,"end\n");
 
 	if(result_msg > -1)
 	{

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -2806,9 +2806,6 @@ static int send_symlink( struct work_queue *q, struct work_queue_worker *w, stru
 Send a single file (or a piece of a file) to the remote worker.
 The transfer time is controlled by the size of the file.
 If the transfer takes too long, then abort.
-
-Problem: This is about the third time stat() has been called
-on the file.  Find a way to minimize stat calls.
 */
 
 static int send_file( struct work_queue *q, struct work_queue_worker *w, struct work_queue_task *t, const char *localname, const char *remotename, off_t offset, int64_t length, struct stat info, int64_t *total_bytes )

--- a/work_queue/src/work_queue_protocol.h
+++ b/work_queue/src/work_queue_protocol.h
@@ -19,7 +19,8 @@ This file should not be installed and should only be included by .c files.
 /* 6: worker only report total, max, and min resources. */
 /* 7: added category message */
 /* 8: worker send feature message. */
-#define WORK_QUEUE_PROTOCOL_VERSION 8
+/* 9: recursive send/recv and filename encoding. */
+#define WORK_QUEUE_PROTOCOL_VERSION 9
 
 #define WORK_QUEUE_LINE_MAX 4096       /**< Maximum length of a work queue message line. */
 #define WORK_QUEUE_POOL_NAME_MAX 128   /**< Maximum length of a work queue pool name. */

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1162,11 +1162,16 @@ static int do_put_single_file( struct link *master, char *filename, int64_t leng
 		path_dirname(filename,dirname);
 		if(!create_dir(dirname,0777)) {
 			debug(D_WQ, "could not create directory %s: %s",dirname,strerror(errno));
+			free(cached_filename);
 			return 0;
 		}
 	}
 
-	return do_put_file_internal(master,cached_filename,length,mode);
+	int result = do_put_file_internal(master,cached_filename,length,mode);
+
+	free(cached_filename);
+
+	return result;
 }
 
 static int file_from_url(const char *url, const char *filename) {

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -462,7 +462,7 @@ int link_recursive( const char *source, const char *target )
 {
 	struct stat info;
 
-	if(stat(source,&info)<0) return 0;
+	if(lstat(source,&info)<0) return 0;
 
 	if(S_ISDIR(info.st_mode)) {
 		DIR *dir = opendir(source);

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1090,14 +1090,14 @@ static int do_put_dir_internal( struct link *master, char *dirname )
 	while(1) {
 		if(!recv_master_message(master,line,sizeof(line),time(0)+active_timeout)) return 0;
 
-		/* XXX need to check for success of each call. */
+		int r = 0;
 
 		if(sscanf(line,"put %s %" SCNd64 " %o",name,&size,&mode)==3) {
 
 			if(!is_valid_filename(name)) return 0;
 
 			char *subname = string_format("%s/%s",dirname,name);
-			do_put_file_internal(master,subname,size,mode);
+			r = do_put_file_internal(master,subname,size,mode);
 			free(subname);
 
 		} else if(sscanf(line,"symlink %s %" SCNd64,name,&size)==2) {
@@ -1105,7 +1105,7 @@ static int do_put_dir_internal( struct link *master, char *dirname )
 			if(!is_valid_filename(name)) return 0;
 
 			char *subname = string_format("%s/%s",dirname,name);
-			do_put_symlink_internal(master,subname,size);
+			r = do_put_symlink_internal(master,subname,size);
 			free(subname);
 
 		} else if(sscanf(line,"dir %s",name)==1) {
@@ -1113,12 +1113,14 @@ static int do_put_dir_internal( struct link *master, char *dirname )
 			if(!is_valid_filename(name)) return 0;
 
 			char *subname = string_format("%s/%s",dirname,name);
-			do_put_dir_internal(master,subname);
+			r = do_put_dir_internal(master,subname);
 			free(subname);
 
 		} else if(!strcmp(line,"end")) {
 			break;
 		}
+
+		if(!r) return 0;
 	}
 
 	return 1;

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -798,7 +798,7 @@ static int stream_output_item(struct link *master, const char *filename, int rec
 		fd = open(cached_filename, O_RDONLY, 0);
 		if(fd >= 0) {
 			length = info.st_size;
-			send_master_message(master, "file %s %"PRId64" 0%o\n", filename, length, info.st_mode);
+			send_master_message(master, "file %s %"PRId64"\n", filename, length );
 			actual = link_stream_from_fd(master, fd, length, time(0) + active_timeout);
 			close(fd);
 			if(actual != length) {

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1071,7 +1071,7 @@ static int do_put_dir_internal( struct link *master, char *dirname )
 			if(!is_valid_filename(name)) return 0;
 
 			char *subname = string_format("%s/%s",dirname,name);
-			do_put_dir_internal(master,name);
+			do_put_dir_internal(master,subname);
 			free(subname);
 
 		} else if(!strcmp(line,"end")) {

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -798,7 +798,7 @@ static int stream_output_item(struct link *master, const char *filename, int rec
 		fd = open(cached_filename, O_RDONLY, 0);
 		if(fd >= 0) {
 			length = info.st_size;
-			send_master_message(master, "file %s %"PRId64"\n", filename, length);
+			send_master_message(master, "file %s %"PRId64" 0%o\n", filename, length, info.st_mode);
 			actual = link_stream_from_fd(master, fd, length, time(0) + active_timeout);
 			close(fd);
 			if(actual != length) {

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1036,8 +1036,10 @@ static int do_put_file_internal( struct link *master, char *filename, int64_t le
 /*
 Handle an incoming directory inside the recursive dir protocol.
 Notice that we have already checked the dirname for validity,
-and now we process "file" and "dir" commands within the list
-until "end" is reached.
+and now we process "put" and "dir" commands within the list
+until "end" is reached.  Note that "put" is used instead of
+"file" for historical reasons, to support recursive reuse
+of existing code.
 */
 
 static int do_put_dir_internal( struct link *master, char *dirname )
@@ -1056,7 +1058,7 @@ static int do_put_dir_internal( struct link *master, char *dirname )
 	while(1) {
 		if(!recv_master_message(master,line,sizeof(line),time(0)+active_timeout)) return 0;
 
-		if(sscanf(line,"file %s %" SCNd64 " %o",name,&size,&mode)==3) {
+		if(sscanf(line,"put %s %" SCNd64 " %o",name,&size,&mode)==3) {
 
 			if(!is_valid_filename(name)) return 0;
 

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1558,12 +1558,11 @@ static int handle_master(struct link *master) {
 	int64_t length;
 	int64_t taskid = 0;
 	int mode, r, n;
-	int flags;
 
 	if(recv_master_message(master, line, sizeof(line), idle_stoptime )) {
 		if(sscanf(line,"task %" SCNd64, &taskid)==1) {
 			r = do_task(master, taskid,time(0)+active_timeout);
-		} else if(sscanf(line,"put %s %"SCNd64" %d %d",filename_encoded,&length,&mode,&flags)==4) {
+		} else if(sscanf(line,"put %s %"SCNd64" %d",filename_encoded,&length,&mode)==3) {
 			url_decode(filename_encoded,filename,sizeof(filename));
 			if(path_within_dir(filename, workspace)) {
 				r = do_put_single_file(master, filename, length, mode);

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1562,7 +1562,7 @@ static int handle_master(struct link *master) {
 	if(recv_master_message(master, line, sizeof(line), idle_stoptime )) {
 		if(sscanf(line,"task %" SCNd64, &taskid)==1) {
 			r = do_task(master, taskid,time(0)+active_timeout);
-		} else if(sscanf(line,"put %s %"SCNd64" %d",filename_encoded,&length,&mode)==3) {
+		} else if(sscanf(line,"put %s %"SCNd64" %o",filename_encoded,&length,&mode)==3) {
 			url_decode(filename_encoded,filename,sizeof(filename));
 			r = do_put_single_file(master, filename, length, mode);
 			reset_idle_timer();

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1150,24 +1150,20 @@ protocol (above) is preferred instead.
 
 static int do_put_single_file( struct link *master, char *filename, int64_t length, int mode )
 {
-	char cached_filename[WORK_QUEUE_LINE_MAX];
-
 	if(!path_within_dir(filename, workspace)) {
 		debug(D_WQ, "Path - %s is not within workspace %s.", filename, workspace);
 		return 0;
 	}
 
-	char *slash = strrchr(cached_filename, '/');
+	char * cached_filename = string_format("cache/%s",filename);
 
-	string_nformat(cached_filename, sizeof(cached_filename), "cache/%s", slash);
-
-	if(slash) {
-		*slash = '\0';
-		if(!create_dir(cached_filename, mode | 0700)) {
-			debug(D_WQ, "Could not create directory - %s (%s)\n", cached_filename, strerror(errno));
+	if(strchr(filename,'/')) {
+		char dirname[WORK_QUEUE_LINE_MAX];
+		path_dirname(filename,dirname);
+		if(!create_dir(dirname,0777)) {
+			debug(D_WQ, "could not create directory %s: %s",dirname,strerror(errno));
 			return 0;
 		}
-		*slash = '/';
 	}
 
 	return do_put_file_internal(master,cached_filename,length,mode);


### PR DESCRIPTION
(Note: This hasn't been tested at all, I'm making a PR so I don't lose the code here.)

Address the performance problem of sending large directories via WQ.
The existing implementation of recursive put stinks b/c it sends every file
as a distinct transaction, forcing the worker to check for and create all
parent directories for every file.

This implementation provides a proper streaming put protocol, to go with
the streaming get protocol already in use.  Directories are sent via a stream
of data:

```
dir d
file x size mode
(data)
file y size mode
(data)
file z size mode
...
end
```

In this scheme, all file names must be simple names without paths.
Should minimize the metadata interactions that the worker has with the underlying filesystem.
