### PR TITLE
WQ: Assign Tasks to Specific GPUs

### DIFF
--- a/makeflow/src/parser_jx.c
+++ b/makeflow/src/parser_jx.c
@@ -107,7 +107,7 @@ static int resources_from_jx(struct hash_table *h, struct jx *j, int nodeid)
 				debug(D_MAKEFLOW_PARSER, "%d memory", memory);
 				dag_variable_add_value(RESOURCES_MEMORY, h, nodeid, string_format("%d", memory));
 			}
-		} else if(!strcmp(key, "memory")) {
+		} else if(!strcmp(key, "gpus")) {
 			int gpus = jx_lookup_integer(j, "gpus");
 			if(gpus) {
 				debug(D_MAKEFLOW_PARSER, "%d gpus", gpus);

--- a/work_queue/src/Makefile
+++ b/work_queue/src/Makefile
@@ -13,7 +13,8 @@ SOURCES_LIBRARY = \
 
 SOURCES_WORKER = \
 	work_queue_process.o \
-	work_queue_watcher.o
+	work_queue_watcher.o \
+	work_queue_gpus.o
 
 PUBLIC_HEADERS = work_queue.h
 
@@ -39,7 +40,7 @@ $(PROGRAMS) $(TEST_PROGRAMS): libwork_queue.a $(EXTERNAL_DEPENDENCIES)
 
 bindings: libwork_queue.a work_queue.i $(EXTERNAL_DEPENDENCIES)
 	@$(MAKE) -C bindings
-	
+
 sge_submit_workers: sge_submit_workers_common
 	sed -e "s/SGE_CUSTOM_PARAMETERS/${CCTOOLS_SGE_PARAMETERS}/" $< > $@
 	chmod 755 $@

--- a/work_queue/src/work_queue_gpus.c
+++ b/work_queue/src/work_queue_gpus.c
@@ -87,12 +87,12 @@ char *work_queue_gpus_to_string( int taskid )
 	buffer_init(&b);
 	for(i=0;i<total_resources->gpus.total;i++) {
 		if(gpu_to_task[i]==taskid) {
-			buffer_putfstring(&b,"%d",i);
 			if(first) {
 				first = 0;
 			} else {
 				buffer_putfstring(&b,",");
 			}
+			buffer_putfstring(&b,"%d",i);
 		}
 	}
 	char *str = strdup(buffer_tostring(&b));

--- a/work_queue/src/work_queue_gpus.c
+++ b/work_queue/src/work_queue_gpus.c
@@ -1,0 +1,101 @@
+#include "work_queue_gpus.h"
+#include "work_queue_resources.h"
+#include "buffer.h"
+#include "debug.h"
+
+extern struct work_queue_resources *total_resources;
+
+/* Array tracks which task is assigned to each GPU. */
+static int *gpu_to_task = 0;
+
+/*
+Initialize the GPU tracking state.
+Note that this may be called many times,
+but should only initialized once.
+*/
+
+void work_queue_gpus_init( int ngpus )
+{
+	if(!gpu_to_task) gpu_to_task = calloc(ngpus,sizeof(int));
+}
+
+/*
+Display the GPUs associated with each task.
+*/
+
+void work_queue_gpus_debug()
+{
+	buffer_t b;
+	buffer_init(&b);
+	buffer_putfstring(&b,"GPUs Assigned: ");
+	int i;
+	for(i=0;i<total_resources->gpus.total;i++) {
+		buffer_putfstring(&b,"GPU %d: Task %d ",i,gpu_to_task[i]);
+	}
+	debug(D_WQ,"%s",buffer_tostring(&b));
+	buffer_free(&b);
+}
+
+/*
+Free all of the GPUs associated with this taskid.
+*/
+
+void work_queue_gpus_free( int taskid )
+{
+	int i;
+	for(i=0;i<total_resources->gpus.total;i++) {
+		if(gpu_to_task[i]==taskid) {
+			gpu_to_task[i] = 0;
+		}
+	}
+}
+
+/*
+Allocate n specific GPUs to the given task.
+This assumes the total number of GPUs has been
+accurately tracked: this function will fatal()
+if not enough are available.
+*/
+
+void work_queue_gpus_allocate( int n, int task )
+{
+	int i;
+	for(i=0;i<total_resources->gpus.total && n>0;i++) {
+		if(gpu_to_task[i]==0) {
+			gpu_to_task[i] = task;
+			n--;
+		}
+	}
+
+	if(n>0) fatal("work_queue_gpus_allocate: accounting error: ran out of gpus to assign!");
+
+	work_queue_gpus_debug();
+}
+
+/*
+Return a string representing the GPUs allocated to taskid.
+For example, if GPUs 1 and 3 are allocated, return "1,3"
+This string must be freed after use.
+*/
+
+char *work_queue_gpus_to_string( int taskid )
+{
+	int i;
+	int first = 1;
+	buffer_t b;
+	buffer_init(&b);
+	for(i=0;i<total_resources->gpus.total;i++) {
+		if(gpu_to_task[i]==taskid) {
+			buffer_putfstring(&b,"%d",i);
+			if(first) {
+				first = 0;
+			} else {
+				buffer_putfstring(&b,",");
+			}
+		}
+	}
+	char *str = strdup(buffer_tostring(&b));
+	buffer_free(&b);
+	return str;
+}
+

--- a/work_queue/src/work_queue_gpus.c
+++ b/work_queue/src/work_queue_gpus.c
@@ -27,11 +27,12 @@ void work_queue_gpus_debug()
 {
 	buffer_t b;
 	buffer_init(&b);
-	buffer_putfstring(&b,"GPUs Assigned: ");
+	buffer_putfstring(&b,"GPUs Assigned to Tasks: [ ");
 	int i;
 	for(i=0;i<total_resources->gpus.total;i++) {
-		buffer_putfstring(&b,"GPU %d: Task %d ",i,gpu_to_task[i]);
+		buffer_putfstring(&b,"%d ",gpu_to_task[i]);
 	}
+	buffer_putfstring(&b," ]");
 	debug(D_WQ,"%s",buffer_tostring(&b));
 	buffer_free(&b);
 }

--- a/work_queue/src/work_queue_gpus.h
+++ b/work_queue/src/work_queue_gpus.h
@@ -1,0 +1,10 @@
+#ifndef WORK_QUEUE_GPUS_H
+#define WORK_QUEUE_GPUS_H
+
+void work_queue_gpus_init( int ngpus );
+void work_queue_gpus_debug();
+void work_queue_gpus_free( int taskid );
+void work_queue_gpus_allocate( int n, int task );
+char *work_queue_gpus_to_string( int taskid );
+
+#endif

--- a/work_queue/src/work_queue_process.c
+++ b/work_queue/src/work_queue_process.c
@@ -180,6 +180,7 @@ static void specify_integer_env_var( struct work_queue_process *p, const char *n
 static void specify_resources_vars(struct work_queue_process *p) {
 	if(p->task->resources_requested->cores > 0) {
 		specify_integer_env_var(p, "CORES", p->task->resources_requested->cores);
+		specify_integer_env_var(p, "OMP_NUM_THREADS", p->task->resources_requested->cores);
 	}
 
 	if(p->task->resources_requested->memory > 0) {

--- a/work_queue/src/work_queue_process.c
+++ b/work_queue/src/work_queue_process.c
@@ -194,7 +194,7 @@ static void specify_resources_vars(struct work_queue_process *p) {
 	if(p->task->resources_requested->gpus > 0) {
 		specify_integer_env_var(p, "GPUS", p->task->resources_requested->gpus);
 		char *str = work_queue_gpus_to_string(p->task->taskid);
-		work_queue_task_specify_environment_variable(p,"CUDA_VISIBLE_DEVICES",str);
+		work_queue_task_specify_environment_variable(p->task,"CUDA_VISIBLE_DEVICES",str);
 		free(str);
 	}
 }


### PR DESCRIPTION
The worker now keeps track of which specific GPUs each task is assigned to and then sets CUDA_VISIBLE_DEVICES to match that assignment.  That will  now allow us to run multiple concurrent GPU task such that each one stays in its lane.

There is still an oddity in how the manager assigns the total number of gpus to an execution request, but I'll bring that up in a separate issue.
