### PR TITLE
Dataswarm DB Initial

### DIFF
--- a/dataswarm/common/ds_blob.c
+++ b/dataswarm/common/ds_blob.c
@@ -94,7 +94,7 @@ int ds_blob_to_file( struct ds_blob *b, const char *filename )
 	return 1;
 }
 
-char *ds_blob_state_string( ds_blob_state_t state )
+const char *ds_blob_state_string( ds_blob_state_t state )
 {
 	switch(state) {
 		case DS_BLOB_NEW: return "new";

--- a/dataswarm/common/ds_blob.h
+++ b/dataswarm/common/ds_blob.h
@@ -41,6 +41,6 @@ int ds_blob_to_file( struct ds_blob *b, const char *filename );
 
 void ds_blob_delete( struct ds_blob *b );
 
-char *ds_blob_state_string( ds_blob_state_t state );
+const char *ds_blob_state_string( ds_blob_state_t state );
 
 #endif

--- a/dataswarm/manager/Makefile
+++ b/dataswarm/manager/Makefile
@@ -4,7 +4,7 @@ include ../../rules.mk
 TARGETS=$(PROGRAMS)
 PROGRAMS=ds_manager
 
-SOURCES=ds_manager.c ds_client_rep.c ds_worker_rep.c ds_rpc.c ds_test.c ds_client_ops.c ds_validate.c ds_file.c
+SOURCES=ds_manager.c ds_client_rep.c ds_worker_rep.c ds_rpc.c ds_test.c ds_client_ops.c ds_validate.c ds_file.c ds_db.c
 OBJECTS=$(SOURCES:%.c=%.o)
 LOCAL_CCFLAGS = -I ../common
 LOCAL_LINKAGE = -L ../common -ldataswarm_common -L ../../dttools/src -ldttools

--- a/dataswarm/manager/Makefile
+++ b/dataswarm/manager/Makefile
@@ -4,7 +4,7 @@ include ../../rules.mk
 TARGETS=$(PROGRAMS)
 PROGRAMS=ds_manager
 
-SOURCES=ds_manager.c ds_client_rep.c ds_worker_rep.c ds_rpc.c ds_test.c ds_client_ops.c ds_validate.c ds_file.c ds_db.c
+SOURCES=ds_manager.c ds_client_rep.c ds_worker_rep.c ds_rpc.c ds_test.c ds_client_ops.c ds_validate.c ds_file.c ds_db.c ds_ids.c
 OBJECTS=$(SOURCES:%.c=%.o)
 LOCAL_CCFLAGS = -I ../common
 LOCAL_LINKAGE = -L ../common -ldataswarm_common -L ../../dttools/src -ldttools

--- a/dataswarm/manager/ds_client_ops.c
+++ b/dataswarm/manager/ds_client_ops.c
@@ -14,27 +14,27 @@
 
 char *ds_client_task_submit(struct ds_manager *m, struct jx *task)
 {
-    if(!validate_json(task, SUBMIT_TASK)){
-        return NULL;
-    }
+	if(!validate_json(task, SUBMIT_TASK)) {
+		return NULL;
+	}
 
-    char *taskid = ds_create_taskid(m);
+	char *taskid = ds_create_taskid(m);
 
-    jx_insert_string(task, "task-id", taskid);
+	jx_insert_string(task, "task-id", taskid);
 
-    struct ds_task *t = ds_task_create(task);
+	struct ds_task *t = ds_task_create(task);
 
-    hash_table_insert(m->task_table, taskid, t);
-    ds_db_commit_task(m,taskid);
+	hash_table_insert(m->task_table, taskid, t);
+	ds_db_commit_task(m, taskid);
 
-    return taskid;
+	return taskid;
 }
 
 struct ds_task *ds_client_task_delete(struct ds_manager *m, const char *uuid)
 {
 	struct ds_task *t = hash_table_lookup(m->task_table, uuid);
 	t->state = DS_TASK_DELETING;
-	ds_db_commit_task(m,uuid);
+	ds_db_commit_task(m, uuid);
 	return t;
 }
 
@@ -46,122 +46,129 @@ struct jx *ds_client_task_retrieve(struct ds_manager *m, const char *uuid)
 
 struct ds_file *ds_client_file_declare(struct ds_manager *m, struct jx *params)
 {
-    if(!validate_json(params, DECLARE_FILE)){
-        return NULL;
-    }
+	if(!validate_json(params, DECLARE_FILE)) {
+		return NULL;
+	}
 
-    char *fileid = ds_create_fileid(m);
+	char *fileid = ds_create_fileid(m);
 
-    struct ds_file *f = ds_file_create(
-            fileid,
-            jx_lookup_string(params, "project"),
-            jx_lookup_integer(params, "size"),
-            jx_lookup(params, "metadata"));
+	struct ds_file *f = ds_file_create(fileid,
+					   jx_lookup_string(params, "project"),
+					   jx_lookup_integer(params, "size"),
+					   jx_lookup(params, "metadata"));
 
-    hash_table_insert(m->file_table, fileid, f);
-    ds_db_commit_file(m,fileid);
+	hash_table_insert(m->file_table, fileid, f);
+	ds_db_commit_file(m, fileid);
 
-    return f;
+	return f;
 }
 
-struct ds_file *ds_client_file_commit(struct ds_manager *m, const char *uuid) {
+struct ds_file *ds_client_file_commit(struct ds_manager *m, const char *uuid)
+{
 
-    //get file metadata from mapping
-    struct ds_file *f = hash_table_lookup(m->file_table, uuid);
+	//get file metadata from mapping
+	struct ds_file *f = hash_table_lookup(m->file_table, uuid);
 
-    //TODO: change all blobs to RO
+	//TODO: change all blobs to RO
 
-    //TODO: change state to immutable
+	//TODO: change state to immutable
 
-    return f;
+	return f;
 
 }
 
 struct ds_file *ds_client_file_delete(struct ds_manager *m, const char *uuid)
 {
-	struct ds_file *f = hash_table_lookup(m->file_table,uuid);
+	struct ds_file *f = hash_table_lookup(m->file_table, uuid);
 	f->state = DS_FILE_DELETING;
-	ds_db_commit_file(m,uuid);
-	return f; // Why are we returning the file here?
+	ds_db_commit_file(m, uuid);
+	return f;		// Why are we returning the file here?
 }
 
 struct ds_file *ds_client_file_copy(struct ds_manager *m, const char *uuid)
 {
-    //get file data from mapping
-    struct ds_file *f = hash_table_lookup(m->file_table, uuid);
+	//get file data from mapping
+	struct ds_file *f = hash_table_lookup(m->file_table, uuid);
 
-    //TODO: replicate file data to mapping
-    return f;
+	//TODO: replicate file data to mapping
+	return f;
 }
 
-char *ds_client_service_submit(struct ds_manager *m, struct jx *service){
+char *ds_client_service_submit(struct ds_manager *m, struct jx *service)
+{
 
-    if(!validate_json(service, SUBMIT_SERVICE)){
-        return NULL;
-    }
+	if(!validate_json(service, SUBMIT_SERVICE)) {
+		return NULL;
+	}
 
-    char *serviceid = ds_create_serviceid(m);
+	char *serviceid = ds_create_serviceid(m);
 
-    jx_insert_string(service, "uuid", serviceid);
+	jx_insert_string(service, "uuid", serviceid);
 
-    //TODO: save UUID to file mapping in memory
+	//TODO: save UUID to file mapping in memory
 
-    return serviceid;;
+	return serviceid;;
 }
 
-struct jx *ds_client_service_delete(struct ds_manager *m, struct jx *params) {
+struct jx *ds_client_service_delete(struct ds_manager *m, struct jx *params)
+{
 
-    //TODO: get service data from mapping
+	//TODO: get service data from mapping
 
-    //TODO: remove service data from mapping
-    return NULL;
+	//TODO: remove service data from mapping
+	return NULL;
 }
 
-char *ds_client_project_create(struct ds_manager *m, struct jx *params) {
+char *ds_client_project_create(struct ds_manager *m, struct jx *params)
+{
 
-    // assign a UUID to the project
-    cctools_uuid_t *uuid = 0;
-    cctools_uuid_create(uuid);
+	// assign a UUID to the project
+	cctools_uuid_t *uuid = 0;
+	cctools_uuid_create(uuid);
 
-    char * uuid_str = strdup(uuid->str);
+	char *uuid_str = strdup(uuid->str);
 
-    //TODO: create jx with project_name and uuid
+	//TODO: create jx with project_name and uuid
 
-    //TODO: save UUID to file mapping in memory
+	//TODO: save UUID to file mapping in memory
 
-    //return task UUID
-    return uuid_str;
-
-}
-
-struct jx *ds_client_project_delete(struct ds_manager *m, struct jx *params) {
-
-    //TODO: get project data from mapping
-
-    //TODO: remove project data from mapping
-
-    return NULL;
+	//return task UUID
+	return uuid_str;
 
 }
 
-struct jx *ds_client_wait(struct ds_manager *m, struct jx *params) {
+struct jx *ds_client_project_delete(struct ds_manager *m, struct jx *params)
+{
 
-    //TODO: block until something happens
+	//TODO: get project data from mapping
 
-    return NULL;
+	//TODO: remove project data from mapping
 
-}
-
-int ds_client_queue_empty(struct ds_manager *m, struct jx *params) {
-
-    //TODO: return true if the queue of tasks is empty
-
-    return 0;
+	return NULL;
 
 }
 
-struct jx *ds_client_status(struct ds_manager *m, struct jx *params) {
+struct jx *ds_client_wait(struct ds_manager *m, struct jx *params)
+{
 
-    return NULL;
+	//TODO: block until something happens
+
+	return NULL;
+
+}
+
+int ds_client_queue_empty(struct ds_manager *m, struct jx *params)
+{
+
+	//TODO: return true if the queue of tasks is empty
+
+	return 0;
+
+}
+
+struct jx *ds_client_status(struct ds_manager *m, struct jx *params)
+{
+
+	return NULL;
 
 }

--- a/dataswarm/manager/ds_client_ops.c
+++ b/dataswarm/manager/ds_client_ops.c
@@ -7,64 +7,59 @@
 #include "ds_client_ops.h"
 #include "uuid.h"
 #include "ds_validate.h"
+#include "ds_ids.h"
+#include "ds_db.h"
 
 #include <string.h>
 
-char *ds_client_task_submit(struct ds_manager *m, struct jx *task) {
-
+char *ds_client_task_submit(struct ds_manager *m, struct jx *task)
+{
     if(!validate_json(task, SUBMIT_TASK)){
         return NULL;
     }
 
-    // assign a UUID to the task
-    cctools_uuid_t *uuid = 0;
-    cctools_uuid_create(uuid);
+    char *taskid = ds_create_taskid(m);
 
-    char *uuid_str = strdup(uuid->str);
-
-    //add state and uuid to task
-    jx_insert_string(task, "task-id", uuid_str);
+    jx_insert_string(task, "task-id", taskid);
 
     struct ds_task *t = ds_task_create(task);
 
-    //save UUID to task mapping in memory
-    hash_table_insert(m->task_table, uuid_str, t);
+    hash_table_insert(m->task_table, taskid, t);
+    ds_db_commit_task(m,taskid);
 
-    //return task UUID
-    return uuid_str;
+    return taskid;
 }
 
-struct ds_task *ds_client_task_delete(struct ds_manager *m, const char *uuid) {
-
-    return hash_table_remove(m->task_table, uuid);
-
+struct ds_task *ds_client_task_delete(struct ds_manager *m, const char *uuid)
+{
+	struct ds_task *t = hash_table_lookup(m->task_table, uuid);
+	t->state = DS_TASK_DELETING;
+	ds_db_commit_task(m,uuid);
+	return t;
 }
 
-struct jx *ds_client_task_retrieve(struct ds_manager *m, const char *uuid) {
-
-    struct ds_task *t = hash_table_lookup(m->task_table, uuid);
-    return ds_task_to_jx(t);
-
+struct jx *ds_client_task_retrieve(struct ds_manager *m, const char *uuid)
+{
+	struct ds_task *t = hash_table_lookup(m->task_table, uuid);
+	return ds_task_to_jx(t);
 }
 
-struct ds_file *ds_client_file_declare(struct ds_manager *m, struct jx *params) {
-    //validate json
+struct ds_file *ds_client_file_declare(struct ds_manager *m, struct jx *params)
+{
     if(!validate_json(params, DECLARE_FILE)){
         return NULL;
     }
 
-    // assign a UUID to the file
-    cctools_uuid_t uuid;
-    cctools_uuid_create(&uuid);
+    char *fileid = ds_create_fileid(m);
 
     struct ds_file *f = ds_file_create(
-            uuid.str,
+            fileid,
             jx_lookup_string(params, "project"),
             jx_lookup_integer(params, "size"),
             jx_lookup(params, "metadata"));
 
-    //save UUID to file mapping in memory
-    hash_table_insert(m->file_table, uuid.str, f);
+    hash_table_insert(m->file_table, fileid, f);
+    ds_db_commit_file(m,fileid);
 
     return f;
 }
@@ -82,14 +77,16 @@ struct ds_file *ds_client_file_commit(struct ds_manager *m, const char *uuid) {
 
 }
 
-struct ds_file *ds_client_file_delete(struct ds_manager *m, const char *uuid) {
-
-    return hash_table_remove(m->file_table, uuid);
-
+struct ds_file *ds_client_file_delete(struct ds_manager *m, const char *uuid)
+{
+	struct ds_file *f = hash_table_lookup(m->file_table,uuid);
+	f->state = DS_FILE_DELETING;
+	ds_db_commit_file(m,uuid);
+	return f; // Why are we returning the file here?
 }
 
-struct ds_file *ds_client_file_copy(struct ds_manager *m, const char *uuid) {
-
+struct ds_file *ds_client_file_copy(struct ds_manager *m, const char *uuid)
+{
     //get file data from mapping
     struct ds_file *f = hash_table_lookup(m->file_table, uuid);
 
@@ -103,18 +100,13 @@ char *ds_client_service_submit(struct ds_manager *m, struct jx *service){
         return NULL;
     }
 
-    // assign a UUID to the service
-    cctools_uuid_t *uuid = 0;
-    cctools_uuid_create(uuid);
+    char *serviceid = ds_create_serviceid(m);
 
-    char * uuid_str = strdup(uuid->str);
-
-    //add state and uuid to service
-    jx_insert_string(service, "uuid", uuid_str);
+    jx_insert_string(service, "uuid", serviceid);
 
     //TODO: save UUID to file mapping in memory
 
-    return uuid_str;
+    return serviceid;;
 }
 
 struct jx *ds_client_service_delete(struct ds_manager *m, struct jx *params) {

--- a/dataswarm/manager/ds_db.c
+++ b/dataswarm/manager/ds_db.c
@@ -1,0 +1,128 @@
+
+#include "ds_db.h"
+#include "ds_task.h"
+#include "ds_file.h"
+
+#include "debug.h"
+#include "stringtools.h"
+#include "hash_table.h"
+#include "create_dir.h"
+
+#include <dirent.h>
+#include <string.h>
+#include <errno.h>
+
+void ds_db_commit_task( struct ds_manager *m, const char *taskid )
+{
+	struct ds_task *t = hash_table_lookup(m->task_table,taskid);
+	if(!t) return;
+
+	char *filename = string_format("%s/tasks/%s",m->dbpath,taskid);
+	char *tempname = string_format("%s.tmp",filename);
+
+	if(ds_task_to_file(t,tempname) && rename(tempname,filename)==0) {
+		// success
+	} else {
+		fatal("couldn't write task to %s: %s",filename,strerror(errno));
+	}
+	
+	free(tempname);
+	free(filename);
+}
+
+void ds_db_commit_file( struct ds_manager *m, const char *fileid )
+{
+	struct ds_file *f = hash_table_lookup(m->file_table,fileid);
+	if(!f) return;
+
+	char *filename = string_format("%s/files/%s",m->dbpath,fileid);
+	char *tempname = string_format("%s.tmp",filename);
+
+	if(ds_file_to_file(f,tempname) && rename(tempname,filename)==0) {
+		// success
+	} else {
+		fatal("couldn't write file to %s: %s",filename,strerror(errno));
+	}
+	
+	free(tempname);
+	free(filename);
+}
+
+void ds_db_recover_files( struct ds_manager *m, const char *path )
+{
+	DIR *dir;
+	struct dirent *d;
+	int count = 0;
+
+	dir = opendir(path);
+	if(!dir) fatal("couldn't opendir %s: %s",path,strerror(errno));
+
+	while((d=readdir(dir))) {
+		if(!strcmp(d->d_name,".")) continue;
+		if(!strcmp(d->d_name,"..")) continue;
+		if(!strcmp(string_back(d->d_name,4),".tmp")) continue;
+
+		char *filename = string_format("%s/files/%s",path,d->d_name);
+
+		struct ds_file *f = ds_file_create_from_file(filename);
+		if(!f) fatal("could not parse file: %s",filename);
+		hash_table_insert(m->file_table,d->d_name,f);
+
+		free(filename);
+
+		count++;
+	}
+	
+	closedir(dir);
+
+	printf("recovered %d files from %s\n",count,path);
+}
+
+void ds_db_recover_tasks( struct ds_manager *m, const char *path)
+{
+	DIR *dir;
+	struct dirent *d;
+	int count = 0;
+
+	dir = opendir(path);
+	if(!dir) fatal("couldn't opendir %s: %s",path,strerror(errno));
+
+	while((d=readdir(dir))) {
+		if(!strcmp(d->d_name,".")) continue;
+		if(!strcmp(d->d_name,"..")) continue;
+		if(!strcmp(string_back(d->d_name,4),".tmp")) continue;
+
+		char *filename = string_format("%s/tasks/%s",path,d->d_name);
+
+		struct ds_task *t = ds_task_create_from_file(filename);
+		if(!t) fatal("could not parse file: %s",filename);
+		hash_table_insert(m->task_table,d->d_name,t);
+
+		free(filename);
+		count++;
+	}
+	
+	closedir(dir);
+
+	printf("recovered %d tasks from %s\n",count,path);
+}
+
+void ds_db_recover_all( struct ds_manager *m )
+{
+	create_dir_parents(m->dbpath,0777);
+
+	char *taskpath = string_format("%s/tasks",m->dbpath);
+	char *filepath = string_format("%s/files",m->dbpath);
+
+	create_dir(taskpath,0777);
+	ds_db_recover_tasks(m,taskpath);
+
+	create_dir(filepath,0777);
+	ds_db_recover_files(m,filepath);
+
+	free(taskpath);
+	free(filepath);
+}
+
+
+

--- a/dataswarm/manager/ds_db.h
+++ b/dataswarm/manager/ds_db.h
@@ -3,6 +3,14 @@
 
 #include "ds_manager.h"
 
+/*
+Implements a trivial persistent database for tasks and files.
+At startup, all tasks and files are read into the manager hash tables.
+When a task or file is modified, call ds_db_commit_{task|file} to
+force its storage to local disk.
+*/
+
+
 void ds_db_commit_task( struct ds_manager *m, const char *taskid );
 void ds_db_commit_file( struct ds_manager *m, const char *fileid );
 

--- a/dataswarm/manager/ds_db.h
+++ b/dataswarm/manager/ds_db.h
@@ -1,0 +1,11 @@
+#ifndef DS_DB_H
+#define DS_DB_H
+
+#include "ds_manager.h"
+
+void ds_db_commit_task( struct ds_manager *m, const char *taskid );
+void ds_db_commit_file( struct ds_manager *m, const char *fileid );
+
+void ds_db_recover_all( struct ds_manager *m );
+
+#endif

--- a/dataswarm/manager/ds_file.c
+++ b/dataswarm/manager/ds_file.c
@@ -36,9 +36,22 @@ struct ds_file *ds_file_create_from_file( const char *filename )
 		return 0;
 	}
 
-	struct ds_file *f = ds_file_from_jx(j);
+	struct ds_file *f = ds_file_create_from_jx(j);
 	jx_delete(j);
 	fclose(file);
+	return f;
+}
+
+struct ds_file * ds_file_create_from_jx( struct jx *j )
+{
+	struct ds_file *f = malloc(sizeof(*f));
+
+	f->fileid = jx_lookup_string_dup(j,"file-id");
+	f->projectid = jx_lookup_string_dup(j,"project-id");
+	f->metadata = jx_lookup(j,"metadata");
+	f->size = jx_lookup_integer(j,"size");
+	f->state = jx_lookup_integer(j,"state");
+
 	return f;
 }
 
@@ -97,19 +110,6 @@ int ds_file_to_file( struct ds_file *f, const char *filename )
 	fclose(file);
 
 	return 0;
-}
-
-struct ds_file * ds_file_from_jx( struct jx *j )
-{
-	struct ds_file *f = malloc(sizeof(*f));
-
-	f->fileid = jx_lookup_string_dup(j,"file-id");
-	f->projectid = jx_lookup_string_dup(j,"project-id");
-	f->metadata = jx_lookup(j,"metadata");
-	f->size = jx_lookup_integer(j,"size");
-	f->state = jx_lookup_integer(j,"state");
-
-	return f;
 }
 
 void ds_file_delete(struct ds_file *f)

--- a/dataswarm/manager/ds_file.h
+++ b/dataswarm/manager/ds_file.h
@@ -33,7 +33,7 @@ struct ds_file {
 
 struct ds_file *ds_file_create(const char *uuid, const char *projectid, jx_int_t size, struct jx *metadata);
 struct ds_file *ds_file_create_from_file( const char *filename );
-struct ds_file *ds_file_from_jx( struct jx *j );
+struct ds_file *ds_file_create_from_jx( struct jx *j );
 
 struct jx *ds_file_to_jx(struct ds_file *file);
 int        ds_file_to_file( struct ds_file *file, const char *filename );

--- a/dataswarm/manager/ds_file.h
+++ b/dataswarm/manager/ds_file.h
@@ -32,7 +32,12 @@ struct ds_file {
 };
 
 struct ds_file *ds_file_create(const char *uuid, const char *projectid, jx_int_t size, struct jx *metadata);
+struct ds_file *ds_file_create_from_file( const char *filename );
+struct ds_file *ds_file_from_jx( struct jx *j );
+
 struct jx *ds_file_to_jx(struct ds_file *file);
+int        ds_file_to_file( struct ds_file *file, const char *filename );
+
 const char *ds_file_state_string(ds_file_state_t state);
 void ds_file_delete(struct ds_file *f);
 

--- a/dataswarm/manager/ds_ids.c
+++ b/dataswarm/manager/ds_ids.c
@@ -1,0 +1,33 @@
+#include "ds_ids.h"
+
+#include "uuid.h"
+#include "stringtools.h"
+
+char *ds_create_taskid( struct ds_manager *m )
+{
+	cctools_uuid_t uuid;
+	cctools_uuid_create(&uuid);
+	return string_format("T-%s",uuid.str);
+}
+
+char *ds_create_fileid( struct ds_manager *m )
+{
+	cctools_uuid_t uuid;
+	cctools_uuid_create(&uuid);
+	return string_format("F-%s",uuid.str);
+}
+
+char *ds_create_blobid( struct ds_manager *m )
+{
+	cctools_uuid_t uuid;
+	cctools_uuid_create(&uuid);
+	return string_format("B-%s",uuid.str);
+}
+
+char *ds_create_serviceid( struct ds_manager *m )
+{
+	cctools_uuid_t uuid;
+	cctools_uuid_create(&uuid);
+	return string_format("S-%s",uuid.str);
+}
+

--- a/dataswarm/manager/ds_ids.h
+++ b/dataswarm/manager/ds_ids.h
@@ -1,0 +1,11 @@
+#ifndef DS_IDS_H
+#define DS_IDS_H
+
+#include "ds_manager.h"
+
+char *ds_create_taskid( struct ds_manager *m );
+char *ds_create_fileid( struct ds_manager *m );
+char *ds_create_blobid( struct ds_manager *m );
+char *ds_create_serviceid( struct ds_manager *m );
+
+#endif

--- a/dataswarm/manager/ds_manager.h
+++ b/dataswarm/manager/ds_manager.h
@@ -9,11 +9,14 @@
 struct ds_manager {
 	struct hash_table *worker_table;
 	struct hash_table *client_table;
-    struct hash_table *task_table;
-    struct hash_table *file_table;
+	struct hash_table *task_table;
+	struct hash_table *file_table;
 
 	struct mq *manager_socket;
 	struct mq_poll *polling_group;
+
+	/* Path to local storage for tasks, files, etc. */
+	char *dbpath; 
 
 	int connect_timeout;
 	int stall_timeout;
@@ -31,7 +34,6 @@ struct ds_manager {
 };
 
 struct ds_manager *ds_manager_create();
-
 
 /* declares a blob in a worker so that it can be manipulated via blob rpcs. */
 struct ds_blob_rep *ds_manager_add_blob_to_worker( struct ds_manager *m, struct ds_worker_rep *r, const char *blobid);


### PR DESCRIPTION
A first pass at a simple persistence layer for the manager.
On restart, the manager loads all objects from disk.
Manipulate objects in hash tables as before.
When you complete a transaction on a task/file, then call ds_db_commit_task/file to force it to disk.
Not hooked up to anything yet.
