### PR TITLE
DS Recover Blob Table from Disk

### DIFF
--- a/dataswarm/common/ds_message.h
+++ b/dataswarm/common/ds_message.h
@@ -16,7 +16,8 @@ typedef enum {
     DS_RESULT_TOO_FULL,       /* insufficient resources to complete request */
     DS_RESULT_BAD_PERMISSION, /* insufficient privileges to complete request */
     DS_RESULT_UNABLE,         /* could not complete request for internal reason */
-    DS_RESULT_PENDING         /* rpc not completed yet. */
+    DS_RESULT_PENDING,        /* rpc not completed yet. */
+    DS_RESULT_BAD_STATE,      /* cannot take that action in this state. */
 } ds_result_t;
 
 int        ds_json_send( struct link *l, struct jx *j, time_t stoptime );

--- a/dataswarm/worker/ds_blob_table.h
+++ b/dataswarm/worker/ds_blob_table.h
@@ -14,7 +14,7 @@ ds_result_t ds_blob_table_delete( struct ds_worker *w, const char *blobid);
 ds_result_t ds_blob_table_commit( struct ds_worker *w, const char *blobid);
 ds_result_t ds_blob_table_copy( struct ds_worker *w, const char *blobid, const char *blobid_src);
 
-void ds_blob_table_purge( struct ds_worker *w );
+void ds_blob_table_recover( struct ds_worker *w );
 
 
 #endif

