### PR TITLE
Proposal for default resources

### DIFF
--- a/doc/man/md/work_queue_status.md
+++ b/doc/man/md/work_queue_status.md
@@ -129,7 +129,7 @@ The **-A** option shows a summary of the resources observed per task
 category.
 
 ```
-$ work_queue_status -T cclws16.cse.nd.edu 9001
+$ work_queue_status -A cclws16.cse.nd.edu 9001
 CATEGORY        RUNNING    WAITING  FIT-WORKERS  MAX-CORES MAX-MEMORY   MAX-DISK
 analysis            216        784           54          4      ~1011      ~3502
 merge                20         92           30         ~1      ~4021      21318

--- a/doc/manuals/work_queue/index.md
+++ b/doc/manuals/work_queue/index.md
@@ -641,8 +641,8 @@ particular worker.
 When some of the resources are left unspecified, then Work Queue tries to find
 some reasonable defaults as follows:
 
-- If no resources are specified, then a single task from the category will
-  consume a **whole worker**.
+- If no resources are specified, or all resources are specified to be 0, then a
+  single task from the category will consume a **whole worker**.
 - Unspecified gpus are always zero.
 - If a task specifies gpus, then the default cores is zero.
 - Unspecified cores, memory and disk will get a default according to the
@@ -651,7 +651,6 @@ some reasonable defaults as follows:
   disk, it will be allocated %50 of memory and disk in 4-core workers, or %25
   in 8-core workers. When more than one resource is specified, the default uses
   the largest proportion.
-- It is an error to specify all resources to 0.
 
 The current Work Queue implementation only accepts whole integers for its
 resources, which means that no worker can concurrently execute more tasks than

--- a/dttools/test/test_runner_common.sh
+++ b/dttools/test/test_runner_common.sh
@@ -95,7 +95,7 @@ run_local_worker()
 		exit 1
 	fi
 	echo "Running worker."
-	if ! "$WORK_QUEUE_WORKER" --single-shot --timeout=10s --cores 1 --memory 250 --disk 250 --debug=all --debug-file="$log" localhost $(cat "$port_file"); then
+	if ! "$WORK_QUEUE_WORKER" --single-shot --timeout=10s --cores ${cores:-1} --memory ${memory:-250} --disk ${disk:-250} --gpus ${gpus:-0} --debug=all --debug-file="$log" localhost $(cat "$port_file"); then
 		echo "ERROR: could not start worker"
 		exit 1
 	fi

--- a/work_queue/src/bindings/perl/Work_Queue.pm
+++ b/work_queue/src/bindings/perl/Work_Queue.pm
@@ -1145,11 +1145,11 @@ Hash reference indicating minimum values. See @resources_measured for possible f
 
 A minimum of 2 cores is found on any worker:
 
-		q->specify_min_resources({'cores' => 2});
+		$q->specify_min_resources({'cores' => 2});
 
 A minimum of 4 cores, 1GB of memory, and 10GB disk are found on any worker:
 
-		q->specify_min_resources({'cores' => 4, 'memory' => 1024, 'disk' => 10240});
+		$q->specify_min_resources({'cores' => 4, 'memory' => 1024, 'disk' => 10240});
 
 
 =head3 C<specify_category_max_resources>
@@ -1168,11 +1168,11 @@ Hash reference indicating maximum values. See @resources_measured for possible f
 
 A maximum of 4 cores is found on any worker:
 
-		q->specify_category_max_resources('my_category', {'cores' => 4});
+		$q->specify_category_max_resources('my_category', {'cores' => 4});
 
 A maximum of 8 cores, 1GB of memory, and 10GB disk are found on any worker:
 
-		q->specify_category_max_resources('my_category', {'cores' => 8, 'memory' => 1024, 'disk' => 10240});
+		$q->specify_category_max_resources('my_category', {'cores' => 8, 'memory' => 1024, 'disk' => 10240});
 
 
 =head3 C<specify_category_min_resources>

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4315,9 +4315,6 @@ struct work_queue_task *work_queue_task_create(const char *command_line)
 	t->resources_measured  = rmsummary_create(-1);
 	t->resources_allocated = rmsummary_create(-1);
 
-	/* Default gpus are 0, rather than whole workers: */
-	t->resources_requested->gpus = 0;
-
 	t->category = xxstrdup("default");
 
 	return t;

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -3358,12 +3358,6 @@ static work_queue_result_code_t send_input_files( struct work_queue *q, struct w
 	return WQ_SUCCESS;
 }
 
-/* if max defined, use minimum of max or largest worker
- * else if min is less than largest, chose largest, otherwise 'infinity' */
-#define task_worker_box_size_resource(w, min, max, field)\
-	( max->field  >  -1 ? max->field :\
-	  min->field <= w->resources->field.largest ? w->resources->field.largest : w->resources->field.largest + 1 )
-
 static struct rmsummary *task_worker_box_size(struct work_queue *q, struct work_queue_worker *w, struct work_queue_task *t) {
 
 	const struct rmsummary *min = task_min_resources(q, t);
@@ -3373,10 +3367,91 @@ static struct rmsummary *task_worker_box_size(struct work_queue *q, struct work_
 
 	rmsummary_merge_override(limits, max);
 
-	limits->cores  = task_worker_box_size_resource(w, min, max, cores);
-	limits->memory = task_worker_box_size_resource(w, min, max, memory);
-	limits->disk   = task_worker_box_size_resource(w, min, max, disk);
-	limits->gpus   = task_worker_box_size_resource(w, min, max, gpus);
+	int use_whole_worker = 1;
+
+	struct category *c = work_queue_category_lookup_or_create(q, t->category);
+	if(c->allocation_mode == CATEGORY_ALLOCATION_MODE_FIXED) {
+		double max_proportion = -1;
+		if(w->resources->cores.largest > 0) {
+			max_proportion = MAX(max_proportion, limits->cores / w->resources->cores.largest);
+		}
+
+		if(w->resources->memory.largest > 0) {
+			max_proportion = MAX(max_proportion, limits->memory / w->resources->memory.largest);
+		}
+
+		if(w->resources->disk.largest > 0) {
+			max_proportion = MAX(max_proportion, limits->disk / w->resources->disk.largest);
+		}
+
+		if(w->resources->gpus.largest > 0) {
+			max_proportion = MAX(max_proportion, limits->gpus / w->resources->gpus.largest);
+		}
+
+		if(max_proportion > 0) {
+			use_whole_worker = 0;
+			/* when cores are unspecified, they are set to 0 if gpus are specified.
+			 * Otherwise they get a proportion according to specified
+			 * resources. Tasks will get at least one core. */
+			if(limits->cores < 0) {
+				if(limits->gpus > 0) {
+					limits->cores = 0;
+				} else {
+					limits->cores = MAX(1, floor(w->resources->cores.largest * max_proportion));
+				}
+			}
+
+			if(limits->gpus < 0) {
+				/* unspecified gpus are always 0 */
+				limits->gpus = 0;
+			}
+
+			if(limits->memory < 0) {
+				limits->memory = MAX(1, floor(w->resources->memory.largest * max_proportion));
+			}
+
+			if(limits->disk < 0) {
+				limits->disk = MAX(1, floor(w->resources->disk.largest * max_proportion));
+			}
+		}
+	}
+
+	if(limits->cores < 1 && limits->gpus < 1 && limits->memory < 1 && limits->disk < 1) {
+		/* no resource was specified, using whole worker */
+		use_whole_worker = 1;
+	}
+
+	if((limits->cores > 0 && limits->cores >= w->resources->cores.largest) ||
+			(limits->gpus > 0 && limits->gpus >= w->resources->gpus.largest) ||
+			(limits->memory > 0 && limits->memory >= w->resources->memory.largest) ||
+			(limits->disk > 0 && limits->disk >= w->resources->disk.largest)) {
+		/* at least one specified resource would use the whole worker, thus
+		 * using whole worker for all unspecified resources. */
+		use_whole_worker = 1;
+	}
+
+	if(use_whole_worker) {
+		/* default cores for tasks that define gpus is 0 */
+		if(limits->cores <= 0) {
+			limits->cores = limits->gpus > 0 ? 0 : w->resources->cores.largest;
+		}
+
+		/* default gpus is 0 */
+		if(limits->gpus <= 0) {
+			limits->gpus = 0;
+		}
+
+		if(limits->memory <= 0) {
+			limits->memory = w->resources->memory.largest;
+		}
+
+		if(limits->disk <= 0) {
+			limits->disk = w->resources->disk.largest;
+		}
+	}
+
+	/* never go below specified min resources. */
+	rmsummary_merge_max(limits, min);
 
 	return limits;
 }

--- a/work_queue/test/TR_work_queue_allocations.sh
+++ b/work_queue/test/TR_work_queue_allocations.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+set -e
+
+. ../../dttools/test/test_runner_common.sh
+
+python=${CCTOOLS_PYTHON_TEST_EXEC}
+python_dir=${CCTOOLS_PYTHON_TEST_DIR}
+
+STATUS_FILE=wq.status
+PORT_FILE=wq.port
+
+
+check_needed()
+{
+	[ -n "${python}" ] || return 1
+}
+
+prepare()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+
+	return 0
+}
+
+run()
+{
+	# worker resources (used by run_local_worker):
+	cores=4
+	memory=200
+	disk=200
+	gpus=8
+
+	echo $(pwd) ${python}
+
+	# send makeflow to the background, saving its exit status.
+	(PYTHONPATH=$(pwd)/../src/bindings/${python_dir} ${python} wq_alloc_test.py $PORT_FILE $cores $memory $disk $gpus; echo $? > $STATUS_FILE) &
+
+	# wait at most 5 seconds for makeflow to find a port.
+	wait_for_file_creation $PORT_FILE 2
+
+	run_local_worker $PORT_FILE worker.log
+
+	# wait for wq script to exit.
+	wait_for_file_creation $STATUS_FILE 5
+
+	# retrieve wq script exit status
+	status=$(cat $STATUS_FILE)
+	if [ $status -ne 0 ]
+	then
+		exit 1
+	fi
+
+	exit 0
+}
+
+clean()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+
+	rm -rf input.file
+	rm -rf output.file
+	rm -rf executable.file
+	rm -rf testdir
+
+	exit 0
+}
+
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/work_queue/test/wq_alloc_test.py
+++ b/work_queue/test/wq_alloc_test.py
@@ -1,0 +1,103 @@
+#! /usr/bin/env python
+
+# work queue python binding tests
+# tests for missing/recursive inputs/outputs.
+
+import sys
+import work_queue as wq
+
+def check_task(category, category_mode, max, min, expected):
+    q.specify_category_max_resources(category, max)
+    q.specify_category_min_resources(category, min)
+    q.specify_category_mode(category, category_mode)
+
+    t = wq.Task('/bin/echo hello')
+    t.specify_category(category)
+    q.submit(t)
+
+    t = q.wait(5)
+    if not t:
+        print("Task did not complete in the allotted time.")
+        sys.exit(1)
+    else:
+        print("{}:".format(category))
+        print("expected: {}".format(expected))
+        print("allocated: {}".format({
+            'cores': t.resources_allocated.cores,
+            'memory': t.resources_allocated.memory,
+            'disk': t.resources_allocated.disk,
+            'gpus': t.resources_allocated.gpus}))
+
+        assert(t.resources_allocated.cores == expected['cores'])
+        assert(t.resources_allocated.memory == expected['memory'])
+        assert(t.resources_allocated.disk == expected['disk'])
+        assert(t.resources_allocated.gpus == expected['gpus'])
+
+
+port_file = None
+try:
+    port_file = sys.argv[1]
+    (worker_cores, worker_memory, worker_disk, worker_gpus) = (int(sys.argv[i]) for i in range(2,6))
+except IndexError:
+    sys.stderr.write("Usage: {} PORTFILE WORKER_CORES WORKER_MEMORY WORKER_DISK\n".format(sys.argv[0]))
+
+
+q = wq.WorkQueue(0)
+with open(port_file, 'w') as f:
+    print('Writing port {port} to file {file}'.format(port=q.port, file=port_file))
+    f.write(str(q.port))
+
+print(wq.__file__)
+
+r = {'cores': 1, 'memory': 2, 'disk': 3, 'gpus': 4}
+check_task('all_specified', wq.WORK_QUEUE_ALLOCATION_MODE_FIXED, max = r, min = {}, expected = r)
+
+check_task('all_specified_no_gpu',
+        wq.WORK_QUEUE_ALLOCATION_MODE_FIXED,
+        max = {'cores': 1, 'memory': 2, 'disk': 3},
+        min = {},
+        expected = {'cores': 1, 'memory': 2, 'disk': 3, 'gpus': 0})
+
+check_task('all_specified_no_cores',
+        wq.WORK_QUEUE_ALLOCATION_MODE_FIXED,
+        max = {'gpus': 4, 'memory': 2, 'disk': 3},
+        min = {},
+        expected = {'cores': 0, 'memory': 2, 'disk': 3, 'gpus': 4})
+
+check_task('all_zero',
+        wq.WORK_QUEUE_ALLOCATION_MODE_FIXED,
+        max = {'cores': 0, 'memory': 0, 'disk': 0, 'gpus': 0},
+        min = {},
+        expected = {'cores': worker_cores, 'memory': worker_memory, 'disk': worker_disk, 'gpus': 0})
+
+check_task('only_memory',
+        wq.WORK_QUEUE_ALLOCATION_MODE_FIXED,
+        max = {'memory': worker_memory/2},
+        min = {},
+        expected = {'cores': worker_cores/2, 'memory': worker_memory/2, 'disk': worker_disk/2, 'gpus': 0})
+
+check_task('only_cores',
+        wq.WORK_QUEUE_ALLOCATION_MODE_FIXED,
+        max = {'cores': worker_cores},
+        min = {},
+        expected = {'cores': worker_cores, 'memory': worker_memory, 'disk': worker_disk, 'gpus': 0})
+
+check_task('only_memory_w_minimum',
+        wq.WORK_QUEUE_ALLOCATION_MODE_FIXED,
+        max = {'memory': worker_memory/2},
+        min = {'cores': 3, 'gpus': 2},
+        expected = {'cores': 3, 'memory': worker_memory/2, 'disk': worker_disk/2, 'gpus': 2})
+
+check_task('auto_whole_worker',
+        wq.WORK_QUEUE_ALLOCATION_MODE_MIN_WASTE,
+        max = {},
+        min = {},
+        expected = {'cores': worker_cores, 'memory': worker_memory, 'disk': worker_disk, 'gpus': 0})
+
+q.specify_category_first_allocation_guess('auto_with_guess', {'cores': 1, 'memory': 2, 'disk': 3})
+check_task('auto_with_guess',
+        wq.WORK_QUEUE_ALLOCATION_MODE_MIN_WASTE,
+        max = {},
+        min = {},
+        expected = {'cores': 1, 'memory': 2, 'disk': 3, 'gpus': 0})
+


### PR DESCRIPTION
In summary:
- default not specified gpus are 0.
- In fixed mode (the default) cores, memory and disk not specified get a value proportional to the resources specified, rounded, and taking the max if more than one of cores, memory, disk or **gpus** are specified.
- Not specifying anything gets you the whole worker.
- Specifying everything to 0 uses the whole worker.

Nothing is implemented, this is an update to the wq manual with the proposed changes.