### PR TITLE
Stream file descriptors via MQ

### DIFF
--- a/dttools/src/buffer.h
+++ b/dttools/src/buffer.h
@@ -179,6 +179,17 @@ size_t buffer_pos(buffer_t * b);
  */
 int buffer_grow(buffer_t * b, size_t n);
 
+/** Seek to a position.
+ *
+ * Similar to @ref buffer_rewind(), but allows seeking past the end of the buffer.
+ * Note that seeking beyond the currently allocated memory may result in a
+ * buffer filled with garbage data (but still null-terminated).
+ * @param b The buffer.
+ * @param n Absolute position to seek to.
+ * @returns -1 on error.
+ */
+int buffer_seek(buffer_t * b, size_t pos);
+
 /** Allocate a buffer named `name' on the stack of at most `size' bytes.
 	Does not abort on failure, but hits the max size and drops further bytes
 	written. You can turn on aborts on failure manually using

--- a/dttools/src/mq.c
+++ b/dttools/src/mq.c
@@ -375,7 +375,10 @@ static int flush_recv(struct mq *mq) {
 
 				if (rc == -1 && errno_is_temporary(errno)) {
 					return 0;
-				} else if (rc <= 0) {
+				} else if (rc == 0) {
+					errno = ECONNRESET;
+					return -1;
+				} else if (rc < 0) {
 					return -1;;
 				}
 				rcv->buf_pos = checked_add(rcv->buf_pos, rc);

--- a/dttools/src/mq.c
+++ b/dttools/src/mq.c
@@ -248,16 +248,11 @@ static int flush_send(struct mq *mq) {
 		if (!snd) return 0;
 
 		if (snd->buffering) {
-			if (snd->hung_up) {
-				snd->len = snd->buf_pos;
-				snd->type |= HDR_MSG_END;
-			}
-
 			if (snd->buf_pos < snd->len) {
 				ssize_t rc = read(snd->pipefd,
 					(char *) buffer_tostring(snd->buffer) + snd->buf_pos,
 					snd->len - snd->buf_pos);
-				if (rc == -1 && errno_is_temporary(errno)) {
+				if (rc == -1 && errno_is_temporary(errno) && !snd->hung_up) {
 					return 0;
 				} else if (rc == 0) {
 					snd->len = snd->buf_pos;

--- a/dttools/src/mq.h
+++ b/dttools/src/mq.h
@@ -182,6 +182,24 @@ struct mq *mq_accept(struct mq *server);
  */
 int mq_wait(struct mq *mq, time_t stoptime);
 
+/** Set the tag associated with the given queue.
+ *
+ * The tag is not used by this module; it is intended to allow for finding the
+ * worker/connection associated with the given queue. This may be useful when
+ * using @ref mq_poll_readable and friends.
+ * @param mq The queue to use.
+ * @param tag The new tag to set.
+ */
+void mq_set_tag(struct mq *mq, void *tag);
+
+/** Get the tag associated with the given queue.
+ *
+ * See @ref mq_set_tag for details.
+ * @param mq The queue to check.
+ * @returns The tag previously associated with mq. Defaults to NULL.
+ */
+void *mq_get_tag(struct mq *mq);
+
 
 //------------Polling API-----------------//
 
@@ -205,18 +223,13 @@ void mq_poll_delete(struct mq_poll *p);
 
 /** Add a message queue to a polling group.
  *
- * The tag value is returned from @ref mq_poll_readable and friends.
- * This could be a pointer to some client/worker struct that
- * knows its own channel, or NULL to just use mq. Note that a
- * queue can only be added to a single polling group.
+ * Note that a queue can (currently) only be added to a single polling group.
  * @param p The polling group to add to.
  * @param mq The queue to add.
- * @param tag A pointer to identify the queue. If tag is NULL, mq will
- *  be used instead.
  * @returns 0 on success.
  * @returns -1 on error, with errno set appropriately.
  */
-int mq_poll_add(struct mq_poll *p, struct mq *mq, void *tag);
+int mq_poll_add(struct mq_poll *p, struct mq *mq);
 
 /** Remove a message queue from a polling group.
  *
@@ -246,41 +259,41 @@ int mq_poll_wait(struct mq_poll *p, time_t stoptime);
 
 /** Find a queue with messages waiting.
  *
- * Returns the tag of an arbitrary queue in the polling group, and may
+ * Returns the an arbitrary queue in the polling group, and may
  * return the same queue until its messages are popped. This is more
  * efficient than looping over a list of message queues and calling
  * @ref mq_recv on all of them, since the polling group keeps track of
  * queue states internally.
  * @param p The polling group to inspect.
- * @returns The tag associated with a queue with messages waiting.
+ * @returns A queue with messages waiting.
  * @returns NULL if no queues in the polling group have messages waiting.
  */
