### PR TITLE
Work Queue Failure Only Flag

### DIFF
--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -237,8 +237,8 @@ class Task(object):
     # Add a input file to the task.
     #
     # This is just a wrapper for @ref specify_file with type set to @ref WORK_QUEUE_INPUT.
-    def specify_input_file(self, local_name, remote_name=None, flags=None, cache=None, failure_only=None):
-        return self.specify_file(local_name, remote_name, WORK_QUEUE_INPUT, flags, cache, failure_only)
+    def specify_input_file(self, local_name, remote_name=None, flags=None, cache=None):
+        return self.specify_file(local_name, remote_name, WORK_QUEUE_INPUT, flags, cache, failure_only=None)
 
     ##
     # Add a output file to the task.

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -61,8 +61,8 @@ class Task(object):
             work_queue_task_delete(self._task)
 
     @staticmethod
-    def _determine_file_flags(flags, cache):
-        # if flags is defined, use its value. Otherwise do not cache only if
+    def _determine_file_flags(flags, cache, failure_only):
+        # if flags is defined, use its value. Otherwise do not cache or failure_only only if
         # asked explicitely.
 
         if flags is None:
@@ -73,6 +73,12 @@ class Task(object):
                 flags = flags | WORK_QUEUE_CACHE
             else:
                 flags = flags & ~(WORK_QUEUE_CACHE)
+
+        if failure_only is not None:
+            if failure_only:
+                flags = flags | WORK_QUEUE_FAILURE_ONLY
+            else:
+                flags = flags & ~(WORK_QUEUE_FAILURE_ONLY)
 
         return flags
 
@@ -151,22 +157,24 @@ class Task(object):
     #                       - @ref WORK_QUEUE_NOCACHE (default)
     #                       - @ref WORK_QUEUE_CACHE
     #                       - @ref WORK_QUEUE_WATCH
-    # @param cache          Legacy parameter for setting file caching attribute. (True/False, deprecated, use the flags parameter.)
+    #                       - @ref WORK_QUEUE_FAILURE_ONLY
+    # @param cache         Whether the file should be cached at workers (True/False)
+    # @param failure_only  For output files, whether the file should be retrieved only when the task fails (e.g., debug logs).
     #
     # For example:
     # @code
     # # The following are equivalent
-    # >>> task.specify_file("/etc/hosts", type=WORK_QUEUE_INPUT, flags=WORK_QUEUE_CACHE)
-    # >>> task.specify_file("/etc/hosts", "hosts", type=WORK_QUEUE_INPUT)
+    # >>> task.specify_file("/etc/hosts", type=WORK_QUEUE_INPUT, cache = True)
+    # >>> task.specify_file("/etc/hosts", "hosts", type=WORK_QUEUE_INPUT, cache = True)
     # @endcode
-    def specify_file(self, local_name, remote_name=None, type=None, flags=None, cache=None):
+    def specify_file(self, local_name, remote_name=None, type=None, flags=None, cache=None, failure_only=None):
         if remote_name is None:
             remote_name = os.path.basename(local_name)
 
         if type is None:
             type = WORK_QUEUE_INPUT
 
-        flags = Task._determine_file_flags(flags, cache)
+        flags = Task._determine_file_flags(flags, cache, failure_only)
         return work_queue_task_specify_file(self._task, local_name, remote_name, type, flags)
 
     ##
@@ -183,18 +191,20 @@ class Task(object):
     #                       - @ref WORK_QUEUE_NOCACHE (default)
     #                       - @ref WORK_QUEUE_CACHE
     #                       - @ref WORK_QUEUE_WATCH
-    # @param cache          Legacy parameter for setting file caching attribute. (True/False, deprecated, use the flags parameter.)
+    #                       - @ref WORK_QUEUE_FAILURE_ONLY
+    # @param cache         Whether the file should be cached at workers (True/False)
+    # @param failure_only  For output files, whether the file should be retrieved only when the task fails (e.g., debug logs).
     #
     # For example:
     # @code
     # # The following are equivalent
     # >>> task.specify_file_command("my.result", "chirp_put %% chirp://somewhere/result.file", type=WORK_QUEUE_OUTPUT)
     # @endcode
-    def specify_file_command(self, remote_name, cmd, type=None, flags=None, cache=None):
+    def specify_file_command(self, remote_name, cmd, type=None, flags=None, cache=None, failure_only=None):
         if type is None:
             type = WORK_QUEUE_INPUT
 
-        flags = Task._determine_file_flags(flags, cache)
+        flags = Task._determine_file_flags(flags, cache, failure_only)
         return work_queue_task_specify_file_command(self._task, remote_name, cmd, type, flags)
 
     ##
@@ -210,30 +220,32 @@ class Task(object):
     #                       of the @ref work_queue_file_flags_t or'd together The most common are:
     #                       - @ref WORK_QUEUE_NOCACHE (default)
     #                       - @ref WORK_QUEUE_CACHE
-    # @param cache          Legacy parameter for setting file caching attribute. (True/False, deprecated, use the flags parameter.)
-    def specify_file_piece(self, local_name, remote_name=None, start_byte=0, end_byte=0, type=None, flags=None, cache=None):
+    #                       - @ref WORK_QUEUE_FAILURE_ONLY
+    # @param cache         Whether the file should be cached at workers (True/False)
+    # @param failure_only  For output files, whether the file should be retrieved only when the task fails (e.g., debug logs).
+    def specify_file_piece(self, local_name, remote_name=None, start_byte=0, end_byte=0, type=None, flags=None, cache=None, failure_only=None):
         if remote_name is None:
             remote_name = os.path.basename(local_name)
 
         if type is None:
             type = WORK_QUEUE_INPUT
 
