### PR TITLE
wq third put/get fix

### DIFF
--- a/work_queue/src/bindings/perl/Work_Queue/Task.pm
+++ b/work_queue/src/bindings/perl/Work_Queue/Task.pm
@@ -105,6 +105,23 @@ sub specify_file {
 					$args{flags});
 }
 
+sub specify_file_command {
+	my $self = shift;
+	my %args = @_;
+
+	croak "At least remote_name and cmd should be specified." unless $args{remote_name} and $args{cmd};
+
+	$args{type}        //= $WORK_QUEUE_INPUT;
+	$args{cache}       //= 1;
+	$args{flags}         = _determine_file_flags($args{flags}, $args{cache});
+
+	return work_queue_task_specify_file_command($self->{_task},
+					$args{remote_name},
+					$args{cmd},
+					$args{type},
+					$args{flags});
+}
+
 sub specify_file_piece {
 	my $self = shift;
 	my %args = @_;
@@ -591,6 +608,43 @@ Legacy parameter for setting file caching attribute.  By default this is enabled
 		$t->specify_file(local_name => ...);
 
 		$t->specify_file(local_name => ..., remote_name => ..., );
+
+=head3 C<specify_file_command>
+
+Add a file to the task which will be transfered with a command at the worker.
+
+=item remote_name
+
+The name of the file at the execution site.
+
+=item cmd
+
+The shell command to transfer the file. Any occurance of the string %% will be
+replaced with the internal name that work queue uses for the file.
+
+=item type
+
+Must be one of the following values: $Work_Queue::WORK_QUEUE_INPUT or $Work_Queue::WORK_QUEUE_OUTPUT
+
+=item flags
+
+May be zero to indicate no special handling, or any of the following or'd together:
+
+=over 24
+
+=item $Work_Queue::WORK_QUEUE_NOCACHE
+
+=item $Work_Queue::WORK_QUEUE_CACHE
+
+=back
+
+=item cache
+
+Legacy parameter for setting file caching attribute.  By default this is enabled.
+
+=back
+
+        $t->specify_file_command("my.result", "chirp_put %% chirp://somewhere/result.file", type=$Work_Queue::WORK_QUEUE_OUTPUT)
 
 =head3 C<specify_file_piece>
 

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -170,6 +170,34 @@ class Task(object):
         return work_queue_task_specify_file(self._task, local_name, remote_name, type, flags)
 
     ##
+    # Add a file to the task which will be transfered with a command at the worker.
+    #
+    # @param self           Reference to the current task object.
+    # @param remote_name    The name of the file as seen by the task.
+    # @param cmd            The shell command to transfer the file. Any
+    #                       occurance of the string %% will be replaced with the
+    #                       internal name that work queue uses for the file.
+    # @param type           Must be one of the following values: @ref WORK_QUEUE_INPUT or @ref WORK_QUEUE_OUTPUT
+    # @param flags          May be zero to indicate no special handling, or any
+    #                       of the @ref work_queue_file_flags_t or'd together The most common are:
+    #                       - @ref WORK_QUEUE_NOCACHE (default)
+    #                       - @ref WORK_QUEUE_CACHE
+    #                       - @ref WORK_QUEUE_WATCH
+    # @param cache          Legacy parameter for setting file caching attribute. (True/False, deprecated, use the flags parameter.)
+    #
+    # For example:
+    # @code
+    # # The following are equivalent
+    # >>> task.specify_file_command("my.result", "chirp_put %% chirp://somewhere/result.file", type=WORK_QUEUE_OUTPUT)
+    # @endcode
+    def specify_file_command(self, remote_name, cmd, type=None, flags=None, cache=None):
+        if type is None:
+            type = WORK_QUEUE_INPUT
+
+        flags = Task._determine_file_flags(flags, cache)
+        return work_queue_task_specify_file_command(self._task, remote_name, cmd, type, flags)
+
+    ##
     # Add a file piece to the task.
     #
     # @param self           Reference to the current task object.

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4793,6 +4793,10 @@ int work_queue_task_specify_file_command(struct work_queue_task *t, const char *
 		}
 	}
 
+	if(strstr(cmd, "%%") == NULL) {
+		fatal("command to transfer file does not contain %%%% specifier: %s", cmd);
+	}
+
 	tf = work_queue_file_create(cmd, remote_name, WORK_QUEUE_REMOTECMD, flags);
 	if(!tf) return 0;
 

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -408,6 +408,20 @@ int work_queue_task_specify_buffer(struct work_queue_task *t, const char *data, 
 */
 int work_queue_task_specify_directory(struct work_queue_task *t, const char *local_name, const char *remote_name, work_queue_file_type_t type, work_queue_file_flags_t, int recursive);
 
+/** Gets/puts file at remote_name using cmd at worker.
+@param t A task object.
+@param remote_name The name of the file as seen by the task.
+@param cmd The shell command to transfer the file. For input files, it should read the contents from remote_name via stdin. For output files, it should write the contents to stdout.
+@param type Must be one of the following values:
+- @ref WORK_QUEUE_INPUT to indicate an input file to be consumed by the task
+- @ref WORK_QUEUE_OUTPUT to indicate an output file to be produced by the task
+@param flags	May be zero to indicate no special handling or any of @ref work_queue_file_flags_t or'd together. The most common are:
+- @ref WORK_QUEUE_CACHE indicates that the file should be cached for later tasks. (recommended)
+- @ref WORK_QUEUE_NOCACHE indicates that the file should not be cached for later tasks.
+@return 1 if the task file is successfully specified, 0 if either of @a t or @a remote_name is null or @a remote_name is an absolute path.
+*/
+int work_queue_task_specify_file_command(struct work_queue_task *t, const char *remote_name, const char *cmd, work_queue_file_type_t type, work_queue_file_flags_t flags);
+
 /** Specify the number of times this task is retried on worker errors. If less than one, the task is retried indefinitely (this the default). A task that did not succeed after the given number of retries is returned with result WORK_QUEUE_RESULT_MAX_RETRIES.
 @param t A task object.
 @param max_retries The number of retries.
@@ -609,7 +623,7 @@ explicitely given by work_queue_task's monitor_output_file.
 summaries are kept only when monitor_output_directory is specify per task, but
 resources_measured from work_queue_task is updated.  @return 1 on success, 0 if
 @param watchdog if not 0, kill tasks that exhaust declared resources.
-monitoring was not enabled.
+@return 1 on success, o if monitoring was not enabled.
 */
 int work_queue_enable_monitoring(struct work_queue *q, char *monitor_output_directory, int watchdog);
 


### PR DESCRIPTION
Adds work_queue_task_file_command to work_queue.h. (Function existed in .c file.)
    
Changed cmd so that %% is replaced with cache name at worker. Before the contents of the file were read/writen from stdin/stdout, which was not supported by all commands.
    
Implementation bug: I did not change the original implementation when dealing with errors. If transfer command fails, worker disconnects and transfer is tried in another worker. If command is incorrect, or the file is not accessible, this will disconnect all workers. Ideally, we would simply fail or retry the task somewhere else.