-void *mq_poll_readable(struct mq_poll *p);
+struct mq *mq_poll_readable(struct mq_poll *p);
 
 /** Find a server queue with connections waiting.
  *
- * Returns the tag of an arbitrary server queue in the polling group, and may
+ * Returns an arbitrary server queue in the polling group, and may
  * return the same queue until its connections are accepted. This is more
  * efficient than looping over a list of queues and calling @ref mq_accept
  * on all of them, since the polling group keeps track of queue states
  * internally.
  * @param p The polling group to inspect.
- * @returns The tag associated with a queue with connections waiting.
+ * @returns A queue with connections waiting.
  * @returns NULL if no queues in the polling group have connections waiting.
  */
-void *mq_poll_acceptable(struct mq_poll *p);
+struct mq *mq_poll_acceptable(struct mq_poll *p);
 
 /** Find a queue in the error state or closed socket.
  *
- * Returns the tag of an arbitrary queue in the polling group, and may
- * return the same queue until it it removed. This is more efficient than
+ * Returns an arbitrary queue in the polling group, and may
+ * return the same queue until it is removed. This is more efficient than
  * looping over a list of message queues and checking for errors on all
  * of them, since the polling group keeps track of queue states internally.
  * @param p The polling group to inspect.
- * @returns The tag of a queue in the error state or with closed socket.
+ * @returns A queue in the error state or with a closed socket.
  * @returns NULL if no queues in the polling group are in error.
  */
-void *mq_poll_error(struct mq_poll *p);
+struct mq *mq_poll_error(struct mq_poll *p);
 
 
 //------------Send/Recv-------------------//

--- a/dttools/src/mq.h
+++ b/dttools/src/mq.h
@@ -312,11 +312,12 @@ struct mq *mq_poll_error(struct mq_poll *p);
  * Only use heap-allocated buffers here.
  * @param mq The message queue.
  * @param buf The message to send.
+ * @param maxlen Send at most maxlen bytes, or if 0 use the entire buffer.
  * @returns 0 on success. Note that this only indicates that the message was
  *  successfully queued. It gives no indication about delivery.
  * @returns -1 on failure.
  */
-int mq_send_buffer(struct mq *mq, buffer_t *buf);
+int mq_send_buffer(struct mq *mq, buffer_t *buf, size_t maxlen);
 
 /** Stream a file descriptor across the wire.
  *
@@ -328,11 +329,12 @@ int mq_send_buffer(struct mq *mq, buffer_t *buf);
  * slices from within files.
  * @param mq The message queue.
  * @param fd The file descriptor to read.
+ * @param maxlen Send at most maxlen bytes, or if 0 read to EOF.
  * @returns 0 on success. Note that this only indicates that the message was
  *  successfully queued. It gives no indication about delivery.
  * @returns -1 on failure.
  */
-int mq_send_fd(struct mq *mq, int fd);
+int mq_send_fd(struct mq *mq, int fd, size_t maxlen);
 
 /** Store the next message in the given buffer.
  *

--- a/dttools/src/mq.h
+++ b/dttools/src/mq.h
@@ -312,7 +312,7 @@ struct mq *mq_poll_error(struct mq_poll *p);
  * Only use heap-allocated buffers here.
  * @param mq The message queue.
  * @param buf The message to send.
- * @param maxlen Send at most maxlen bytes, or if 0 use the entire buffer.
+ * @param maxlen Maximum number of bytes to send, or 0 to use the entire buffer.
  * @returns 0 on success. Note that this only indicates that the message was
  *  successfully queued. It gives no indication about delivery.
  * @returns -1 on failure.
@@ -329,7 +329,7 @@ int mq_send_buffer(struct mq *mq, buffer_t *buf, size_t maxlen);
  * slices from within files.
  * @param mq The message queue.
  * @param fd The file descriptor to read.
- * @param maxlen Send at most maxlen bytes, or if 0 read to EOF.
+ * @param maxlen Maximum number of bytes to send, or 0 to read to EOF.
  * @returns 0 on success. Note that this only indicates that the message was
  *  successfully queued. It gives no indication about delivery.
  * @returns -1 on failure.
@@ -345,13 +345,15 @@ int mq_send_fd(struct mq *mq, int fd, size_t maxlen);
  * It is undefined behavior to call this if a message has already been
  * partially received. It is therefore only safe to call this before
  * calling *_wait() for the first time or immediately after receiving a message
- * from @ref mq_recv().
+ * from @ref mq_recv(). Note that if a message exceeds maxlen the connection
+ * will be killed, so use with caution.
  * @param mq The message queue.
  * @param buf The buffer to use to store the next message.
+ * @param maxlen Maximum bytes to accept, or 0 for no limit.
  * @returns 0 on success.
  * @returns -1 on failure, with errno set appropriately.
  */
