### PR TITLE
Adds JX querying functionality

### DIFF
--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -71,6 +71,7 @@ SOURCES = \
 	jx_export.c \
 	jx_eval.c \
 	jx_function.c \
+	jx_querytools.c \
 	link.c \
 	link_auth.c \
 	list.c \
@@ -144,6 +145,7 @@ HEADERS_PUBLIC = \
 	itable.h \
 	jx.h \
 	jx_match.h \
+	jx_querytools.h \
 	link.h \
 	list.h \
 	load_average.h \
@@ -179,7 +181,7 @@ PROGRAMS = $(MOST_PROGRAMS) catalog_query
 
 SCRIPTS = cctools_gpu_autodetect
 TARGETS = $(LIBRARIES) $(PRELOAD_LIBRARIES) $(PROGRAMS) $(TEST_PROGRAMS)
-TEST_PROGRAMS = auth_test disk_alloc_test jx_test microbench multirun jx_count_obj_test histogram_test category_test jx_binary_test
+TEST_PROGRAMS = auth_test disk_alloc_test jx_test jx_query microbench multirun jx_count_obj_test histogram_test category_test jx_binary_test
 
 all: $(TARGETS) catalog_query
 

--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -93,7 +93,7 @@ SOURCES = \
 	rmonitor_poll.c \
 	rmsummary.c \
 	set.c \
-    semaphore.c \
+	semaphore.c \
 	sha1.c \
 	shell.c \
 	sh_popen.c\

--- a/dttools/src/jx_eval.c
+++ b/dttools/src/jx_eval.c
@@ -6,7 +6,6 @@ See the file COPYING for details.
 
 #include "jx_eval.h"
 #include "debug.h"
-#include "jx_canonicalize.h"
 #include "jx_function.h"
 #include "jx_print.h"
 
@@ -215,19 +214,19 @@ static struct jx *jx_eval_call(struct jx *func, struct jx *args, struct jx *ctx)
 		return jx_function_listdir(args);
 	} else if (!strcmp(func->u.symbol_name, "escape")) {
 		return jx_function_escape(args);
-    } else if (!strcmp(func->u.symbol_name, "template")) {
+	} else if (!strcmp(func->u.symbol_name, "template")) {
 		return jx_function_template(args, ctx);
-    } else if (!strcmp(func->u.symbol_name, "len")) {
+	} else if (!strcmp(func->u.symbol_name, "len")) {
 		return jx_function_len(args);
-    } else if (!strcmp(func->u.symbol_name, "fetch")) {
+	} else if (!strcmp(func->u.symbol_name, "fetch")) {
 		return jx_function_fetch(args);
-    } else if (!strcmp(func->u.symbol_name, "select")) {
+	} else if (!strcmp(func->u.symbol_name, "select")) {
 		return jx_function_select(args, ctx);
-    } else if (!strcmp(func->u.symbol_name, "project")) {
+	} else if (!strcmp(func->u.symbol_name, "project")) {
 		return jx_function_project(args, ctx);
-    } else if (!strcmp(func->u.symbol_name, "schema")) {
-        return jx_function_schema(args, ctx);
-    } else {
+	} else if (!strcmp(func->u.symbol_name, "schema")) {
+		return jx_function_schema(args, ctx);
+	} else {
 		return jx_error(jx_format(
 			"on line %d, unknown function: %s",
 			func->line,
@@ -342,13 +341,12 @@ static struct jx * jx_eval_operator( struct jx_operator *o, struct jx *context )
 	struct jx *right = NULL;
 	struct jx *result = NULL;
 
-    //Capture expression for select query before it gets evaluated
+	//Capture expression for select query before it gets evaluated
 	//Stringify it to prevent early evaluation
-    if(!strcmp("select", jx_print_string(o->left))) {
+	if(!strcmp("select", jx_print_string(o->left))) {
 		struct jx *r = jx_array_shift(o->right);
 		r = jx_string(jx_print_string((r)));
 		jx_array_insert(o->right, r);
-		fprintf(stderr, "inserting: %s\n", jx_print_string(o->right));
 	}
 
 	right = jx_eval(o->right,context);

--- a/dttools/src/jx_eval.c
+++ b/dttools/src/jx_eval.c
@@ -354,7 +354,7 @@ static struct jx * jx_eval_operator( struct jx_operator *o, struct jx *context )
 		result = right;
 		right = NULL;
 		goto DONE;
-	} 
+	}
 
 	if (o->type == JX_OP_CALL) return jx_eval_call(o->left, right, context);
 
@@ -363,7 +363,7 @@ static struct jx * jx_eval_operator( struct jx_operator *o, struct jx *context )
 		result = left;
 		left = NULL;
 		goto DONE;
-	} 
+	}
 
 	if (o->type == JX_OP_SLICE) return jx_operator(JX_OP_SLICE, left, right);
 

