### PR TITLE
python_package_run  time measurements

### DIFF
--- a/python_environments/python_package_run
+++ b/python_environments/python_package_run
@@ -4,6 +4,15 @@
 # This software is distributed under the GNU General Public License.
 # See the file COPYING for details.
 
+# Executes a command line inside a conda environment.
+# The conda environment can be supplied via a tar file or a directory.
+#
+# It is assumed that the conda environment can be used in the absence of a
+# local conda installation. This means it should include conda and conda-unpack
+# itself. This requirement can be fulfilled with the generic recipe shown with
+# the --help-env-creation option:
+#
+
 usage() {
     echo "Usage: python_package_run [options] -e <file> command and args ..."
     echo "where options are:"
@@ -12,10 +21,35 @@ usage() {
     echo "                            a temporary directory is used."
     echo " -w, --wait-for-lock <secs> Number of seconds to wait to get a writing lock"
     echo "                            on <dir>. Default is 300"
-    echo " -h, --help                 Show this help screen"
+    echo " --help-env-creation        Show instructions to create conda environments as tar files."
+    echo " -h, --help                 Show this help screen."
     echo "command and args            Command to execute inside the given environment."
     echo
     exit 1
+}
+
+function help_env_creation {
+cat << EOF
+
+Environments should include conda and conda-unpack so they can be used
+in the absence of a local conda installation. Environment creation follows
+the generic recipe:
+
+$ conda create --prefix ./my-conda-env python=X.XX conda
+$ source ./my-conda-env/bin/activate
+$ conda install -c conda-forge conda-pack
+... conda and pip install rest of packages ...
+$ python -c 'import conda_pack; conda_pack.pack(prefix="my-conda-env")
+
+The above generates my-conda-env.tar.gz ready to be used by this script as:
+
+$0 --environment my-conda-env.tar.gz -- python -c 'print(42)'
+
+The directory ./my-conda-env can be safely removed.
+
+EOF
+}
+
 }
 
 UNPACK_TO=
@@ -30,6 +64,10 @@ parse_arguments() {
 		case $1 in
 			-h | --help)
                 usage
+                ;;
+			--help-env*)
+                help_env_creation
+                exit 0
                 ;;
             -d | --unpack-to)
                 shift

--- a/python_environments/python_package_run
+++ b/python_environments/python_package_run
@@ -25,7 +25,6 @@ usage() {
     echo " -h, --help                 Show this help screen."
     echo "command and args            Command to execute inside the given environment."
     echo
-    exit 1
 }
 
 function help_env_creation {
@@ -64,6 +63,7 @@ parse_arguments() {
 		case $1 in
 			-h | --help)
                 usage
+                exit 0
                 ;;
 			--help-env*)
                 help_env_creation

--- a/python_environments/python_package_run
+++ b/python_environments/python_package_run
@@ -13,14 +13,18 @@
 # the --help-env-creation option:
 #
 
+start_time=$(date +'%s%N')
+
 usage() {
     echo "Usage: python_package_run [options] -e <file> command and args ..."
     echo "where options are:"
-    echo " -e, --environment <file>   Conda environment as a tar file. (Required.)"
-    echo " -d, --unpack-to <dir>      Directory to unpack the environment. If not given,"
-    echo "                            a temporary directory is used."
+    echo " -e, --environment <path>   Conda environment as a tar file or a directory. (Required.)"
+    echo " -u, --unpack-to <dir>      Directory to unpack the environment. If not given,"
+    echo "                            a temporary directory is used. If the argument to"
+    echo "                            --environment is a directory, --unpack-to is ignored."
     echo " -w, --wait-for-lock <secs> Number of seconds to wait to get a writing lock"
     echo "                            on <dir>. Default is 300"
+    echo " -d, --debug                Print debug messages."
     echo " --help-env-creation        Show instructions to create conda environments as tar files."
     echo " -h, --help                 Show this help screen."
     echo "command and args            Command to execute inside the given environment."
@@ -49,6 +53,18 @@ The directory ./my-conda-env can be safely removed.
 EOF
 }
 
+
+function logmsg {
+    if [[ "${PYTHON_PACKAGE_RUN_DEBUG}" = yes ]]
+    then
+        printf "%s python_package_run: " "$(date +'%Y-%m-%dT%T.%N')"
+        echo "$@"
+    fi
+}
+
+function errmsg {
+    local PYTHON_PACKAGE_RUN_DEBUG=yes
+    logmsg "$@"
 }
 
 UNPACK_TO=
@@ -69,9 +85,12 @@ parse_arguments() {
                 help_env_creation
                 exit 0
                 ;;
-            -d | --unpack-to)
+            -u | --unpack-to)
                 shift
                 UNPACK_TO="$1"
+                ;;
+            -d | --debug)
+                export PYTHON_PACKAGE_RUN_DEBUG=yes
                 ;;
             -e | --environment)
                 shift
