### PR TITLE
DS unify blob enums

### DIFF
--- a/dataswarm/common/ds_blob.c
+++ b/dataswarm/common/ds_blob.c
@@ -94,3 +94,18 @@ int ds_blob_to_file( struct ds_blob *b, const char *filename )
 	return 1;
 }
 
+char *ds_blob_state_string( ds_blob_state_t state )
+{
+	switch(state) {
+		case DS_BLOB_NEW: return "new";
+		case DS_BLOB_RW: return "rw";
+		case DS_BLOB_PUT: return "put";
+		case DS_BLOB_COPIED: return "copied";
+		case DS_BLOB_GET: return "get";
+		case DS_BLOB_DELETING: return "deleting";
+		case DS_BLOB_DELETED: return "deleted";
+		case DS_BLOB_ERROR: return "error";
+		default: return "unknown";
+	}
+}
+

--- a/dataswarm/common/ds_blob.h
+++ b/dataswarm/common/ds_blob.h
@@ -3,11 +3,25 @@
 
 #include "jx.h"
 
+/* blob_state_t is used to track the state of blobs in workers, and the
+ * knowledge of blob transitions as seen by the manager. The worker only needs
+ * DS_BLOB_RW for new blobs declared from the manager, DS_BLOB_RO for committed blobs, and
+ * DS_BLOB_DELETING for blobs in the process of being deleted, and DS_BLOB_DELETED as a terminal state.
+ *
+ * The manager declares new blobs as BLOB_NEW, and only transitions to
+ * DS_BLOB_RW once the blob is declared in the worker, and so on. See
+ * manager/ds_blob_rep.h for the blob state transitions according to the
+ * manager. */
+
 typedef enum {
-	DS_BLOB_RW,
-	DS_BLOB_RO,
+	DS_BLOB_NEW = 0,
+	DS_BLOB_RW,                   /* blobs are created as read-write */
+	DS_BLOB_PUT, DS_BLOB_COPIED,
+	DS_BLOB_RO,                   /* committed blobs are read-only */
+	DS_BLOB_GET,
 	DS_BLOB_DELETING,
-	DS_BLOB_DELETED
+	DS_BLOB_DELETED,
+	DS_BLOB_ERROR
 } ds_blob_state_t;
 
 struct ds_blob {

--- a/dataswarm/common/ds_blob.h
+++ b/dataswarm/common/ds_blob.h
@@ -41,4 +41,6 @@ int ds_blob_to_file( struct ds_blob *b, const char *filename );
 
 void ds_blob_delete( struct ds_blob *b );
 
+char *ds_blob_state_string( ds_blob_state_t state );
+
 #endif

--- a/dataswarm/common/ds_message.c
+++ b/dataswarm/common/ds_message.c
@@ -86,11 +86,11 @@ struct jx * ds_message_task_update( const char *taskid, const char *state )
 	return message;
 }
 