-        flags = Task._determine_file_flags(flags, cache)
+        flags = Task._determine_file_flags(flags, cache, failure_only)
         return work_queue_task_specify_file_piece(self._task, local_name, remote_name, start_byte, end_byte, type, flags)
 
     ##
     # Add a input file to the task.
     #
     # This is just a wrapper for @ref specify_file with type set to @ref WORK_QUEUE_INPUT.
-    def specify_input_file(self, local_name, remote_name=None, flags=None, cache=None):
-        return self.specify_file(local_name, remote_name, WORK_QUEUE_INPUT, flags, cache)
+    def specify_input_file(self, local_name, remote_name=None, flags=None, cache=None, failure_only=None):
+        return self.specify_file(local_name, remote_name, WORK_QUEUE_INPUT, flags, cache, failure_only)
 
     ##
     # Add a output file to the task.
     #
     # This is just a wrapper for @ref specify_file with type set to @ref WORK_QUEUE_OUTPUT.
-    def specify_output_file(self, local_name, remote_name=None, flags=None, cache=None):
-        return self.specify_file(local_name, remote_name, WORK_QUEUE_OUTPUT, flags, cache)
+    def specify_output_file(self, local_name, remote_name=None, flags=None, cache=None, failure_only=None):
+        return self.specify_file(local_name, remote_name, WORK_QUEUE_OUTPUT, flags, cache, failure_only)
 
     ##
     # Add a directory to the task.
@@ -246,16 +258,18 @@ class Task(object):
     #                       - @ref WORK_QUEUE_NOCACHE
     #                       - @ref WORK_QUEUE_CACHE
     # @param recursive      Indicates whether just the directory (False) or the directory and all of its contents (True) should be included.
-    # @param cache          Legacy parameter for setting file caching attribute. (True/False, deprecated, use the flags parameter.)
+    #                       - @ref WORK_QUEUE_FAILURE_ONLY
+    # @param cache         Whether the file should be cached at workers (True/False)
+    # @param failure_only  For output directories, whether the file should be retrieved only when the task fails (e.g., debug logs).
     # @return 1 if the task directory is successfully specified, 0 if either of @a local_name, or @a remote_name is null or @a remote_name is an absolute path.
-    def specify_directory(self, local_name, remote_name=None, type=None, flags=None, recursive=False, cache=None):
+    def specify_directory(self, local_name, remote_name=None, type=None, flags=None, recursive=False, cache=None, failure_only=None):
         if remote_name is None:
             remote_name = os.path.basename(local_name)
 
         if type is None:
             type = WORK_QUEUE_INPUT
 
-        flags = Task._determine_file_flags(flags, cache)
+        flags = Task._determine_file_flags(flags, cache, failure_only)
         return work_queue_task_specify_directory(self._task, local_name, remote_name, type, flags, recursive)
 
     ##
@@ -265,7 +279,8 @@ class Task(object):
     # @param buffer         The contents of the buffer to pass as input.
     # @param remote_name    The name of the remote file to create.
     # @param flags          May take the same values as @ref specify_file.
-    # @param cache          Legacy parameter for setting buffer caching attribute. (True/False, deprecated, use the flags parameter.)
+    # @param cache          Whether the file should be cached at workers (True/False)
+    # @param failure_only   For output directories, whether the file should be retrieved only when the task fails (e.g., debug logs).
     def specify_buffer(self, buffer, remote_name, flags=None, cache=None):
         flags = Task._determine_file_flags(flags, cache)
         return work_queue_task_specify_buffer(self._task, buffer, len(buffer), remote_name, flags)

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1348,6 +1348,9 @@ static work_queue_result_code_t get_output_files( struct work_queue *q, struct w
 	if(t->output_files) {
 		list_first_item(t->output_files);
 		while((f = list_next_item(t->output_files))) {
+			// skip failure-only files if task succeeded
+			if(f->flags&WORK_QUEUE_FAILURE_ONLY && t->result==WORK_QUEUE_RESULT_SUCCESS && t->return_status==0) continue;
+			// otherwise, get the file.
 			result = get_output_file(q,w,t,f);
 			//if success or app-level failure, continue to get other files.
 			//if worker failure, return.

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -42,7 +42,8 @@ typedef enum {
 	WORK_QUEUE_PREEXIST = 4, /**< If the filename already exists on the host, use it in place. */
 	WORK_QUEUE_THIRDGET = 8, /**< Access the file on the client from a shared filesystem */
 	WORK_QUEUE_THIRDPUT = 8, /**< Access the file on the client from a shared filesystem (same as WORK_QUEUE_THIRDGET, included for readability) */
-	WORK_QUEUE_WATCH    = 16 /**< Watch the output file and send back changes as the task runs. */
+	WORK_QUEUE_WATCH    = 16, /**< Watch the output file and send back changes as the task runs. */
+	WORK_QUEUE_FAILURE_ONLY = 32 /**< Only return this output file if the task failed.  (Useful for returning large log files.) */
 } work_queue_file_flags_t;
 
 typedef enum {


### PR DESCRIPTION
Files marked at WORK_QUEUE_FAILURE_ONLY will only be returned if the task does not succeed.  This is handy for tasks that generate large log files at runtime.  Don't bother bringing them back if not needed.