### PR TITLE
first pass at conda environments on wq

### DIFF
--- a/work_queue/src/Makefile
+++ b/work_queue/src/Makefile
@@ -24,7 +24,7 @@ LIBRARIES = libwork_queue.a
 OBJECTS = $(OBJECTS_LIBRARY) $(OBJECTS_WORKER) work_queue_test_main.o
 OBJECTS_LIBRARY = $(SOURCES_LIBRARY:%.c=%.o)
 OBJECTS_WORKER = $(SOURCES_WORKER:%.c=%.o)
-PROGRAMS = work_queue_worker work_queue_status work_queue_example
+PROGRAMS = work_queue_worker work_queue_status work_queue_example work_queue_conda_example
 PUBLIC_HEADERS = work_queue.h work_queue_catalog.h work_queue_json.h
 SCRIPTS = work_queue_submit_common condor_submit_workers sge_submit_workers torque_submit_workers pbs_submit_workers slurm_submit_workers work_queue_graph_log
 TEST_PROGRAMS = work_queue_example work_queue_test work_queue_test_watch work_queue_priority_test work_queue_json_example

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -68,7 +68,8 @@ typedef enum {
 	WORK_QUEUE_RESULT_MAX_RETRIES         = 6 << 3, /**< The task could not be completed successfully in the given number of retries. **/
 	WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME   = 7 << 3, /**< The task ran for more than the specified time (relative since running in a worker). **/
 	WORK_QUEUE_RESULT_DISK_ALLOC_FULL     = 8 << 3, /**< The task filled its loop device allocation but needed more space. **/
-	WORK_QUEUE_RESULT_RMONITOR_ERROR      = 9 << 3  /**< The task failed because the monitor did not produce a summary report. **/
+	WORK_QUEUE_RESULT_RMONITOR_ERROR      = 9 << 3,  /**< The task failed because the monitor did not produce a summary report. **/
+	WORK_QUEUE_RESULT_ENV_SETUP_ERROR     = 10 << 3  /**< The task failed because setting up the environment failed. **/
 } work_queue_result_t;
 
 typedef enum {
@@ -109,6 +110,7 @@ struct work_queue_task {
 	struct list *input_files;                         /**< The files to transfer to the worker and place in the executing directory. */
 	struct list *output_files;                        /**< The output files (other than the standard output stream) created by the program to be retrieved from the task. */
 	struct list *env_list;                            /**< Environment variables applied to the task. */
+    char *conda_environment;                          /**< Local name of a tarball that contains a conda environment from conda-pack. */
 	int taskid;                                       /**< A unique task id number. */
 	int return_status;                                /**< The exit code of the command line. */
 	work_queue_result_t result;                       /**< The result of the task (see @ref work_queue_result_t */
@@ -507,6 +509,14 @@ To change the scheduling algorithm for all tasks, use @ref work_queue_specify_al
 */
 void work_queue_task_specify_algorithm(struct work_queue_task *t, work_queue_schedule_t algorithm);
 
+/** Specify a conda environment to run the task.
+ The environment should be contained in a tarball file created by conda-pack.
+ The environment will be unpacked only once per worker, and can be used unpacked by many tasks.
+@param t A task object.
+@param local_tarball The filename of the tarball that contains the conda environment.
+*/
+void work_queue_task_specify_conda_env(struct work_queue_task *t, const char *local_tarball);
+
 /** Specify a custom name for the monitoring summary. If @ref work_queue_enable_monitoring is also enabled, the summary is also written to that directory.
 @param t A task object.
 @param monitor_output Resource summary file.
@@ -572,7 +582,6 @@ For more information, consult the manual of the resource_monitor.
 */
 
 int work_queue_specify_snapshot_file(struct work_queue_task *t, const char *monitor_snapshot_file);
-
 
 //@}
 

--- a/work_queue/src/work_queue_conda_example.c
+++ b/work_queue/src/work_queue_conda_example.c
@@ -1,0 +1,35 @@
+#include <stdio.h>
+
+#include "work_queue.h"
+#include "timestamp.h"
+
+int main(int argc, char **argv) {
+    struct work_queue *q = work_queue_create(9123);
+
+    struct work_queue_task *t_vanilla = work_queue_task_create("python --version");
+    work_queue_task_specify_tag(t_vanilla, "vanilla");
+
+    struct work_queue_task *t_conda   = work_queue_task_create("python --version");
+    work_queue_task_specify_tag(t_conda, "with conda");
+    work_queue_task_specify_conda_env(t_conda, "conda-coffea-wq-env-py3.8.tar.gz");
+
+    struct work_queue_task *t_conda_b   = work_queue_task_create("python --version");
+    work_queue_task_specify_tag(t_conda_b, "with conda");
+    work_queue_task_specify_conda_env(t_conda_b, "conda-coffea-wq-env-py3.8.tar.gz");
+
+    work_queue_submit(q, t_vanilla);
+    work_queue_submit(q, t_conda);
+    work_queue_submit(q, t_conda_b);
+
+    timestamp_t origin = timestamp_get();
+
+    while(!work_queue_empty(q)) {
+        struct work_queue_task *t = work_queue_wait(q, -1);
+        if(t) {
+            printf("%lf task %s output: %s\n", (timestamp_get() - origin)/1e6, t->tag, t->output);
+            work_queue_task_delete(t);
+        }
+    }
+
+    work_queue_delete(q);
+}

--- a/work_queue/src/work_queue_protocol.h
+++ b/work_queue/src/work_queue_protocol.h
@@ -20,7 +20,8 @@ This file should not be installed and should only be included by .c files.
 /* 7: added category message */
 /* 8: worker send feature message. */
 /* 9: recursive send/recv and filename encoding. */
-#define WORK_QUEUE_PROTOCOL_VERSION 9
+/* 10: adds conda_env for conda environments. */
+#define WORK_QUEUE_PROTOCOL_VERSION 10
 
 #define WORK_QUEUE_LINE_MAX 4096       /**< Maximum length of a work queue message line. */
 #define WORK_QUEUE_POOL_NAME_MAX 128   /**< Maximum length of a work queue pool name. */

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -549,7 +549,6 @@ static int setup_conda_environment(struct work_queue_process *p) {
 				"mkdir -p %s\n"
 				"/bin/tar -C %s -xf cache/%s\n"
 				"%s/bin/conda-unpack", e->expansion, e->expansion, p->task->conda_environment, e->expansion);
-		debug(D_WQ, cmd);
 		int status = system(cmd);
 		free(cmd);
 


### PR DESCRIPTION
Here is the prototype for conda environments in work queue. The major complication was assigning the correct failure to the task. By default, the worker disconnects if something goes wrong with an input file, but in this case that this not very useful.

The conda environment is untared and unpacked just after the sandbox for the task is setup. This ensures that the process is only tried once per environment. If that process fails, I create a fake pid to associate with the task, so that the rest of the worker machinery can deal with the task as usual. (It is a fake pid in the sense that the task never runs, but it is a real pid as it comes from a fork that immediately exits. This to ensure that we don't send a signal to the wrong process.)

When the task is run inside the environment, the directory for the environment is accessed inside the cache directory (i.e.: "source ../cache/.....env-dir-name-expanded; task command). This breaks abstraction a little bit, but it was the only safe choice in order not to create a name that the task will later use.

You can see an example of its use in `work_queue_conda_example`.  Some preliminary numbers for a worker running locally:

```
./work_queue_conda_example 
0.930142 task vanilla output: Python 2.7.5

9.346275 task with conda output: Python 3.8.2

9.355874 task with conda output: Python 3.8.2
```
It takes about one second for the worker to connect, and the task without an environment to run. Then about 8 seconds to send the environment and untar it/unpacked it. Once the environment is setup, the second task using the environment runs almost immediately.

If this looks ok, I can make the python/perl bindings.

