### PR TITLE
adds context switches to the resource_monitor

### DIFF
--- a/dttools/src/rmonitor_poll_internal.h
+++ b/dttools/src/rmonitor_poll_internal.h
@@ -48,6 +48,7 @@ int rmonitor_poll_maps_once(   struct itable *processes, struct rmonitor_mem_inf
 void rmonitor_info_to_rmsummary(struct rmsummary *tr, struct rmonitor_process_info *p, struct rmonitor_wdir_info *d, struct rmonitor_filesys_info *f, uint64_t start_time);
 
 int rmonitor_get_cpu_time_usage(pid_t pid,        struct rmonitor_cpu_time_info *cpu);
+int rmonitor_get_ctxsw_usage(   pid_t pid,        struct rmonitor_ctxsw_info *ctx);
 int rmonitor_get_mem_usage(     pid_t pid,        struct rmonitor_mem_info *mem);
 int rmonitor_get_sys_io_usage(  pid_t pid,        struct rmonitor_io_info *io);
 int rmonitor_get_map_io_usage(  pid_t pid,        struct rmonitor_io_info *io);
@@ -58,6 +59,7 @@ int rmonitor_get_loadavg(struct rmonitor_load_info *load);
 int rmonitor_get_wd_usage(struct rmonitor_wdir_info *d, int max_time_for_measurement);
 
 void acc_cpu_time_usage( struct rmonitor_cpu_time_info *acc, struct rmonitor_cpu_time_info *other);
+void acc_ctxsw_usage(    struct rmonitor_ctxsw_info *acc,    struct rmonitor_ctxsw_info *other);
 void acc_mem_usage(      struct rmonitor_mem_info *acc,      struct rmonitor_mem_info *other);
 void acc_sys_io_usage(   struct rmonitor_io_info *acc,       struct rmonitor_io_info *other);
 void acc_map_io_usage(   struct rmonitor_io_info *acc,       struct rmonitor_io_info *other);

--- a/dttools/src/rmonitor_types.h
+++ b/dttools/src/rmonitor_types.h
@@ -44,6 +44,12 @@ struct rmonitor_cpu_time_info
 	uint64_t delta;
 };
 
