### PR TITLE
WQ: Deny GPU access if not declared.

### DIFF
--- a/work_queue/src/work_queue_process.c
+++ b/work_queue/src/work_queue_process.c
@@ -196,6 +196,9 @@ static void specify_resources_vars(struct work_queue_process *p) {
 		char *str = work_queue_gpus_to_string(p->task->taskid);
 		work_queue_task_specify_environment_variable(p->task,"CUDA_VISIBLE_DEVICES",str);
 		free(str);
+	} else {
+		// If the task is not assigned to any GPUs, then inhibit GPU use.
+		specify_integer_env_var(p,"CUDA_VISIBLE_DEVICES",-1);
 	}
 }
 

--- a/work_queue/src/work_queue_process.c
+++ b/work_queue/src/work_queue_process.c
@@ -197,8 +197,12 @@ static void specify_resources_vars(struct work_queue_process *p) {
 		work_queue_task_specify_environment_variable(p->task,"CUDA_VISIBLE_DEVICES",str);
 		free(str);
 	} else {
-		// If the task is not assigned to any GPUs, then inhibit GPU use.
-		specify_integer_env_var(p,"CUDA_VISIBLE_DEVICES",-1);
+		// If the task is not assigned to any GPUs, then inhibit GPU use, but
+		// only if the worker is running in an environment where gpus have not
+		// been manually assigned.
+		if(!getenv("CUDA_VISIBLE_DEVICES")) {
+			specify_integer_env_var(p,"CUDA_VISIBLE_DEVICES",-1);
+		}
 	}
 }
 


### PR DESCRIPTION
Proposing this, but slightly concerned it could backfire.   If the manager tells the worker that gpus=0, then the worker will set CUDA_VISIBLE_DEVICES=-1 to prevent the task from using any GPUs and messing others up.

Note that the question what what the **user** tells the **manager** about resources is a little more complicated.  Currently, if the user tells the manager nothing about resources, then the manager will assign all resources (including all gpus) to the task, and this clause does not come into play.