### PR TITLE
add status operation to WQ-JSON API

### DIFF
--- a/apps/wq_bwa_json/wq_bwa_json.py
+++ b/apps/wq_bwa_json/wq_bwa_json.py
@@ -93,7 +93,7 @@ def main():
     #connect to server
     q.connect('127.0.0.1', 0, 0, "wq_bwa_json")
 
-    response = q.stats()
+    response = q.status()
     print(response)
   
     #submit tasks

--- a/apps/wq_bwa_json/wq_bwa_json.py
+++ b/apps/wq_bwa_json/wq_bwa_json.py
@@ -91,7 +91,10 @@ def main():
     q = WorkQueueServer()
 
     #connect to server
-    q.connect('127.0.0.1', 2345, 1234, "wq_bwa_json")
+    q.connect('127.0.0.1', 0, 0, "wq_bwa_json")
+
+    response = q.stats()
+    print(response)
   
     #submit tasks
     for t in tasks:

--- a/work_queue/src/clients/python3/work_queue_server.py
+++ b/work_queue/src/clients/python3/work_queue_server.py
@@ -101,7 +101,7 @@ class WorkQueueServer:
 
         return self.send_recv(request)
 
-    def stats(self):
+    def status(self):
         request = {
             "jsonrpc" : "2.0",
             "method" : "stats",

--- a/work_queue/src/clients/python3/work_queue_server.py
+++ b/work_queue/src/clients/python3/work_queue_server.py
@@ -101,6 +101,17 @@ class WorkQueueServer:
 
         return self.send_recv(request)
 
+    def stats(self):
+        request = {
+            "jsonrpc" : "2.0",
+            "method" : "stats",
+            "id" : self.id,
+            "params" : ""
+        }
+
+        return self.send_recv(request)
+
+
     def disconnect(self):
         self.socket.close()
 	self.server.terminate()
@@ -122,3 +133,5 @@ class WorkQueueServer:
             return False
         else:
             return True
+
+

--- a/work_queue/src/work_queue_json.c
+++ b/work_queue/src/work_queue_json.c
@@ -395,30 +395,30 @@ char *work_queue_json_remove(struct work_queue *q, int id)
 
 char *work_queue_json_get_status(struct work_queue *q)
 {
-    char *status;
-    struct work_queue_stats s;
+	char *status;
+	struct work_queue_stats s;
 	struct jx *j;
 	struct jx_pair *workers_connected, *workers_idle, *workers_busy, *tasks_waiting, *tasks_on_workers, *tasks_running, *tasks_with_results, *tasks_submitted, *tasks_done, *tasks_failed, *bytes_sent, *bytes_received;
 
-    work_queue_get_stats(q, &s);
+	work_queue_get_stats(q, &s);
 
-    workers_connected = jx_pair(jx_string("workers_connected"), jx_integer(s.workers_connected), NULL);
-    workers_idle = jx_pair(jx_string("workers_idle"), jx_integer(s.workers_idle), workers_connected);
-    workers_busy = jx_pair(jx_string("workers_busy"), jx_integer(s.workers_busy), workers_idle);
-    tasks_waiting = jx_pair(jx_string("tasks_waiting"), jx_integer(s.tasks_waiting), workers_busy);
-    tasks_on_workers = jx_pair(jx_string("tasks_on_workers"), jx_integer(s.tasks_on_workers), tasks_waiting);
-    tasks_running = jx_pair(jx_string("tasks_running"), jx_integer(s.tasks_running), tasks_on_workers);
-    tasks_with_results = jx_pair(jx_string("tasks_with_results"), jx_integer(s.tasks_with_results), tasks_running);
-    tasks_submitted = jx_pair(jx_string("tasks_submitted"), jx_integer(s.tasks_submitted), tasks_with_results);
-    tasks_done = jx_pair(jx_string("tasks_done"), jx_integer(s.tasks_done), tasks_submitted);
-    tasks_failed = jx_pair(jx_string("tasks_failed"), jx_integer(s.tasks_failed), tasks_done);
-    bytes_sent = jx_pair(jx_string("bytes_sent"), jx_integer(s.bytes_sent), tasks_failed);
-    bytes_received = jx_pair(jx_string("bytes_received"), jx_integer(s.bytes_received), bytes_sent);
+	workers_connected = jx_pair(jx_string("workers_connected"), jx_integer(s.workers_connected), NULL);
+	workers_idle = jx_pair(jx_string("workers_idle"), jx_integer(s.workers_idle), workers_connected);
+	workers_busy = jx_pair(jx_string("workers_busy"), jx_integer(s.workers_busy), workers_idle);
+	tasks_waiting = jx_pair(jx_string("tasks_waiting"), jx_integer(s.tasks_waiting), workers_busy);
+	tasks_on_workers = jx_pair(jx_string("tasks_on_workers"), jx_integer(s.tasks_on_workers), tasks_waiting);
+	tasks_running = jx_pair(jx_string("tasks_running"), jx_integer(s.tasks_running), tasks_on_workers);
+	tasks_with_results = jx_pair(jx_string("tasks_with_results"), jx_integer(s.tasks_with_results), tasks_running);
+	tasks_submitted = jx_pair(jx_string("tasks_submitted"), jx_integer(s.tasks_submitted), tasks_with_results);
+	tasks_done = jx_pair(jx_string("tasks_done"), jx_integer(s.tasks_done), tasks_submitted);
+	tasks_failed = jx_pair(jx_string("tasks_failed"), jx_integer(s.tasks_failed), tasks_done);
+	bytes_sent = jx_pair(jx_string("bytes_sent"), jx_integer(s.bytes_sent), tasks_failed);
+	bytes_received = jx_pair(jx_string("bytes_received"), jx_integer(s.bytes_received), bytes_sent);
 
-    j = jx_object(bytes_received);
+	j = jx_object(bytes_received);
 
-    status = jx_print_string(j);
+	status = jx_print_string(j);
 
-    return status;
+	return status;
 
 }

--- a/work_queue/src/work_queue_json.c
+++ b/work_queue/src/work_queue_json.c
@@ -393,9 +393,9 @@ char *work_queue_json_remove(struct work_queue *q, int id)
 
 }
 
