### PR TITLE
WQ: Increase the minimum file transfer time to 60 seconds.

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4974,7 +4974,7 @@ struct work_queue *work_queue_create(int port)
 	q->asynchrony_multiplier = 1.0;
 	q->asynchrony_modifier = 0;
 
-	q->minimum_transfer_timeout = 10;
+	q->minimum_transfer_timeout = 60;
 	q->foreman_transfer_timeout = 3600;
 	q->transfer_outlier_factor = 10;
 	q->default_transfer_rate = 1*MEGABYTE;


### PR DESCRIPTION
Rationale: Although 10 seconds ought to be plenty for an epsilon-sized file,
consider what happens when streaming a large directory.  A large set of files
gets pushed over to the worker, which stuffs everything in the buffer/cache.
Suddenly, when the buffer cache is full, transfers stutter as data is pushed
to disk.  The transfer time of a single item may be affected as much by what
came before, than by its own size.

An even better solution would take into account the time to transfer everything
prior to this item.  But until we have that more sophisticated approach, this
change will make things a little more stable.