### PR TITLE
Fixes/improvements to Python packaging

### DIFF
--- a/python_environments/python_package_analyze
+++ b/python_environments/python_package_analyze
@@ -95,6 +95,14 @@ def search_pkg(overrides, conda_env, pip_env, conda_pkgs, pip_pkgs, pkg):
         choose_dep(conda_env, pip_env, conda_pkgs, pip_pkgs, overrides[pkg])
         return
 
+    # If there's a conda/pip package with the exact name, that's
+    # probably what we want
+    try:
+        choose_dep(conda_env, pip_env, conda_pkgs, pip_pkgs, pkg)
+        return
+    except ImportError:
+        pass
+
     # See who provides the file, falling back to the literal name
     lookup = PKG_MAP.get(importlib.import_module(pkg).__file__, pkg)
     choose_dep(conda_env, pip_env, conda_pkgs, pip_pkgs, lookup)

--- a/python_environments/python_package_cache
+++ b/python_environments/python_package_cache
@@ -21,6 +21,8 @@ TAR_EXT = '.tar.gz'
 CACHEDIR = os.path.join(tempfile.gettempdir(), 'python_package-{}'.format(os.geteuid()))
 SPECS = {}
 PKGSETS = {}
+PKGSIZE = {}
+PKGMTIME = {}
 
 def jaccard(a, b):
     return 1 - float(len(a & b))/len(a | b)
@@ -71,25 +73,36 @@ def compatible(a, b):
 def load_cache():
     os.makedirs(CACHEDIR, exist_ok=True)
     for a in os.scandir(CACHEDIR):
-        name, ext = os.path.splitext(a.name)
-        if ext != '.json':
-            continue
-        with open(os.path.join(CACHEDIR, a.name)) as f:
-            s = json.load(f)
-        SPECS[name] = s
-        c, p = extract_deps(s)
-        PKGSETS[deps_to_set(c, p)] = name
+        if a.is_dir():
+            pass
+        elif a.is_file():
+            name, ext = os.path.splitext(a.name)
+            if ext != '.json':
+                continue
+            with open(os.path.join(CACHEDIR, a.name)) as f:
+                s = json.load(f)
+            SPECS[name] = s
+            c, p = extract_deps(s)
+            PKGSETS[deps_to_set(c, p)] = name
+            s = os.stat(os.path.join(CACHEDIR, a.name) + TAR_EXT)
+            PKGSIZE[name] = s.st_size
+            PKGMTIME[name] = s.st_mtime
+    sys.stderr.write(
+            'package cache contains {} env(s) totalling {} bytes\n'.format(
+                    len(SPECS), sum(PKGSIZE.values())))
 
 def find_exact(spec):
     h = hash_spec(spec)
     path = os.path.join(CACHEDIR, h + TAR_EXT)
     if os.access(path, os.R_OK):
+        sys.stderr.write('found exact match\n')
         return path
 
 def find_matching(spec):
     s = deps_to_set(*extract_deps(spec))
     hits = [x for x in PKGSETS.keys() if s.issubset(x)]
     hits.sort(key=lambda x: jaccard(s, x))
+    sys.stderr.write('found {} env(s) that satisfy requirements\n'.format(len(hits)))
     if len(hits) > 0:
         return os.path.join(CACHEDIR, PKGSETS[hits[0]] + TAR_EXT)
 
@@ -102,6 +115,7 @@ def insert(spec):
     meta.close()
 
     tarball_fd, tarball_path = tempfile.mkstemp(dir=CACHEDIR, suffix=TAR_EXT)
+    sys.stderr.write('creating new env at {}\n'.format(tarball_path))
     os.close(tarball_fd)
     subprocess.run(['python_package_create', meta_path, tarball_path],
             check=True, stdout=sys.stderr)
@@ -116,7 +130,10 @@ def merge(spec, alpha):
     candidates = [x for x in PKGSETS.keys() if compatible(x, s) and jaccard(x, s) < alpha]
     candidates.sort(key=lambda x: jaccard(s, x))
     if len(candidates) == 0:
+        sys.stderr.write('no similar envs found (max distance={})\n'.format(alpha))
         return
+    sys.stderr.write('merging with similar env (distance={})'.format(
+            jaccard(s, candidates[0])))
 
     existing = SPECS[PKGSETS[candidates[0]]]
     path = os.path.join(CACHEDIR, hash_spec(existing))

