### PR TITLE
fix an error in the work_queue_graph_log help message (python2-3)

### DIFF
--- a/work_queue/src/work_queue_graph_log
+++ b/work_queue/src/work_queue_graph_log
@@ -255,24 +255,29 @@ def check_gnuplot_version(gnuplot_cmd):
             exit(1)
 
 def show_usage():
-
-    usage_string = '''\n%s [options] <work-queue-log>\n
-                        \t-h\t\t\tThis message.
-                        \t-c <gnuplot-path>\tSpecify the location of the gnuplot executable.
-                        \t\t\t\tDefault is gnuplot.
-                        \t-o <prefix-output>\tGenerate prefix-output.{workers,workers-accum,tasks,tasks-accum,time-master,time-workers,transfer,cores}.%s.'
-                        \t\t\t\tDefault is <work-queue-log>.\n
-                        \t-r <range>\t\tRange of time to plot, in time units (see -u) from
-                        \t\t\t\tthe start of execution. Of the form: min:max, min:, or :max.
-                        \t-s <seconds>\t\tSample log every <seconds> (default is %f).'
-                        \t-u <time-unit>\t\tTime scale to output. One of s,m,h or d, for seconds,
-                        \t\t\t\tminutes (default), hours or days.\n
-                        \t-T <output-format>\tSet output format. Default is %s.
-                        \t\t\t\tIf \'text\', then the gnuplot scripts are written instead of the images.
-                        \t-g <width,height>\tSize of each plot. Default is %s.\n
-                        ''' % (os.path.basename(sys.argv[0],), format, resolution, format, geometry)
-
+    usage_string = """
+{command} [options] <work-queue-log>
+        -h                  This message.
+        -c <gnuplot-path>   Specify the location of the gnuplot executable.
+                            Default is gnuplot.
+        -o <prefix-output>  Generate prefix-output.{{workers,workers-accum,
+                                                    tasks,tasks-accum,
+                                                    time-master,time-workers,
+                                                    transfer,cores}}.{format}
+                            Default is <work-queue-log>.
+        -r <range>          Range of time to plot, in time units (see -u) from
+                            the start of execution. Of the form: min:max,
+                            min:, or :max.
+        -s <seconds>        Sample log every <seconds> (default is {format}).
+        -u <time-unit>      Time scale to output. One of s,m,h or d, for seconds,
+                            minutes (default), hours or days.
+        -T <output-format>  Set output format. Default is {format}.
+                            If \'text\', then the gnuplot scripts are written
+                            instead of the images.
+        -g <width,height>   Size of each plot. Default is {geometry}.
+""".format(command=os.path.basename(sys.argv[0],), format=format, resolution=resolution, geometry=geometry)
     print(usage_string)
+
 
 if __name__ == '__main__':
 

--- a/work_queue/src/work_queue_graph_log
+++ b/work_queue/src/work_queue_graph_log
@@ -255,20 +255,24 @@ def check_gnuplot_version(gnuplot_cmd):
             exit(1)
 
 def show_usage():
-    print '\n%s [options] <work-queue-log>\n' % (os.path.basename(sys.argv[0],))
-    print '\t-h\t\t\tThis message.'
-    print '\t-c <gnuplot-path>\tSpecify the location of the gnuplot executable.'
-    print '\t\t\t\tDefault is gnuplot.'
-    print '\t-o <prefix-output>\tGenerate prefix-output.{workers,workers-accum,tasks,tasks-accum,time-master,time-workers,transfer,cores}.%s.' % (format,)
-    print '\t\t\t\tDefault is <work-queue-log>.\n'
-    print '\t-r <range>\t\tRange of time to plot, in time units (see -u) from'
-    print '\t\t\t\tthe start of execution. Of the form: min:max, min:, or :max.'
-    print '\t-s <seconds>\t\tSample log every <seconds> (default is %f).' % (resolution,)
-    print '\t-u <time-unit>\t\tTime scale to output. One of s,m,h or d, for seconds,'
-    print '\t\t\t\tminutes (default), hours or days.\n'
-    print '\t-T <output-format>\tSet output format. Default is %s.' % (format,)
-    print '\t\t\t\tIf \'text\', then the gnuplot scripts are written instead of the images.'
-    print '\t-g <width,height>\tSize of each plot. Default is %s.\n' % (geometry,)
+
+    usage_string = '''\n%s [options] <work-queue-log>\n
+                        \t-h\t\t\tThis message.
+                        \t-c <gnuplot-path>\tSpecify the location of the gnuplot executable.
+                        \t\t\t\tDefault is gnuplot.
+                        \t-o <prefix-output>\tGenerate prefix-output.{workers,workers-accum,tasks,tasks-accum,time-master,time-workers,transfer,cores}.%s.'
+                        \t\t\t\tDefault is <work-queue-log>.\n
+                        \t-r <range>\t\tRange of time to plot, in time units (see -u) from
+                        \t\t\t\tthe start of execution. Of the form: min:max, min:, or :max.
+                        \t-s <seconds>\t\tSample log every <seconds> (default is %f).'
+                        \t-u <time-unit>\t\tTime scale to output. One of s,m,h or d, for seconds,
+                        \t\t\t\tminutes (default), hours or days.\n
+                        \t-T <output-format>\tSet output format. Default is %s.
+                        \t\t\t\tIf \'text\', then the gnuplot scripts are written instead of the images.
+                        \t-g <width,height>\tSize of each plot. Default is %s.\n
+                        ''' % (os.path.basename(sys.argv[0],), format, resolution, format, geometry)
+
+    print(usage_string)
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
The print statements in the usage function of work_queue_graph_log was using the syntax from python2. I was able to fix it to be able to work with python3.