### PR TITLE
Forward declare struct work_queue.

### DIFF
--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -317,6 +317,9 @@ struct work_queue_stats {
 	int avg_capacity;               /**< @deprecated Use capacity_cores instead. */
 };
 
+/* Forward declare the queue's structure. This structure is opaque and defined in work_queue.c */
+struct work_queue;
+
 
 /** @name Functions - Tasks */
 


### PR DESCRIPTION
Newer compilers warn about this missing declaration:

warning: ‘struct work_queue’ declared inside parameter list will not be
visible outside of this definition or declaration.