### PR TITLE
Monitor no enf

### DIFF
--- a/doc/man/md/resource_monitor.md
+++ b/doc/man/md/resource_monitor.md
@@ -127,6 +127,7 @@ disk                      current size of working directories in the tree, in MB
 - **-c --sh <str>** Read command line from **str**, and execute as '/bin/sh -c **str**'.
 - **-l --limits-file <file>** Use maxfile with list of var: value pairs for resource limits.
 - **-L --limits <string>** String of the form "var: value, var: value\ to specify resource limits. (Could be specified multiple times.)
+- **--measure-only Do not enforce resource limits, only measure resources.
 - **-f, --child-in-foreground** Keep the monitored process in foreground (for interactive use).
 - **-O --with-output-files <template>** Specify **template** for log files (default=**resource-pid**).
 - **--with-time-series** Write resource time series to **template.series**.

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -5477,28 +5477,29 @@ void work_queue_monitor_add_files(struct work_queue *q, struct work_queue_task *
 
 char *work_queue_monitor_wrap(struct work_queue *q, struct work_queue_worker *w, struct work_queue_task *t, struct rmsummary *limits)
 {
-	char *extra_options = string_format("-V 'task_id: %d'", t->taskid);
+	buffer_t b;
+	buffer_init(&b);
+
+	buffer_printf(&b, "-V 'task_id: %d'", t->taskid);
 
 	if(t->category) {
-		char *tmp = extra_options;
-		extra_options = string_format("%s -V 'category: %s'", extra_options, t->category);
-		free(tmp);
+		buffer_printf(&b, " -V 'category: %s'", t->category);
 	}
 
 	if(t->monitor_snapshot_file) {
-		char *tmp = extra_options;
-		extra_options = string_format("%s --snapshot-events %s", tmp, RESOURCE_MONITOR_REMOTE_NAME_EVENTS);
-		free(tmp);
+		buffer_printf(&b, " --snapshot-events %s", RESOURCE_MONITOR_REMOTE_NAME_EVENTS);
+	}
+
+	if(q->monitor_mode & MON_WATCHDOG) {
+		buffer_printf(&b, " --measure-only");
 	}
 
 	int extra_files = (q->monitor_mode & MON_FULL);
 
-	struct rmsummary *watch_limits = (q->monitor_mode & MON_WATCHDOG) ? limits : NULL;
-
-	char *monitor_cmd = resource_monitor_write_command("./" RESOURCE_MONITOR_REMOTE_NAME, RESOURCE_MONITOR_REMOTE_NAME, watch_limits, extra_options, /* debug */ extra_files, /* series */ extra_files, /* inotify */ 0, /* measure_dir */ NULL);
+	char *monitor_cmd = resource_monitor_write_command("./" RESOURCE_MONITOR_REMOTE_NAME, RESOURCE_MONITOR_REMOTE_NAME, limits, /* extra options */ buffer_tostring(&b), /* debug */ extra_files, /* series */ extra_files, /* inotify */ 0, /* measure_dir */ NULL);
 	char *wrap_cmd  = string_wrap_command(t->command_line, monitor_cmd);
 
-	free(extra_options);
+	buffer_free(&b);
 	free(monitor_cmd);
 
 	return wrap_cmd;


### PR DESCRIPTION
In recent tests, it was useful to measure the resources used by a process, and to indicate whether certain resources limits were broken,  but without terminating the process. 

This pr adds the --measure-only to the resource monitor. If a limit is broken, this information is included in the final summary, but the process continues as normal.

wq already had the capability of turning off the monitor enforcement by not declaring  a taks limits. This pr updates wq to use the --measure-only option of the monitor.