### PR TITLE
adds WQ tasks resources display

### DIFF
--- a/dttools/src/jx_table.c
+++ b/dttools/src/jx_table.c
@@ -112,7 +112,13 @@ void jx_table_print( struct jx_table *t, struct jx *j, FILE * f, int columns_max
 		}
 		else if(t->mode == JX_TABLE_MODE_MEGABYTES) {
 			line = malloc(10);
-			string_metric(jx_lookup_integer(j,t->name), -1, line);
+			string_metric(jx_lookup_integer(j,t->name), 0, line);
+			for (int i = 0; line[i] != '\0'; i++){
+				if (line[i] == '.'){
+					line[i] = '\0';
+					break;
+				}				
+			}
 		} else {
 			int found;
 			struct jx *v = jx_lookup_guard(j,t->name,&found);

--- a/dttools/src/jx_table.c
+++ b/dttools/src/jx_table.c
@@ -109,6 +109,10 @@ void jx_table_print( struct jx_table *t, struct jx *j, FILE * f, int columns_max
 			line = malloc(10);
 			string_metric(jx_lookup_integer(j,t->name), -1, line);
 			strcat(line, "B");
+		}
+		else if(t->mode == JX_TABLE_MODE_MEGABYTES) {
+			line = malloc(10);
+			string_metric(jx_lookup_integer(j,t->name), -1, line);
 		} else {
 			int found;
 			struct jx *v = jx_lookup_guard(j,t->name,&found);

--- a/dttools/src/jx_table.h
+++ b/dttools/src/jx_table.h
@@ -7,6 +7,7 @@
 typedef enum {
 	JX_TABLE_MODE_PLAIN,
 	JX_TABLE_MODE_METRIC,
+	JX_TABLE_MODE_MEGABYTES,
 	JX_TABLE_MODE_URL
 } jx_table_mode_t;
 

--- a/work_queue/src/work_queue_status.c
+++ b/work_queue/src/work_queue_status.c
@@ -98,6 +98,9 @@ static struct jx_table manager_resource_headers[] = {
 {"cores_total", "CORES",  JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 10},
 {"memory_total","MEMORY", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 15},
 {"disk_total",  "DISK",   JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 20},
+{"tasks_total_cores", "TASKS_CORES", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 15},
+{"tasks_total_memory", "TASKS_MEMORY", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 15},
+{"tasks_total_disk", "TASKS_DISK", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 20},
 {NULL,NULL,0,0,0}
 };
 

--- a/work_queue/src/work_queue_status.c
+++ b/work_queue/src/work_queue_status.c
@@ -95,12 +95,12 @@ static struct jx_table workers_able_headers[] = {
 
 static struct jx_table manager_resource_headers[] = {
 {"project",				"MANAGER", 		JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 30},
-{"cores_total", 		"CORES",  		JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 10},
-{"tasks_total_cores",	"TASKS_CORES", 	JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 15},
-{"memory_total",		"MEMORY", 		JX_TABLE_MODE_METRIC, JX_TABLE_ALIGN_LEFT, 15},
-{"tasks_total_memory",	"TASKS_MEMORY", JX_TABLE_MODE_METRIC, JX_TABLE_ALIGN_LEFT, 15},
-{"disk_total",  		"DISK",   		JX_TABLE_MODE_METRIC, JX_TABLE_ALIGN_LEFT, 20},
-{"tasks_total_disk", 	"TASKS_DISK", 	JX_TABLE_MODE_METRIC, JX_TABLE_ALIGN_LEFT, 20},
+{"cores_total", 		"CORES",  		JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 15},
+{"tasks_total_cores",	"TASKS_CORES", 	JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 15},
+{"memory_total",		"MEMORY", 		JX_TABLE_MODE_MEGABYTES, JX_TABLE_ALIGN_RIGHT, 15},
+{"tasks_total_memory",	"TASKS_MEMORY", JX_TABLE_MODE_MEGABYTES, JX_TABLE_ALIGN_RIGHT, 15},
+{"disk_total",  		"DISK",   		JX_TABLE_MODE_MEGABYTES, JX_TABLE_ALIGN_RIGHT, 15},
+{"tasks_total_disk", 	"TASKS_DISK", 	JX_TABLE_MODE_MEGABYTES, JX_TABLE_ALIGN_RIGHT, 15},
 {NULL,NULL,0,0,0}
 };
 

--- a/work_queue/src/work_queue_status.c
+++ b/work_queue/src/work_queue_status.c
@@ -94,13 +94,13 @@ static struct jx_table workers_able_headers[] = {
 };
 
 static struct jx_table manager_resource_headers[] = {
-{"project",				"MANAGER", 		JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 30},
-{"cores_total", 		"CORES",  		JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 15},
-{"tasks_total_cores",	"TASKS_CORES", 	JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 15},
-{"memory_total",		"MEMORY", 		JX_TABLE_MODE_MEGABYTES, JX_TABLE_ALIGN_RIGHT, 15},
-{"tasks_total_memory",	"TASKS_MEMORY", JX_TABLE_MODE_MEGABYTES, JX_TABLE_ALIGN_RIGHT, 15},
-{"disk_total",  		"DISK",   		JX_TABLE_MODE_MEGABYTES, JX_TABLE_ALIGN_RIGHT, 15},
-{"tasks_total_disk", 	"TASKS_DISK", 	JX_TABLE_MODE_MEGABYTES, JX_TABLE_ALIGN_RIGHT, 15},
+{"project",			"MANAGER", 		JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 30},
+{"cores_total",		"TOTAL_CORES",  JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 20},
+{"cores_inuse",		"CORES_USED", 	JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 20},
+{"memory_total",	"TOTAL_MEMORY (MB)", JX_TABLE_MODE_MEGABYTES, JX_TABLE_ALIGN_RIGHT, 20},
+{"memory_inuse",	"MEMORY_USED (MB)", 	JX_TABLE_MODE_MEGABYTES, JX_TABLE_ALIGN_RIGHT, 20},
+{"disk_total",  	"TOTAL_DISK (MB)",  	JX_TABLE_MODE_MEGABYTES, JX_TABLE_ALIGN_RIGHT, 20},
+{"disk_inuse",		"DISK_USED (MB)", 	JX_TABLE_MODE_MEGABYTES, JX_TABLE_ALIGN_RIGHT, 20},
 {NULL,NULL,0,0,0}
 };
 

--- a/work_queue/src/work_queue_status.c
+++ b/work_queue/src/work_queue_status.c
@@ -94,13 +94,13 @@ static struct jx_table workers_able_headers[] = {
 };
 
 static struct jx_table manager_resource_headers[] = {
-{"project",     "MANAGER", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 30},
-{"cores_total", "CORES",  JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 10},
-{"memory_total","MEMORY", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 15},
-{"disk_total",  "DISK",   JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 20},
-{"tasks_total_cores", "TASKS_CORES", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 15},
-{"tasks_total_memory", "TASKS_MEMORY", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 15},
-{"tasks_total_disk", "TASKS_DISK", JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 20},
+{"project",				"MANAGER", 		JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 30},
+{"cores_total", 		"CORES",  		JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 10},
+{"tasks_total_cores",	"TASKS_CORES", 	JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT, 15},
+{"memory_total",		"MEMORY", 		JX_TABLE_MODE_METRIC, JX_TABLE_ALIGN_LEFT, 15},
+{"tasks_total_memory",	"TASKS_MEMORY", JX_TABLE_MODE_METRIC, JX_TABLE_ALIGN_LEFT, 15},
+{"disk_total",  		"DISK",   		JX_TABLE_MODE_METRIC, JX_TABLE_ALIGN_LEFT, 20},
+{"tasks_total_disk", 	"TASKS_DISK", 	JX_TABLE_MODE_METRIC, JX_TABLE_ALIGN_LEFT, 20},
 {NULL,NULL,0,0,0}
 };
 


### PR DESCRIPTION
WQ resources for tasks are now displayed when using 
`work_queue_status -R`