-char *work_queue_json_get_stats(struct work_queue *q)
+char *work_queue_json_get_status(struct work_queue *q)
 {
-    char *stats;
+    char *status;
     struct work_queue_stats s;
 	struct jx *j;
 	struct jx_pair *workers_connected, *workers_idle, *workers_busy, *tasks_waiting, *tasks_on_workers, *tasks_running, *tasks_with_results, *tasks_submitted, *tasks_done, *tasks_failed, *bytes_sent, *bytes_received;
@@ -417,8 +417,8 @@ char *work_queue_json_get_stats(struct work_queue *q)
 
     j = jx_object(bytes_received);
 
-    stats = jx_print_string(j);
+    status = jx_print_string(j);
 
-    return stats;
+    return status;
 
 }

--- a/work_queue/src/work_queue_json.c
+++ b/work_queue/src/work_queue_json.c
@@ -392,3 +392,33 @@ char *work_queue_json_remove(struct work_queue *q, int id)
 	return task;
 
 }
+
+char *work_queue_json_get_stats(struct work_queue *q)
+{
+    char *stats;
+    struct work_queue_stats s;
+	struct jx *j;
+	struct jx_pair *workers_connected, *workers_idle, *workers_busy, *tasks_waiting, *tasks_on_workers, *tasks_running, *tasks_with_results, *tasks_submitted, *tasks_done, *tasks_failed, *bytes_sent, *bytes_received;
+
+    work_queue_get_stats(q, &s);
+
+    workers_connected = jx_pair(jx_string("workers_connected"), jx_integer(s.workers_connected), NULL);
+    workers_idle = jx_pair(jx_string("workers_idle"), jx_integer(s.workers_idle), workers_connected);
+    workers_busy = jx_pair(jx_string("workers_busy"), jx_integer(s.workers_busy), workers_idle);
+    tasks_waiting = jx_pair(jx_string("tasks_waiting"), jx_integer(s.tasks_waiting), workers_busy);
+    tasks_on_workers = jx_pair(jx_string("tasks_on_workers"), jx_integer(s.tasks_on_workers), tasks_waiting);
+    tasks_running = jx_pair(jx_string("tasks_running"), jx_integer(s.tasks_running), tasks_on_workers);
+    tasks_with_results = jx_pair(jx_string("tasks_with_results"), jx_integer(s.tasks_with_results), tasks_running);
+    tasks_submitted = jx_pair(jx_string("tasks_submitted"), jx_integer(s.tasks_submitted), tasks_with_results);
+    tasks_done = jx_pair(jx_string("tasks_done"), jx_integer(s.tasks_done), tasks_submitted);
+    tasks_failed = jx_pair(jx_string("tasks_failed"), jx_integer(s.tasks_failed), tasks_done);
+    bytes_sent = jx_pair(jx_string("bytes_sent"), jx_integer(s.bytes_sent), tasks_failed);
+    bytes_received = jx_pair(jx_string("bytes_received"), jx_integer(s.bytes_received), bytes_sent);
+
+    j = jx_object(bytes_received);
+
+    stats = jx_print_string(j);
+
+    return stats;
+
+}

