### PR TITLE
fix specify_enviroment_variable typo in wq api

### DIFF
--- a/batch_job/src/batch_job_work_queue.c
+++ b/batch_job/src/batch_job_work_queue.c
@@ -63,7 +63,7 @@ static void specify_envlist( struct work_queue_task *t, struct jx *envlist )
 	if(envlist) {
 		struct jx_pair *p;
 		for(p=envlist->u.pairs;p;p=p->next) {
-			work_queue_task_specify_enviroment_variable(t,p->key->u.string_value,p->value->u.string_value);
+			work_queue_task_specify_environment_variable(t,p->key->u.string_value,p->value->u.string_value);
 		}
 	}
 }

--- a/work_queue/src/bindings/perl/Work_Queue/Task.pm
+++ b/work_queue/src/bindings/perl/Work_Queue/Task.pm
@@ -240,7 +240,7 @@ sub specify_priority {
 
 sub specify_environment_variable {
 	my ($self, $name, $value) = @_;
-	return work_queue_task_specify_enviroment_variable($self->{_task}, $name, $value);
+	return work_queue_task_specify_environment_variable($self->{_task}, $name, $value);
 }
 
 sub specify_monitor_output {

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -339,7 +339,7 @@ class Task(object):
     # Set this environment variable before running the task.
     # If value is None, then variable is unset.
     def specify_environment_variable(self, name, value=None):
-        return work_queue_task_specify_enviroment_variable(self._task, name, value)
+        return work_queue_task_specify_environment_variable(self._task, name, value)
 
     ##
     # Set a name for the resource summary output directory from the monitor.

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4248,7 +4248,7 @@ void work_queue_task_specify_command( struct work_queue_task *t, const char *cmd
 	t->command_line = xxstrdup(cmd);
 }
 
-void work_queue_task_specify_enviroment_variable( struct work_queue_task *t, const char *name, const char *value )
+void work_queue_task_specify_environment_variable( struct work_queue_task *t, const char *name, const char *value )
 {
 	if(value) {
 		list_push_tail(t->env_list,string_format("%s=%s",name,value));
@@ -4256,6 +4256,11 @@ void work_queue_task_specify_enviroment_variable( struct work_queue_task *t, con
 		/* Specifications without = indicate variables to me unset. */
 		list_push_tail(t->env_list,string_format("%s",name));
 	}
+}
+
+/* same as above, but with a typo. can't remove as it is part of already published api. */
+void work_queue_task_specify_enviroment_variable( struct work_queue_task *t, const char *name, const char *value ) {
+	work_queue_task_specify_environment_variable(t, name, value);
 }
 
 void work_queue_task_specify_max_retries( struct work_queue_task *t, int64_t max_retries ) {

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -495,7 +495,7 @@ Specify an environment variable to be added to the task.
 @param name Name of the variable.
 @param value Value of the variable.
  */
-void work_queue_task_specify_enviroment_variable( struct work_queue_task *t, const char *name, const char *value );
+void work_queue_task_specify_environment_variable( struct work_queue_task *t, const char *name, const char *value );
 
 /** Select the scheduling algorithm for a single task.
 To change the scheduling algorithm for all tasks, use @ref work_queue_specify_algorithm instead.
@@ -1097,6 +1097,11 @@ int work_queue_task_specify_output_file_do_not_cache(struct work_queue_task *t, 
  @return The string corresponding to the filename.
 */
 char *work_queue_generate_disk_alloc_full_filename(char *pwd, int taskid);
+
+
+/** Same as work_queue_task_specify_environment_variable, but with a typo in environment
+ */
+void work_queue_task_specify_enviroment_variable( struct work_queue_task *t, const char *name, const char *value );
 
 //@}
 

--- a/work_queue/src/work_queue_json.c
+++ b/work_queue/src/work_queue_json.c
@@ -163,7 +163,7 @@ static int specify_environment(struct jx *environment, struct work_queue_task *t
 	struct jx *value = jx_iterate_values(environment, &i);
 
     while(key != NULL) {
-        work_queue_task_specify_enviroment_variable(task, key, value->u.string_value);
+        work_queue_task_specify_environment_variable(task, key, value->u.string_value);
         key = jx_iterate_keys(environment, &j);
         value = jx_iterate_values(environment, &i);
     }

--- a/work_queue/src/work_queue_process.c
+++ b/work_queue/src/work_queue_process.c
@@ -173,7 +173,7 @@ static void export_environment( struct work_queue_process *p )
 
 static void specify_integer_env_var( struct work_queue_process *p, const char *name, int64_t value) {
 	char *value_str = string_format("%" PRId64, value);
-	work_queue_task_specify_enviroment_variable(p->task, name, value_str);
+	work_queue_task_specify_environment_variable(p->task, name, value_str);
 	free(value_str);
 }
 

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -949,7 +949,7 @@ static int do_task( struct link *master, int taskid, time_t stoptime )
 			if(value) {
 				*value = 0;
 				value++;
-				work_queue_task_specify_enviroment_variable(task,env,value);
+				work_queue_task_specify_environment_variable(task,env,value);
 			}
 			free(env);
 		} else {


### PR DESCRIPTION
I changed it to specify_enviro**n**ment_variable.  
I left the original  specify_enviroment_variable, but in the deprecated section.

The perl and python bindings had the correct spelling, so this is mostly for our internal code that uses C.