### PR TITLE
Clean deltadb, parrot and ftp_lite *.o files from executables

### DIFF
--- a/deltadb/src/Makefile
+++ b/deltadb/src/Makefile
@@ -16,7 +16,7 @@ libdeltadb.a: $(OBJECTS)
 $(PROGRAMS): $(LIBRARIES) $(EXTERNAL_DEPENDENCIES)
 
 clean:
-	rm -f $(OBJECTS) $(TARGETS)
+	rm -f $(OBJECTS) $(TARGETS) *.o
 
 install: all
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/bin

--- a/ftp_lite/src/Makefile
+++ b/ftp_lite/src/Makefile
@@ -17,7 +17,7 @@ libftp_lite.a: $(OBJECTS)
 $(PROGRAMS): libftp_lite.a $(EXTERNAL_DEPENDENCIES)
 
 clean:
-	rm -f $(OBJECTS) $(TARGETS)
+	rm -f $(OBJECTS) $(TARGETS) *.o
 
 install: all
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/lib

--- a/parrot/src/Makefile
+++ b/parrot/src/Makefile
@@ -81,7 +81,7 @@ parrot_namespace: pfs_mountfile.o pfs_resolve_mount.o
 $(PROGRAMS): $(EXTERNAL_DEPENDENCIES)
 
 clean:
-	rm -f $(OBJECTS) $(TARGETS) $(PROGRAMS) $(LIBRARIES) tracer.table.c tracer.table.h tracer.table64.c tracer.table64.h
+	rm -f $(OBJECTS) $(TARGETS) $(PROGRAMS) $(LIBRARIES) tracer.table.c tracer.table.h tracer.table64.c tracer.table64.h *.o
 
 install: all
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/bin


### PR DESCRIPTION
Objects from executables were not being deleted.  Only those explicitly defined in $(OBJECTS )were