--- a/work_queue/src/work_queue_json.h
+++ b/work_queue/src/work_queue_json.h
@@ -89,4 +89,10 @@ char *work_queue_json_wait(struct work_queue *q, int timeout);
 */
 char *work_queue_json_remove(struct work_queue *q, int id);
 
+/** Get the stats for a given work queue.
+@param q A work queue object.
+@return A JSON description of the stats of the given work queue object.
+*/
+char *work_queue_json_get_stats(struct work_queue *q);
+
 #endif

--- a/work_queue/src/work_queue_json.h
+++ b/work_queue/src/work_queue_json.h
@@ -89,10 +89,10 @@ char *work_queue_json_wait(struct work_queue *q, int timeout);
 */
 char *work_queue_json_remove(struct work_queue *q, int id);
 
-/** Get the stats for a given work queue.
+/** Get the status for a given work queue.
 @param q A work queue object.
 @return A JSON description of the stats of the given work queue object.
 */
-char *work_queue_json_get_stats(struct work_queue *q);
+char *work_queue_json_get_status(struct work_queue *q);
 
 #endif

--- a/work_queue/src/work_queue_server.c
+++ b/work_queue/src/work_queue_server.c
@@ -180,9 +180,9 @@ void mainloop(struct work_queue *queue, struct link *client)
 			} else {
 				reply(client, method, "Not Empty", id);
 			}
-		} else if(!strcmp(method, "stats")) {
-            char *stats = work_queue_json_get_stats(queue);
-            reply(client, method, stats, id);
+		} else if(!strcmp(method, "status")) {
+            char *status = work_queue_json_get_status(queue);
+            reply(client, method, status, id);
         } else {
 			error = "Method not recognized";
 			reply(client, "error", error, id);

--- a/work_queue/src/work_queue_server.c
+++ b/work_queue/src/work_queue_server.c
@@ -144,34 +144,25 @@ void mainloop(struct work_queue *queue, struct link *client)
 
 		//submit or wait
 		if(!strcmp(method, "submit")) {
-
 			char *task = val->u.string_value;
-
 			int taskid = work_queue_json_submit(queue, task);
-
 			if(taskid < 0) {
 				error = "Could not submit task";
 				reply(client, "error", error, id);
 			} else {
 				reply(client, method, "Task submitted successfully.", id);
 			}
-
 		} else if(!strcmp(method, "wait")) {
-
 			int time_out = val->u.integer_value;
-
 			char *task = work_queue_json_wait(queue, time_out);
-
 			if(!task) {
 				error = "timeout reached with no task returned";
 				reply(client, "error", error, id);
 			} else {
 				reply(client, method, task, id);
 			}
-
 		} else if(!strcmp(method, "remove")) {
 			int taskid = val->u.integer_value;
-
 			char *task = work_queue_json_remove(queue, taskid);
 			if(!task) {
 				error = "task not able to be removed from queue";
@@ -179,7 +170,6 @@ void mainloop(struct work_queue *queue, struct link *client)
 			} else {
 				reply(client, method, "Task removed successfully.", id);
 			}
-
 		} else if(!strcmp(method, "disconnect")) {
 			reply(client, method, "Successfully disconnected.", id);
 			break;
@@ -190,7 +180,10 @@ void mainloop(struct work_queue *queue, struct link *client)
 			} else {
 				reply(client, method, "Not Empty", id);
 			}
-		} else {
+		} else if(!strcmp(method, "stats")) {
+            char *stats = work_queue_json_get_stats(queue);
+            reply(client, method, stats, id);
+        } else {
 			error = "Method not recognized";
 			reply(client, "error", error, id);
 		}


### PR DESCRIPTION
Addresses the stats operation aspect of issue #2321 

Uses work_queue_get_stats to obtain some of the worker and task stats.