@@ -88,16 +107,16 @@ parse_arguments() {
         shift
     done
 
-    if [ -z "${ENV_NAME}" ]
+    if [[ -z "${ENV_NAME}" ]]
     then
-        echo "An environment tarball should be specified with the --environment option."
+        errmsg "a tarball or directory should be specified with the --environment option."
         usage
         exit 1
     fi
 
-    if [ $# -lt 1 ]
+    if [[ $# -lt 1 ]]
     then
-        echo "No command line was specified."
+        errmsg "no command line was specified."
         usage
         exit 1
     fi
@@ -109,85 +128,117 @@ parse_arguments() {
 }
 
 function cleanup {
-    if [ "${UNPACK_IS_TMP}" = yes ]
+    if [[ "${UNPACK_IS_TMP}" = yes ]]
     then
         rm -rf "${UNPACK_TO}"
     fi
 
     rm -f "${UNTAR_SCRIPT}"
+
+    end_time=$(date +'%s%N')
+
+    ns=$((end_time-start_time))
+    s=$((ns/1000000000))
+    ns=$((ns-s))
+
+    logmsg total runtime: ${s}.${ns} seconds
 }
 trap cleanup EXIT
 
 parse_arguments "$@"
 
-
 #after shift, whatever is left is taken as the command line to execute.
 arg_counsumed=$?
 shift ${arg_counsumed}
 
+ENV_NAME_IS_DIR=no
 UNPACK_IS_TMP=no
 NEED_TO_UNPACK=yes
 
-if [ -z "${UNPACK_TO}" ]
+if [[ -d "${ENV_NAME}" ]]
+then
+    ENV_NAME_IS_DIR=yes
+
+    if [[ -n "${UNPACK_TO}" ]]
+    then
+        errmsg "ignoring --unpack-to argument as --environment is a directory." 
+    fi
+
+    UNPACK_TO="${ENV_NAME}"
+fi
+
+if [[ -z "${UNPACK_TO}" ]]
 then
     UNPACK_IS_TMP=yes
     UNPACK_TO="$(mktemp -d)"
 fi
 
 UNPACK_TO=$(realpath ${UNPACK_TO})
-echo Unpacking conda environment to ${UNPACK_TO}
+logmsg setting up conda environment at ${UNPACK_TO}
 
-if [ -f "${UNPACK_TO}" ]
+if [[ -f "${UNPACK_TO}" ]]
 then
-    echo "--unpack-to argument is an already existing file. It should be the name of a directory."
+    errmsg "--unpack-to argument is an already existing file. It should be the name of a directory."
     exit 1
 fi
 
+# unpacking environment if needed...
+LOCKFILE="${UNPACK_TO}/.unpacking_python_package_run_lock"
+mkdir -p "${UNPACK_TO}"
+
 UNTAR_SCRIPT=$(mktemp python_package_run.XXXXXX)
 cat > ${UNTAR_SCRIPT} << EOF
-if [ "\$(find ${UNPACK_TO} -mindepth 1 -maxdepth 1 | wc -l)" = 1 ]
+if [ "\$(find ${UNPACK_TO} -mindepth 1 -maxdepth 1 -not -name $(basename ${LOCKFILE}) | wc -l)" = 0 ]
 then
     # Directory is empty (the only file there is the lock). It is safe to untar.
     if ! tar -xf "${ENV_NAME}" -C "${UNPACK_TO}"
     then
-        echo "Could not uncompress environment: ${ENV_NAME}"
+        echo "python_package_run: could not uncompress environment: ${ENV_NAME}"
         exit 1
     fi
 else
-    echo "Directory ${UNPACK_TO} is not empty. Not unpacking environment again."
+    if [[ "${PYTHON_PACKAGE_RUN_DEBUG}" = yes ]]
+    then
+        echo "python_package_run: directory ${UNPACK_TO} is not empty. Not expanding environment file again."
+    fi
 fi
 exit 0
 EOF
 
-# unpacking environment if needed.
-LOCKFILE="${UNPACK_TO}/.unpacking_python_package_run_lock"
-mkdir -p "${UNPACK_TO}"
-
-flock -w ${LOCK_WAIT} ${LOCKFILE} -c "/bin/sh ${UNTAR_SCRIPT}"
-if [ "$?" != 0 ]
+if [[ "${ENV_NAME_IS_DIR}" = no ]]
 then
-    echo -e "Could not untar environment: ${ENV_NAME}"
-    exit 1
+    logmsg expanding environment file
+    flock -w ${LOCK_WAIT} ${LOCKFILE} -c "/bin/sh ${UNTAR_SCRIPT}"
+    if [ "$?" != 0 ]
+    then
+        errmsg "could not untar environment: ${ENV_NAME}"
+        exit 1
+    fi
 fi
 
 #activate and unpack the environment
+logmsg activating environment
 unset PYTHONPATH
 source "${UNPACK_TO}/bin/activate"
 if [ "$?" != 0 ]
 then
-    echo -e "Could not activate environment: ${ENV_NAME}"
+    errmsg "could not activate environment: ${ENV_NAME}"
     exit 1
 fi
 
+logmsg relocating paths
 flock -w ${LOCK_WAIT} ${LOCKFILE} conda-unpack
 if [ "$?" != 0 ]
 then
-    echo -e "Could not unpack environment: ${ENV_NAME}"
+    errmsg "could not unpack environment: ${ENV_NAME}"
     exit 1
 fi
 
 # Finally run the command line:
+logmsg executing command line: "${@}"
 "${@}"
 status=$?
+
+logmsg command line exit code: $status
 
 exit $status

--- a/python_environments/python_package_run
+++ b/python_environments/python_package_run
@@ -100,6 +100,10 @@ parse_arguments() {
                 shift
                 LOCK_WAIT="$1"
                 ;;
+            --)
+                shift
+                break
+                ;;
             *)
                 break
                 ;;


### PR DESCRIPTION
- Adds debug log messages to measure the time each step takes (untaring, unpacking, command line, etc.). Activate with -d or --debug  options.

- Adds --help-env-creation which shows a recipe on how to create an environment that this script can consume. (Mainly ensure that conda and conda-pack are included.)

- Accept -- as a separator between options and command line to be executed.

- Accept a directory as a possible conda environment (as an alternative to a tar file).

This is the script used when testing pr #2290 