### PR TITLE
WQ GPU Factory/Capacity Fixups

### DIFF
--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -702,8 +702,9 @@ int read_config_file(const char *config_file) {
 	assign_new_value(new_worker_timeout, worker_timeout, timeout, int, JX_INTEGER, integer_value)
 
 	assign_new_value(new_num_cores_option, resources->cores, cores,    int, JX_INTEGER, integer_value)
-	assign_new_value(new_num_disk_option,  resources->disk, disk,      int, JX_INTEGER, integer_value)
 	assign_new_value(new_num_memory_option, resources->memory, memory, int, JX_INTEGER, integer_value)
+	assign_new_value(new_num_disk_option,  resources->disk, disk,      int, JX_INTEGER, integer_value)
+	assign_new_value(new_num_gpus_option, resources->gpus, gpus,       int, JX_INTEGER, integer_value)
 
 	assign_new_value(new_autosize_option, autosize, autosize, int, JX_INTEGER, integer_value)
 
@@ -767,6 +768,7 @@ int read_config_file(const char *config_file) {
 	resources->cores  = new_num_cores_option;
 	resources->memory = new_num_memory_option;
 	resources->disk   = new_num_disk_option;
+	resources->gpus   = new_num_gpus_option;
 
 	if(tasks_per_worker < 1) {
 		tasks_per_worker = resources->cores > 0 ? resources->cores : 1;
@@ -821,6 +823,10 @@ int read_config_file(const char *config_file) {
 
 	if(resources->disk > -1) {
 		fprintf(stdout, "disk: %" PRId64 " MB\n", resources->disk);
+	}
+
+	if(resources->gpus > -1) {
+		fprintf(stdout, "gpus: %" PRId64 "\n", resources->gpus);
 	}
 
 	if(extra_worker_args) {

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -180,10 +180,12 @@ int manager_workers_needed_by_resource(struct jx *j) {
 	int tasks_total_cores  = jx_lookup_integer(j, "tasks_total_cores");
 	int tasks_total_memory = jx_lookup_integer(j, "tasks_total_memory");
 	int tasks_total_disk   = jx_lookup_integer(j, "tasks_total_disk");
+	int tasks_total_gpus   = jx_lookup_integer(j, "tasks_total_gpus");
 
 	const int cores = resources->cores;
 	const int memory = resources->memory;
 	const int disk = resources->disk;
+	const int gpus = resources->gpus;
 
 	int needed = 0;
 
@@ -197,6 +199,10 @@ int manager_workers_needed_by_resource(struct jx *j) {
 
 	if(disk > 0  && tasks_total_disk > 0) {
 		needed = MAX(needed, DIV_INT_ROUND_UP(tasks_total_disk, disk));
+	}
+
+	if(gpus > 0 && tasks_total_gpus > 0) {
+		needed = MAX(needed, DIV_INT_ROUND_UP(tasks_total_gpus, gpus));
 	}
 
 	return needed;
@@ -334,6 +340,10 @@ static void set_worker_resources_options( struct batch_queue *queue )
 
 		if(resources->disk > -1) {
 			buffer_printf(&b, " --disk=%" PRId64, resources->disk);
+		}
+
+		if(resources->gpus > -1) {
+			buffer_printf(&b, " --gpus=%" PRId64, resources->gpus);
 		}
 	}
 

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -137,16 +137,19 @@ int manager_workers_capacity(struct jx *j) {
 	int capacity_cores   = jx_lookup_integer(j, "capacity_cores");
 	int capacity_memory  = jx_lookup_integer(j, "capacity_memory");
 	int capacity_disk    = jx_lookup_integer(j, "capacity_disk");
+	int capacity_gpus    = jx_lookup_integer(j, "capacity_gpus");
 	int capacity_weighted = jx_lookup_integer(j, "capacity_weighted");
 
 	const int cores = resources->cores;
 	const int memory = resources->memory;
 	const int disk = resources->disk;
+	const int gpus = resources->gpus;
 
 	debug(D_WQ, "capacity_tasks: %d", capacity_tasks);
 	debug(D_WQ, "capacity_cores: %d", capacity_cores);
 	debug(D_WQ, "capacity_memory: %d", capacity_memory);
 	debug(D_WQ, "capacity_disk: %d", capacity_disk);
+	debug(D_WQ, "capacity_gpus: %d", capacity_gpus);
 
 	// first, assume one task per worker
 	int capacity = capacity_tasks;
@@ -171,6 +174,10 @@ int manager_workers_capacity(struct jx *j) {
 
 	if(disk > 0 && capacity_disk > 0) {
 		capacity = MIN(capacity, DIV_INT_ROUND_UP(capacity_disk, disk));
+	}
+
+	if(gpus > 0 && capacity_gpus > 0) {
+		capacity = MIN(capacity, DIV_INT_ROUND_UP(capacity_gpus, gpus));
 	}
 
 	return capacity;

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -2419,6 +2419,7 @@ static struct jx * queue_to_jx( struct work_queue *q, struct link *foreman_uplin
 	jx_insert_integer(j,"tasks_total_cores",total->cores);
 	jx_insert_integer(j,"tasks_total_memory",total->memory);
 	jx_insert_integer(j,"tasks_total_disk",total->disk);
+	jx_insert_integer(j,"tasks_total_gpus",total->gpus);
 
 	return j;
 }
@@ -2482,6 +2483,7 @@ static struct jx * queue_lean_to_jx( struct work_queue *q, struct link *foreman_
 	jx_insert_integer(j,"tasks_total_cores",total->cores);
 	jx_insert_integer(j,"tasks_total_memory",total->memory);
 	jx_insert_integer(j,"tasks_total_disk",total->disk);
+	jx_insert_integer(j,"tasks_total_gpus",total->gpus);
 
 	//worker information for general work_queue_status report
 	jx_insert_integer(j,"workers",info.workers_connected);

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -2382,6 +2382,7 @@ static struct jx * queue_to_jx( struct work_queue *q, struct link *foreman_uplin
 	jx_insert_integer(j,"capacity_cores",info.capacity_cores);
 	jx_insert_integer(j,"capacity_memory",info.capacity_memory);
 	jx_insert_integer(j,"capacity_disk",info.capacity_disk);
+	jx_insert_integer(j,"capacity_gpus",info.capacity_gpus);
 	jx_insert_integer(j,"capacity_instantaneous",info.capacity_instantaneous);
 	jx_insert_integer(j,"capacity_weighted",info.capacity_weighted);
 	jx_insert_integer(j,"manager_load",info.manager_load);
@@ -2475,6 +2476,7 @@ static struct jx * queue_lean_to_jx( struct work_queue *q, struct link *foreman_
 	jx_insert_integer(j,"capacity_cores",info.capacity_cores);
 	jx_insert_integer(j,"capacity_memory",info.capacity_memory);
 	jx_insert_integer(j,"capacity_disk",info.capacity_disk);
+	jx_insert_integer(j,"capacity_gpus",info.capacity_gpus);
 	jx_insert_integer(j,"capacity_weighted",info.capacity_weighted);
 	jx_insert_double(j,"manager_load",info.manager_load);
 
@@ -3448,6 +3450,7 @@ static void compute_capacity(const struct work_queue *q, struct work_queue_stats
 		capacity->resources->cores  = 1;
 		capacity->resources->memory = 512;
 		capacity->resources->disk   = 1024;
+		capacity->resources->gpus   = 0;
 
 		capacity->exec_time     = WORK_QUEUE_DEFAULT_CAPACITY_TASKS;
 		capacity->transfer_time = 1;
@@ -3468,6 +3471,7 @@ static void compute_capacity(const struct work_queue *q, struct work_queue_stats
 				capacity->resources->cores  += tr->resources ? tr->resources->cores  : 1;
 				capacity->resources->memory += tr->resources ? tr->resources->memory : 512;
 				capacity->resources->disk   += tr->resources ? tr->resources->disk   : 1024;
+				capacity->resources->gpus   += tr->resources ? tr->resources->gpus   : 0;
 			}
 		}
 
@@ -3496,6 +3500,7 @@ static void compute_capacity(const struct work_queue *q, struct work_queue_stats
 	q->stats->capacity_cores  = DIV_INT_ROUND_UP(capacity->resources->cores  * ratio, count);
 	q->stats->capacity_memory = DIV_INT_ROUND_UP(capacity->resources->memory * ratio, count);
 	q->stats->capacity_disk   = DIV_INT_ROUND_UP(capacity->resources->disk   * ratio, count);
+	q->stats->capacity_gpus   = DIV_INT_ROUND_UP(capacity->resources->gpus   * ratio, count);
 	q->stats->capacity_instantaneous = DIV_INT_ROUND_UP(capacity_instantaneous, 1);
 
 	task_report_delete(capacity);

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -248,6 +248,7 @@ struct work_queue_stats {
 	int capacity_cores;     /**< The estimated number of workers' cores that this manager can effectively support.*/
 	int capacity_memory;    /**< The estimated number of workers' MB of RAM that this manager can effectively support.*/
 	int capacity_disk;      /**< The estimated number of workers' MB of disk that this manager can effectively support.*/
+	int capacity_gpus;      /**< The estimated number of workers' GPUs that this manager can effectively support.*/
 	int capacity_instantaneous;      /**< The estimated number of tasks that this manager can support considering only the most recently completed task. */
 	int capacity_weighted;  /**< The estimated number of tasks that this manager can support placing greater weight on the most recently completed task. */
 


### PR DESCRIPTION
The WQ factory and the capacity computations did not include GPUs as a resource.  This PR fixes that.