--- a/dataswarm/worker/ds_process.c
+++ b/dataswarm/worker/ds_process.c
@@ -56,8 +56,6 @@ void ds_process_delete(struct ds_process *p)
 {
 	if(!p) return;
 
-	// XXX move sandbox to deleting dir.
-
 	if(!ds_process_isdone(p)) {
 		ds_process_kill(p);
 		while(!ds_process_isdone(p)) {
@@ -67,9 +65,9 @@ void ds_process_delete(struct ds_process *p)
 
 	// don't free taskid, it's a circular link
 	if(p->sandbox) {
-		delete_dir(p->sandbox);
 		free(p->sandbox);
 	}
+
 	if(p->tmpdir) free(p->tmpdir);
 	free(p);
 }

--- a/dataswarm/worker/ds_process.c
+++ b/dataswarm/worker/ds_process.c
@@ -1,5 +1,6 @@
 
 #include "ds_process.h"
+#include "ds_worker.h"
 
 #include "debug.h"
 #include "errno.h"
@@ -28,7 +29,7 @@
 #include <sys/types.h>
 #include <stdlib.h>
 
-struct ds_process *ds_process_create( struct ds_task *task, const char *workspace )
+struct ds_process *ds_process_create( struct ds_task *task, struct ds_worker *w )
 {
 	struct ds_process *p = malloc(sizeof(*p));
 	memset(p,0,sizeof(*p));
@@ -37,7 +38,7 @@ struct ds_process *ds_process_create( struct ds_task *task, const char *workspac
 	p->state = DS_PROCESS_READY;
 
 	/* create a unique directory for this task */
-	p->sandbox = string_format("%s/task/%s/sandbox", workspace, p->task->taskid );
+	p->sandbox = ds_worker_task_sandbox(w,p->task->taskid);
 	if(!create_dir(p->sandbox, 0777)) goto failure;
 
 	/* inside the sandbox, make a unique tempdir for this task */
@@ -121,11 +122,11 @@ static int flags_to_unix_mode( dataswarm_flags_t flags )
 	}
 }
 
-static int setup_mount( struct ds_mount *m, struct ds_process *p, const char *workspace )
+static int setup_mount( struct ds_mount *m, struct ds_process *p, struct ds_worker *w )
 {
 	// XXX Check for validity of blob modes here.
 	//
-	char *blobpath = string_format("%s/blob/%s/data",workspace,m->uuid);
+	char *blobpath = ds_worker_blob_data(w,m->uuid);
 
 	if(m->type==DS_MOUNT_PATH) {
 		int r = symlink(blobpath,m->path);
@@ -153,18 +154,18 @@ static int setup_mount( struct ds_mount *m, struct ds_process *p, const char *wo
 	return 1;
 }
 
-static int setup_namespace( struct ds_process *p, const char *workspace )
+static int setup_namespace( struct ds_process *p, struct ds_worker *w )
 {
 	struct ds_mount *m;
 
 	for(m=p->task->mounts;m;m=m->next) {
-		if(!setup_mount(m,p,workspace)) return 0;
+		if(!setup_mount(m,p,w)) return 0;
 	}
 
 	return 1;
 }
 
-int ds_process_start( struct ds_process *p, const char *workspace )
+int ds_process_start( struct ds_process *p, struct ds_worker *w )
 {
 	/*
 	Before forking a process, it is necessary to flush all standard I/O stream,
@@ -201,7 +202,7 @@ int ds_process_start( struct ds_process *p, const char *workspace )
 		}
 
 		// Check errors on these.
-		setup_namespace(p,workspace);
+		setup_namespace(p,w);
 		clear_environment();
 		specify_resources_vars(p);
 		export_environment(p);

--- a/dataswarm/worker/ds_process.h
+++ b/dataswarm/worker/ds_process.h
@@ -2,6 +2,7 @@
 #define DATASWARM_PROCESS_H
 
 #include "../common/ds_task.h"
+#include "ds_worker.h"
 #include "timestamp.h"
 
 #include <unistd.h>
@@ -49,10 +50,10 @@ struct ds_process {
 };
 
 /* Create a new process for this task and set up the corresponding sandbox. */
-struct ds_process * ds_process_create( struct ds_task *task, const char *workspace );
+struct ds_process * ds_process_create( struct ds_task *task, struct ds_worker *worker );
 
 /* Start the process running, return true on success. */
-int  ds_process_start( struct ds_process *p, const char *workspace );
+int  ds_process_start( struct ds_process *p, struct ds_worker *w );
 
 /* Send a kill signal to a process (if still running).  After doing so, must call isdone() to collect the status. */
 void ds_process_kill( struct ds_process *p );

--- a/dataswarm/worker/ds_task_table.c
+++ b/dataswarm/worker/ds_task_table.c
@@ -22,7 +22,7 @@ static void update_task_state( struct ds_worker *w, struct ds_task *task, ds_tas
 {
 	task->state = state;
 
-	char * task_meta = string_format("%s/task/%s/meta",w->workspace,task->taskid);
+	char * task_meta = ds_worker_task_meta(w,task->taskid);
 	ds_task_to_file(task,task_meta);
 	free(task_meta);
 
@@ -83,11 +83,11 @@ void ds_task_table_advance( struct ds_worker *w )
 		switch(task->state) {
 			case DS_TASK_READY:
 				// XXX only start tasks when resources available.
-				process = ds_process_create(task,w->workspace);
+				process = ds_process_create(task,w);
 				if(process) {
 					hash_table_insert(w->process_table,taskid,process);
 					// XXX check for invalid mounts?
-					if(ds_process_start(process,w->workspace)) {
+					if(ds_process_start(process,w)) {
 						update_task_state(w,task,DS_TASK_RUNNING,1);
 					} else {
 						update_task_state(w,task,DS_TASK_FAILED,1);
@@ -169,7 +169,7 @@ void ds_task_table_recover( struct ds_worker *w )
 
 		debug(D_DATASWARM,"recovering task %s",d->d_name);
 
-		task_meta = string_format("%s/task/%s/meta",w->workspace,d->d_name);
+		task_meta = ds_worker_task_meta(w,d->d_name);
 
 		task = ds_task_create_from_file(task_meta);
 		if(task) {

--- a/dataswarm/worker/ds_task_table.h
+++ b/dataswarm/worker/ds_task_table.h
@@ -15,7 +15,4 @@ void ds_task_table_advance( struct ds_worker *w );
 /* Load all existing tasks from disk. */
 void ds_task_table_recover( struct ds_worker *w );
 
-/* Remove all previously-deleted tasks on startup. */
-void ds_task_table_purge( struct ds_worker *w );
-
 #endif

--- a/dataswarm/worker/ds_worker.c
+++ b/dataswarm/worker/ds_worker.c
@@ -275,6 +275,7 @@ struct ds_worker *ds_worker_create(const char *workspace)
 
 	w->task_table = hash_table_create(0, 0);
 	w->process_table = hash_table_create(0,0);
+	w->blob_table = hash_table_create(0,0);
 	w->workspace = strdup(workspace);
 
 	w->idle_timeout = 300;
@@ -308,6 +309,7 @@ void ds_worker_delete(struct ds_worker *w)
 		return;
 	hash_table_delete(w->task_table);
 	hash_table_delete(w->process_table);
+	hash_table_delete(w->blob_table);
 	free(w->workspace);
 	free(w);
 }

--- a/dataswarm/worker/ds_worker.h
+++ b/dataswarm/worker/ds_worker.h
@@ -15,6 +15,9 @@ struct ds_worker {
 	// Table mapping taskids to ds_process objects representing running tasks.
 	struct hash_table *process_table;
 
+	// Table mapping blobids to ds_blob objects.
+	struct hash_table *blob_table;
+
 	// Path to top of workspace containing tasks and blobs.
 	char *workspace;
 

--- a/dataswarm/worker/ds_worker.h
+++ b/dataswarm/worker/ds_worker.h
@@ -58,7 +58,7 @@ void ds_worker_connect_loop( struct ds_worker *w, const char *manager_host, int 
 void ds_worker_delete(struct ds_worker *w);
 
 char * ds_worker_task_dir( struct ds_worker *w, const char *taskid );
-char * ds_worker_task_data( struct ds_worker *w, const char *taskid );
+char * ds_worker_task_sandbox( struct ds_worker *w, const char *taskid );
 char * ds_worker_task_meta( struct ds_worker *w, const char *taskid );
 char * ds_worker_task_deleting( struct ds_worker *w );
 

--- a/dataswarm/worker/ds_worker_main.c
+++ b/dataswarm/worker/ds_worker_main.c
@@ -82,7 +82,8 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	ds_blob_table_purge(w);
+	/* Now load all saved task/blob state from disk. */
+	ds_blob_table_recover(w);
 	ds_task_table_purge(w);
 	ds_task_table_recover(w);
 

--- a/dataswarm/worker/ds_worker_main.c
+++ b/dataswarm/worker/ds_worker_main.c
@@ -84,7 +84,6 @@ int main(int argc, char *argv[])
 
 	/* Now load all saved task/blob state from disk. */
 	ds_blob_table_recover(w);
-	ds_task_table_purge(w);
 	ds_task_table_recover(w);
 
 	if(manager_name) {


### PR DESCRIPTION
On worker startup, both the blob table and the task table are recovered from disk,
and then previously deleted tasks and blobs are addressed consistently.
Next step is to send a catalog of information back to the manager.
