### PR TITLE
Correctly set number of MPI processes for slurm

### DIFF
--- a/batch_job/src/batch_job_cluster.c
+++ b/batch_job/src/batch_job_cluster.c
@@ -126,8 +126,8 @@ static char *cluster_set_resource_string(struct batch_queue *q, const struct rms
 		}
 		/* The value of max_concurrent_processes is set by the .MAKEFLOW MPI_PROCESSES.
 		 * If set, the number of cores should be divisible by max_concurrent_processes. */
-		int procs = resources->max_concurrent_processes > 0 ? resources->max_concurrent_processes : 1;
-		int cores = resources->cores > 0 ? resources->cores : 1;
+		int64_t procs = resources->max_concurrent_processes > 0 ? resources->max_concurrent_processes : 1;
+		int64_t cores = resources->cores > 0 ? resources->cores : 1;
 
 		if(procs > 1) {
 			cores = cores / procs;
@@ -138,7 +138,7 @@ static char *cluster_set_resource_string(struct batch_queue *q, const struct rms
 		}
 		// Currently leaving out tmp as SLURM assumes a shared FS and tmp may be limiting
 		// char *disk = string_format(" --tmp=%" PRId64 "M", resources->disk);
-		cluster_resources = string_format(" -N 1 -n %d -c %" PRId64 "%s ",
+		cluster_resources = string_format(" -N 1 -n %" PRId64 " -c %" PRId64 "%s ",
 				procs, cores,
 				(resources->memory>0 && mem) ? mem : "") ;
 		free(mem);

--- a/doc/manuals/makeflow/index.md
+++ b/doc/manuals/makeflow/index.md
@@ -356,7 +356,7 @@ This will add the values for cores and memory. These values will be added onto
 `sbatch` in this format:  
 
 ```sh
--N 1 -n ${CORES} --mem=${MEMORY}M
+-N 1 -n 1 -c ${CORES} --mem=${MEMORY}M
 ```
 
 To remove resources specification at submission use Makeflow option `--safe-submit-mode`.
@@ -369,6 +369,31 @@ highly dependent on host site.
 Note: Some SLURM sites disallow specifying memory (example Stampede2). To
 avoid specification errors the Makeflow option `--ignore-memory-spec` removes
 memory from `sbatch`.
+
+
+#### SLURM and MPI jobs
+
+If your rules should run as an MPI jobs, you can set the environment variables
+"MPI_PROCESSES" and "CORES", or alternatively, use the makeflow directives
+".MAKEFLOW MPI_PROCESSES" and ".MAKEFLOW CORES". The value of MPI_PROCESSES
+sets the number of MPI processes the rule should spawn, and it should exactly
+divide the value of CORES. The value of sbatch used is something similar to:
+
+```sh
+-N 1 -n ${MPI_PROCESSES} ${CORES_divided_by_MPI_PROCESSES} --mem=${MEMORY}M
+```
+
+Further, the commands in your rules should be prepended with the `srun` command
+appropiate to your prefered MPI API, for example, here is a rule that uses 4
+MPI process, with 2 CORES each, using the `pmi2` API:
+
+```make
+.MAKEFLOW MPI_PROCESSES 4
+.MAKEFLOW CORES 8
+output: input
+srun --mpi=pmi2 -- ./my-mpi-job -i input -o output
+```
+
 
 ### Moab Scheduler
 

--- a/doc/manuals/makeflow/index.md
+++ b/doc/manuals/makeflow/index.md
@@ -380,7 +380,7 @@ sets the number of MPI processes the rule should spawn, and it should exactly
 divide the value of CORES. The value of sbatch used is something similar to:
 
 ```sh
--N 1 -n ${MPI_PROCESSES} ${CORES_divided_by_MPI_PROCESSES} --mem=${MEMORY}M
+-N 1 -n ${MPI_PROCESSES} -c ${CORES_divided_by_MPI_PROCESSES} --mem=${MEMORY}M
 ```
 
 Further, the commands in your rules should be prepended with the `srun` command
@@ -390,8 +390,23 @@ MPI process, with 2 CORES each, using the `pmi2` API:
 ```make
 .MAKEFLOW MPI_PROCESSES 4
 .MAKEFLOW CORES 8
+
 output: input
-srun --mpi=pmi2 -- ./my-mpi-job -i input -o output
+    srun --mpi=pmi2 -- ./my-mpi-job -i input -o output
+```
+
+Some installations may require a queue and time limit specifications. Since
+both `sbatch` (used internally by makeflow), and `srun` require these options,
+the environment variable can be used in the following way:
+
+```make
+# Setting queue and time limit needed as in xsede stampede2:
+BATCH_OPTIONS=-pnormal -t900
+.MAKEFLOW MPI_PROCESSES 4
+.MAKEFLOW CORES 8
+
+output: input
+    srun $(BATCH_OPTIONS) --mpi=pmi2 -- ./my-mpi-job -i input -o output
 ```
 
 

--- a/dttools/src/rmsummary.h
+++ b/dttools/src/rmsummary.h
@@ -20,6 +20,7 @@ COPYING for details.
 #define RESOURCES_DISK      "DISK"
 #define RESOURCES_WALL_TIME "WALL_TIME"
 #define RESOURCES_GPUS      "GPUS"
+#define RESOURCES_MPI_PROCESSES "MPI_PROCESSES"
 
 // These fields are defined as signed integers, even though they
 // will only contain positive numbers. This is to conversion to

--- a/makeflow/src/dag.c
+++ b/makeflow/src/dag.c
@@ -58,6 +58,7 @@ struct dag *dag_create()
 	string_set_insert(d->special_vars, RESOURCES_MEMORY);
 	string_set_insert(d->special_vars, RESOURCES_DISK);
 	string_set_insert(d->special_vars, RESOURCES_GPUS);
+	string_set_insert(d->special_vars, RESOURCES_MPI_PROCESSES);
 	string_set_insert(d->special_vars, RESOURCES_WALL_TIME);
 
 	/* export all variables related to resources */
@@ -66,6 +67,7 @@ struct dag *dag_create()
 	string_set_insert(d->export_vars, RESOURCES_MEMORY);
 	string_set_insert(d->export_vars, RESOURCES_DISK);
 	string_set_insert(d->export_vars, RESOURCES_GPUS);
+	string_set_insert(d->export_vars, RESOURCES_MPI_PROCESSES);
 	string_set_insert(d->export_vars, RESOURCES_WALL_TIME);
 
 	memset(d->node_states, 0, sizeof(int) * DAG_NODE_STATE_MAX);

--- a/makeflow/src/parser.c
+++ b/makeflow/src/parser.c
@@ -185,6 +185,11 @@ void rmsummary_set_resources_from_env(struct rmsummary *rs, struct dag_variable_
 		rs->gpus = atoll(val->value);
 	}
 
+	val = dag_variable_lookup(RESOURCES_MPI_PROCESSES, &s);
+	if(val) {
+		rs->max_concurrent_processes = atoll(val->value);
+	}
+
 	val = dag_variable_lookup(RESOURCES_WALL_TIME, &s);
 	if(val) {
 		rs->wall_time = atoll(val->value);

--- a/makeflow/src/parser_make.c
+++ b/makeflow/src/parser_make.c
@@ -367,7 +367,7 @@ static int dag_parse_make_directive_MAKEFLOW(struct lexer *bk, struct dag_node *
 
 	if(t->type != TOKEN_LITERAL)
 	{
-		lexer_report_error(bk, "Expected LITERAL token (CATEGORY|MODE|CORES|DISK|MEMORY|SIZE), got: %s\n", lexer_print_token(t));
+		lexer_report_error(bk, "Expected LITERAL token (CATEGORY|MODE|CORES|DISK|MEMORY|SIZE|MPI_PROCESSES), got: %s\n", lexer_print_token(t));
 	}
 
 	struct token *t2 = lexer_next_token(bk);
@@ -387,7 +387,8 @@ static int dag_parse_make_directive_MAKEFLOW(struct lexer *bk, struct dag_node *
 	}
 	else if((   !strcmp("CORES",  t->lexeme))
 			|| (!strcmp("DISK",   t->lexeme))
-			|| (!strcmp("MEMORY", t->lexeme)))
+			|| (!strcmp("MEMORY", t->lexeme))
+			|| (!strcmp("MPI_PROCESSES", t->lexeme)))
 	{
 		if(!(string_metric_parse(t2->lexeme) >= 0))
 		{
@@ -426,7 +427,7 @@ static int dag_parse_make_directive_MAKEFLOW(struct lexer *bk, struct dag_node *
 	}
 	else
 	{
-		lexer_report_error(bk, "Unsupported .MAKEFLOW directive, expected (CATEGORY|MODE|CORES|DISK|MEMORY|SIZE), got: %s\n", t->lexeme);
+		lexer_report_error(bk, "Unsupported .MAKEFLOW directive, expected (CATEGORY|MODE|CORES|DISK|MEMORY|SIZE|MPI_PROCESSES), got: %s\n", t->lexeme);
 	}
 
 	if(set_var) {


### PR DESCRIPTION
In response to issue #2328 