--- a/dttools/src/jx_function.c
+++ b/dttools/src/jx_function.c
@@ -16,10 +16,14 @@ See the file COPYING for details.
 #include <dirent.h>
 #include <errno.h>
 #include <ctype.h>
+#include <unistd.h>
 
 #include "jx.h"
+#include "jx_eval.h"
 #include "jx_match.h"
+#include "jx_parse.h"
 #include "jx_print.h"
+#include "jx_querytools.h"
 #include "stringtools.h"
 #include "xxmalloc.h"
 
@@ -602,6 +606,194 @@ struct jx *jx_function_len(struct jx *args){
 
 	return jx_integer(length);
 
+}
+
+struct jx *jx_function_fetch(struct jx *orig_args) {
+    assert(orig_args);
+	const char *funcname = "fetch";
+	const char *err = NULL;
+
+	struct jx *args = jx_copy(orig_args);
+	struct jx *val = jx_array_shift(args);
+	struct jx *result = NULL;
+
+	int length = jx_array_length(orig_args);
+	if(length>1){
+		err = "too many arguments";
+		goto FAILURE;
+	} else if(length<=0){
+		err = "too few arguments";
+		goto FAILURE;
+	}
+
+    const char *string_val = val->u.string_value;
+	switch (val->type) {
+		case JX_STRING:
+            if(string_match_regex(string_val, "http://")) {
+                //Assume an HTTP request is to a TLQ log server
+                char *fetch = string_format("curl %s -o tmp.json", string_val);
+                int f = system(fetch);
+                if(f == -1) {
+                    err = string_format("error encountered performing curl fetch - %s", strerror(errno));
+                    goto FAILURE;
+                }
+                struct jx_parser *c = jx_parser_create(0);
+                const char *parsed = jx_parse_from_html("tmp.json");
+                jx_parser_read_string(c, parsed);
+                result = jx_parse(c);
+                jx_parser_delete(c);
+                unlink("tmp.json");
+                if(!result) {
+                    err = "error parsing JSON document";
+                    goto FAILURE;
+                }
+                if(jx_parser_errors(c)) {
+                    err = "invalid JSON context";
+                    goto FAILURE;
+                }
+            }
+            else {
+                //Otherwise, attempt to open file locally
+                FILE *document = fopen(string_val, "r");
+                if(!document) {
+                    err = string_format("error opening JSON file: %s - %s\n", string_val, strerror(errno));
+                    goto FAILURE;
+                }
+                struct jx_parser *c = jx_parser_create(0);
+                jx_parser_read_stream(c, document);
+                result = jx_parse(c);
+                fclose(document);
+                if(!result) {
+                    err = "error parsing JSON document";
+                    goto FAILURE;
+                }
+                if(jx_parser_errors(c)) {
+                    err = "invalid JSON context";
+                    goto FAILURE;
+                }
+            }
+            break;
+        default:
+            err = "arg of invalid type";
+            goto FAILURE;
+	}	
+
+	jx_delete(args);
+	jx_delete(val);
+	return result;
+	
+	FAILURE:
+	jx_delete(args);
+	jx_delete(val);
+	FAIL(funcname, orig_args, err);
+}
+
+struct jx *jx_function_select(struct jx *orig_args, struct jx *ctx) {
+	assert(orig_args);
+	assert(jx_istype(ctx, JX_OBJECT));
+	const char *funcname = "select";
+	const char *err = NULL;
+
+	struct jx *args = jx_copy(orig_args);
+    struct jx *val = jx_array_shift(args);
+	struct jx *context = jx_array_shift(args);
+	assert(jx_istype(context, JX_ARRAY));
+    struct jx *result = jx_array(0);
+
+    struct jx *item;
+    for(void *i = NULL; (item = jx_iterate_array(context, &i));) {
+        struct jx *j = jx_eval(val, item);
+	    assert(jx_istype(j, JX_BOOLEAN));
+        if(!j) {
+            err = "error evaluating select expression";
+            goto FAILURE;
+        }
+        if(j->u.boolean_value) jx_array_append(result, item);
+    }
+    jx_delete(args);
+	jx_delete(val);
+    return result;
+    
+    FAILURE:
+	jx_delete(args);
+    jx_delete(val);
+	FAIL(funcname, orig_args, err);
+}
+
+struct jx *jx_function_project(struct jx *orig_args, struct jx *ctx) {
+    assert(orig_args);
+	assert(jx_istype(ctx, JX_OBJECT));
+	const char *funcname = "project";
+	const char *err = NULL;
+
+	struct jx *args = jx_copy(orig_args);
+	struct jx *val = jx_array_shift(args);
+    struct jx *context = jx_array_shift(args);
+	assert(jx_istype(context, JX_ARRAY));
+    struct jx *result = jx_array(0);
+
+    struct jx *item;
+    for(void *i = NULL; (item = jx_iterate_array(context, &i));) {
+        struct jx *j = jx_eval(val, item);
+        if(!j) {
+            err = "error evaluating project expression";
+            goto FAILURE;
+        }
+        jx_array_append(result, j);
+    }
+    jx_delete(args);
+	jx_delete(val);
+    return result;
+
+	FAILURE:
+	jx_delete(args);
+	jx_delete(val);
+	FAIL(funcname, orig_args, err);
+}
+
+struct jx *jx_function_schema(struct jx *orig_args, struct jx *ctx) {
+    assert(orig_args);
+	assert(jx_istype(ctx, JX_OBJECT));
+	const char *funcname = "project";
+	const char *err = NULL;
+
+	struct jx *args = jx_copy(orig_args);
+    struct jx *context = jx_array_shift(args);
+	assert(jx_istype(context, JX_ARRAY));
+    struct jx *result = jx_array(0);
+
+    int length = jx_array_length(orig_args);
+	if(length>1){
+		err = "too many arguments";
+		goto FAILURE;
+	} else if(length<=0){
+		err = "too few arguments";
+		goto FAILURE;
+	}
+
+    struct jx *item;
+    for(void *i = NULL; (item = jx_iterate_array(context, &i));) {
+        const char *key;
+        struct jx *keys = jx_object(0);
+        for(void *j = NULL; (key = jx_iterate_keys(item, &j));) {
+           struct jx *lookup = jx_lookup(item, key);
+           const char *type = jx_type_string(lookup->type);
+           struct jx *k = jx_string(key);
+           struct jx *v = jx_string(type);
+           struct jx_pair *p = jx_pair(k, v, 0);
+           keys = jx_merge(keys, jx_object(p), NULL);
+           //jx_array_append(keys, p);
+        }
+        jx_array_append(result, keys);
+    }
+    jx_delete(args);
+	jx_delete(context);
+    return result;
+
+	FAILURE:
+	jx_delete(args);
+	jx_delete(context);
+	FAIL(funcname, orig_args, err);
 }
 
 /*vim: set noexpandtab tabstop=4: */

