### PR TITLE
Compiler Fixes

### DIFF
--- a/batch_job/src/batch_job_blue_waters.c
+++ b/batch_job/src/batch_job_blue_waters.c
@@ -17,6 +17,7 @@ See the file COPYING for details.
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <assert.h>
 
 #include <sys/stat.h>
 
@@ -255,7 +256,8 @@ static int batch_job_cluster_remove (struct batch_queue *q, batch_job_id_t jobid
 	info->exit_signal = 1;
 
 	char *command = string_format("%s %" PRIbjid, cluster_remove_cmd, jobid);
-	system(command);
+	int rc = system(command);
+	assert(rc == 0);
 	free(command);
 
 	return 1;

--- a/batch_job/src/batch_job_cluster.c
+++ b/batch_job/src/batch_job_cluster.c
@@ -20,6 +20,7 @@ See the file COPYING for details.
 #include <errno.h>
 #include <ctype.h>
 #include <unistd.h>
+#include <assert.h>
 
 #include <sys/stat.h>
 
@@ -68,7 +69,8 @@ static int setup_batch_wrapper(struct batch_queue *q, const char *sysname )
 	fchmod(fileno(file), 0755);
 
 	char path[PATH_MAX];
-	getcwd(path, PATH_MAX);
+	char *rc = getcwd(path, PATH_MAX);
+	assert(rc != NULL);
 
 	fprintf(file, "#!/bin/sh\n");
 	fprintf(file, "#$ -S /bin/sh\n");
@@ -338,7 +340,8 @@ static int batch_job_cluster_remove (struct batch_queue *q, batch_job_id_t jobid
 	info->exit_signal = 1;
 
 	char *command = string_format("%s %" PRIbjid, cluster_remove_cmd, jobid);
-	system(command);
+	int rc = system(command);
+	assert(rc == 0);
 	free(command);
 
 	return 1;

--- a/batch_job/src/batch_job_condor.c
+++ b/batch_job/src/batch_job_condor.c
@@ -19,6 +19,7 @@ See the file COPYING for details.
 #include <string.h>
 #include <signal.h>
 #include <sys/stat.h>
+#include<assert.h>
 
 static int setup_condor_wrapper(const char *wrapperfile)
 {
@@ -299,7 +300,8 @@ static batch_job_id_t batch_job_condor_wait (struct batch_queue * q, struct batc
 
 					info->finished = current;
 
-					fgets(line, sizeof(line), logfile);
+					char *rc = fgets(line, sizeof(line), logfile);
+					assert(rc != NULL);
 					if(sscanf(line, " (%d) Normal termination (return value %d)", &logcode, &exitcode) == 2) {
 						debug(D_BATCH, "job %" PRIbjid " completed normally with status %d.", jobid, exitcode);
 						info->exited_normally = 1;

--- a/batch_job/src/batch_job_internal.h
+++ b/batch_job/src/batch_job_internal.h
@@ -11,6 +11,7 @@ See the file COPYING for details.
 
 #include <limits.h>
 #include <stdlib.h>
+#include <assert.h>
 
 #include "batch_job.h"
 #include "copy_stream.h"
@@ -65,7 +66,7 @@ struct batch_queue {
 #define batch_queue_stub_option_update(name)  static void batch_queue_##name##_option_update (struct batch_queue *Q, const char *what, const char *value) { return; }
 
 #define batch_fs_stub_chdir(name)  static int batch_fs_##name##_chdir (struct batch_queue *Q, const char *path) { return chdir(path); }
-#define batch_fs_stub_getcwd(name)  static int batch_fs_##name##_getcwd (struct batch_queue *Q, char *buf, size_t size) { getcwd(buf, size); return 0; }
+#define batch_fs_stub_getcwd(name)  static int batch_fs_##name##_getcwd (struct batch_queue *Q, char *buf, size_t size) { char *rc = getcwd(buf, size); assert(rc != NULL); return 0; }
 #define batch_fs_stub_mkdir(name)  static int batch_fs_##name##_mkdir (struct batch_queue *Q, const char *path, mode_t mode, int recursive) { if (recursive) return create_dir(path, mode); else return mkdir(path, mode); }
 #define batch_fs_stub_putfile(name)  static int batch_fs_##name##_putfile (struct batch_queue *Q, const char *lpath, const char *rpath) { return copy_file_to_file(lpath, rpath); }
 #define batch_fs_stub_rename(name)  static int batch_fs_##name##_rename (struct batch_queue *Q, const char *lpath, const char *rpath) { return create_dir_parents(rpath, 0755) && !rename(lpath, rpath) ? 0 : -1; }

--- a/batch_job/src/batch_job_k8s.c
+++ b/batch_job/src/batch_job_k8s.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <signal.h>
 #include <float.h>
+#include <assert.h>
 
 #define MAX_BUF_SIZE 4096
 
@@ -573,7 +574,8 @@ static batch_job_id_t batch_job_k8s_wait (struct batch_queue * q,
 			if(!cmd_fp) {
 				return -1;
 			}
-			fgets(log_tail_content, sizeof(log_tail_content)-1, cmd_fp);
+			char *rc = fgets(log_tail_content, sizeof(log_tail_content)-1, cmd_fp);
+			assert(rc != NULL);
 			int ret = pclose(cmd_fp);	
 			// If child process terminated abnormally, we will 
 			// retry it 5 times
@@ -679,7 +681,8 @@ static int batch_queue_k8s_free(struct batch_queue *q)
 {
 	char *cmd_rm_tmp_files = string_format("rm %s-*.json %s %s", 
 			mf_uuid->str, k8s_script_file_name, kubectl_failed_log);
-	system(cmd_rm_tmp_files);
+	int rc = system(cmd_rm_tmp_files);
+	assert(rc == 0);
 	return 0;
 	
 }

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -38,6 +38,7 @@ See the file COPYING for details.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 #include <math.h>
 #include <sys/stat.h>
@@ -124,7 +125,8 @@ invoke, so we construct a string and emit it with a low-level write.
 static void handle_abort( int sig )
 {
 	const char *msg = "received abort signal, shutting down workers...\n";
-	write(1,msg,strlen(msg));
+	ssize_t rc = write(1,msg,strlen(msg));
+	assert(rc != -1);
 	abort_flag = 1;
 }
 
@@ -1422,7 +1424,8 @@ int main(int argc, char *argv[])
 
 	if(password_file) {
 		cmd = string_format("cp %s %s/pwfile",password_file,scratch_dir);
-		system(cmd);
+		int rc = system(cmd);
+		assert(rc == 0);
 		free(cmd);
 	}
 

--- a/chirp/src/chirp_audit.c
+++ b/chirp/src/chirp_audit.c
@@ -17,6 +17,7 @@ See the file COPYING for details.
 #include <string.h>
 #include <errno.h>
 #include <sys/stat.h>
+#include <assert.h>
 
 static int audit_count = 0;
 
@@ -118,7 +119,8 @@ struct hash_table *chirp_audit(const char *path)
 	   anyone else.
 	 */
 
-	nice(10);
+	int rc = nice(10);
+	assert(rc != -1);
 
 	table = hash_table_create(0, 0);
 	if(!table)

--- a/chirp/src/chirp_matrix.c
+++ b/chirp/src/chirp_matrix.c
@@ -21,6 +21,7 @@ See the file COPYING for details.
 #include <stdlib.h>
 #include <sys/time.h>
 #include <sys/wait.h>
+#include <assert.h>
 
 #define SEPCHARS " \n"
 #define SEPCHARS2 "/"
@@ -98,7 +99,8 @@ struct chirp_matrix *chirp_matrix_create(const char *host, const char *path, int
 	for(i = 0; (int) i < nhosts; i++) {
 		if(!fgets(line, sizeof(line), file)) {
 			rewind(file);
-			fgets(line, sizeof(line), file);
+			char *rc = fgets(line, sizeof(line), file);
+			assert(rc != NULL);
 		}
 		hosts[i] = strdup(line);
 		int len = strlen(hosts[i]);

--- a/chirp/src/chirp_server.c
+++ b/chirp/src/chirp_server.c
@@ -1527,7 +1527,8 @@ static void chirp_handler(struct link *l, const char *addr, const char *subject)
 			result = 0;
 			// send this message to the parent for processing.
 			strcat(line, "\n");
-			write(config_pipe[1], line, strlen(line));
+			ssize_t rc = write(config_pipe[1], line, strlen(line));
+			assert(rc != -1);
 			debug_flags_set(chararg1);
 		} else if(sscanf(line, "search %s %s %" PRId64, chararg1, path, &flags) == 3) {
 			link_putliteral(l, "0\n", stalltime);
@@ -2132,7 +2133,8 @@ int main(int argc, char *argv[])
 		debug(D_CHIRP, "transient directory: `%s'", chirp_transient_path);
 	}
 
-	chdir("/"); /* no more relative path access from this point on */
+	int rc = chdir("/"); /* no more relative path access from this point on */
+	assert(rc == 0);
 
 	if(!create_dir(chirp_transient_path, S_IRWXU)) {
 		fatal("could not create transient data directory '%s': %s", chirp_transient_path, strerror(errno));

--- a/chirp/src/chirp_stats.c
+++ b/chirp/src/chirp_stats.c
@@ -17,6 +17,7 @@ See the file COPYING for details.
 #include <string.h>
 #include <errno.h>
 #include <time.h>
+#include <assert.h>
 
 static struct hash_table *stats_table = 0;
 
@@ -116,7 +117,8 @@ void chirp_stats_report(int pipefd, const char *addr, const char *subject, int i
 
 	if(time(0) - child_report_time > interval) {
 		snprintf(line, PIPE_BUF, "stats %s %s %" PRId64 " %" PRId64 " %" PRId64 "\n", addr, subject, child_ops, child_bytes_read, child_bytes_written);
-		write(pipefd, line, strlen(line));
+		ssize_t rc = write(pipefd, line, strlen(line));
+		assert(rc != -1);
 		debug(D_DEBUG, "sending stats: %s", line);
 		child_ops = child_bytes_read = child_bytes_written = 0;
 		child_report_time = time(0);

--- a/chirp/src/chirp_tool.c
+++ b/chirp/src/chirp_tool.c
@@ -181,8 +181,10 @@ static INT64_T do_lcd(int argc, char **argv)
 {
 	char full_path[CHIRP_PATH_MAX];
 	complete_local_path(argv[1], full_path);
+	char *rc;
 	if(chdir(full_path) == 0) {
-		getcwd(current_local_dir, CHIRP_PATH_MAX);
+		rc = getcwd(current_local_dir, CHIRP_PATH_MAX);
+		assert(rc != NULL);
 		return 0;
 	} else {
 		return -1;
@@ -997,10 +999,13 @@ static INT64_T do_xattr_get(int argc, char **argv)
 	complete_remote_path(argv[1], full_path);
 	char data[65536];
 	INT64_T size;
+	ssize_t rc;
 
 	if((size = chirp_reli_getxattr(current_host, full_path, argv[2], data, sizeof(data), stoptime)) > 0) {
-		write(STDOUT_FILENO, data, (size_t) size);
-		write(STDOUT_FILENO, "\n", 1);
+		rc = write(STDOUT_FILENO, data, (size_t) size);
+		assert(rc != -1);
+		rc = write(STDOUT_FILENO, "\n", 1);
+		assert(rc != -1);
 		return 0;
 	} else {
 		return -1;
@@ -1013,12 +1018,15 @@ static INT64_T do_xattr_list(int argc, char **argv)
 	complete_remote_path(argv[1], full_path);
 	char data[65536];
 	INT64_T size;
+	ssize_t rc;
 
 	if((size = chirp_reli_listxattr(current_host, full_path, data, sizeof(data), stoptime)) > 0) {
 		char *current;
 		for(current = data; *current; current = current + strlen(current) + 1) {
-			write(STDOUT_FILENO, current, strlen(current));
-			write(STDOUT_FILENO, "\n", 1);
+			rc = write(STDOUT_FILENO, current, strlen(current));
+			assert(rc != -1);
+			rc = write(STDOUT_FILENO, "\n", 1);
+			assert(rc != -1);
 		}
 		return 0;
 	} else {
@@ -1216,6 +1224,7 @@ int main(int argc, char *argv[])
 	char **user_argv = 0;
 	int user_argc;
 	int c;
+	char *rc;
 	INT64_T result = 0;
 
 	debug_config(argv[0]);
@@ -1280,7 +1289,8 @@ int main(int argc, char *argv[])
 		auth_ticket_load(NULL);
 	}
 
-	getcwd(current_local_dir, CHIRP_PATH_MAX);
+	rc = getcwd(current_local_dir, CHIRP_PATH_MAX);
+	assert(rc != NULL);
 
 	/* interactive mode if input is a TTY but we are not simply executing a
 	 * command from argv */

--- a/dttools/src/disk_alloc.c
+++ b/dttools/src/disk_alloc.c
@@ -17,6 +17,7 @@ See the file COPYING for details.
 #include <string.h>
 #include <ctype.h>
 #include <errno.h>
+#include <assert.h>
 
 #include "disk_alloc.h"
 #include "stringtools.h"
@@ -185,7 +186,8 @@ int disk_alloc_delete(char *loc) {
 	FILE *loop_find;
 	losetup_args = string_format("losetup -j %s", device_loc);
 	loop_find = popen(losetup_args, "r");
-	fscanf(loop_find, "%s %s %s", loop_dev, loop_info, loop_mount);
+	int rc = fscanf(loop_find, "%s %s %s", loop_dev, loop_info, loop_mount);
+	assert(rc == 3);
 	pclose(loop_find);
 	int loop_dev_path_length = strlen(loop_mount);
 	loop_mount[loop_dev_path_length - 1] = '\0';

--- a/dttools/src/gpu_info.c
+++ b/dttools/src/gpu_info.c
@@ -16,7 +16,7 @@ See the file COPYING for details.
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
-
+#include <assert.h>
 
 
 #define GPU_AUTODETECT "cctools_gpu_autodetect"
@@ -24,7 +24,8 @@ See the file COPYING for details.
 int gpu_info_get()
 {
 	int pipefd[2];
-	pipe(pipefd);
+	int rc = pipe(pipefd);
+	assert(rc == 0);
 
 	pid_t pid = fork();
 

--- a/dttools/src/host_memory_info.c
+++ b/dttools/src/host_memory_info.c
@@ -45,6 +45,7 @@ int host_memory_info_get(UINT64_T * avail, UINT64_T * total)
 #include <sys/resource.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <assert.h>
 
 int host_memory_usage_get(UINT64_T * rssp, UINT64_T * totalp)
 {
@@ -60,7 +61,8 @@ int host_memory_usage_get(UINT64_T * rssp, UINT64_T * totalp)
 	if(!file)
 		return 0;
 
-	fscanf(file, "%lu %lu %lu %lu %lu %lu %lu", &total, &rss, &shared, &text, &libs, &data, &dirty);
+	int rc = fscanf(file, "%lu %lu %lu %lu %lu %lu %lu", &total, &rss, &shared, &text, &libs, &data, &dirty);
+	assert(rc == 7);
 
 	fclose(file);
 

--- a/dttools/src/list.c
+++ b/dttools/src/list.c
@@ -42,7 +42,8 @@ struct list_cursor {
 
 static void oom(void) {
 	const char *message = "out of memory\n";
-	write(STDERR_FILENO, message, strlen(message));
+	ssize_t rc = write(STDERR_FILENO, message, strlen(message));
+	assert(rc >= 0);
 	abort();
 }
 

--- a/dttools/src/load_average.c
+++ b/dttools/src/load_average.c
@@ -4,6 +4,8 @@ This software is distributed under the GNU General Public License.
 See the file COPYING for details.
 */
 
+#include <assert.h>
+
 #if defined(CCTOOLS_OPSYS_DARWIN)
 
 #include <unistd.h>
@@ -42,7 +44,8 @@ void load_average_get(double *avg)
 	avg[0] = avg[1] = avg[2] = 0;
 	f = fopen("/proc/loadavg", "r");
 	if(f) {
-		fscanf(f, "%lf %lf %lf", &avg[0], &avg[1], &avg[2]);
+		int rc = fscanf(f, "%lf %lf %lf", &avg[0], &avg[1], &avg[2]);
+		assert(rc == 3);
 		fclose(f);
 	}
 }

--- a/dttools/src/memfdexe.c
+++ b/dttools/src/memfdexe.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 int memfdexe (const char *name, const char *extradir)
 {
@@ -65,7 +66,8 @@ int memfdexe (const char *name, const char *extradir)
 					continue;
 				}
 				munmap(addr, pagesize);
-				ftruncate(fd, 0);
+				int rc = ftruncate(fd, 0);
+				assert(rc == 0);
 				break;
 			} else {
 				debug(D_DEBUG, "could not create memfdexe: %s", strerror(errno));

--- a/dttools/src/username.c
+++ b/dttools/src/username.c
@@ -11,6 +11,7 @@ See the file COPYING for details.
 #include <unistd.h>
 #include <sys/types.h>
 #include <string.h>
+#include <assert.h>
 
 int username_is_super()
 {
@@ -65,8 +66,11 @@ int username_set(const char *name)
 	if(result < 0)
 		return 0;
 
-	setuid(uid);
-	setgid(gid);
+	int rc;
+	rc = setuid(uid);
+	assert(rc == 0);
+	rc = setgid(gid);
+	assert(rc == 0);
 
 	return 1;
 }

--- a/makeflow/src/dag_visitors.c
+++ b/makeflow/src/dag_visitors.c
@@ -17,6 +17,7 @@ See the file COPYING for details.
 #include <pwd.h>
 #include <time.h>
 #include <unistd.h>
+#include <assert.h>
 
 #include "hash_table.h"
 #include "xxmalloc.h"
@@ -355,7 +356,8 @@ void dag_to_dax_replica_catalog(const struct dag *d, FILE *output)
 	list_first_item(input_files);
 	while((f = (struct dag_file*)list_next_item(input_files)))
 	{
-		realpath(f->filename, fn);
+		char *rc = realpath(f->filename, fn);
+		assert(rc != NULL);
 		fprintf(output, "%s\tfile://%s\t%s\n", path_basename(f->filename), fn, "pool=\"local\"");
 	}
 }
@@ -383,7 +385,8 @@ void dag_to_dax_transform_catalog(const struct dag *d, FILE *output)
 	list_first_item(transforms);
 	while((fn = list_next_item(transforms))) {
 		if(path_lookup(getenv("PATH"), fn, pfn, PATH_MAX)){
-			realpath(fn, pfn);
+			char *rc = realpath(fn, pfn);
+			assert(rc != NULL);
 			type = "STAGEABLE";
 		} else {
 			type = "INSTALLED";

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -1125,7 +1125,8 @@ static void handle_abort(int sig)
 	if (fd >= 0) {
 		char buf[256];
 		string_nformat(buf, sizeof(buf), "received signal %d (%s), cleaning up remote jobs and files...\n",sig,strsignal(sig));
-		write(fd, buf, strlen(buf));
+		ssize_t rc = write(fd, buf, strlen(buf));
+		assert(rc != -1);
 		close(fd);
 	}
 
@@ -2336,8 +2337,10 @@ int main(int argc, char *argv[])
 
 	makeflow_parse_input_outputs(d);
 
-	if (change_dir)
-		chdir(change_dir);
+	if (change_dir) {
+		int rc = chdir(change_dir);
+		assert(rc == 0);
+	}
 
 	if(!disable_afs_check && (batch_queue_type==BATCH_QUEUE_TYPE_CONDOR)) {
 		char *cwd = path_getcwd();

--- a/makeflow/src/makeflow_analyze.c
+++ b/makeflow/src/makeflow_analyze.c
@@ -16,6 +16,7 @@ See the file COPYING for details.
 #include <fcntl.h>
 #include <dirent.h>
 #include <unistd.h>
+#include <assert.h>
 
 #include "cctools.h"
 #include "catalog_query.h"
@@ -327,7 +328,8 @@ int main(int argc, char *argv[])
 		char expanded_path[PATH_MAX];
 
 		collect_input_files(d, bundle_directory, bundler_rename);
-		realpath(bundle_directory, expanded_path);
+		char *rc = realpath(bundle_directory, expanded_path);
+		assert(rc != NULL);
 
 		char output_makeflow[PATH_MAX];
 		string_nformat(output_makeflow, sizeof(output_makeflow), "%s/%s", expanded_path, path_basename(dagfile));

--- a/makeflow/src/makeflow_gc.c
+++ b/makeflow/src/makeflow_gc.c
@@ -202,7 +202,8 @@ void makeflow_clean_node(struct dag *d, struct batch_queue *queue, struct dag_no
 		char *command = string_format("%s --clean",n->task->command);
 		printf("%s\n",command);
 		jx_export(n->task->envlist);
-		system(command);
+		int rc = system(command);
+		assert(rc == 0);
 		printf("done cleaning sub-workflow %s\n",n->workflow_file);
 		free(command);
 	}

--- a/makeflow/src/makeflow_mpi_submitter.c
+++ b/makeflow/src/makeflow_mpi_submitter.c
@@ -16,6 +16,7 @@
 #include "list.h"
 #include "xxmalloc.h"
 #include <unistd.h>
+#include <assert.h>
 
 static const struct option long_options[] = {
     {"makeflow-arguments", required_argument, 0, 'm'},
@@ -482,7 +483,8 @@ int main(int argc, char** argv) {
             //submit job
             FILE* submitret = popen(tmp, "r");
             char outs[1024];
-            fgets(outs, 1024, submitret);
+            char *rc = fgets(outs, 1024, submitret);
+            assert(rc != NULL);
             int id = getnum(outs);
             int* idp = malloc(sizeof (int)*1);
             *idp = id;
@@ -515,7 +517,8 @@ int main(int argc, char** argv) {
                     tmp = string_format(" ");
                     break;
             }
-            system(tmp);
+            int rc = system(tmp);
+            assert(rc == 0);
             free(tmp);
         }
         

--- a/parrot/src/parrot_package_create.c
+++ b/parrot/src/parrot_package_create.c
@@ -16,7 +16,7 @@
 #include <sys/sendfile.h>
 #include <time.h>
 #include <limits.h>
-
+#include <assert.h>
 
 #include "copy_stream.h"
 #include "debug.h"
@@ -262,7 +262,8 @@ int prepare_work()
 		}
 		char mkdir_cmd[PATH_MAX * 2];
 		if(snprintf(mkdir_cmd, sizeof(mkdir_cmd), "mkdir -p %s", packagepath) >= 0) {
-			system(mkdir_cmd);
+			int rc = system(mkdir_cmd);
+			assert(rc == 0);
 		}
 		if(access(packagepath, F_OK) != 0) {
 			fprintf(stderr, "mkdir(`%s`) fails: %s\n", packagepath, strerror(errno));
@@ -825,9 +826,9 @@ int main(int argc, char *argv[])
 	char special_filename_tmp[PATH_MAX];
 	string_nformat(special_filename_tmp, sizeof(special_filename_tmp), "%s%s", special_filename, ".tmp");
 	char sort_cmd[PATH_MAX * 2];
-	if(snprintf(sort_cmd, PATH_MAX * 2, "sort -u %s>>%s", special_filename, special_filename_tmp) >= 0)
-		system(sort_cmd);
-	else {
+	int rc = snprintf(sort_cmd, PATH_MAX * 2, "sort -u %s>>%s", special_filename, special_filename_tmp);
+	assert(rc >= 0);
+	if (system(sort_cmd) != 0) {
 		debug(D_DEBUG, "sort special_files fails.\n");
 		exit(EXIT_FAILURE);
 	}

--- a/parrot/src/pfs_channel.c
+++ b/parrot/src/pfs_channel.c
@@ -21,6 +21,7 @@ See the file COPYING for details.
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 struct entry {
 	char *name;
@@ -108,7 +109,8 @@ int pfs_channel_init( pfs_size_t size )
 	}
 
 	channel_size = size;
-	ftruncate(channel_fd,channel_size);
+	int rc = ftruncate(channel_fd,channel_size);
+	assert(rc == 0);
 
 	channel_base = (char*) mmap(0,channel_size,PROT_READ|PROT_WRITE,MAP_SHARED,channel_fd,0);
 	if(channel_base==MAP_FAILED) {
@@ -193,7 +195,8 @@ int pfs_channel_alloc( const char *name, pfs_size_t length, pfs_size_t *start )
 			debug(D_CHANNEL,"channel expanded to 0x%" PRIu64 " bytes at base 0x%" PRIdPTR, newsize, (uintptr_t) newbase);
 			return pfs_channel_alloc(name,length,start);
 		}
-		ftruncate64(channel_fd,channel_size);
+		int rc = ftruncate64(channel_fd,channel_size);
+		assert(rc == 0);
 	}
 
 	debug(D_CHANNEL|D_NOTICE,"out of channel space: %s",strerror(errno));

--- a/parrot/src/pfs_file_cache.cc
+++ b/parrot/src/pfs_file_cache.cc
@@ -28,6 +28,7 @@ extern "C" {
 #include <stdlib.h>
 #include <utime.h>
 #include <time.h>
+#include <assert.h>
 
 extern struct file_cache *pfs_file_cache;
 extern int pfs_session_cache;
@@ -208,7 +209,10 @@ pfs_file * pfs_cache_open( pfs_name *name, int flags, mode_t mode )
 
 	fd = file_cache_open(pfs_file_cache,name->path,flags,txn,buf.st_size,0);
 	if(fd>=0) {
-		if(flags&O_TRUNC) ftruncate(fd,0);
+		if(flags&O_TRUNC) {
+			int rc = ftruncate(fd,0);
+			assert(rc == 0);
+		}
 		return new pfs_file_cached(name,fd,mode,buf.st_ctime,buf.st_ino);
 	} else {
 		debug(D_DEBUG, "file cache lookup failed: %s", strerror(errno));

--- a/parrot/src/pfs_main.cc
+++ b/parrot/src/pfs_main.cc
@@ -704,6 +704,7 @@ int main( int argc, char *argv[] )
 	const char *s;
 	char *key;
 	char *value = NULL;
+	int rc;
 
 	s = getenv("PARROT_BLOCK_SIZE");
 	if(s) pfs_service_set_block_size(string_metric_parse(s));
@@ -966,9 +967,9 @@ int main( int argc, char *argv[] )
 				return 1;
 			}
 			char cmd[PATH_MAX];
-			if(snprintf(cmd, sizeof(cmd), "find /lib*/ -name ld-linux*>>%s 2>/dev/null", optarg) >= 0)
-				system(cmd);
-			else {
+			rc = snprintf(cmd, sizeof(cmd), "find /lib*/ -name ld-linux*>>%s 2>/dev/null", optarg);
+			assert(rc >= 0);
+			if (system(cmd) != 0) {
 				debug(D_DEBUG, "writing ld-linux* into namelist file failed.");
 				return 1;
 			}
@@ -1210,7 +1211,8 @@ int main( int argc, char *argv[] )
 		for (int i = 0; environ[i]; i++)
 			fprintf(fp, "%s%c", environ[i], '\0');
 		char working_dir[PATH_MAX];
-		::getcwd(working_dir,sizeof(working_dir));
+		char *rc = ::getcwd(working_dir,sizeof(working_dir));
+		assert(rc != NULL);
 		if(working_dir == NULL)
 			fatal("Can not obtain the current working directory!");
 		fprintf(fp, "PWD=%s\n", working_dir);

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -102,7 +102,8 @@ pfs_table::pfs_table()
 	if(pfs_initial_working_directory) {
 		strcpy(working_dir,pfs_initial_working_directory);
 	} else {
-		::getcwd(working_dir,sizeof(working_dir));
+		char *rc = ::getcwd(working_dir,sizeof(working_dir));
+		assert(rc != NULL);
 	}
 	pointer_count = sysconf(_SC_OPEN_MAX);
 	pointers = new pfs_pointer* [pointer_count];

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -109,6 +109,7 @@ See the file COPYING for details.
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <assert.h>
 
 #include <time.h>
 #include <unistd.h>
@@ -1684,7 +1685,8 @@ void write_helper_lib(void)
         return;
 
     n = sizeof(lib_helper_data);
-    write(flib, lib_helper_data, n);
+    ssize_t rc = write(flib, lib_helper_data, n);
+    assert(rc != -1);
     close(flib);
 
     chmod(lib_helper_name, 0777);

--- a/resource_monitor/src/rmonitor_helper_comm.c
+++ b/resource_monitor/src/rmonitor_helper_comm.c
@@ -19,6 +19,7 @@ See the file COPYING for details.
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <limits.h>
+#include <assert.h>
 
 #include "stringtools.h"
 #include "xxmalloc.h"
@@ -229,8 +230,10 @@ int rmonitor_helper_init(char *lib_default_path, int *fd, int stop_short_running
 	char *helper_path = rmonitor_helper_locate(lib_default_path);
 	char helper_absolute[PATH_MAX + 1];
 	char *rmonitor_port;
+	char *rc;
 
-	realpath(helper_path, helper_absolute);
+	rc = realpath(helper_path, helper_absolute);
+	assert(rc != NULL);
 
 	if(access(helper_absolute,R_OK|X_OK)==0) {
 		debug(D_RMON, "found helper in %s\n", helper_absolute);

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1801,7 +1801,8 @@ static work_queue_result_code_t get_update( struct work_queue *q, struct work_qu
 
 	lseek(fd,offset,SEEK_SET);
 	link_stream_to_fd(w->link,fd,length,stoptime);
-	ftruncate(fd,offset+length);
+	int rc = ftruncate(fd,offset+length);
+	assert(rc == 0);
 	close(fd);
 
 	return WQ_SUCCESS;
@@ -4950,6 +4951,7 @@ struct work_queue *work_queue_create(int port)
 		return 0;
 	}
 	char *envstring;
+	char *rc;
 
 	random_init();
 
@@ -4979,7 +4981,8 @@ struct work_queue *work_queue_create(int port)
 		link_address_local(q->master_link, address, &q->port);
 	}
 
-	getcwd(q->workingdir,PATH_MAX);
+	rc = getcwd(q->workingdir,PATH_MAX);
+	assert(rc != NULL);
 
 	q->next_taskid = 1;
 

--- a/work_queue/src/work_queue_json.c
+++ b/work_queue/src/work_queue_json.c
@@ -13,6 +13,7 @@ See the file COPYING for details.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 static const char *work_queue_properties[] = { "name", "port", "priority", "num_tasks_left", "next_taskid", "workingdir", "master_link",
 	"poll_table", "poll_table_size", "tasks", "task_state_map", "ready_list", "worker_table",
@@ -181,7 +182,9 @@ static struct work_queue_task *create_task(const char *str)
 	struct jx *input_files = NULL;
 	struct jx *output_files = NULL;
 	struct jx *environment = NULL;
-	int cores, memory, disk;
+	int cores = 0;
+	int memory = 0;
+	int disk = 0;
 
 	struct jx *json = jx_parse_string(str);
 	if(!json) {

--- a/work_queue/src/work_queue_server.c
+++ b/work_queue/src/work_queue_server.c
@@ -119,8 +119,8 @@ void mainloop(struct work_queue *queue, struct link *client)
 		const char *key = jx_iterate_keys(jsonrpc, &k);
 		struct jx *value = jx_iterate_values(jsonrpc, &v);
 
-		char *method;
-		struct jx *val;
+		char *method = NULL;
+		struct jx *val = NULL;
 
 		while(key) {
 

--- a/work_queue/src/work_queue_test.c
+++ b/work_queue/src/work_queue_test.c
@@ -19,6 +19,7 @@ See the file COPYING for details.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -34,7 +35,8 @@ int submit_tasks(struct work_queue *q, int input_size, int run_time, int output_
 
 	sprintf(input_file, "input.%d",ntasks);
 	sprintf(gen_input_cmd, "dd if=/dev/zero of=%s bs=1048576 count=%d",input_file,input_size);
-	system(gen_input_cmd);
+	int rc = system(gen_input_cmd);
+	assert(rc == 0);
 
 	/*
 	Note that bs=1m and similar are not portable across various

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -2469,6 +2469,7 @@ int main(int argc, char *argv[])
 	double fast_abort_multiplier = 0;
 	char *foreman_stats_filename = NULL;
 	char * catalog_hosts = CATALOG_HOST;
+	int rc;
 
 	features = hash_table_create(4, 0);
 
@@ -2784,7 +2785,8 @@ int main(int argc, char *argv[])
 	}
 
 	// change to workspace
-	chdir(workspace);
+	rc = chdir(workspace);
+	assert(rc == 0);
 
 	if(worker_mode == WORKER_MODE_FOREMAN) {
 		char foreman_string[WORK_QUEUE_LINE_MAX];
@@ -2827,14 +2829,16 @@ int main(int argc, char *argv[])
 	if(container_mode == CONTAINER_MODE_DOCKER && load_from_tar == 1) {
 		char load_cmd[1024];
 		string_nformat(load_cmd, sizeof(load_cmd), "docker load < %s", tar_fn);
-		system(load_cmd);
+		int rc = system(load_cmd);
+		assert(rc == 0);
 	}
 
 	if(container_mode == CONTAINER_MODE_DOCKER_PRESERVE) {
 		if (load_from_tar == 1) {
 			char load_cmd[1024];
 			string_nformat(load_cmd, sizeof(load_cmd), "docker load < %s", tar_fn);
-			system(load_cmd);
+			int rc = system(load_cmd);
+			assert(rc == 0);
 		}
 
 		string_nformat(container_name, sizeof(container_name), "worker-%d-%d", (int) getuid(), (int) getpid());
@@ -2842,7 +2846,8 @@ int main(int argc, char *argv[])
 		char start_container_cmd[1024];
 		string_nformat(container_mnt_point, sizeof(container_mnt_point), "%s:%s", workspace, DOCKER_WORK_DIR);
 		string_nformat(start_container_cmd, sizeof(start_container_cmd), "docker run -i -d --name=\"%s\" -v %s -w %s %s", container_name, container_mnt_point, DOCKER_WORK_DIR, img_name);
-		system(start_container_cmd);
+		int rc = system(start_container_cmd);
+		assert(rc == 0);
 	}
 
 	procs_running  = itable_create(0);
@@ -2933,10 +2938,13 @@ int main(int argc, char *argv[])
 		string_nformat(rm_container_cmd, sizeof(rm_container_cmd), "docker rm %s", container_name);
 
 		if(container_mode == CONTAINER_MODE_DOCKER_PRESERVE) {
+			int rc;
 			//1. stop the container
-			system(stop_container_cmd);
+			rc = system(stop_container_cmd);
+			assert(rc == 0);
 			//2. remove the container
-			system(rm_container_cmd);
+			rc = system(rm_container_cmd);
+			assert(rc == 0);
 		}
 
 	}


### PR DESCRIPTION
This PR fixes a bunch of compiler warnings (mostly due to un-checked return codes). Strict build works for me under Nix (for #2326  and #2327). There are quite a few changes, so I was just going for quick error checks (e.g. crash on unexpected failure).