### PR TITLE
Adds TLQ URL retrieval to Makeflow, WQ Master, and WQ Worker

### DIFF
--- a/batch_job/src/batch_job_work_queue.c
+++ b/batch_job/src/batch_job_work_queue.c
@@ -221,6 +221,12 @@ static void batch_queue_wq_option_update (struct batch_queue *q, const char *wha
 	} else if(strcmp(what, "name") == 0) {
 		if(value)
 			work_queue_specify_name(q->data, value);
+	} else if(strcmp(what, "debug") == 0) {
+		if(value)
+			work_queue_specify_debug_path(q->data, value);
+	} else if(strcmp(what, "tlq-port") == 0) {
+		if(value)
+			work_queue_specify_tlq_port(q->data, atoi(value));
 	} else if(strcmp(what, "priority") == 0) {
 		if(value)
 			work_queue_specify_priority(q->data, atoi(value));

--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -107,6 +107,7 @@ SOURCES = \
 	text_list.c \
 	timer.c \
 	timestamp.c \
+	tlq_config.c \
 	unlink_recursive.c \
 	uptime.c \
 	url_encode.c \

--- a/dttools/src/address.c
+++ b/dttools/src/address.c
@@ -157,27 +157,4 @@ int address_parse_hostport( const char *hostport, char *host, int *port, int def
 	}
 }
 
-char *address_get_tlq_url( int port, const char *log_path ) {
-	struct sockaddr_in serv_addr;
-	char buffer[256];
-	strcpy(buffer, log_path);
-	serv_addr.sin_family = AF_INET;
-	serv_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
-	serv_addr.sin_port = htons(port);
-	debug(D_NOTICE, "set server socket information");
-
-	int sockfd = socket(AF_INET, SOCK_STREAM, 0);
-	if(sockfd < 0) debug(D_NOTICE, "error opening local INET socket: %d - %s", errno, strerror(errno));
-	if(connect(sockfd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0) debug(D_NOTICE, "error connecting to local INET socket: %d - %s", errno, strerror(errno));
-	int serv_write = write(sockfd, buffer, strlen(buffer));
-	if(serv_write < 0) debug(D_NOTICE, "error writing to local INET socket: %d - %s", errno, strerror(errno));
-	bzero(buffer, 256);
-	int serv_read = read(sockfd, buffer, 255);
-	if(serv_read < 0) debug(D_NOTICE, "error reading from local INET socket: %d - %s", errno, strerror(errno));
-	close(sockfd);
-	char *url = xxstrdup(buffer);
-	if(!url) url = "NONE";
-	return xxstrdup(buffer);
-}
-
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/address.c
+++ b/dttools/src/address.c
@@ -1,10 +1,14 @@
 #include "address.h"
 #include "debug.h"
+#include "xxmalloc.h"
 #include <assert.h>
+#include <errno.h>
 #include <string.h>
 #include <arpa/inet.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 int address_check_mode( struct addrinfo *info ) {
 	assert(info);
@@ -153,4 +157,27 @@ int address_parse_hostport( const char *hostport, char *host, int *port, int def
 	}
 }
 