--- a/dttools/src/jx_function.c
+++ b/dttools/src/jx_function.c
@@ -755,17 +755,17 @@ struct jx *jx_function_project(struct jx *orig_args, struct jx *ctx) {
 }
 
 struct jx *jx_function_schema(struct jx *orig_args, struct jx *ctx) {
-    assert(orig_args);
+	assert(orig_args);
 	assert(jx_istype(ctx, JX_OBJECT));
 	const char *funcname = "schema";
 	const char *err = NULL;
 
 	struct jx *args = jx_copy(orig_args);
-    struct jx *context = jx_array_shift(args);
+	struct jx *context = jx_array_shift(args);
 	assert(jx_istype(context, JX_ARRAY));
-    struct jx *result = jx_array(0);
+	struct jx *result = jx_array(0);
 
-    int length = jx_array_length(orig_args);
+	int length = jx_array_length(orig_args);
 	if(length>1){
 		err = "too many arguments";
 		goto FAILURE;
@@ -774,23 +774,23 @@ struct jx *jx_function_schema(struct jx *orig_args, struct jx *ctx) {
 		goto FAILURE;
 	}
 
-    struct jx *item;
-    for(void *i = NULL; (item = jx_iterate_array(context, &i));) {
-        const char *key;
-        struct jx *keys = jx_object(0);
-        for(void *j = NULL; (key = jx_iterate_keys(item, &j));) {
-            struct jx *lookup = jx_lookup(item, key);
+	struct jx *item;
+	for(void *i = NULL; (item = jx_iterate_array(context, &i));) {
+		const char *key;
+		struct jx *keys = jx_object(0);
+		for(void *j = NULL; (key = jx_iterate_keys(item, &j));) {
+			struct jx *lookup = jx_lookup(item, key);
 			const char *type = jx_type_string(lookup->type);
 			struct jx *k = jx_string(key);
 			struct jx *v = jx_string(type);
 			struct jx_pair *p = jx_pair(k, v, 0);
 			keys = jx_merge(keys, jx_object(p), NULL);
-        }
-        jx_array_append(result, keys);
-    }
-    jx_delete(args);
+		}
+		jx_array_append(result, keys);
+	}
+	jx_delete(args);
 	jx_delete(context);
-    return result;
+	return result;
 
 	FAILURE:
 	jx_delete(args);

--- a/dttools/src/jx_function.h
+++ b/dttools/src/jx_function.h
@@ -20,5 +20,9 @@ struct jx *jx_function_listdir(struct jx *args);
 struct jx *jx_function_escape(struct jx *args);
 struct jx *jx_function_template(struct jx *args, struct jx *ctx);
 struct jx *jx_function_len(struct jx *args);
+struct jx *jx_function_fetch(struct jx *args);
+struct jx *jx_function_select(struct jx *args, struct jx *ctx);
+struct jx *jx_function_project(struct jx *args, struct jx *ctx);
+struct jx *jx_function_schema(struct jx *args, struct jx *ctx);
 
 #endif

--- a/dttools/src/jx_match.h
+++ b/dttools/src/jx_match.h
@@ -88,7 +88,7 @@ See the file COPYING for details.
 #ifndef JX_MATCH_H
 #define JX_MATCH_H
 
-#include <jx.h>
+#include "jx.h"
 
 #ifndef JX_ANY
 #define JX_ANY -1

--- a/dttools/src/jx_print.c
+++ b/dttools/src/jx_print.c
@@ -79,17 +79,17 @@ const char * jx_operator_string( jx_operator_t type )
 const char * jx_type_string( jx_type_t type )
 {
 	switch(type) {
-        case JX_NULL: return "null";
-        case JX_BOOLEAN: return "boolean";
-        case JX_INTEGER: return "integer";
-        case JX_DOUBLE: return "float";
-        case JX_STRING: return "string";
-        case JX_SYMBOL: return "symbol";
-        case JX_ARRAY: return "array";
-        case JX_OBJECT: return "object";
-        case JX_OPERATOR: return "operator";
-        case JX_ERROR: return "error";
-        default: return "???";
+		case JX_NULL: return "null";
+		case JX_BOOLEAN: return "boolean";
+		case JX_INTEGER: return "integer";
+		case JX_DOUBLE: return "float";
+		case JX_STRING: return "string";
+		case JX_SYMBOL: return "symbol";
+		case JX_ARRAY: return "array";
+		case JX_OBJECT: return "object";
+		case JX_OPERATOR: return "operator";
+		case JX_ERROR: return "error";
+		default: return "???";
 	}
 }
 

--- a/dttools/src/jx_print.c
+++ b/dttools/src/jx_print.c
@@ -76,6 +76,22 @@ const char * jx_operator_string( jx_operator_t type )
 	}
 }
 
