### PR TITLE
simplify blob-get

### DIFF
--- a/dataswarm/manager/dataswarm_blob_rep.h
+++ b/dataswarm/manager/dataswarm_blob_rep.h
@@ -7,9 +7,8 @@ typedef enum {
 	DS_BLOB_WORKER_STATE_NEW = 0,
 	DS_BLOB_WORKER_STATE_CREATED,
 	DS_BLOB_WORKER_STATE_PUT, DS_BLOB_WORKER_STATE_COPIED,
-	DS_BLOB_WORKER_STATE_GET,
-	DS_BLOB_WORKER_STATE_RETRIEVED,
 	DS_BLOB_WORKER_STATE_COMMITTED,
+	DS_BLOB_WORKER_STATE_GET,
 	DS_BLOB_WORKER_STATE_DELETED,
 } dataswarm_blob_worker_state_t;
 
@@ -19,7 +18,7 @@ struct dataswarm_blob_rep {
 	 * state, in_transition, and result represent the state of the blob in the
 	 * worker according to the manager according to the following invariants:
 	 *
-	 * 1) state always records the latest rpc succesfully completed.
+	 * 1) state always records the latest rpc successfully completed.
 	 * 2) result always records the result of the latest rpc, whether it has
 	 *    completed. If it has not completed, then result == DS_RESULT_PENDING.
 	 * 3) result == DS_RESULT_SUCCESS implies state == in_transition.
@@ -28,16 +27,12 @@ struct dataswarm_blob_rep {
 	 *    reached because of the error in result.
 	 * 5) state and in_transition are strictly monotonically increasing
 	 *    according to DS_BLOB_WORKER_STATE: NEW, CREATED, ((PUT or COPIED), COMMITTED) or
-	 *    (GET, RETRIEVED). DELETED may occur at any time after create.
+	 *    (COMMITTED, GET) or GET. DELETED may occur at any time after create.
 	 *
-	 * To get a blob there are two stages: GET which prompts the worker to
-	 * start sending the blob. The manager is free to do other things while
-	 * an in_transition GET has a result of DS_RESULT_PENDING. When it
-	 * becomes DS_RESULT_SUCCESS, then the in_transition becomes RETRIEVED.
-	 *
-	 * Note that RETRIEVED does not really represent an rpc, but the inflight
-	 * contents of the buffer. This is necessary, as the GET may succeed,
-	 * but the overall transfer may fail.
+	 * With GET, state and in_transition are immediately set to GET, as the
+	 * state of the blob in the worker does not change. result is set to
+	 * DS_RESULT_PENDING, and changed to DS_RESULT_SUCCESS once the file is
+	 * retrieved.
 	 *
 	 */
 

--- a/dataswarm/manager/dataswarm_manager.h
+++ b/dataswarm/manager/dataswarm_manager.h
@@ -19,8 +19,6 @@ struct dataswarm_manager {
 	int server_port;
 	int message_id;
 
-	/* maps taskid's to tasks */
-	struct hash_table *task_table;
 	int task_id;
 
 	int force_update;

--- a/dataswarm/worker/dataswarm_blob_table.h
+++ b/dataswarm/worker/dataswarm_blob_table.h
@@ -9,7 +9,7 @@
 
 dataswarm_result_t dataswarm_blob_table_create( struct dataswarm_worker *w, const char *blobid, jx_int_t size, struct jx *meta );
 dataswarm_result_t dataswarm_blob_table_put( struct dataswarm_worker *w, const char *blobid, struct link *l);
-dataswarm_result_t dataswarm_blob_table_get( struct dataswarm_worker *w, const char *blobid, struct link *l);
+dataswarm_result_t dataswarm_blob_table_get(struct dataswarm_worker *w, const char *blobid, struct link *l, jx_int_t msgid, int *should_respond);
 dataswarm_result_t dataswarm_blob_table_delete( struct dataswarm_worker *w, const char *blobid);
 dataswarm_result_t dataswarm_blob_table_commit( struct dataswarm_worker *w, const char *blobid);
 dataswarm_result_t dataswarm_blob_table_copy( struct dataswarm_worker *w, const char *blobid, const char *blobid_src);


### PR DESCRIPTION
Getting the blob is reduced to one state.

The tricky part is the worker function that sends the contents. It has to create the rpc response before sending the contents of the blob. However, on error we want it to behave as any other rpc. I added an *argument that indicates whether the dispatcher should send a response of its own.

The other minor issue is that once the transfer initiates, the rpc is set to 'success'. The manager is able to rectify to 'unable' if the transfer fails. So, for the worker 'success' means 'successfully started the transfer', and for the manager it means 'successfully got the whole blob'.