### PR TITLE
Do not force debug messages to the console

### DIFF
--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -1020,7 +1020,7 @@ static void show_help(const char *cmd)
 	printf(" %-30s Specify the linking libraries for running mesos (for use with -T mesos).\n", "--mesos-preload");
 	printf(" %-30s Specify the container image for using Kubernetes (for use with -T k8s).\n", "--k8s-image");
 	printf(" %-30s Specify the container image that contains work_queue_worker availabe for using Kubernetes (for use with -T k8s).\n", "--k8s-worker-image");
-	printf(" %-30s Send debugging to this file (can also be :stderr, :stdout, :syslog, or :journal).\n", "-o,--debug-file=<file>");
+	printf(" %-30s Send debugging to this file (can also be :stderr, or :stdout).\n", "-o,--debug-file=<file>");
 	printf(" %-30s Specify the size of the debug file (must use with -o option).\n", "-O,--debug-file-size=<mb>");
 	printf(" %-30s Specify the binary to use for the worker (relative or hard path). It should accept the same arguments as the default work_queue_worker.\n", "--worker-binary=<file>");
 	printf(" %-30s Will make a best attempt to ensure the worker will execute in the specified OS environment, regardless of the underlying OS.\n","--runos=<img>");

--- a/chirp/src/chirp_fuse.c
+++ b/chirp/src/chirp_fuse.c
@@ -583,7 +583,7 @@ static void show_help(const char *cmd)
 	fprintf(stdout, " %-30s Run in foreground for debugging.\n", "-f,--foreground");
 	fprintf(stdout, " %-30s Comma-delimited list of tickets to use for authentication.\n", "-i,--tickets=<files>");
 	fprintf(stdout, " %-30s Mount options passed to FUSE.\n", "-m,--mount-options=<options>");
-	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)\n", "-o,--debug-file=<file>");
+	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr, or :stdout)\n", "-o,--debug-file=<file>");
 	fprintf(stdout, " %-30s Timeout for network operations. (default is %ds)\n", "-t,--timeout=<timeout>", chirp_fuse_timeout);
 	fprintf(stdout, " %-30s Show program version.\n", "-v,--version");
 	fprintf(stdout, " %-30s This message.\n", "-h,--help");

--- a/chirp/src/chirp_server.c
+++ b/chirp/src/chirp_server.c
@@ -1846,7 +1846,7 @@ static void show_help(const char *cmd)
 	fprintf(stdout, "The most common options are:\n");
 	fprintf(stdout, " %-30s URL of storage directory, like `file://path' or `hdfs://host:port/path'.\n", "-r,--root=<url>");
 	fprintf(stdout, " %-30s Enable debugging for this subsystem.\n", "-d,--debug=<name>");
-	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)\n", "-o,--debug-file=<file>");
+	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr, or :stdout)\n", "-o,--debug-file=<file>");
 	fprintf(stdout, " %-30s Send status updates to this host. (default: `%s')\n", "-u,--advertise=<host>", CATALOG_HOST);
 	fprintf(stdout, " %-30s Show version info.\n", "-v,--version");
 	fprintf(stdout, " %-30s This message.\n", "-h,--help");

--- a/chirp/src/chirp_status.c
+++ b/chirp/src/chirp_status.c
@@ -46,7 +46,7 @@ static void show_help(const char *cmd)
 	fprintf(stdout, "where options are:\n");
 	fprintf(stdout, " %-30s Query the catalog on this host.\n", "-c,--catalog=<host>");
 	fprintf(stdout, " %-30s Enable debugging for this sybsystem\n", "-d,--debug=<flag>");
-	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)\n", "-o,--debug-file=<file>");
+	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr, or :stdout)\n", "-o,--debug-file=<file>");
 	fprintf(stdout, " %-30s Rotate file once it reaches this size. (default 10M, 0 disables)\n", "-O,--debug-rotate-max=<bytes>");
 	fprintf(stdout, " %-30s Only show servers with this space available. (example: -A 100MB)\n", "-A,--server-space=<size>");
 	fprintf(stdout, " %-30s Only show servers with this project.\n", "   --server-project=<name>");

--- a/chirp/src/chirp_tool.c
+++ b/chirp/src/chirp_tool.c
@@ -1198,7 +1198,7 @@ static void show_help(const char *cmd)
 	fprintf(stdout, "where options are:\n");
 	fprintf(stdout, " %-30s Require this authentication mode.\n", "-a,--auth=<flag>");
 	fprintf(stdout, " %-30s Enable debugging for this subsystem.\n", "-d,--debug=<flag>");