+const char * jx_type_string( jx_type_t type )
+{
+	switch(type) {
+        case JX_NULL: return "null";
+        case JX_BOOLEAN: return "boolean";
+        case JX_INTEGER: return "integer";
+        case JX_DOUBLE: return "float";
+        case JX_STRING: return "string";
+        case JX_SYMBOL: return "symbol";
+        case JX_ARRAY: return "array";
+        case JX_OBJECT: return "object";
+        case JX_OPERATOR: return "operator";
+        case JX_ERROR: return "error";
+        default: return "???";
+	}
+}
 
 void jx_escape_string( const char *s, buffer_t *b )
 {

--- a/dttools/src/jx_print.h
+++ b/dttools/src/jx_print.h
@@ -39,6 +39,9 @@ void jx_print_args( struct jx *j, buffer_t *b );
 /** Get a string representation of an operator. @param type The operator to get. */
 const char * jx_operator_string( jx_operator_t type );
 
+/** Get a string representation of an object type. @param type The object type to get. */
+const char * jx_type_string( jx_type_t type );
+
 // internal function for printing list comprehension expressions
 void jx_comprehension_print(struct jx_comprehension *comp, buffer_t *b);
 #endif

--- a/dttools/src/jx_query.c
+++ b/dttools/src/jx_query.c
@@ -1,0 +1,154 @@
+/*
+Copyright (C) 2020- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+/*
+This is a test program for the jx library.
+It first reads in a path to a JSON document which is used as the evaluation context.
+Then, it reads a JX expression which is evaluated upon the given context.
+The program exits either with the evaluated result of the expression or on the first failure.
+*/
+
+#include "getopt.h"
+#include "hash_table.h"
+#include "jx.h"
+#include "jx_getopt.h"
+#include "jx_parse.h"
+#include "jx_print.h"
+#include "jx_querytools.h"
+#include "stringtools.h"
+
+#include <errno.h>
+#include <stdio.h>
+
+int get_deposits(const char* path) {
+    if(!path) return 1;
+    return 0;
+}
+
+static void show_help() {
+    printf("Use: ./jx_query [options] \n");
+    printf("Basic Options:\n");
+    printf(" -p,--path=<file>               Use the JSON document located at this path.\n");
+    printf(" -u,--url=<url>                 Use the JSON document located at this URL.\n");
+    printf(" -h,--help                      Show this help screen.\n");
+    return;
+}
+
+int unlink_document(char *json) {
+    int result = unlink(json);
+    if(result == -1) {
+        fprintf(stderr, "Could not delete local JSON document: %s - %s\n", json, strerror(errno));
+        return 1;
+    }
+    return 0;
+}
+
+int main(int argc, char *argv[]) {
+    int o, path, url;
+    char *document;
+    static const struct option long_options_run[] = {
+        {"help", no_argument, 0, 'h'},
+        {"path", required_argument, 0, 'p'},
+        {"url", required_argument, 0, 'u'}
+    };
+
+    static const char option_string_run[] = "aAB:c::C:d:Ef:F:g:G:hj:J:l:L:m:M:N:o:Op:P:r:RS:t:T:u:vW:X:zZ:";
+    struct hash_table *h = hash_table_create(0, NULL);
+
+    while((o = jx_getopt(argc, argv, option_string_run, long_options_run, NULL)) >= 0) {
+        switch(o) {
+            case 'h':
+                show_help();
+                return 1;
+            case 'p':
+                if(url) {
+                    fprintf(stderr, "Please use either a path or a URL, not both.\n");
+                    show_help();
+                    return 1;
+                }
+                document = optarg;
+                path = 1;
+                break;
+            case 'u':
+                if(path) {
+                    fprintf(stderr, "Please use either a path or a URL, not both.\n");
+                    show_help();
+                    return 1;
+                }
+                fprintf(stderr, "Attempting to fetch: %s\n", optarg);
+                char *fetch = string_format("curl %s -o tmp.json", optarg);
+                int result = system(fetch);
+                fprintf(stderr, "Fetch returned: %d - %s\n", result, strerror(errno));
+                document = "tmp.json";
+                url = 1;
+                break;
+            default:
+                show_help();
+                return 1;
+        }
+    }
+
+    if(document == NULL || (!path && !url)) {
+        fprintf(stderr, "Must specify a JSON document.\n");
+        show_help();
+        return 1;
+    }
+
+    FILE *json;
+    if(path || url) json = fopen(document, "r");
+    if(!json) {
+        fprintf(stderr, "Error opening JSON file: %s - %s\n", document, strerror(errno));
+        if(url) unlink_document(document);
+        return 1;
+    }
+
+    struct jx_parser *c = jx_parser_create(0);
+    if(path) jx_parser_read_stream(c, json);
+    else {
+        const char *parsed = jx_parse_from_html(document);
+        jx_parser_read_string(c, parsed);
+    }
+    struct jx *context = jx_parse(c);
+    fclose(json);
+    if(!context) {
+        fprintf(stderr, "Error parsing JSON document: %s\n", jx_parser_error_string(c));
+        if(url) unlink_document(document);
+        return 1;
+    }
+    if(jx_parser_errors(c)) {
+        fprintf(stderr, "Invalid context expression: %s\n", jx_parser_error_string(c));
+        if(url) unlink_document(document);
+        return 1;
+    }
+
+    fprintf(stdout, "Enter expression:\n");
+    while(1) {
+        struct jx *k = jx_evaluate_query(context);
+        if(!k) {
+            jx_parser_delete(c);
+            hash_table_clear(h);
+            hash_table_delete(h);
+            if(url) unlink_document(document);
+            return 1;
+        }
+        else if(k->type != JX_ERROR) {
+            char *value = jx_print_string(k);
+            char *key = string_format("%u", hash_string(value));
+            char *file = string_format("%s.json", key);
+            FILE *f = fopen(file, "w");
+            fprintf(f, value);
+            fclose(f);
+            hash_table_insert(h, key, file);
+            free(value);
+            fprintf(stderr, "New JX context saved with as: %s\n", file);
+        }
+        jx_delete(k);
+        fprintf(stdout, "Enter expression:\n");
+    }
+    return 0;
+}
+
+// vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab shiftround autoindent

--- a/dttools/src/jx_query.c
+++ b/dttools/src/jx_query.c
@@ -97,7 +97,7 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    FILE *json;
+    FILE *json = NULL;
     if(path || url) json = fopen(document, "r");
     if(!json) {
         fprintf(stderr, "Error opening JSON file: %s - %s\n", document, strerror(errno));
@@ -139,7 +139,7 @@ int main(int argc, char *argv[]) {
             char *key = string_format("%u", hash_string(value));
             char *file = string_format("%s.json", key);
             FILE *f = fopen(file, "w");
-            fprintf(f, value);
+            fprintf(f, "%s", value);
             fclose(f);
             hash_table_insert(h, key, file);
             free(value);

--- a/dttools/src/jx_querytools.c
+++ b/dttools/src/jx_querytools.c
@@ -15,10 +15,6 @@ See the file COPYING for details.
 #include <stdio.h>
 #include <string.h>
 
-struct jx * jx_fetch_from_url ( const char *u ) {
-    return NULL;
-}
-
 const char * jx_parse_from_html ( const char *d ) {
     FILE *html = fopen(d, "r");
     char * line = NULL;
@@ -29,10 +25,6 @@ const char * jx_parse_from_html ( const char *d ) {
         if(string_match_regex(line, "<h1>Dumping raw contents of")) flag = 1;
     }
     return "";
-}
-
-struct jx * jx_query_project ( struct jx *c, struct jx *e ) {
-    return NULL;
 }
 
 struct jx * jx_query_select ( struct jx *c, struct jx *e ) {

--- a/dttools/src/jx_querytools.c
+++ b/dttools/src/jx_querytools.c
@@ -1,0 +1,64 @@
+/*
+Copyright (C) 2020- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include "jx.h"
+#include "jx_eval.h"
+#include "jx_getopt.h"
+#include "jx_parse.h"
+#include "jx_print.h"
+#include "stringtools.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+struct jx * jx_fetch_from_url ( const char *u ) {
+    return NULL;
+}
+
+const char * jx_parse_from_html ( const char *d ) {
+    FILE *html = fopen(d, "r");
+    char * line = NULL;
+    size_t len = 0;
+    int flag;
+    while (getline(&line, &len, html) != -1) {
+        if(flag) return line;
+        if(string_match_regex(line, "<h1>Dumping raw contents of")) flag = 1;
+    }
+    return "";
+}
+
+struct jx * jx_query_project ( struct jx *c, struct jx *e ) {
+    return NULL;
+}
+
+struct jx * jx_query_select ( struct jx *c, struct jx *e ) {
+    printf("expression: ");
+    jx_print_stream(e,stdout);
+    printf("\n");
+    struct jx *k = jx_eval(e,c);
+    printf("value:      ");
+    jx_print_stream(k,stdout);
+    printf("\n\n");
+    return k;
+}
+
+struct jx * jx_evaluate_query ( struct jx *c ) {
+    struct jx_parser *p = jx_parser_create(0);
+    jx_parser_read_stream(p, stdin);
+    struct jx *j = jx_parse(p); 
+    if(!jx_parser_errors(p)) {
+        struct jx *k = jx_query_select(c,j);
+        jx_parser_delete(p);
+        return k;
+    } 
+    printf("\"jx parse error: %s\"\n",jx_parser_error_string(p));
+    jx_parser_delete(p);
+    jx_delete(j);
+    return NULL;
+}
+
+// vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab shiftround autoindent

--- a/dttools/src/jx_querytools.h
+++ b/dttools/src/jx_querytools.h
@@ -1,0 +1,49 @@
+/*
+Copyright (C) 2020- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#ifndef JX_QUERYTOOLS_H
+#define JX_QUERYTOOLS_H
+
+#include "jx.h"
+
+/** Perform JX query upon a JSON document.
+@param q The string representation of the JX query expression to evaluate.
+@param c The JSON context upon which to evaluate as string.
+@return The output value of the evaluated expression as JX.
+Returns NULL on error.
+*/
+struct jx * jx_evaluate_query ( struct jx *c );
+
+/** Fetch a JSON document from a URL within a JX expression.
+Fetched JSON is parsed stored in a JX object.
+@param u The URL from which to fetch the document.
+@return The JX object of the fetched and parsed JSON.
+*/
+struct jx * jx_fetch_from_url ( const char *u );
+
+/** Parses JSON from an HTML document.
+The HTML document is assumed to be formatted as a
+server response from the TLQ troubleshooting tool.
+@param d The path to the HTML document to parse.
+@return  The JSON document contained within the HTML as string.
+*/
+const char * jx_parse_from_html ( const char *d );
+
+/** PLACEHOLDER
+@param c The context upon which to project via an expression.
+@param e The expression from which to perform the projection.
+@return The projected JX expression.
+*/
+struct jx * jx_query_project ( struct jx *c, struct jx *e );
+
+/** PLACEHOLDER
+@param c The context upon which to select via an expression.
+@param e The expression from which to perform the selection.
+@return The selected JX expression.
+*/
+struct jx * jx_query_select ( struct jx *c, struct jx *e );
+
+#endif


### PR DESCRIPTION
Adds JX fetch by URL or path
Adds JX select by boolean query
Adds JX project by arbitrary query
Adds JX schema retrieval
Adds JX object type-to-string
Fixes mislabeling of header file

Currently implemented functionality:
```
fetch(URL); || fetch(path);

select(bool-expr, [obj1, obj2, ...]);

project(expr, [obj1, obj2, ...]);

schema([obj1, obj2, ...]);
```