### PR TITLE
rmonitor: Remove race condition when detecting root process

### DIFF
--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -2006,6 +2006,10 @@ struct rmonitor_process_info *spawn_first_process(const char *executable, char *
 
         debug(D_RMON, "executing: %s\n", executable);
 
+		char *pid_s = string_format("%d", getpid());
+		setenv(RESOURCE_MONITOR_ROOT_PROCESS, pid_s, 1);
+		free(pid_s);
+
 		errno = 0;
         execvp(executable, argv);
         //We get here only if execlp fails.

--- a/resource_monitor/src/rmonitor_helper_comm.c
+++ b/resource_monitor/src/rmonitor_helper_comm.c
@@ -257,9 +257,6 @@ int rmonitor_helper_init(char *lib_default_path, int *fd, int stop_short_running
 			setenv(RESOURCE_MONITOR_HELPER_STOP_SHORT, "1", 1);
 		}
 
-		/* First process will unset this variable. */
-		setenv(RESOURCE_MONITOR_ROOT_PROCESS, "1", 1);
-
 		/* Each process sets this variable to its start time after a fork,
 		 * except for the first process, which for which we set here. */
 		char *start_time = string_format("%" PRId64, timestamp_get());


### PR DESCRIPTION
For long-running subprocesses (i.e., running for more than .25s), the
resource_monitor measures the resources one last time before the process
exits. This is not done for short-running subprocesses, as the measurement
overhead becomes noticeable (e.g., madgraph in HEP, that internally uses
make, gcc, and a series of very small python and shell scripts).

However, this distinction is only relevant for subprocesses, and not for
the very first process created by the application to be measured. A
measurement before exit is always done for this first process, as this
guarantees a measurement of any of the short-running subprocesses via
getrusage.

The previous code that labeled a process as the first process had a race
condition in which several processes may identify themselves as the root
process, with the potential of a noticeable overhead. This commit fixes
this by labeling the first process before the exec call, rather than
using the ld preloaded monitoring helper library to label the correct
process.

The incorrect behaviour was observed by running scripts
with  #!/bin/bash. (This was not observed with !#/bin/sh.)