### PR TITLE
WQ: Rename Unprotected Symbols

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1579,7 +1579,7 @@ static void fetch_output_from_worker(struct work_queue *q, struct work_queue_wor
 	}
 
 	/* print warnings if the task ran for a very short time (1s) and exited with common non-zero status */
-	if(t->result == WORK_QUEUE_RESULT_WQ_SUCCESS && t->time_workers_execute_last < 1000000) {
+	if(t->result == WORK_QUEUE_RESULT_SUCCESS && t->time_workers_execute_last < 1000000) {
 		switch(t->return_status) {
 			case(126):
 				warn(D_WQ, "Task %d ran for a very short time and exited with code %d.\n", t->taskid, t->return_status);
@@ -5607,7 +5607,7 @@ const char *task_result_str(work_queue_result_t result) {
 	const char *str;
 
 	switch(result) {
-		case WORK_QUEUE_RESULT_WQ_SUCCESS:
+		case WORK_QUEUE_RESULT_SUCCESS:
 			str = "WQ_SUCCESS";
 			break;
 		case WORK_QUEUE_RESULT_INPUT_MISSING:
@@ -5980,7 +5980,7 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 		if(t) {
 			change_task_state(q, t, WORK_QUEUE_TASK_DONE);
 
-			if( t->result != WORK_QUEUE_RESULT_WQ_SUCCESS )
+			if( t->result != WORK_QUEUE_RESULT_SUCCESS )
 			{
 				q->stats->tasks_failed++;
 			}
@@ -6889,7 +6889,7 @@ void work_queue_accumulate_task(struct work_queue *q, struct work_queue_task *t)
 
 	q->stats->tasks_done++;
 
-	if(t->result == WORK_QUEUE_RESULT_WQ_SUCCESS)
+	if(t->result == WORK_QUEUE_RESULT_SUCCESS)
 	{
 		q->stats->time_workers_execute_good += t->time_workers_execute_last;
 		q->stats->time_send_good            += t->time_when_commit_end - t->time_when_commit_end;
@@ -6915,7 +6915,7 @@ void work_queue_accumulate_task(struct work_queue *q, struct work_queue_task *t)
 
 	/* accumulate resource summary to category only if task result makes it meaningful. */
 	switch(t->result) {
-		case WORK_QUEUE_RESULT_WQ_SUCCESS:
+		case WORK_QUEUE_RESULT_SUCCESS:
 		case WORK_QUEUE_RESULT_SIGNAL:
 		case WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION:
 		case WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME:

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -5608,7 +5608,7 @@ const char *task_result_str(work_queue_result_t result) {
 
 	switch(result) {
 		case WORK_QUEUE_RESULT_SUCCESS:
-			str = "WQ_SUCCESS";
+			str = "SUCCESS";
 			break;
 		case WORK_QUEUE_RESULT_INPUT_MISSING:
 			str = "INPUT_MISS";
@@ -6859,7 +6859,7 @@ int work_queue_specify_transactions_log(struct work_queue *q, const char *logfil
 		fprintf(q->transactions_logfile, "# time master-pid TASK taskid WAITING category-name {FIRST_RESOURCES|MAX_RESOURCES} resources-requested\n");
 		fprintf(q->transactions_logfile, "# time master-pid TASK taskid RUNNING worker-address {FIRST_RESOURCES|MAX_RESOURCES} resources-given\n");
 		fprintf(q->transactions_logfile, "# time master-pid TASK taskid WAITING_RETRIEVAL worker-address\n");
-		fprintf(q->transactions_logfile, "# time master-pid TASK taskid {RETRIEVED|DONE} {WQ_SUCCESS|SIGNAL|END_TIME|FORSAKEN|MAX_RETRIES|MAX_WALLTIME|UNKNOWN|RESOURCE_EXHAUSTION} {exit-code} {limits-exceeded} {resources-measured}\n\n");
+		fprintf(q->transactions_logfile, "# time master-pid TASK taskid {RETRIEVED|DONE} {SUCCESS|SIGNAL|END_TIME|FORSAKEN|MAX_RETRIES|MAX_WALLTIME|UNKNOWN|RESOURCE_EXHAUSTION} {exit-code} {limits-exceeded} {resources-measured}\n\n");
 
 		write_transaction(q, "MASTER START");
 		return 1;


### PR DESCRIPTION
A small thing, but it's bugging me:

Renamed unprotected symbols:
SUCCESS -> WQ_SUCCESS
WORKER_FAILURE -> WQ_WORKER_FAILURE
APP_FAILURE -> WQ_APP_FAILURE