### PR TITLE
Check actual resources consumption in work_queue_hungry

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -6197,13 +6197,8 @@ int work_queue_hungry(struct work_queue *q)
 	}
 	
 	//check if there's any workers joined from start
-	//if there's none, wait for 5 seconds for workers to join and return true
+	//if there's none, return true
 	if (q->stats->workers_joined == 0){
-		time_t cur_time = time(NULL);
-		time_t cont_time = cur_time + 5;
-		while (cont_time > cur_time){
-			cur_time = time(NULL);
-		}
 		return 1;
 	}
 	
@@ -6231,7 +6226,7 @@ int work_queue_hungry(struct work_queue *q)
 		ready_tasks_total_disk += t->resources_allocated->disk;
 	}
 	
-	//Check limiting factors (expand features later?)
+	//Check limiting factors
 	if (ready_tasks_total_cores > workers_total_avail_cores){
 		return 0;
 	}

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -6197,47 +6197,60 @@ int work_queue_hungry(struct work_queue *q)
 	}
 	
 	//check if there's any workers joined from start
-	//if there's none, return true
+	//if there's none, limit the number of ready tasks in queue to 10
+	//ready = submitted - dispatched
+	//10 is chosen to be the default number of ready tasks in queue to keep queue efficient
 	if (q->stats->workers_joined == 0){
-		return 1;
+		if (q->stats->tasks_submitted - q->stats->tasks_dispatched < 10){
+			return 4;
+		}
+		return 0;
+	}
+	
+	//if number of ready tasks is less than 10, return true for more tasks in queue 
+	//ready = submitted - dispatched
+	//10 is chosen to be the default number of ready tasks in queue to keep queue efficient
+	if (q->stats->tasks_submitted - q->stats->tasks_dispatched < 10){
+		return 2;
 	}
 	
 	//get total available resources consumption (cores, memory, disk) of all workers of this manager
 	//available = total (all) - committed (actual in use)
-	int64_t workers_total_avail_cores = 0;
-	int64_t workers_total_avail_memory = 0;
-	int64_t workers_total_avail_disk = 0;
+	int64_t workers_total_avail_cores 	= 0;
+	int64_t workers_total_avail_memory 	= 0;
+	int64_t workers_total_avail_disk 	= 0;
 	
-	workers_total_avail_cores = q->stats->total_cores - q->stats->committed_cores;
-	workers_total_avail_memory = q->stats->total_memory - q->stats->committed_memory;
-	workers_total_avail_disk = q->stats->total_disk - q->stats->committed_disk;
+	workers_total_avail_cores 	= q->stats->total_cores - q->stats->committed_cores;
+	workers_total_avail_memory 	= q->stats->total_memory - q->stats->committed_memory;
+	workers_total_avail_disk 	= q->stats->total_disk - q->stats->committed_disk;
 
-	//get total required resources (cores, memory, disk) of the waiting tasks
-	int64_t ready_tasks_total_cores = 0;
-	int64_t ready_tasks_total_memory = 0;
-	int64_t ready_tasks_total_disk = 0;
+	//get required resources (cores, memory, disk) of one waiting task
+	int64_t ready_task_cores 	= 0;
+	int64_t ready_task_memory 	= 0;
+	int64_t ready_task_disk 	= 0;
 
 	struct work_queue_task *t;
-
-	list_first_item(q->ready_list);
-	while ((t = list_next_item(q->ready_list))){
-		ready_tasks_total_cores += t->resources_allocated->cores;
-		ready_tasks_total_memory += t->resources_allocated->memory;
-		ready_tasks_total_disk += t->resources_allocated->disk;
-	}
 	