-struct jx * ds_message_blob_update( const char *blobid, const char *state )
+struct jx * ds_message_blob_update( const char *blobid, ds_blob_state_t state )
 {
 	struct jx *params = jx_object(0);
 	jx_insert_string(params,"blob-id",blobid);
-	jx_insert_string(params,"state",state);
+	jx_insert_integer(params,"state",state);
 
 	struct jx *message = jx_object(0);
 	jx_insert_string(message, "method", "blob-update");

--- a/dataswarm/common/ds_message.h
+++ b/dataswarm/common/ds_message.h
@@ -5,6 +5,9 @@
 #include "jx.h"
 #include "buffer.h"
 
+#include "ds_task.h"
+#include "ds_blob.h"
+
 #include <time.h>
 
 typedef enum {
@@ -31,6 +34,6 @@ struct jx *ds_parse_message(buffer_t *buf);
 
 struct jx * ds_message_standard_response( int64_t id, ds_result_t code, struct jx *params );
 struct jx * ds_message_task_update( const char *taskid, const char *state );
-struct jx * ds_message_blob_update( const char *blobid, const char *state );
+struct jx * ds_message_blob_update( const char *blobid, ds_blob_state_t state );
 
 #endif

--- a/dataswarm/manager/ds_blob_rep.h
+++ b/dataswarm/manager/ds_blob_rep.h
@@ -2,15 +2,7 @@
 #define DATASWARM_BLOB_REP_H
 
 #include "ds_rpc.h"  /* needed for ds_result_t */
-
-typedef enum {
-	DS_BLOB_WORKER_STATE_NEW = 0,
-	DS_BLOB_WORKER_STATE_CREATED,
-	DS_BLOB_WORKER_STATE_PUT, DS_BLOB_WORKER_STATE_COPIED,
-	DS_BLOB_WORKER_STATE_COMMITTED,
-	DS_BLOB_WORKER_STATE_GET,
-	DS_BLOB_WORKER_STATE_DELETED,
-} ds_blob_worker_state_t;
+#include "ds_blob.h" /* needed for ds_blob_state_t */
 
 struct ds_blob_rep {
 	/* Records the lifetime of a blob in a worker.
@@ -26,8 +18,10 @@ struct ds_blob_rep {
 	 *    in_transition records the blob's lifetime stage that could not been
 	 *    reached because of the error in result.
 	 * 5) state and in_transition are strictly monotonically increasing
-	 *    according to DS_BLOB_WORKER_STATE: NEW, CREATED, ((PUT or COPIED), COMMITTED) or
-	 *    (COMMITTED, GET) or GET. DELETED may occur at any time after create.
+	 *    according to DS_BLOB_: NEW, RW, ((PUT or COPIED), RO))) or
+	 *    (RO, GET) or GET. DELETING may occur at any time after create. DELETE
+	 *    is never an in_transition as this state is set from an asynchronous
+	 *    update from the worker once deleting the blob is done.
 	 *
 	 * With GET, state and in_transition are immediately set to GET, as the
 	 * state of the blob in the worker does not change. result is set to
@@ -36,8 +30,8 @@ struct ds_blob_rep {
 	 *
 	 */
 
-	ds_blob_worker_state_t state;
-	ds_blob_worker_state_t in_transition;
+	ds_blob_state_t state;
+	ds_blob_state_t in_transition;
 	ds_result_t result;
 
 	/* this blob id */

--- a/dataswarm/manager/ds_manager.c
+++ b/dataswarm/manager/ds_manager.c
@@ -87,7 +87,7 @@ struct ds_blob_rep *ds_manager_add_blob_to_worker( struct ds_manager *m, struct 
 	}
 
 	b = calloc(1,sizeof(struct ds_blob_rep));
-	b->state = DS_BLOB_WORKER_STATE_NEW;
+	b->state = DS_BLOB_NEW;
 	b->in_transition = b->state;
 	b->result = DS_RESULT_SUCCESS;
 

--- a/dataswarm/manager/ds_rpc.c
+++ b/dataswarm/manager/ds_rpc.c
@@ -57,7 +57,7 @@ ds_result_t ds_rpc_get_response( struct ds_manager *m, struct ds_worker_rep *r)
 	if(b) {
 		b->result = result;
 		if(b->result == DS_RESULT_SUCCESS) {
-			if(b->state == DS_BLOB_WORKER_STATE_GET) {
+			if(b->state == DS_BLOB_GET) {
 				b->result = blob_get_aux(m,r,b->blobid);
 				set_storage = 1;
 			}
@@ -100,7 +100,7 @@ jx_int_t ds_rpc( struct ds_manager *m, struct ds_worker_rep *r, struct jx *rpc)
 	return msgid;
 }
 
-jx_int_t ds_rpc_for_blob( struct ds_manager *m, struct ds_worker_rep *r, struct ds_blob_rep *b, struct jx *rpc, ds_blob_worker_state_t in_transition )
+jx_int_t ds_rpc_for_blob( struct ds_manager *m, struct ds_worker_rep *r, struct ds_blob_rep *b, struct jx *rpc, ds_blob_state_t in_transition )
 {
 	jx_int_t msgid = ds_rpc(m, r, rpc);
 
@@ -140,7 +140,7 @@ jx_int_t ds_rpc_blob_create( struct ds_manager *m, struct ds_worker_rep *r, cons
 													 NULL),
 								NULL);
 
-	return ds_rpc_for_blob(m, r, b, msg, DS_BLOB_WORKER_STATE_CREATED);
+	return ds_rpc_for_blob(m, r, b, msg, DS_BLOB_RO);
 }
 
 jx_int_t ds_rpc_blob_commit( struct ds_manager *m, struct ds_worker_rep *r, const char *blobid )
@@ -157,7 +157,7 @@ jx_int_t ds_rpc_blob_commit( struct ds_manager *m, struct ds_worker_rep *r, cons
 													 NULL),
 								NULL);
 
-	return ds_rpc_for_blob(m, r, b, msg, DS_BLOB_WORKER_STATE_COMMITTED);
+	return ds_rpc_for_blob(m, r, b, msg, DS_BLOB_RO);
 }
 
 jx_int_t ds_rpc_blob_delete( struct ds_manager *m, struct ds_worker_rep *r, const char *blobid )
@@ -174,7 +174,7 @@ jx_int_t ds_rpc_blob_delete( struct ds_manager *m, struct ds_worker_rep *r, cons
 													 NULL),
 								NULL);
 
-	return ds_rpc_for_blob(m, r, b, msg, DS_BLOB_WORKER_STATE_DELETED);
+	return ds_rpc_for_blob(m, r, b, msg, DS_BLOB_DELETING);
 }
 
 jx_int_t ds_rpc_blob_copy( struct ds_manager *m, struct ds_worker_rep *r, const char *blobid_source, const char *blobid_target )
@@ -192,7 +192,7 @@ jx_int_t ds_rpc_blob_copy( struct ds_manager *m, struct ds_worker_rep *r, const 
 													 NULL),
 								NULL);
 
-	return ds_rpc_for_blob(m, r, b, msg, DS_BLOB_WORKER_STATE_COPIED);
+	return ds_rpc_for_blob(m, r, b, msg, DS_BLOB_COPIED);
 }
 
 