+char *address_get_tlq_url( int port, const char *log_path ) {
+	struct sockaddr_in serv_addr;
+	char buffer[256];
+	strcpy(buffer, log_path);
+	serv_addr.sin_family = AF_INET;
+	serv_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+	serv_addr.sin_port = htons(port);
+	debug(D_NOTICE, "set server socket information");
 
+	int sockfd = socket(AF_INET, SOCK_STREAM, 0);
+	if(sockfd < 0) debug(D_NOTICE, "error opening local INET socket: %d - %s", errno, strerror(errno));
+	if(connect(sockfd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0) debug(D_NOTICE, "error connecting to local INET socket: %d - %s", errno, strerror(errno));
+	int serv_write = write(sockfd, buffer, strlen(buffer));
+	if(serv_write < 0) debug(D_NOTICE, "error writing to local INET socket: %d - %s", errno, strerror(errno));
+	bzero(buffer, 256);
+	int serv_read = read(sockfd, buffer, 255);
+	if(serv_read < 0) debug(D_NOTICE, "error reading from local INET socket: %d - %s", errno, strerror(errno));
+	close(sockfd);
+	char *url = xxstrdup(buffer);
+	if(!url) url = "NONE";
+	return xxstrdup(buffer);
+}
+
+/* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/address.h
+++ b/dttools/src/address.h
@@ -20,5 +20,6 @@ int address_to_sockaddr( const char *addr, int port, struct sockaddr_storage *s,
 int address_from_sockaddr( char *str, struct sockaddr *saddr );
 int address_parse_hostport( const char *hostport, char *host, int *port, int default_port );
 int address_check_mode( struct addrinfo *info );
+char *address_get_tlq_url( int port, const char *log_path );
 
 #endif

--- a/dttools/src/debug.c
+++ b/dttools/src/debug.c
@@ -96,6 +96,7 @@ static struct flag_info table[] = {
 	{"rmonitor", D_RMON},
 	{"confuga", D_CONFUGA},
 	{"dataswarm", D_DATASWARM},
+	{"tlq", D_TLQ},
 	{"jx", D_JX},
 	{"all", D_ALL},
 	{"time", 0},		/* backwards compatibility */

--- a/dttools/src/debug.h
+++ b/dttools/src/debug.h
@@ -94,6 +94,7 @@ unless it has the flags D_NOTICE or D_FATAL.  For example, a main program might 
 #define D_MAKEFLOW_HOOK  (1LL<<46)  /**< Debug makeflow's hook system */
 #define D_EXT      (1LL<<47)  /**< Debug the ext module in Parrot */
 #define D_DATASWARM (1LL<<48) /**< Debug the dataswarm service. */
+#define D_TLQ (1LL<<49) /**< Debug the TLQ service's interactions with CCTools. */
 
 /** Debug all remote I/O operations. */
 #define D_REMOTE   (D_HTTP|D_FTP|D_NEST|D_CHIRP|D_DCAP|D_RFIO|D_LFC|D_GFAL|D_MULTI|D_GROW|D_IRODS|D_HDFS|D_BXGRID|D_XROOTD|D_CVMFS)

--- a/dttools/src/tlq_config.c
+++ b/dttools/src/tlq_config.c
@@ -3,28 +3,25 @@
 #include "link.h"
 #include "xxmalloc.h"
 #include <errno.h>
-#include <arpa/inet.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <time.h>
 #include <string.h>
-#include <sys/socket.h>
-#include <unistd.h>
 
-char *tlq_config_url( int port, const char *log_path ) {
+char *tlq_config_url( int port, const char *log_path, time_t stoptime ) {
 	char buffer[256];
 	struct link *server;
 	strcpy(buffer, log_path);
-	server = link_connect("127.0.0.1", port, time(0) + 10);
+	server = link_connect("127.0.0.1", port, stoptime);
 	if(!server) {
 		debug(D_NOTICE, "error opening local INET socket: %d - %s", errno, strerror(errno));
 		return NULL;
 	}
 	
-	ssize_t serv_write = link_write(server, buffer, sizeof(buffer), time(0) + 10);
+	ssize_t serv_write = link_write(server, buffer, sizeof(buffer), stoptime);
 	if(serv_write < 0) debug(D_NOTICE, "error writing to local INET socket: %d - %s", errno, strerror(errno));
 	bzero(buffer, 256);
-	int serv_read = link_read(server, buffer, sizeof(buffer), time(0) + 10);
+	int serv_read = link_read(server, buffer, sizeof(buffer), stoptime);
 	if(serv_read < 0) debug(D_NOTICE, "error reading from local INET socket: %d - %s", errno, strerror(errno));
+	link_close(server);
 	return xxstrdup(buffer);
 }
 

--- a/dttools/src/tlq_config.c
+++ b/dttools/src/tlq_config.c
@@ -1,0 +1,28 @@
+#include "tlq_config.h"
+#include "debug.h"
+#include "link.h"
+#include "xxmalloc.h"
+#include <errno.h>
+#include <arpa/inet.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+char *tlq_config_url( int port, const char *log_path ) {
+	char buffer[256];
+	struct link *server;
+	strcpy(buffer, log_path);
+	server = link_connect("127.0.0.1", port, time(0) + 10);
+	if(!server) debug(D_NOTICE, "error opening local INET socket: %d - %s", errno, strerror(errno));
+	
+	ssize_t serv_write = link_write(server, buffer, sizeof(buffer), time(0) + 10);
+	if(serv_write < 0) debug(D_NOTICE, "error writing to local INET socket: %d - %s", errno, strerror(errno));
+	bzero(buffer, 256);
+	int serv_read = link_read(server, buffer, sizeof(buffer), time(0) + 10);
+	if(serv_read < 0) debug(D_NOTICE, "error reading from local INET socket: %d - %s", errno, strerror(errno));
+	return xxstrdup(buffer);
+}
+
+/* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/tlq_config.c
+++ b/dttools/src/tlq_config.c
@@ -15,7 +15,10 @@ char *tlq_config_url( int port, const char *log_path ) {
 	struct link *server;
 	strcpy(buffer, log_path);
 	server = link_connect("127.0.0.1", port, time(0) + 10);
-	if(!server) debug(D_NOTICE, "error opening local INET socket: %d - %s", errno, strerror(errno));
+	if(!server) {
+		debug(D_NOTICE, "error opening local INET socket: %d - %s", errno, strerror(errno));
+		return NULL;
+	}
 	
 	ssize_t serv_write = link_write(server, buffer, sizeof(buffer), time(0) + 10);
 	if(serv_write < 0) debug(D_NOTICE, "error writing to local INET socket: %d - %s", errno, strerror(errno));

--- a/dttools/src/tlq_config.h
+++ b/dttools/src/tlq_config.h
@@ -1,6 +1,8 @@
 #ifndef TLQ_CONFIG_H
 #define TLQ_CONFIG_H
 
-char *tlq_config_url( int port, const char *log_path );
+#include <time.h>
+
+char *tlq_config_url( int port, const char *log_path, time_t stoptime );
 
 #endif

--- a/dttools/src/tlq_config.h
+++ b/dttools/src/tlq_config.h
@@ -1,0 +1,6 @@
+#ifndef TLQ_CONFIG_H
+#define TLQ_CONFIG_H
+
+char *tlq_config_url( int port, const char *log_path );
+
+#endif

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -4,7 +4,6 @@ This software is distributed under the GNU General Public License.
 See the file COPYING for details.
 */
 
-#include "address.h"
 #include "auth_all.h"
 #include "auth_ticket.h"
 #include "batch_job.h"
@@ -34,6 +33,7 @@ See the file COPYING for details.
 #include "jx_print.h"
 #include "create_dir.h"
 #include "sha1.h"
+#include "tlq_config.h"
 
 #include "dag.h"
 #include "dag_node.h"
@@ -2484,7 +2484,7 @@ int main(int argc, char *argv[])
 
 	if(tlq_port && debug_file_name) {
 		debug(D_TLQ, "looking up makeflow TLQ URL");
-		char *local_tlq_url = address_get_tlq_url(tlq_port, debug_file_name);
+		char *local_tlq_url = tlq_config_url(tlq_port, debug_file_name);
 		if(!local_tlq_url) {
 			debug(D_TLQ, "error looking up makeflow TLQ URL - setting it to NONE");
 			local_tlq_url = "NONE";

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -2484,14 +2484,12 @@ int main(int argc, char *argv[])
 
 	if(tlq_port && debug_file_name) {
 		debug(D_TLQ, "looking up makeflow TLQ URL");
-		char *local_tlq_url = tlq_config_url(tlq_port, debug_file_name);
-		if(!local_tlq_url) {
-			debug(D_TLQ, "error looking up makeflow TLQ URL - setting it to NONE");
-			local_tlq_url = "NONE";
-		}
-		debug(D_TLQ, "set makeflow TLQ URL: %s", local_tlq_url);
+		time_t config_stoptime = time(0) + 10;
+		char *local_tlq_url = tlq_config_url(tlq_port, debug_file_name, config_stoptime);
+		if(!local_tlq_url) debug(D_TLQ, "error looking up makeflow TLQ URL");
+		else debug(D_TLQ, "set makeflow TLQ URL: %s", local_tlq_url);
 	}
-	else if(tlq_port && !debug_file_name) debug(D_TLQ, "cannot lookup TLQ URL: debug log not set");
+	else if(tlq_port && !debug_file_name) debug(D_TLQ, "cannot lookup makeflow TLQ URL: debug log not set");
 
 	makeflow_run(d);
 

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -4,6 +4,7 @@ This software is distributed under the GNU General Public License.
 See the file COPYING for details.
 */
 
+#include "address.h"
 #include "auth_all.h"
 #include "auth_ticket.h"
 #include "batch_job.h"
@@ -226,6 +227,11 @@ files at the DAG level.
 static char *mountfile = NULL;
 static char *mount_cache = NULL;
 static int use_mountfile = 0;
+
+/*
+Options related to TLQ debugging
+*/
+static int tlq_port = 0;
 
 /*
 If enabled, then all environment variables are sent
@@ -1263,6 +1269,10 @@ static void show_help_run(const char *cmd)
 	printf(" --monitor-with-opened-files    Enable monitoring of opened files.\n");
 	printf(" --monitor-log-fmt=<fmt>        Format for monitor logs.(def: resource-rule-%%)\n");
 	printf(" --allocation=<mode>            Specify allocation mode (see manual).\n");
+	        /********************************************************************************/
+	
+	printf("\nTLQ Options:\n");
+	printf(" --tlq=<port> Set the port for TLQ URL lookup (-d and -o required).\n");
 }
 
 int main(int argc, char *argv[])
@@ -1457,6 +1467,7 @@ int main(int argc, char *argv[])
 		LONG_OPT_VERBOSE_JOBNAMES,
 		LONG_OPT_MPI_CORES,
 		LONG_OPT_MPI_MEMORY,
+		LONG_OPT_TLQ,
 	};
 
 	static const struct option long_options_run[] = {
@@ -1575,6 +1586,7 @@ int main(int argc, char *argv[])
 		{"verbose-jobnames", no_argument, 0, LONG_OPT_VERBOSE_JOBNAMES},
 		{"mpi-cores", required_argument,0, LONG_OPT_MPI_CORES},
 		{"mpi-memory", required_argument,0, LONG_OPT_MPI_MEMORY},
+		{"tlq", required_argument, 0, LONG_OPT_TLQ},
 		{0, 0, 0, 0}
 	};
 
@@ -2103,6 +2115,9 @@ int main(int argc, char *argv[])
 			case LONG_OPT_MPI_MEMORY:
 				mpi_memory = atoi(optarg);
 				break;
+			case LONG_OPT_TLQ:
+				tlq_port = atoi(optarg);
+				break;
 			default:
 				show_help_run(argv[0]);
 				return 1;
@@ -2298,6 +2313,7 @@ int main(int argc, char *argv[])
 	batch_queue_set_option(remote_queue, "password", work_queue_password);
 	batch_queue_set_option(remote_queue, "master-mode", work_queue_master_mode);
 	batch_queue_set_option(remote_queue, "name", project);
+	batch_queue_set_option(remote_queue, "debug", debug_file_name);
 	batch_queue_set_option(remote_queue, "priority", priority);
 	batch_queue_set_option(remote_queue, "keepalive-interval", work_queue_keepalive_interval);
 	batch_queue_set_option(remote_queue, "keepalive-timeout", work_queue_keepalive_timeout);
@@ -2312,6 +2328,7 @@ int main(int argc, char *argv[])
 	batch_queue_set_option(remote_queue, "safe-submit-mode", safe_submit ? "yes" : "no");
 	batch_queue_set_option(remote_queue, "ignore-mem-spec", ignore_mem_spec ? "yes" : "no");
 	batch_queue_set_option(remote_queue, "mem-type", batch_mem_type);
+	batch_queue_set_int_option(remote_queue, "tlq-port", tlq_port);
 
 	char *fa_multiplier = string_format("%f", wq_option_fast_abort_multiplier);
 	batch_queue_set_option(remote_queue, "fast-abort", fa_multiplier);
@@ -2464,6 +2481,17 @@ int main(int argc, char *argv[])
 	makeflow_log_started_event(d);
 
 	runtime = timestamp_get();
+
+	if(tlq_port && debug_file_name) {
+		debug(D_TLQ, "looking up makeflow TLQ URL");
+		char *local_tlq_url = address_get_tlq_url(tlq_port, debug_file_name);
+		if(!local_tlq_url) {
+			debug(D_TLQ, "error looking up makeflow TLQ URL - setting it to NONE");
+			local_tlq_url = "NONE";
+		}
+		debug(D_TLQ, "set makeflow TLQ URL: %s", local_tlq_url);
+	}
+	else if(tlq_port && !debug_file_name) debug(D_TLQ, "cannot lookup TLQ URL: debug log not set");
 
 	makeflow_run(d);
 

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -578,7 +578,7 @@ work_queue_msg_code_t advertise_tlq_url(struct work_queue *q, struct work_queue_
 	if(q->tlq_port && q->debug_path && !q->tlq_url) {
 		debug(D_TLQ, "looking up master TLQ URL");
 		q->tlq_url = address_get_tlq_url(q->tlq_port, q->debug_path);
-		f(q->tlq_url) debug(D_TLQ, "set master TLQ URL: %s", q->tlq_url);
+		if(q->tlq_url) debug(D_TLQ, "set master TLQ URL: %s", q->tlq_url);
 		else {
 			debug(D_TLQ, "error setting master TLQ URL - setting it to NONE");
 			q->tlq_url = "NONE";

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -571,24 +571,19 @@ work_queue_msg_code_t advertise_tlq_url(struct work_queue *q, struct work_queue_
 	//attempt to find local TLQ server to retrieve master URL
 	if(q->tlq_port && q->debug_path && !q->tlq_url) {
 		debug(D_TLQ, "looking up master TLQ URL");
-		q->tlq_url = tlq_config_url(q->tlq_port, q->debug_path);
+		time_t config_stoptime = time(0) + 10;
+		q->tlq_url = tlq_config_url(q->tlq_port, q->debug_path, config_stoptime);
 		if(q->tlq_url) debug(D_TLQ, "set master TLQ URL: %s", q->tlq_url);
-		else {
-			debug(D_TLQ, "error setting master TLQ URL - setting it to NONE");
-			q->tlq_url = "NONE";
-		}
+		else debug(D_TLQ, "error setting master TLQ URL");
 	}
-	else if(q->tlq_port && !q->debug_path && !q->tlq_url) {
-		debug(D_TLQ, "cannot get master TLQ URL: no debug log path set");
-		q->tlq_url = "NONE";
-	}
+	else if(q->tlq_port && !q->debug_path && !q->tlq_url) debug(D_TLQ, "cannot get master TLQ URL: no debug log path set");
 
 	char worker_url[WORK_QUEUE_LINE_MAX];
 	int n = sscanf(line, "tlq %s", worker_url);
 	if(n != 1) debug(D_TLQ, "empty TLQ URL received from worker (%s)", w->addrport);
 	else debug(D_TLQ, "received worker (%s) TLQ URL %s", w->addrport, worker_url);
 
-	//send master TLQ URL if there is one. otherwise send NONE
+	//send master TLQ URL if there is one
 	if(q->tlq_url) {
 		debug(D_TLQ, "sending master TLQ URL to worker (%s)", w->addrport);
 		send_worker_msg(q, w, "tlq %s\n", q->tlq_url);

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -853,6 +853,18 @@ const char *work_queue_name(struct work_queue *q);
 */
 void work_queue_specify_name(struct work_queue *q, const char *name);
 
+/** Change the debug log path for a given queue (used by TLQ).
+@param q A work queue object.
+@param name The debug log path.
+*/
+void work_queue_specify_debug_path(struct work_queue *q, const char *path);
+
+/** Change the home host and port for a given queue (used by TLQ).
+@param q A work queue object.
+@param flag Indicates whether master should look up its TLQ URL locally.
+*/
+void work_queue_specify_tlq_port(struct work_queue *q, int port);
+
 /** Change the priority for a given queue.
 @param q A work queue object.
 @param priority The new priority of the queue.  Higher priority masters will attract workers first.


### PR DESCRIPTION
This allows for makeflows, masters, and workers to retrieve their TLQ URL from their local TLQ log server and to advertise their URLs to each other.

Makeflow and workers are passed a --tlq=<port> flag. Makeflow passes this port to the master (along with the path to the debug log) via the batch queue interface. Makeflow, WQ master, and WQ workers each look up their TLQ URL from their local log server via TCP connection.

This functionality is turned on only when the makeflow (by extension the master) or a worker have been given the --tlq option.

Rework of #2357 