-	//Check limiting factors
-	if (ready_tasks_total_cores > workers_total_avail_cores){
+	list_first_item(q->ready_list); 
+	t = list_next_item(q->ready_list);
+
+	ready_task_cores 	+= t->resources_allocated->cores;
+	ready_task_memory 	+= t->resources_allocated->memory;
+	ready_task_disk 	+= t->resources_allocated->disk;
+	
+	//check possible limiting factors
+	//return false if required resources exceed available resources
+	if (ready_task_cores > workers_total_avail_cores){
 		return 0;
 	}
- 	if (ready_tasks_total_memory > workers_total_avail_memory){
+ 	if (ready_task_memory > workers_total_avail_memory){
 		return 0;
 	}
-	if (ready_tasks_total_disk > workers_total_avail_disk){
+	if (ready_task_disk > workers_total_avail_disk){
 		return 0;
 	}
 
-	return 1;	//all good
+	return 3;	//all good
 }
 
 int work_queue_shut_down_workers(struct work_queue *q, int n)

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -6220,20 +6220,23 @@ int work_queue_hungry(struct work_queue *q)
 		return 1;
 	}
 	
-	//get total available resources consumption (cores, memory, disk) of all workers of this manager
+	//get total available resources consumption (cores, memory, disk, gpus) of all workers of this manager
 	//available = total (all) - committed (actual in use)
 	int64_t workers_total_avail_cores 	= 0;
 	int64_t workers_total_avail_memory 	= 0;
 	int64_t workers_total_avail_disk 	= 0;
+	int64_t workers_total_avail_gpus 	= 0;
 	
 	workers_total_avail_cores 	= q->stats->total_cores - q->stats->committed_cores;
 	workers_total_avail_memory 	= q->stats->total_memory - q->stats->committed_memory;
 	workers_total_avail_disk 	= q->stats->total_disk - q->stats->committed_disk;
+	workers_total_avail_gpus	= q->stats->total_gpus - q->stats->committed_gpus;
 
-	//get required resources (cores, memory, disk) of one waiting task
+	//get required resources (cores, memory, disk, gpus) of one waiting task
 	int64_t ready_task_cores 	= 0;
 	int64_t ready_task_memory 	= 0;
 	int64_t ready_task_disk 	= 0;
+	int64_t ready_task_gpus		= 0;
 
 	struct work_queue_task *t;
 	
@@ -6243,7 +6246,8 @@ int work_queue_hungry(struct work_queue *q)
 	ready_task_cores 	+= t->resources_allocated->cores;
 	ready_task_memory 	+= t->resources_allocated->memory;
 	ready_task_disk 	+= t->resources_allocated->disk;
-	
+	ready_task_gpus 	+= t->resources_allocated->gpus;	
+
 	//check possible limiting factors
 	//return false if required resources exceed available resources
 	if (ready_task_cores > workers_total_avail_cores){
@@ -6253,6 +6257,9 @@ int work_queue_hungry(struct work_queue *q)
 		return 0;
 	}
 	if (ready_task_disk > workers_total_avail_disk){
+		return 0;
+	}
+	if (ready_task_gpus > workers_total_avail_gpus){
 		return 0;
 	}
 

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -6194,20 +6194,13 @@ int work_queue_hungry(struct work_queue *q)
 		return 0;
 	}
 
-	//check if queue's statistics are initialized
-	//return false if not
-	if (q->stats == NULL){
-		return 0;
-	}
-	
-	//update statistics of queue
 	struct work_queue_stats qstats;
 	work_queue_get_stats(q, &qstats);
 
 	//check if there's any workers joined from start
 	//if there's none, limit the number of ready tasks in queue to 10
 	//10 is chosen to be the default number of ready tasks in queue to keep queue efficient
-	if (q->stats->workers_joined == 0){
+	if (qstats.workers_joined == 0){
 		if (qstats.tasks_waiting < 10){
 			return 1;
 		}  


### PR DESCRIPTION
The check for actual resources consumption can be improved to avoid the problem of tasks being submitted in a loop while resources are fragmented? For example, a more comprehensive check that matches specific available workers to appropriate tasks. What do you think?