-	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)\n", "-o,--debug-file=<file>");
+	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr, or :stdout)\n", "-o,--debug-file=<file>");
 	fprintf(stdout, " %-30s Comma-delimited list of tickets to use for authentication.\n", "-i,--tickets=<files>");
 	fprintf(stdout, " %-30s Long transfer information.\n", "-l,--verbose");
 	fprintf(stdout, " %-30s Set remote operation timeout.\n", "-t,--timeout=<time>");

--- a/chirp/src/confuga_adm.c
+++ b/chirp/src/confuga_adm.c
@@ -108,7 +108,7 @@ static void help (const char *argv0)
 	fprintf(stdout, "use: %s [options] <Confuga root> <cmd> [...]\n", argv0);
 	fprintf(stdout, "The most common options are:\n");
 	fprintf(stdout, " %-30s Enable debugging for this subsystem.\n", "-d,--debug=<name>");
-	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)\n", "-o,--debug-file=<file>");
+	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr, or :stdout)\n", "-o,--debug-file=<file>");
 	fprintf(stdout, " %-30s Show version info.\n", "-v,--version");
 	fprintf(stdout, " %-30s This message.\n", "-h,--help");
 	fprintf(stdout, "\n");

--- a/configure
+++ b/configure
@@ -1317,11 +1317,6 @@ optional_include stdint.h      HAS_STDINT_H HAVE_STDINT_H
 optional_include sys/statfs.h  HAS_SYS_STATFS_H
 optional_include sys/statvfs.h HAS_SYS_STATVFS_H
 optional_include sys/vfs.h     HAS_SYS_VFS_H
-optional_include syslog.h      HAS_SYSLOG_H
-
-#if optional_library_function systemd/sd-journal.h sd_journal_print systemd HAS_SYSTEMD_JOURNAL_H; then
-#	external_libraries="${external_libraries} -lsystemd"
-#fi
 
 cctools_doctargets=
 if check_path doxygen

--- a/doc/man/m4/allpairs_master.m4
+++ b/doc/man/m4/allpairs_master.m4
@@ -29,7 +29,7 @@ OPTIONS_BEGIN
 OPTION_TRIPLET(-p,port,port)The port that the master will be listening on.
 OPTION_TRIPLET(-e,extra-args,args)Extra arguments to pass to the comparison function.
 OPTION_TRIPLET(-f,input-file,file)Extra input file needed by the comparison function. (may be given multiple times)
-OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 OPTION_TRIPLET(-O,--output-file,file)Write task output to this file (default to standard output)
 OPTION_TRIPLET(-t,estimated-time,seconds)Estimated time to run one comparison. (default chosen at runtime)
 OPTION_TRIPLET(-x,width,item)Width of one work unit, in items to compare. (default chosen at runtime)

--- a/doc/man/m4/catalog_server.m4
+++ b/doc/man/m4/catalog_server.m4
@@ -49,7 +49,7 @@ OPTION_TRIPLET(-L, update-log,file)Log new updates to this file.
 OPTION_TRIPLET(-m, max-jobs,n)Maximum number of child processes.  (default is 50)
 OPTION_TRIPLET(-M, server-size, size)Maximum size of a server to be believed.  (default is any)
 OPTION_TRIPLET(-n, name, name)Set the preferred hostname of this server.
-OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 OPTION_TRIPLET(-O, debug-rotate-max, bytes)Rotate debug file once it reaches this size (default 10M, 0 disables).
 OPTION_TRIPLET(-p,, port, port)Port number to listen on (default is 9097)
 OPTION_ITEM(`-S, --single')Single process mode; do not fork on queries.

--- a/doc/man/m4/chirp_fuse.m4
+++ b/doc/man/m4/chirp_fuse.m4
@@ -35,7 +35,7 @@ OPTION_ITEM(`-D, --no-optimize')Disable small file optimizations such as recursi
 OPTION_ITEM(`-f, --foreground')Run in foreground for debugging.
 OPTION_TRIPLET(-i,tickets,files)Comma-delimited list of tickets to use for authentication.
 OPTION_TRIPLET(-m,mount-options,option)Pass mount option to FUSE. Can be specified multiple times.
-OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 OPTION_TRIPLET(-t,timeout,timeout)Timeout for network operations. (default is 60s)
 OPTION_ITEM(`-v, --version')Show program version.
 OPTION_ITEM(`-h, --help')Give help information.

--- a/doc/man/m4/chirp_server.m4
+++ b/doc/man/m4/chirp_server.m4
@@ -38,7 +38,7 @@ OPTION_ITEM(`-h, --help')Give help information.
 OPTION_TRIPLET(-I, interface,addr)Listen only on this network interface.
 OPTION_TRIPLET(-M, max-clients,count)Set the maximum number of clients to accept at once. (default unlimited)
 OPTION_TRIPLET(-n, catalog-name,name)Use this name when reporting to the catalog.
-OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 OPTION_TRIPLET(-O, debug-rotate-max,bytes)Rotate debug file once it reaches this size.
 OPTION_TRIPLET(-P,superuser,user)Superuser for all directories. (default is none)
 OPTION_TRIPLET(-p,port,port)Listen on this port (default is 9094, arbitrary is 0)

--- a/doc/man/m4/chirp_status.m4
+++ b/doc/man/m4/chirp_status.m4
@@ -28,7 +28,7 @@ OPTION_ITEM(`-l, --verbose')Long output.
 OPTION_ITEM(`-T, --totals')Totals output.
 OPTION_ITEM(`-v, --version')Show program version.
 OPTION_TRIPLET(-d,debug,flag)Enable debugging for this subsystem.
-OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 OPTION_TRIPLET(-O,debug-rotate-max,bytes)Rotate file once it reaches this size.
 OPTION_ITEM(`-h, --help')Show help text.
 OPTIONS_END

--- a/doc/man/m4/confuga_adm.m4
+++ b/doc/man/m4/confuga_adm.m4
@@ -20,7 +20,7 @@ SECTION(OPTIONS)
 OPTIONS_BEGIN
 OPTION_TRIPLET(-d, debug, flag)Enable debugging for this sybsystem
 OPTION_ITEM(`-h, --help')Give help information.
-OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 OPTION_ITEM(`-v, --version')Show version info.
 OPTIONS_END
 

--- a/doc/man/m4/makeflow.m4
+++ b/doc/man/m4/makeflow.m4
@@ -88,7 +88,7 @@ OPTIONS_END
 SUBSECTION(Debugging Options)
 OPTIONS_BEGIN
 OPTION_TRIPLET(-d, debug, subsystem)Enable debugging for this subsystem.
-OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 OPTION_PAIR(--debug-rotate-max, byte)Rotate debug file once it reaches this size.
 OPTION_ITEM(`--verbose')Display runtime progress on stdout.
 OPTIONS_END

--- a/doc/man/m4/parrot_package_create.m4
+++ b/doc/man/m4/parrot_package_create.m4
@@ -18,7 +18,7 @@ OPTION_ITEM(`    --new-env')The relative path of the environment variable file u
 OPTION_TRIPLET(-n, name-list, path)The path of the namelist list.
 OPTION_TRIPLET(-p, package-path, path)The path of the package.
 OPTION_TRIPLET(-d, debug, flag)Enable debugging for this sub-system.
-OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 OPTION_ITEM(`-h, --help')Show the help info.
 OPTIONS_END
 

--- a/doc/man/m4/parrot_run.m4
+++ b/doc/man/m4/parrot_run.m4
@@ -40,7 +40,7 @@ OPTION_TRIPLET(-e, env-list, path)Record the environment variables.
 OPTION_TRIPLET(-n, name-list, path)Record all the file names.
 OPTION_ITEM(--no-set-foreground)Disable changing the foreground process group of the session.
 OPTION_TRIPLET(-N, hostname, name)Pretend that this is my hostname.
-OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 OPTION_TRIPLET(-O, debug-rotate-max, bytes)Rotate debug files of this size.
 OPTION_TRIPLET(-p, proxy, host:port)Use this proxy server for HTTP requests.
 OPTION_ITEM(-Q, --no-chirp-catalog)Inhibit catalog queries to list /chirp.

--- a/doc/man/m4/resource_monitor.m4
+++ b/doc/man/m4/resource_monitor.m4
@@ -96,7 +96,7 @@ LONGCODE_END
 SECTION(OPTIONS)
 OPTIONS_BEGIN
 OPTION_TRIPLET(-d,debug,subsystem)Enable debugging for this subsystem.
-OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 OPTION_ITEM(`-v,--version')Show version string.
 OPTION_ITEM(`-h,--help')Show help text.
 OPTION_TRIPLET(-i,interval,n)Maximum interval between observations, in seconds (default=1).

--- a/doc/man/m4/resource_monitor_histograms.m4
+++ b/doc/man/m4/resource_monitor_histograms.m4
@@ -51,7 +51,7 @@ LONGCODE_END
 SUBSECTION(Debugging Options)
 OPTIONS_BEGIN
 OPTION_TRIPLET(-d, debug, subsystem)Enable debugging for this subsystem.
-OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 OPTION_ITEM(`--verbose')Display runtime progress on stdout.
 OPTIONS_END
 

--- a/doc/man/m4/wavefront_master.m4
+++ b/doc/man/m4/wavefront_master.m4
@@ -28,7 +28,7 @@ OPTION_ITEM(`-h, --help')Show this help screen
 OPTION_ITEM(`-v, --version')Show version string
 OPTION_TRIPLET(-d, debug, subsystem)Enable debugging for this subsystem. (Try -d all to start.)
 OPTION_TRIPLET(-N, project-name, project)Set the project name to <project>
-OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 OPTION_TRIPLET(-p, port, port)Port number for queue master to listen on.
 OPTION_TRIPLET(-P, priority, num)Priority. Higher the value, higher the priority.
 OPTION_TRIPLET(-Z, port-file, file)Select port at random and write it to this file.  (default is disabled)

--- a/doc/man/m4/work_queue_factory.m4
+++ b/doc/man/m4/work_queue_factory.m4
@@ -78,7 +78,7 @@ OPTION_PAIR(--mesos-path,filepath)Specify path to mesos python library (for use 
 OPTION_PAIR(--mesos-preload,library)Specify the linking libraries for running mesos (for use with -T mesos).
 OPTION_ITEM(--k8s-image)Specify the container image for using Kubernetes (for use with -T k8s).
 OPTION_ITEM(--k8s-worker-image)Specify the container image that contains work_queue_worker availabe for using Kubernetes (for use with -T k8s).
-OPTION_TRIPLET(-o,debug-file,file)Send debugging to this file (can also be :stderr, :stdout, :syslog, or :journal).
+OPTION_TRIPLET(-o,debug-file,file)Send debugging to this file (can also be :stderr, or :stdout).
 OPTION_TRIPLET(-O,debug-file-size,mb)Specify the size of the debug file (must use with -o option).
 OPTION_PAIR(--worker-binary,file)Specify the binary to use for the worker (relative or hard path). It should accept the same arguments as the default work_queue_worker.
 OPTION_PAIR(--runos,img)Will make a best attempt to ensure the worker will execute in the specified OS environment, regardless of the underlying OS.

--- a/doc/man/m4/work_queue_status.m4
+++ b/doc/man/m4/work_queue_status.m4
@@ -37,7 +37,7 @@ OPTION_ITEM(`-l, --verbose')Long output.
 OPTION_TRIPLET(-C, catalog, catalog)Set catalog server to <catalog>. Format: HOSTNAME:PORT
 OPTION_TRIPLET(-d, debug, flag)Enable debugging for the given subsystem. Try -d all as a start.
 OPTION_TRIPLET(-t, timeout, time)RPC timeout (default=300s).
-OPTION_TRIPLET(-o, debug-file, file)Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)
+OPTION_TRIPLET(-o, debug-file, file)Send debugging to this file. (can also be :stderr, or :stdout)
 OPTION_TRIPLET(-O, debug-rotate-max, bytes)Rotate debug file once it reaches this size.
 OPTION_ITEM(`-v, --version')Show work_queue_status version.
 OPTION_ITEM(`-h, --help')Show this help message.

--- a/doc/man/m4/work_queue_worker.m4
+++ b/doc/man/m4/work_queue_worker.m4
@@ -44,7 +44,7 @@ OPTION_ITEM(-h, --help')Show this help message.
 OPTION_TRIPLET(-N,-M, master-name, name)Set the name of the project this worker should work for.  A worker can have multiple projects.
 OPTION_TRIPLET(-C, catalog, catalog)Set catalog server to PARAM(catalog). Format: HOSTNAME:PORT
 OPTION_TRIPLET(-d, debug, flag)Enable debugging for the given subsystem. Try -d all as a start.
-OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+OPTION_TRIPLET(-o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 OPTION_PAIR(--debug-max-rotate, bytes)Set the maximum file size of the debug log.  If the log exceeds this size, it is renamed to "filename.old" and a new logfile is opened.  (default=10M. 0 disables)
 OPTION_ITEM(--debug-release-reset)Debug file will be closed, renamed, and a new one opened after being released from a master.
 OPTION_ITEM(`--foreman')Enable foreman mode.

--- a/doc/man/md/allpairs_master.md
+++ b/doc/man/md/allpairs_master.md
@@ -51,7 +51,7 @@ process and begin executing tasks.
 - **-p --port <port>** The port that the master will be listening on.
 - **-e --extra-args <args>** Extra arguments to pass to the comparison function.
 - **-f --input-file <file>** Extra input file needed by the comparison function. (may be given multiple times)
-- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 - **-O ----output-file <file>** Write task output to this file (default to standard output)
 - **-t --estimated-time <seconds>** Estimated time to run one comparison. (default chosen at runtime)
 - **-x --width <item>** Width of one work unit, in items to compare. (default chosen at runtime)

--- a/doc/man/md/catalog_server.md
+++ b/doc/man/md/catalog_server.md
@@ -71,7 +71,7 @@ overwriting another service's record.
 - **-m --max-jobs <n>** Maximum number of child processes.  (default is 50)
 - **-M --server-size <size>** Maximum size of a server to be believed.  (default is any)
 - **-n --name <name>** Set the preferred hostname of this server.
-- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 - **-O --debug-rotate-max <bytes>** Rotate debug file once it reaches this size (default 10M, 0 disables).
 - **-p -- <port>** Port number to listen on (default is 9097)
 - **-S, --single** Single process mode; do not fork on queries.

--- a/doc/man/md/chirp_fuse.md
+++ b/doc/man/md/chirp_fuse.md
@@ -57,7 +57,7 @@ For complete details with examples, see the
 - **-f, --foreground** Run in foreground for debugging.
 - **-i --tickets <files>** Comma-delimited list of tickets to use for authentication.
 - **-m --mount-options <option>** Pass mount option to FUSE. Can be specified multiple times.
-- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 - **-t --timeout <timeout>** Timeout for network operations. (default is 60s)
 - **-v, --version** Show program version.
 - **-h, --help** Give help information.

--- a/doc/man/md/chirp_server.md
+++ b/doc/man/md/chirp_server.md
@@ -60,7 +60,7 @@ For complete details with examples, see the [Chirp User's Manual](http://ccl.cse
 - **-I --interface <addr>** Listen only on this network interface.
 - **-M --max-clients <count>** Set the maximum number of clients to accept at once. (default unlimited)
 - **-n --catalog-name <name>** Use this name when reporting to the catalog.
-- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 - **-O --debug-rotate-max <bytes>** Rotate debug file once it reaches this size.
 - **-P --superuser <user>** Superuser for all directories. (default is none)
 - **-p --port <port>** Listen on this port (default is 9094, arbitrary is 0)

--- a/doc/man/md/chirp_status.md
+++ b/doc/man/md/chirp_status.md
@@ -50,7 +50,7 @@ When using **chirp_status** with long form option (-l), it lists additional info
 - **-T, --totals** Totals output.
 - **-v, --version** Show program version.
 - **-d --debug <flag>** Enable debugging for this subsystem.
-- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 - **-O --debug-rotate-max <bytes>** Rotate file once it reaches this size.
 - **-h, --help** Show help text.
 

--- a/doc/man/md/confuga_adm.md
+++ b/doc/man/md/confuga_adm.md
@@ -42,7 +42,7 @@ For complete details with examples, see the [Confuga User's Manual](http://ccl.c
 
 - **-d --debug <flag>** Enable debugging for this sybsystem
 - **-h, --help** Give help information.
-- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 - **-v, --version** Show version info.
 
 

--- a/doc/man/md/makeflow.md
+++ b/doc/man/md/makeflow.md
@@ -110,7 +110,7 @@ OPTION_END
 ### Debugging Options
 
 - **-d --debug <subsystem>** Enable debugging for this subsystem.
-- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 - **--debug-rotate-max byte** Rotate debug file once it reaches this size.
 - **--verbose** Display runtime progress on stdout.
 

--- a/doc/man/md/parrot_package_create.md
+++ b/doc/man/md/parrot_package_create.md
@@ -40,7 +40,7 @@ After recording the accessed files and environment variables of one program with
 - **-n --name-list <path>** The path of the namelist list.
 - **-p --package-path <path>** The path of the package.
 - **-d --debug <flag>** Enable debugging for this sub-system.
-- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 - **-h, --help** Show the help info.
 
 

--- a/doc/man/md/parrot_run.md
+++ b/doc/man/md/parrot_run.md
@@ -62,7 +62,7 @@ For complete details with examples, see the [Parrot User's Manual](http://ccl.cs
 - **-n --name-list <path>** Record all the file names.
 - **--no-set-foreground** Disable changing the foreground process group of the session.
 - **-N --hostname <name>** Pretend that this is my hostname.
-- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 - **-O --debug-rotate-max <bytes>** Rotate debug files of this size.
 - **-p --proxy <host:port>** Use this proxy server for HTTP requests.
 - **-Q** Inhibit catalog queries to list /chirp.

--- a/doc/man/md/resource_monitor.md
+++ b/doc/man/md/resource_monitor.md
@@ -118,7 +118,7 @@ disk                      current size of working directories in the tree, in MB
 ## OPTIONS
 
 - **-d --debug <subsystem>** Enable debugging for this subsystem.
-- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 - **-v,--version** Show version string.
 - **-h,--help** Show help text.
 - **-i --interval <n>** Maximum interval between observations, in seconds (default=1).

--- a/doc/man/md/resource_monitor_histograms.md
+++ b/doc/man/md/resource_monitor_histograms.md
@@ -73,7 +73,7 @@ wall_time
 ### Debugging Options
 
 - **-d --debug <subsystem>** Enable debugging for this subsystem.
-- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 - **--verbose** Display runtime progress on stdout.
 
 

--- a/doc/man/md/wavefront_master.md
+++ b/doc/man/md/wavefront_master.md
@@ -50,7 +50,7 @@ then connect back to the master process and begin executing tasks.
 - **-v, --version** Show version string
 - **-d --debug <subsystem>** Enable debugging for this subsystem. (Try -d all to start.)
 - **-N --project-name <project>** Set the project name to <project>
-- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 - **-p --port <port>** Port number for queue master to listen on.
 - **-P --priority <num>** Priority. Higher the value, higher the priority.
 - **-Z --port-file <file>** Select port at random and write it to this file.  (default is disabled)

--- a/doc/man/md/work_queue_factory.md
+++ b/doc/man/md/work_queue_factory.md
@@ -100,7 +100,7 @@ remove all running workers before exiting.
 - **--mesos-preload library** Specify the linking libraries for running mesos (for use with -T mesos).
 - **--k8s-image** Specify the container image for using Kubernetes (for use with -T k8s).
 - **--k8s-worker-image** Specify the container image that contains work_queue_worker availabe for using Kubernetes (for use with -T k8s).
-- **-o --debug-file <file>** Send debugging to this file (can also be :stderr, :stdout, :syslog, or :journal).
+- **-o --debug-file <file>** Send debugging to this file (can also be :stderr, or :stdout).
 - **-O --debug-file-size <mb>** Specify the size of the debug file (must use with -o option).
 - **--worker-binary file** Specify the binary to use for the worker (relative or hard path). It should accept the same arguments as the default work_queue_worker.
 - **--runos img** Will make a best attempt to ensure the worker will execute in the specified OS environment, regardless of the underlying OS.

--- a/doc/man/md/work_queue_status.md
+++ b/doc/man/md/work_queue_status.md
@@ -59,7 +59,7 @@ more detailed information about tasks and workers.
 - **-C --catalog <catalog>** Set catalog server to <catalog>. Format: HOSTNAME:PORT
 - **-d --debug <flag>** Enable debugging for the given subsystem. Try -d all as a start.
 - **-t --timeout <time>** RPC timeout (default=300s).
-- **-o --debug-file <file>** Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)
+- **-o --debug-file <file>** Send debugging to this file. (can also be :stderr, or :stdout)
 - **-O --debug-rotate-max <bytes>** Rotate debug file once it reaches this size.
 - **-v, --version** Show work_queue_status version.
 - **-h, --help** Show this help message.

--- a/doc/man/md/work_queue_worker.md
+++ b/doc/man/md/work_queue_worker.md
@@ -66,7 +66,7 @@ grid or cloud computing environments such as SGE, PBS, SLURM, and HTCondor using
 - **-N ---M <master-name>** Set the name of the project this worker should work for.  A worker can have multiple projects.
 - **-C --catalog <catalog>** Set catalog server to <catalog>. Format: HOSTNAME:PORT
 - **-d --debug <flag>** Enable debugging for the given subsystem. Try -d all as a start.
-- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs be sent to stdout (":stdout"), to the system syslog (":syslog"), or to the systemd journal (":journal").
+- **-o --debug-file <file>** Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.
 - **--debug-max-rotate bytes** Set the maximum file size of the debug log.  If the log exceeds this size, it is renamed to "filename.old" and a new logfile is opened.  (default=10M. 0 disables)
 - **--debug-release-reset** Debug file will be closed, renamed, and a new one opened after being released from a master.
 - **--foreman** Enable foreman mode.

--- a/dttools/src/auth_test.c
+++ b/dttools/src/auth_test.c
@@ -24,7 +24,7 @@ static void show_help(const char *cmd)
 	fprintf(stdout, "Where options are:\n");
 	fprintf(stdout, " %-30s This message\n", "-h,--help=<flag>");
 	fprintf(stdout, " %-30s Debugging\n", "-d,--debug=<flag>");
-	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)\n", "-o,--debug-file=<file>");
+	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr, or :stdout)\n", "-o,--debug-file=<file>");
 	fprintf(stdout, " %-30s Rotate debug files of this size (default 10M, 0 disables)\n", "-O,--debug-rotate-max=<bytes>");
 	fprintf(stdout, " %-30s Allow this auth type\n", "-a,--auth=<type>");
 	fprintf(stdout, " %-30s Port number\n", "-p,--port=<num>");

--- a/dttools/src/catalog_query_tool.c
+++ b/dttools/src/catalog_query_tool.c
@@ -39,7 +39,7 @@ static void show_help(const char *cmd)
 	fprintf(stdout, " %-30s Filter results by this expression.\n", "-w,--where=<expr>");
 	fprintf(stdout, " %-30s Query the catalog on this host.\n", "-c,--catalog=<host>");
 	fprintf(stdout, " %-30s Enable debugging for this sybsystem\n", "-d,--debug=<flag>");
-	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)\n", "-o,--debug-file=<file>");
+	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr, or :stdout)\n", "-o,--debug-file=<file>");
 	fprintf(stdout, " %-30s Rotate file once it reaches this size. (default 10M, 0 disables)\n", "-O,--debug-rotate-max=<bytes>");
 	fprintf(stdout, " %-30s Timeout.\n", "-t,--timeout=<time>");
 	fprintf(stdout, " %-30s This message.\n", "-h,--help");

--- a/dttools/src/catalog_server.c
+++ b/dttools/src/catalog_server.c
@@ -580,7 +580,7 @@ static void show_help(const char *cmd)
 	fprintf(stdout, " %-30s (default is any)\n", "");
 	fprintf(stdout, " %-30s Preferred host name of this server.\n", "-n,--name=<name>");
 	fprintf(stdout, " %-30s Send debugging to this file. (can also\n", "-o,--debug-file=<file>");
-	fprintf(stdout, " %-30s be :stderr, :stdout, :syslog, or :journal)\n", "");
+	fprintf(stdout, " %-30s be :stderr, or :stdout)\n", "");
 	fprintf(stdout, " %-30s Rotate debug file once it reaches this size.\n", "-O,--debug-rotate-max=<bytes>");
 	fprintf(stdout, " %-30s (default 10M, 0 disables)\n", "");
 	fprintf(stdout, " %-30s Port number to listen on (default is %d)\n", "-p,--port=<port>", port);

--- a/dttools/src/debug.c
+++ b/dttools/src/debug.c
@@ -32,11 +32,6 @@ extern int debug_file_path (const char *path);
 extern void debug_file_rename (const char *suffix);
 extern int debug_file_reopen (void);
 
-#ifdef HAS_SYSTEMD_JOURNAL_H
-extern void debug_journal_write (int64_t flags, const char *str);
-#endif
-
-
 static void (*debug_write) (int64_t flags, const char *str) = debug_stderr_write;
 static pid_t (*debug_getpid) (void) = getpid;
 static char debug_program_name[PATH_MAX];
@@ -299,13 +294,6 @@ int debug_config_file_e (const char *path)
 	} else if(strcmp(path, ":stdout") == 0) {
 		debug_write = debug_stdout_write;
 		return 0;
-	} else if (strcmp(path, ":journal") == 0) {
-#ifdef HAS_SYSTEMD_JOURNAL_H
-		debug_write = debug_journal_write;
-		return 0;
-#else
-		return errno = EINVAL, -1;
-#endif
 	} else {
 		debug_write = debug_file_write;
 		return debug_file_path(path);

--- a/dttools/src/debug.c
+++ b/dttools/src/debug.c
@@ -32,11 +32,6 @@ extern int debug_file_path (const char *path);
 extern void debug_file_rename (const char *suffix);
 extern int debug_file_reopen (void);
 
-#ifdef HAS_SYSLOG_H
-extern void debug_syslog_write (int64_t flags, const char *str);
-extern void debug_syslog_config (const char *name);
-#endif
-
 #ifdef HAS_SYSTEMD_JOURNAL_H
 extern void debug_journal_write (int64_t flags, const char *str);
 #endif
@@ -304,14 +299,6 @@ int debug_config_file_e (const char *path)
 	} else if(strcmp(path, ":stdout") == 0) {
 		debug_write = debug_stdout_write;
 		return 0;
-	} else if (strcmp(path, ":syslog") == 0) {
-#ifdef HAS_SYSLOG_H
-		debug_write = debug_syslog_write;
-		debug_syslog_config(debug_program_name);
-		return 0;
-#else
-		return errno = EINVAL, -1;
-#endif
 	} else if (strcmp(path, ":journal") == 0) {
 #ifdef HAS_SYSTEMD_JOURNAL_H
 		debug_write = debug_journal_write;

--- a/parrot/src/parrot_package_create.c
+++ b/parrot/src/parrot_package_create.c
@@ -50,7 +50,7 @@ static void show_help(const char *cmd)
 	fprintf(stdout, " %-34s The path of the namelist list.\n", "-n,--name-list=<listpath>");
 	fprintf(stdout, " %-34s The path of the package.\n", "-p,--package-path=<packagepath>");
 	fprintf(stdout, " %-34s Enable debugging for this sub-system.    (PARROT_DEBUG_FLAGS)\n", "-d,--debug=<name>");
-	fprintf(stdout, " %-34s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal) (PARROT_DEBUG_FILE)\n", "-o,--debug-file=<file>");
+	fprintf(stdout, " %-34s Send debugging to this file. (can also be :stderr, or :stdout) (PARROT_DEBUG_FILE)\n", "-o,--debug-file=<file>");
 	fprintf(stdout, " %-34s Show the help info.\n", "-h,--help");
 	return;
 }

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -249,7 +249,7 @@ static void show_help( const char *cmd )
 	printf( " %-30s Maximum amount of time to retry failures.    (PARROT_TIMEOUT)\n", "-T,--timeout=<time>");
 	printf( " %-30s Enable debugging for this sub-system.    (PARROT_DEBUG_FLAGS)\n", "-d,--debug=<name>");
 	printf( " %-30s Send debugging to this file.              (PARROT_DEBUG_FILE)\n", "-o,--debug-file=<file>");
-	printf( " %-30s     (can also be :stderr, :stdout, :syslog, or :journal)\n", "");
+	printf( " %-30s     (can also be :stderr, or :stdout)\n", "");
 	printf( " %-30s Rotate debug files of this size.     (PARROT_DEBUG_FILE_SIZE)\n", "-O,--debug-rotate-max=<bytes>");
 	printf( " %-30s     (default 10M, 0 disables)\n","");
 	printf( " %-30s Display version number.\n", "-v,--version");

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -2024,7 +2024,7 @@ static void show_help(const char *cmd)
 {
     fprintf(stdout, "\nUse: %s [options] -- command-line-and-options\n\n", cmd);
     fprintf(stdout, "%-30s Enable debugging for this subsystem.\n", "-d,--debug=<subsystem>");
-	fprintf(stdout, "%-30s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)\n", "-o,--debug-file=<file>");
+	fprintf(stdout, "%-30s Send debugging to this file. (can also be :stderr, or :stdout)\n", "-o,--debug-file=<file>");
     fprintf(stdout, "%-30s Show this message.\n", "-h,--help");
     fprintf(stdout, "%-30s Show version string.\n", "-v,--version");
     fprintf(stdout, "\n");

--- a/resource_monitor/src/resource_monitor_histograms.c
+++ b/resource_monitor/src/resource_monitor_histograms.c
@@ -1552,7 +1552,7 @@ static void show_usage(const char *cmd)
 	fprintf(stdout, "\nUse: %s [options] output_directory [workflow_name]\n\n", cmd);
 	fprintf(stdout, "\nIf -L is specified, read the summary file list from standard input.\n\n");
 	fprintf(stdout, "%-20s Enable debugging for this subsystem.\n", "-d <subsystem>");
-	fprintf(stdout, "%-20s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)\n", "-o <file>");
+	fprintf(stdout, "%-20s Send debugging to this file. (can also be :stderr, or :stdout)\n", "-o <file>");
 	fprintf(stdout, "%-20s Read summaries filenames from file <list>.\n", "-L <list>");
 	fprintf(stdout, "%-20s Split on task categories.\n", "-s");
 	fprintf(stdout, "%-20s Use brute force to compute proposed resource allocations. (slow)\n", "-b");

--- a/work_queue/src/work_queue_status.c
+++ b/work_queue/src/work_queue_status.c
@@ -130,7 +130,7 @@ static void show_help(const char *progname)
 	fprintf(stdout, " %-30s Filter results by this expression.\n", "   --where=<expr>");
 	fprintf(stdout, " %-30s RPC timeout (default is %ds).\n", "-t,--timeout=<time>", work_queue_status_timeout);
 	fprintf(stdout, " %-30s Send debugging to this file. (can also be :stderr,\n", "-o,--debug-file=<file>");
-	fprintf(stdout, " %-30s :stdout, :syslog, or :journal)\n", "");
+	fprintf(stdout, " %-30s or :stdout)\n", "");
 	fprintf(stdout, " %-30s Rotate debug file once it reaches this size.\n", "-O,--debug-rotate-max=<bytes>");
 	fprintf(stdout, " %-30s Show work_queue_status version.\n", "-v,--version");
 	fprintf(stdout, " %-30s This message.\n", "-h,--help");

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -2359,7 +2359,7 @@ static void show_help(const char *cmd)
 	printf( " %-30s Name of master (project) to contact.  May be a regular expression.\n", "-N,-M,--master-name=<name>");
 	printf( " %-30s Catalog server to query for masters.  (default: %s:%d) \n", "-C,--catalog=<host:port>",CATALOG_HOST,CATALOG_PORT);
 	printf( " %-30s Enable debugging for this subsystem.\n", "-d,--debug=<subsystem>");
-	printf( " %-30s Send debugging to this file. (can also be :stderr, :stdout, :syslog, or :journal)\n", "-o,--debug-file=<file>");
+	printf( " %-30s Send debugging to this file. (can also be :stderr, or :stdout)\n", "-o,--debug-file=<file>");
 	printf( " %-30s Set the maximum size of the debug log (default 10M, 0 disables).\n", "--debug-rotate-max=<bytes>");
 	printf( " %-30s Set worker to run as a foreman.\n", "--foreman");
 	printf( " %-30s Run as a foreman, and advertise to the catalog server with <name>.\n", "-f,--foreman-name=<name>");


### PR DESCRIPTION
Instead of forcing the message to the terminal, messages are written to stderr.

Also, syslog and journal log options were removed.