--- a/python_environments/python_package_cache
+++ b/python_environments/python_package_cache
@@ -96,6 +96,7 @@ def find_exact(spec):
     path = os.path.join(CACHEDIR, h + TAR_EXT)
     if os.access(path, os.R_OK):
         sys.stderr.write('found exact match\n')
+        os.utime(os.path.join(CACHEDIR, h + '.json'))
         return path
 
 def find_matching(spec):
@@ -104,6 +105,7 @@ def find_matching(spec):
     hits.sort(key=lambda x: jaccard(s, x))
     sys.stderr.write('found {} env(s) that satisfy requirements\n'.format(len(hits)))
     if len(hits) > 0:
+        os.utime(os.path.join(CACHEDIR, PKGSETS[hits[0]] + '.json'))
         return os.path.join(CACHEDIR, PKGSETS[hits[0]] + TAR_EXT)
 
 def insert(spec):
@@ -142,6 +144,28 @@ def merge(spec, alpha):
     insert_deps(existing, *set_to_deps(s | candidates[0]))
     return insert(existing)
 
+def delete(env):
+    prefix = os.path.join(CACHEDIR, env)
+    os.unlink(prefix + '.json')
+    os.unlink(prefix + TAR_EXT)
+    SPECS.pop(env)
+    PKGSETS.pop(env)
+    PKGMTIME.pop(env)
+    return PKGSIZE.pop(env)
+
+def shrink_cache(capacity):
+    if not capacity:
+        return
+    s = sum(PKGSIZE.keys())
+    deleted = 0
+    if s > capacity:
+        sys.stderr.write('clearing {} byte(s) from the cache\n'.format(s - capacity))
+    while s > capacity:
+        s -= delete(min(PKGSIZE, key=PKGMTIME.get))
+        deleted += 1
+    if deleted > 0:
+        sys.stderr.write('deleted {} env(s)\n'.format(deleted))
+
 def get_env(spec, approx, alpha):
     if approx or alpha > 0:
         hit = find_matching(spec)
@@ -162,10 +186,12 @@ if __name__ == '__main__':
     parser.add_argument('spec', help='Spec file, or - to read from stdin.')
     parser.add_argument('--approx', action='store_true', help='Reuse environments containing a superset of spec')
     parser.add_argument('--merge', type=float, default=0, help='Allow merging of similar environments. Implies --approx')
+    parser.add_argument('--capacity', type=int, help='Limit on cache size in bytes')
     args = parser.parse_args()
 
     spec_file = sys.stdin if args.spec == '-' else open(args.spec)
     spec = json.load(spec_file)
 
     load_cache()
+    shrink_cache(args.capacity)
     print(get_env(spec, args.approx, args.merge))

--- a/python_environments/python_package_cache
+++ b/python_environments/python_package_cache
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
 import os
+import re
 import sys
 import json
+import shutil
 import hashlib
 import tempfile
 import argparse
@@ -182,13 +184,46 @@ def get_env(spec, approx, alpha):
 
     return insert(spec)
 
+def check_context(ctx):
+    if not re.match(r'^[-a-zA-Z0-9_]+$', ctx):
+        raise ValueError('contexts must consist of alphanumerics, underscores, and dashes')
+
+def keep(path, ctx):
+    check_context(ctx)
+    prefix = os.path.join(CACHEDIR, ctx)
+    saved = os.path.join(prefix, os.path.basename(path))
+    os.makedirs(prefix, exist_ok=True)
+    try:
+        os.link(path, saved)
+    except FileExistsError:
+        pass
+    return saved
+
+def free_ctx(ctx):
+    check_context(ctx)
+    try:
+        shutil.rmtree(os.path.join(CACHEDIR, ctx))
+    except FileNotFoundError:
+        pass
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=HELP)
-    parser.add_argument('spec', help='Spec file, or - to read from stdin.')
+    parser.add_argument('spec', help='Spec file, or - to read from stdin.', nargs='?')
     parser.add_argument('--approx', action='store_true', help='Reuse environments containing a superset of spec')
     parser.add_argument('--merge', type=float, default=0, help='Allow merging of similar environments. Implies --approx')
     parser.add_argument('--capacity', type=int, help='Limit on cache size in bytes')
+    parser.add_argument('--keep', metavar='CTX', help='Protect the returned environment until the context is freed')
+    parser.add_argument('--free', metavar='CTX', help='Allow environments in the given context to be cleaned up')
     args = parser.parse_args()