@@ -213,7 +213,7 @@ jx_int_t ds_rpc_blob_put( struct ds_manager *m, struct ds_worker_rep *r, const c
 								NULL);
 
 
-	jx_int_t msgid = ds_rpc_for_blob(m, r, b, msg, DS_BLOB_WORKER_STATE_PUT);
+	jx_int_t msgid = ds_rpc_for_blob(m, r, b, msg, DS_BLOB_PUT);
 
 	int file = open(filename, O_RDONLY);
 	if (file < 0) {
@@ -242,7 +242,7 @@ jx_int_t ds_rpc_blob_get( struct ds_manager *m, struct ds_worker_rep *r, const c
 													 NULL),
 								NULL);
 
-	jx_int_t msgid = ds_rpc_for_blob(m, r, b, msg, DS_BLOB_WORKER_STATE_GET);
+	jx_int_t msgid = ds_rpc_for_blob(m, r, b, msg, DS_BLOB_GET);
 
 	//This rpc does not modify the state of the blob at the worker:
 	b->state = b->in_transition;

--- a/dataswarm/worker/ds_blob_table.c
+++ b/dataswarm/worker/ds_blob_table.c
@@ -221,7 +221,7 @@ ds_result_t ds_blob_table_delete(struct ds_worker * w, const char *blobid)
 	char *blob_data = ds_worker_blob_data(w,blobid);
 
 	// Record the deleting state in the metadata
-	b->state = DS_BLOB_DELETING;
+	b->state = DS_BLOB_DELETED;
 	ds_blob_to_file(b,blob_meta);
 
 	// First delete the data which may take some time.
@@ -315,7 +315,7 @@ void ds_blob_table_recover( struct ds_worker *w )
 		if(b) {
 			total_blob_size += b->size;
 			hash_table_insert(w->blob_table,b->blobid,b);
-			if(b->state==DS_BLOB_DELETING) {
+			if(b->state==DS_BLOB_DELETED) {
 				debug(D_DATASWARM, "deleting blob %s",b->blobid);
 				ds_blob_table_delete(w,b->blobid);
 			}

--- a/dataswarm/worker/ds_blob_table.h
+++ b/dataswarm/worker/ds_blob_table.h
@@ -6,6 +6,7 @@
 
 #include "jx.h"
 
+void ds_blob_table_advance( struct ds_worker *w );
 ds_result_t ds_blob_table_create( struct ds_worker *w, const char *blobid, jx_int_t size, struct jx *meta );
 ds_result_t ds_blob_table_put( struct ds_worker *w, const char *blobid);
 ds_result_t ds_blob_table_get(struct ds_worker *w, const char *blobid, jx_int_t msgid, int *should_respond);

--- a/dataswarm/worker/ds_blob_table.h
+++ b/dataswarm/worker/ds_blob_table.h
@@ -9,6 +9,7 @@
 ds_result_t ds_blob_table_create( struct ds_worker *w, const char *blobid, jx_int_t size, struct jx *meta );
 ds_result_t ds_blob_table_put( struct ds_worker *w, const char *blobid);
 ds_result_t ds_blob_table_get(struct ds_worker *w, const char *blobid, jx_int_t msgid, int *should_respond);
+ds_result_t ds_blob_table_deleting( struct ds_worker *w, const char *blobid);
 ds_result_t ds_blob_table_delete( struct ds_worker *w, const char *blobid);
 ds_result_t ds_blob_table_commit( struct ds_worker *w, const char *blobid);
 ds_result_t ds_blob_table_copy( struct ds_worker *w, const char *blobid, const char *blobid_src);

--- a/dataswarm/worker/ds_worker.c
+++ b/dataswarm/worker/ds_worker.c
@@ -115,7 +115,7 @@ void ds_worker_handle_message(struct ds_worker *w)
 	} else if(!strcmp(method, "blob-get")) {
 		result = ds_blob_table_get(w,blobid,id,&should_send_response);
 	} else if(!strcmp(method, "blob-delete")) {
-		result = ds_blob_table_delete(w,blobid);
+		result = ds_blob_table_deleting(w,blobid);
 	} else if(!strcmp(method, "blob-commit")) {
 		result = ds_blob_table_commit(w,blobid);
 	} else if(!strcmp(method, "blob-copy")) {

--- a/dataswarm/worker/ds_worker.c
+++ b/dataswarm/worker/ds_worker.c
@@ -164,8 +164,12 @@ int ds_worker_main_loop(struct ds_worker *w)
 			break;
 		}
 
+
 		/* after processing any messages, work on tasks. */
 		ds_task_table_advance(w);
+
+		/* process any pending blob deletes, etc. */
+		ds_blob_table_advance(w);
 
 		time_t current = time(0);
 


### PR DESCRIPTION
Split ds_blob_table_delete into ds_blob_table_deleting and ds_blob_table_delete.   

*_deleting is called when the rpc blob-delete is received.
*_delete is called in a new function ds_blob_table_advance finds that there is something to do with a blob.

The final delete state is sent to the manager in an asynchronous update, as we do with tasks.