### PR TITLE
Adds TLQ URL retrieval to Makeflow, WQ Master, and WQ Worker

### DIFF
--- a/batch_job/src/batch_job_work_queue.c
+++ b/batch_job/src/batch_job_work_queue.c
@@ -221,6 +221,12 @@ static void batch_queue_wq_option_update (struct batch_queue *q, const char *wha
 	} else if(strcmp(what, "name") == 0) {
 		if(value)
 			work_queue_specify_name(q->data, value);
+	} else if(strcmp(what, "debug") == 0) {
+		if(value)
+			work_queue_specify_debug_path(q->data, value);
+	} else if(strcmp(what, "tlq-home") == 0) {
+		if(value)
+			work_queue_specify_tlq_home(q->data, value);
 	} else if(strcmp(what, "priority") == 0) {
 		if(value)
 			work_queue_specify_priority(q->data, atoi(value));

--- a/dttools/src/debug.c
+++ b/dttools/src/debug.c
@@ -96,6 +96,7 @@ static struct flag_info table[] = {
 	{"rmonitor", D_RMON},
 	{"confuga", D_CONFUGA},
 	{"dataswarm", D_DATASWARM},
+	{"tlq", D_TLQ},
 	{"jx", D_JX},
 	{"all", D_ALL},
 	{"time", 0},		/* backwards compatibility */

--- a/dttools/src/debug.h
+++ b/dttools/src/debug.h
@@ -94,6 +94,7 @@ unless it has the flags D_NOTICE or D_FATAL.  For example, a main program might 
 #define D_MAKEFLOW_HOOK  (1LL<<46)  /**< Debug makeflow's hook system */
 #define D_EXT      (1LL<<47)  /**< Debug the ext module in Parrot */
 #define D_DATASWARM (1LL<<48) /**< Debug the dataswarm service. */
+#define D_TLQ (1LL<<49) /**< Debug the TLQ service's interactions with CCTools. */
 
 /** Debug all remote I/O operations. */
 #define D_REMOTE   (D_HTTP|D_FTP|D_NEST|D_CHIRP|D_DCAP|D_RFIO|D_LFC|D_GFAL|D_MULTI|D_GROW|D_IRODS|D_HDFS|D_BXGRID|D_XROOTD|D_CVMFS)

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -228,6 +228,11 @@ static char *mount_cache = NULL;
 static int use_mountfile = 0;
 
 /*
+Options related to TLQ debugging
+*/
+static char *tlq_home = NULL;
+
+/*
 If enabled, then all environment variables are sent
 from the submission site to the job execution site.
 */
@@ -1263,6 +1268,10 @@ static void show_help_run(const char *cmd)
 	printf(" --monitor-with-opened-files    Enable monitoring of opened files.\n");
 	printf(" --monitor-log-fmt=<fmt>        Format for monitor logs.(def: resource-rule-%%)\n");
 	printf(" --allocation=<mode>            Specify allocation mode (see manual).\n");
+	        /********************************************************************************/
+	
+	printf("\nTLQ Options:\n");
+	printf(" --tlq=<host:port> Set the host:port for TLQ URL lookup (-T wq, -d, and -o required).\n");
 }
 
 int main(int argc, char *argv[])
@@ -1457,6 +1466,7 @@ int main(int argc, char *argv[])
 		LONG_OPT_VERBOSE_JOBNAMES,
 		LONG_OPT_MPI_CORES,
 		LONG_OPT_MPI_MEMORY,
+		LONG_OPT_TLQ,
 	};
 
 	static const struct option long_options_run[] = {
@@ -1575,6 +1585,7 @@ int main(int argc, char *argv[])
 		{"verbose-jobnames", no_argument, 0, LONG_OPT_VERBOSE_JOBNAMES},
 		{"mpi-cores", required_argument,0, LONG_OPT_MPI_CORES},
 		{"mpi-memory", required_argument,0, LONG_OPT_MPI_MEMORY},
+		{"tlq", required_argument, 0, LONG_OPT_TLQ},
 		{0, 0, 0, 0}
 	};
 
@@ -2103,6 +2114,9 @@ int main(int argc, char *argv[])
 			case LONG_OPT_MPI_MEMORY:
 				mpi_memory = atoi(optarg);
 				break;
+			case LONG_OPT_TLQ:
+				tlq_home = xxstrdup(optarg);
+				break;
 			default:
 				show_help_run(argv[0]);
 				return 1;
@@ -2298,6 +2312,8 @@ int main(int argc, char *argv[])
 	batch_queue_set_option(remote_queue, "password", work_queue_password);
 	batch_queue_set_option(remote_queue, "master-mode", work_queue_master_mode);
 	batch_queue_set_option(remote_queue, "name", project);
+	batch_queue_set_option(remote_queue, "debug", debug_file_name);
+	batch_queue_set_option(remote_queue, "tlq-home", tlq_home);
 	batch_queue_set_option(remote_queue, "priority", priority);
 	batch_queue_set_option(remote_queue, "keepalive-interval", work_queue_keepalive_interval);
 	batch_queue_set_option(remote_queue, "keepalive-timeout", work_queue_keepalive_timeout);

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -853,6 +853,18 @@ const char *work_queue_name(struct work_queue *q);
 */
 void work_queue_specify_name(struct work_queue *q, const char *name);
 
+/** Change the debug log path for a given queue (used by TLQ).
+@param q A work queue object.
+@param name The debug log path.
+*/
+void work_queue_specify_debug_path(struct work_queue *q, const char *path);
+
+/** Change the home host and port for a given queue (used by TLQ).
+@param q A work queue object.
+@param name The home host:port.
+*/
+void work_queue_specify_tlq_home(struct work_queue *q, const char *home);
+
 /** Change the priority for a given queue.
 @param q A work queue object.
 @param priority The new priority of the queue.  Higher priority masters will attract workers first.


### PR DESCRIPTION
This allows for Work Queue masters and workers to retrieve their TLQ URL from the catalog server and to advertise their URLs to each other.

Makeflow and workers are passed a `--tlq=<host:port>` flag to provide the phone home address TLQ uses to tell a user it has their logs. This is used to check that we are getting the right URL from the catalog. Makeflow passes this phone home address to the master (along with the path to the debug log) via the batch queue interface.

This functionality is turned on only when both the makeflow (by extension the master) and at least one worker have been given the `--tlq` option.