-int mq_store_buffer(struct mq *mq, buffer_t *buf);
+int mq_store_buffer(struct mq *mq, buffer_t *buf, size_t maxlen);
 
 /** Write the next message to the given file descriptor.
  *
@@ -359,12 +361,15 @@ int mq_store_buffer(struct mq *mq, buffer_t *buf);
  * file descriptor. Callers MUST NOT use/close fd until a successful call to
  * @ref mq_recv indicates completed receipt of a message. This function will not
  * seek fd, so it is possible to write to arbitrary positions within a file.
+ * Note that if a message exceeds maxlen the connection will be killed,
+ * so use with caution.
  * @param mq The message queue.
  * @param fd Then file descriptor to write to.
+ * @param maxlen Maximum bytes to accept, or 0 for no limit.
  * @returns 0 on success.
  * @returns -1 on failure, with errno set appropriately.
  */
-int mq_store_fd(struct mq *mq, int fd);
+int mq_store_fd(struct mq *mq, int fd, size_t maxlen);
 
 /** Pop a message from the receive queue.
  *

--- a/dttools/src/mq_poll_test.c
+++ b/dttools/src/mq_poll_test.c
@@ -32,7 +32,7 @@ int main (int argc, char *argv[]) {
 
 	struct mq_poll *p = mq_poll_create();
 	assert(p);
-	rc = mq_poll_add(p, server, NULL);
+	rc = mq_poll_add(p, server);
 	assert(rc == 0);
 
 	rc = mq_poll_wait(p, time(NULL) + 1);
@@ -41,7 +41,7 @@ int main (int argc, char *argv[]) {
 	struct mq *client = mq_connect("127.0.0.1", 65000);
 	assert(client);
 
-	rc = mq_poll_add(p, client, NULL);
+	rc = mq_poll_add(p, client);
 	assert(rc == 0);
 
 	rc = mq_poll_wait(p, time(NULL) + 1);
@@ -49,7 +49,7 @@ int main (int argc, char *argv[]) {
 
 	struct mq *conn = mq_accept(server);
 	assert(conn);
-	rc = mq_poll_add(p, conn, NULL);
+	rc = mq_poll_add(p, conn);
 	assert(rc == 0);
 
 	rc = mq_send_buffer(client, test1);

--- a/dttools/src/mq_poll_test.c
+++ b/dttools/src/mq_poll_test.c
@@ -57,10 +57,10 @@ int main (int argc, char *argv[]) {
 	rc = mq_store_buffer(conn, &got_string);
 	assert(rc == 0);
 
-	rc = mq_send_buffer(client, test1);
+	rc = mq_send_buffer(client, test1, 0);
 	assert(rc != -1);
 
-	rc = mq_send_buffer(client, test2);
+	rc = mq_send_buffer(client, test2, 0);
 	assert(rc != -1);
 
 	rc = mq_poll_wait(p, time(NULL) + 5);

--- a/dttools/src/mq_poll_test.c
+++ b/dttools/src/mq_poll_test.c
@@ -54,7 +54,7 @@ int main (int argc, char *argv[]) {
 	rc = mq_poll_add(p, conn);
 	assert(rc == 0);
 
-	rc = mq_store_buffer(conn, &got_string);
+	rc = mq_store_buffer(conn, &got_string, 0);
 	assert(rc == 0);
 
 	rc = mq_send_buffer(client, test1, 0);
@@ -74,7 +74,7 @@ int main (int argc, char *argv[]) {
 	rc = mq_recv(conn, NULL);
 	assert(rc == MQ_MSG_NONE);
 
-	rc = mq_store_buffer(conn, &got_string);
+	rc = mq_store_buffer(conn, &got_string, 0);
 	assert(rc == 0);
 
 	rc = mq_poll_wait(p, time(NULL) + 1);

--- a/dttools/src/mq_store_test.c
+++ b/dttools/src/mq_store_test.c
@@ -43,7 +43,7 @@ int main (int argc, char *argv[]) {
 	struct mq *conn = mq_accept(server);
 	assert(conn);
 
-	rc = mq_store_buffer(conn, &got_string);
+	rc = mq_store_buffer(conn, &got_string, 0);
 	assert(rc == 0);
 
 	rc = mq_wait(client, time(NULL) + 1);
@@ -64,7 +64,7 @@ int main (int argc, char *argv[]) {
 
 	rc = mq_send_fd(conn, srcfd, 0);
 	assert(rc == 0);
-	rc = mq_store_fd(client, dstfd);
+	rc = mq_store_fd(client, dstfd, 0);
 	assert(rc == 0);
 
 	rc = mq_poll_wait(p, time(NULL) + 5);
@@ -79,7 +79,7 @@ int main (int argc, char *argv[]) {
 
 	rc = mq_send_fd(client, srcfd, 0);
 	assert(rc == 0);
-	rc = mq_store_buffer(conn, got);
+	rc = mq_store_buffer(conn, got, 0);
 	assert(rc == 0);
 
 	rc = mq_poll_wait(p, time(NULL) + 5);
@@ -89,7 +89,7 @@ int main (int argc, char *argv[]) {
 
 	rc = mq_send_buffer(client, got, 0);
 	assert(rc != -1);
-	rc = mq_store_fd(conn, dstfd);
+	rc = mq_store_fd(conn, dstfd, 0);
 	assert(rc == 0);
 
 	rc = mq_poll_wait(p, time(NULL) + 5);
@@ -103,7 +103,7 @@ int main (int argc, char *argv[]) {
 	rc = mq_send_fd(conn, srcfd, 0);
 	assert(rc == 0);
 
-	rc = mq_store_buffer(client, &got_string);
+	rc = mq_store_buffer(client, &got_string, 0);
 	assert(rc == 0);
 
 	rc = mq_poll_wait(p, time(NULL) + 15);
@@ -118,7 +118,7 @@ int main (int argc, char *argv[]) {
 	rc = mq_send_fd(conn, srcfd, 256);
 	assert(rc == 0);
 
-	rc = mq_store_buffer(client, &got_string);
+	rc = mq_store_buffer(client, &got_string, 0);
 	assert(rc == 0);
 
 	rc = mq_poll_wait(p, time(NULL) + 5);

--- a/dttools/src/mq_store_test.c
+++ b/dttools/src/mq_store_test.c
@@ -57,9 +57,9 @@ int main (int argc, char *argv[]) {
 
 	struct mq_poll *p = mq_poll_create();
 	assert(p);
-	rc = mq_poll_add(p, conn, NULL);
+	rc = mq_poll_add(p, conn);
 	assert(rc == 0);
-	rc = mq_poll_add(p, client, NULL);
+	rc = mq_poll_add(p, client);
 	assert(rc == 0);
 
 	rc = mq_send_fd(conn, srcfd);

--- a/dttools/src/mq_store_test.c
+++ b/dttools/src/mq_store_test.c
@@ -35,7 +35,7 @@ int main (int argc, char *argv[]) {
 	struct mq *client = mq_connect("127.0.0.1", 65000);
 	assert(client);
 
-	rc = mq_send_buffer(client, test1);
+	rc = mq_send_buffer(client, test1, 0);
 	assert(rc != -1);
 
 	rc = mq_wait(server, time(NULL) + 1);
@@ -62,7 +62,7 @@ int main (int argc, char *argv[]) {
 	rc = mq_poll_add(p, client);
 	assert(rc == 0);
 
-	rc = mq_send_fd(conn, srcfd);
+	rc = mq_send_fd(conn, srcfd, 0);
 	assert(rc == 0);
 	rc = mq_store_fd(client, dstfd);
 	assert(rc == 0);
@@ -77,7 +77,7 @@ int main (int argc, char *argv[]) {
 	dstfd = open(argv[2], O_WRONLY|O_CREAT|O_TRUNC, 0777);
 	assert(dstfd != -1);
 
-	rc = mq_send_fd(client, srcfd);
+	rc = mq_send_fd(client, srcfd, 0);
 	assert(rc == 0);
 	rc = mq_store_buffer(conn, got);
 	assert(rc == 0);
@@ -87,7 +87,7 @@ int main (int argc, char *argv[]) {
 	rc = mq_recv(conn, NULL);
 	assert(rc == MQ_MSG_BUFFER);
 
-	rc = mq_send_buffer(client, got);
+	rc = mq_send_buffer(client, got, 0);
 	assert(rc != -1);
 	rc = mq_store_fd(conn, dstfd);
 	assert(rc == 0);
@@ -100,7 +100,7 @@ int main (int argc, char *argv[]) {
 	srcfd = open(argv[3], O_RDONLY);
 	assert(srcfd != -1);
 
-	rc = mq_send_fd(conn, srcfd);
+	rc = mq_send_fd(conn, srcfd, 0);
 	assert(rc == 0);
 
 	rc = mq_store_buffer(client, &got_string);
@@ -111,6 +111,21 @@ int main (int argc, char *argv[]) {
 	rc = mq_recv(client, &got_len);
 	assert(rc == MQ_MSG_BUFFER);
 	assert(got_len == 10);
+
+	srcfd = open(argv[0], O_RDONLY);
+	assert(srcfd != -1);
+
+	rc = mq_send_fd(conn, srcfd, 256);
+	assert(rc == 0);
+
+	rc = mq_store_buffer(client, &got_string);
+	assert(rc == 0);
+
+	rc = mq_poll_wait(p, time(NULL) + 5);
+	assert(rc == 1);
+	rc = mq_recv(client, &got_len);
+	assert(rc == MQ_MSG_BUFFER);
+	assert(got_len == 256);
 
 	buffer_free(&got_string);
 	mq_poll_delete(p);

--- a/dttools/src/mq_store_test.c
+++ b/dttools/src/mq_store_test.c
@@ -95,6 +95,20 @@ int main (int argc, char *argv[]) {
 	rc = mq_recv(conn, NULL);
 	assert(rc == MQ_MSG_FD);
 
+	srcfd = open(argv[3], O_RDONLY);
+	assert(srcfd != -1);
+
+	rc = mq_send_fd(conn, srcfd);
+	assert(rc == 0);
+
+	rc = mq_poll_wait(p, time(NULL) + 15);
+	assert(rc == 1);
+	rc = mq_recv(client, &got);
+	assert(rc == MQ_MSG_NEWBUFFER);
+	assert(buffer_pos(got) == 10);
+
+	buffer_free(got);
+	free(got);
 	mq_poll_delete(p);
 	mq_close(client);
 	mq_close(conn);

--- a/dttools/src/mq_wait_test.c
+++ b/dttools/src/mq_wait_test.c
@@ -30,10 +30,10 @@ int main (int argc, char *argv[]) {
 	struct mq *conn = mq_accept(server);
 	assert(!conn);
 
-	rc = mq_send_buffer(client, test1);
+	rc = mq_send_buffer(client, test1, 0);
 	assert(rc != -1);
 
-	rc = mq_send_buffer(client, test2);
+	rc = mq_send_buffer(client, test2, 0);
 	assert(rc != -1);
 
 	rc = mq_wait(server, time(NULL) + 1);

--- a/dttools/src/mq_wait_test.c
+++ b/dttools/src/mq_wait_test.c
@@ -41,7 +41,7 @@ int main (int argc, char *argv[]) {
 	conn = mq_accept(server);
 	assert(conn);
 
-	rc = mq_store_buffer(conn, &got_string);
+	rc = mq_store_buffer(conn, &got_string, 0);
 	assert(rc == 0);
 
 	rc = mq_wait(client, time(NULL) + 1);
@@ -53,7 +53,7 @@ int main (int argc, char *argv[]) {
 	assert(rc == MQ_MSG_BUFFER);
 	assert(!strcmp(string1, buffer_tostring(&got_string)));
 
-	rc = mq_store_buffer(conn, &got_string);
+	rc = mq_store_buffer(conn, &got_string, 0);
 	assert(rc == 0);
 
 	rc = mq_recv(conn, NULL);

--- a/dttools/src/mq_wait_test.c
+++ b/dttools/src/mq_wait_test.c
@@ -14,13 +14,14 @@ int main (int argc, char *argv[]) {
 
 	buffer_t *test1 = xxmalloc(sizeof(*test1));
 	buffer_t *test2 = xxmalloc(sizeof(*test2));
+	buffer_t got_string;
 	buffer_init(test1);
 	buffer_init(test2);
+	buffer_init(&got_string);
 	buffer_putstring(test1, string1);
 	buffer_putstring(test2, string2);
 
 	int rc;
-	buffer_t *got_string;
 
 	struct mq *server = mq_serve("127.0.0.1", 65000);
 	assert(server);
@@ -40,31 +41,32 @@ int main (int argc, char *argv[]) {
 	conn = mq_accept(server);
 	assert(conn);
 
+	rc = mq_store_buffer(conn, &got_string);
+	assert(rc == 0);
+
 	rc = mq_wait(client, time(NULL) + 1);
 	assert(rc != -1);
 	rc = mq_wait(conn, time(NULL) + 1);
 	assert(rc != -1);
 
-	rc = mq_recv(conn, &got_string);
-	assert(rc == MQ_MSG_NEWBUFFER);
+	rc = mq_recv(conn, NULL);
+	assert(rc == MQ_MSG_BUFFER);
+	assert(!strcmp(string1, buffer_tostring(&got_string)));
 
-	assert(!strcmp(string1, buffer_tostring(got_string)));
-	buffer_free(got_string);
-	free(got_string);
+	rc = mq_store_buffer(conn, &got_string);
+	assert(rc == 0);
 
-	rc = mq_recv(conn, &got_string);
+	rc = mq_recv(conn, NULL);
 	assert(rc == MQ_MSG_NONE);
 
 	rc = mq_wait(conn, time(NULL) + 1);
 	assert(rc != -1);
 
-	rc = mq_recv(conn, &got_string);
-	assert(rc == MQ_MSG_NEWBUFFER);
+	rc = mq_recv(conn, NULL);
+	assert(rc == MQ_MSG_BUFFER);
+	assert(!strcmp(string2, buffer_tostring(&got_string)));
 
-	assert(!strcmp(string2, buffer_tostring(got_string)));
-	buffer_free(got_string);
-	free(got_string);
-
+	buffer_free(&got_string);
 	mq_close(client);
 	mq_close(conn);
 	mq_close(server);

--- a/dttools/test/TR_mq_store.sh
+++ b/dttools/test/TR_mq_store.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . ../../dttools/test/test_runner_common.sh
 
@@ -13,7 +13,7 @@ prepare()
 
 run()
 {
-	$TESTCMD $TESTOUT1 $TESTOUT2 || return $?
+	$TESTCMD $TESTOUT1 $TESTOUT2 <(echo test; sleep 10; echo data) || return $?
 	cmp $TESTCMD $TESTOUT1 || return $?
 	cmp $TESTCMD $TESTOUT2 || return $?
 	return 0

--- a/dttools/test/TR_mq_store.sh
+++ b/dttools/test/TR_mq_store.sh
@@ -2,6 +2,10 @@
 
 . ../../dttools/test/test_runner_common.sh
 
+TESTCMD=../src/mq_store_test
+TESTOUT1=mq_store.out1
+TESTOUT2=mq_store.out2
+
 prepare()
 {
 	return 0
@@ -9,12 +13,15 @@ prepare()
 
 run()
 {
-	../src/mq_store_test
-	return $?
+	$TESTCMD $TESTOUT1 $TESTOUT2 || return $?
+	cmp $TESTCMD $TESTOUT1 || return $?
+	cmp $TESTCMD $TESTOUT2 || return $?
+	return 0
 }
 
 clean()
 {
+	rm -f $TESTOUT1 $TESTOUT2
 	return 0
 }
 


### PR DESCRIPTION
This PR adds support for sending/receiving of file descriptors via MQ. These could be regular files, pipes, `stdin`/`stdout`, etc. In the context of DataSwarm, this is useful for sending/receiving files and directories (e.g. spawn `tar` and hook the stdio stream to MQ). The library is designed to select over all the different file descriptors and handle both the TCP connections and send/recv fds asynchronously. I tried out a number of configurations and checked that everything is being sent properly, no busy waiting, etc. I included tests for most of the cases I can think of and everything seems to be working, so I think this is ready to try out in DataSwarm.

This PR took a while to get right, since there are a number of tricky bits.
- Support unknown-length streams (`tar` will output ??? bytes)
- Streaming fd on one side to buffer on the other side or vice versa
- Switching between socket and/or fd(s) with each message
- Dealing with hangups/disconnects