+
+    if args.free:
+        if args.spec:
+            parser.error('--free must be used by itself')
+        free_ctx(args.free)
+        sys.exit(0)
+
+    if not args.spec:
+        parser.error('spec is required')
 
     spec_file = sys.stdin if args.spec == '-' else open(args.spec)
     spec = json.load(spec_file)
@@ -197,4 +232,9 @@ if __name__ == '__main__':
     if args.capacity:
         shrink_cache(args.capacity)
         load_cache()
-    print(get_env(spec, args.approx, args.merge))
+
+    out = get_env(spec, args.approx, args.merge)
+    if args.keep:
+        print(keep(out, args.keep))
+    else:
+        print(out)

--- a/python_environments/python_package_cache
+++ b/python_environments/python_package_cache
@@ -71,6 +71,10 @@ def compatible(a, b):
     return True
 
 def load_cache():
+    SPECS.clear()
+    PKGSETS.clear()
+    PKGSIZE.clear()
+    PKGMTIME.clear()
     os.makedirs(CACHEDIR, exist_ok=True)
     for a in os.scandir(CACHEDIR):
         if a.is_dir():
@@ -84,11 +88,10 @@ def load_cache():
             SPECS[name] = s
             c, p = extract_deps(s)
             PKGSETS[deps_to_set(c, p)] = name
-            s = os.stat(os.path.join(CACHEDIR, a.name) + TAR_EXT)
-            PKGSIZE[name] = s.st_size
-            PKGMTIME[name] = s.st_mtime
+            PKGSIZE[name] = os.stat(os.path.join(CACHEDIR, name) + TAR_EXT).st_size
+            PKGMTIME[name] = a.stat().st_mtime
     sys.stderr.write(
-            'package cache contains {} env(s) totalling {} bytes\n'.format(
+            'package cache contains {} env(s) totalling {} byte(s)\n'.format(
                     len(SPECS), sum(PKGSIZE.values())))
 
 def find_exact(spec):
@@ -145,23 +148,21 @@ def merge(spec, alpha):
     return insert(existing)
 
 def delete(env):
+    sys.stderr.write('deleting {}\n'.format(env))
     prefix = os.path.join(CACHEDIR, env)
     os.unlink(prefix + '.json')
     os.unlink(prefix + TAR_EXT)
-    SPECS.pop(env)
-    PKGSETS.pop(env)
     PKGMTIME.pop(env)
-    return PKGSIZE.pop(env)
+    return PKGSIZE[env]
 
 def shrink_cache(capacity):
-    if not capacity:
-        return
-    s = sum(PKGSIZE.keys())
+    sys.stdout.write('cleaning cache\n')
+    s = sum(PKGSIZE.values())
     deleted = 0
     if s > capacity:
         sys.stderr.write('clearing {} byte(s) from the cache\n'.format(s - capacity))
     while s > capacity:
-        s -= delete(min(PKGSIZE, key=PKGMTIME.get))
+        s -= delete(min(PKGMTIME, key=PKGMTIME.get))
         deleted += 1
     if deleted > 0:
         sys.stderr.write('deleted {} env(s)\n'.format(deleted))
@@ -193,5 +194,7 @@ if __name__ == '__main__':
     spec = json.load(spec_file)
 
     load_cache()
-    shrink_cache(args.capacity)
+    if args.capacity:
+        shrink_cache(args.capacity)
+        load_cache()
     print(get_env(spec, args.approx, args.merge))

--- a/python_environments/python_package_create
+++ b/python_environments/python_package_create
@@ -19,7 +19,10 @@ def pack_env(spec, out):
         print('Creating temporary environment in {}'.format(env_dir))
         subprocess.check_call(['conda', 'env', 'create', '--prefix', env_dir,
             '--file', spec])
-        conda_pack.pack(prefix=env_dir, output=out, force=True)
+        # Bug breaks bundling common packages (e.g. python).
+        # ignore_missing_files may be safe to remove in the future.
+        # https://github.com/conda/conda-pack/issues/145
+        conda_pack.pack(prefix=env_dir, output=out, force=True, ignore_missing_files=True)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
The consensus in https://github.com/conda/conda-pack/issues/145 seems to be to just add the `--ignore-missing-files` flag, so this might be a semi-permanent workaround. This means our goto advice if a packed environment is **actually** failing with missing files will need to be "try building a fresh conda environment and running from there", unfortunately.