+struct rmonitor_ctxsw_info
+{
+	uint64_t accumulated;
+	uint64_t delta;
+};
+
 struct rmonitor_mem_info
 {
 	uint64_t virtual;
@@ -133,6 +139,7 @@ struct rmonitor_process_info
 
 	struct rmonitor_mem_info      mem;
 	struct rmonitor_cpu_time_info cpu;
+	struct rmonitor_ctxsw_info    ctx;
 	struct rmonitor_io_info       io;
 	struct rmonitor_load_info     load;
 	struct rmonitor_wdir_info    *wd;

--- a/dttools/src/rmsummary.c
+++ b/dttools/src/rmsummary.c
@@ -75,6 +75,7 @@ void initialize_units() {
 	rmsummary_add_conversion_field("cores_avg",                "mcores",  "cores",  "cores",   1000,     1/1000.0,      1);
 	rmsummary_add_conversion_field("machine_cpus",             "cores",   "cores",  "cores",   1,        1,             0);
 	rmsummary_add_conversion_field("machine_load",             "mprocs",  "procs",  "procs",   1000,     1/1000.0,      1);
+	rmsummary_add_conversion_field("context_switches",         "switches","switches","switches", 1,      1,             0);
 	rmsummary_add_conversion_field("max_concurrent_processes", "procs",   "procs",  "procs",   1,        1,             0);
 	rmsummary_add_conversion_field("total_processes",          "procs",   "procs",  "procs",   1,        1,             0);
 	rmsummary_add_conversion_field("total_files",              "files",   "files",  "files",   1,        1,             0);
@@ -339,6 +340,10 @@ int64_t rmsummary_get_int_field(struct rmsummary *s, const char *key) {
 		return s->cores_avg;
 	}
 
+	if(strcmp(key, "context_switches") == 0) {
+		return s->context_switches;
+	}
+
 	if(strcmp(key, "gpus") == 0) {
 		return s->gpus;
 	}
@@ -490,6 +495,11 @@ int rmsummary_assign_int_field(struct rmsummary *s, const char *key, int64_t val
 
 	if(strcmp(key, "cores_avg") == 0) {
 		s->cores_avg = value;
+		return 1;
+	}
+
+	if(strcmp(key, "context_switches") == 0) {
+		s->context_switches = value;
 		return 1;
 	}
 
@@ -645,6 +655,7 @@ struct jx *rmsummary_to_json(const struct rmsummary *s, int only_resources) {
 	field_to_json(output, s, wall_time);
 	field_to_json(output, s, cores);
 	field_to_json(output, s, cores_avg);
+	field_to_json(output, s, context_switches);
 	field_to_json(output, s, end);
 	field_to_json(output, s, start);
 
@@ -997,6 +1008,7 @@ void rmsummary_bin_op(struct rmsummary *dest, const struct rmsummary *src, rm_bi
 	rmsummary_apply_op(dest, src, fn, fs_nodes);
 	rmsummary_apply_op(dest, src, fn, cores);
 	rmsummary_apply_op(dest, src, fn, cores_avg);
+	rmsummary_apply_op(dest, src, fn, context_switches);
 	rmsummary_apply_op(dest, src, fn, machine_cpus);
 	rmsummary_apply_op(dest, src, fn, machine_load);
 
@@ -1093,6 +1105,7 @@ static void merge_limits(struct rmsummary *dest, const struct rmsummary *src)
 	merge_limit(dest, src, disk);
 	merge_limit(dest, src, cores);
 	merge_limit(dest, src, cores_avg);
+	merge_limit(dest, src, context_switches);
 	merge_limit(dest, src, machine_load);
 	merge_limit(dest, src, fs_nodes);
 
@@ -1172,6 +1185,7 @@ void rmsummary_merge_max_w_time(struct rmsummary *dest, const struct rmsummary *
 	max_op_w_time(dest, src, total_files);
 	max_op_w_time(dest, src, disk);
 	max_op_w_time(dest, src, cores);
+	max_op_w_time(dest, src, context_switches);
 	max_op_w_time(dest, src, machine_cpus);
 	max_op_w_time(dest, src, machine_load);
 	max_op_w_time(dest, src, fs_nodes);
@@ -1267,6 +1281,10 @@ size_t rmsummary_field_offset(const char *key) {
 
 	if(!strcmp(key, "cores_avg")) {
 		return offsetof(struct rmsummary, cores_avg);
+	}
+
+	if(!strcmp(key, "context_switches")) {
+		return offsetof(struct rmsummary, context_switches);
 	}
 
 	if(!strcmp(key, "disk")) {

--- a/dttools/src/rmsummary.h
+++ b/dttools/src/rmsummary.h
@@ -58,6 +58,7 @@ struct rmsummary
 
 	int64_t  cores;                          /* peak usage in a small time window */
 	int64_t  cores_avg;
+	int64_t  context_switches;
 	int64_t  gpus;
     int64_t  machine_load;                   /* peak load of the host */
     int64_t  machine_cpus;                   /* number of cpus of the host */

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -951,6 +951,7 @@ void rmonitor_collate_tree(struct rmsummary *tr, struct rmonitor_process_info *p
 
 	/* using .delta here because if we use .accumulated, then we lose information of processes that already terminated. */
 	tr->cpu_time  += p->cpu.delta;
+	tr->context_switches += p->ctx.delta;
 
 	tr->start = summary->start;
 	tr->end   = usecs_since_epoch();


### PR DESCRIPTION
The motivation is to discriminate slowdowns caused by machine load, IO, and memory swap. The implementation follows cpu_time, where at each time step we compute the change from accumulated values. 