### PR TITLE
rename dataswarm_{manager,worker} binaries to ds_*

### DIFF
--- a/dataswarm/manager/Makefile
+++ b/dataswarm/manager/Makefile
@@ -2,7 +2,7 @@ include ../../config.mk
 include ../../rules.mk
 
 TARGETS=$(PROGRAMS)
-PROGRAMS=dataswarm_manager
+PROGRAMS=ds_manager
 
 SOURCES=ds_manager.c ds_client_rep.c ds_worker_rep.c ds_rpc.c ds_test.c
 OBJECTS=$(SOURCES:%.c=%.o)
@@ -12,7 +12,7 @@ LOCAL_LINKAGE = -L ../../dttools/src -ldttools
 
 all: $(TARGETS)
 
-dataswarm_manager: $(OBJECTS) $(DS_OBJECTS)
+ds_manager: $(OBJECTS) $(DS_OBJECTS)
 
 clean:
 	rm -rf $(OBJECTS) $(PROGRAMS)

--- a/dataswarm/worker/Makefile
+++ b/dataswarm/worker/Makefile
@@ -2,7 +2,7 @@ include ../../config.mk
 include ../../rules.mk
 
 TARGETS=$(PROGRAMS)
-PROGRAMS=dataswarm_worker
+PROGRAMS=ds_worker
 
 SOURCES=ds_worker_main.c ds_worker.c ds_task_table.c ds_blob_table.c
 OBJECTS=$(SOURCES:%.c=%.o)
@@ -13,7 +13,7 @@ LOCAL_LINKAGE = -L ../../dttools/src -ldttools
 
 all: $(TARGETS)
 
-dataswarm_worker: $(OBJECTS) $(DS_OBJECTS)
+ds_worker: $(OBJECTS) $(DS_OBJECTS)
 
 clean:
 	rm -rf $(OBJECTS) $(PROGRAMS)


### PR DESCRIPTION
Otherwise the default make rules does not produce the binaries. We
probably want to revisit this, as these binaries will be facing the user
and their name is importat.