### PR TITLE
WQ: Add simple API for fetching manager data via HTTP.

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -2665,8 +2665,8 @@ static work_queue_msg_code_t process_http_request( struct work_queue *q, struct 
 		process_queue_status(q, w, &path[1], stoptime );
 	}
 
-	// Returning failure here causes a disconnect upon return.
-	return MSG_FAILURE;
+	// Return success but require a disconnect now.
+	return MSG_PROCESSED_DISCONNECT;
 }
 
 /*
@@ -2752,8 +2752,6 @@ static work_queue_msg_code_t process_queue_status( struct work_queue *q, struct 
 
 	jx_print_link(a,l,stoptime);
 	jx_delete(a);
-
-	//remove_worker(q, target, WORKER_DISCONNECT_STATUS_WORKER);
 
 	return MSG_PROCESSED;
 }

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -2753,7 +2753,7 @@ static work_queue_msg_code_t process_queue_status( struct work_queue *q, struct 
 	jx_print_link(a,l,stoptime);
 	jx_delete(a);
 
-	return MSG_PROCESSED;
+	return MSG_PROCESSED_DISCONNECT;
 }
 
 static work_queue_msg_code_t process_resource( struct work_queue *q, struct work_queue_worker *w, const char *line )

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -2657,7 +2657,8 @@ static work_queue_msg_code_t process_http_request( struct work_queue *q, struct 
 		process_queue_status(q, w, &path[1], stoptime );
 	}
 
-	return MSG_PROCESSED;
+	// Returning failure here causes a disconnect upon return.
+	return MSG_FAILURE;
 }
 
 /*
@@ -2737,6 +2738,7 @@ static work_queue_msg_code_t process_queue_status( struct work_queue *q, struct 
 		}
 	} else {
 		debug(D_WQ, "Unknown status request: '%s'", line);
+		jx_delete(a);
 		return MSG_FAILURE;
 	}
 


### PR DESCRIPTION
Hitting the manager host and port with a web browser will give a simple data API,
and then allow you to grab task/worker/resources data via JSON, in the same
format as work_queue_status.
