### PR TITLE
adds a nightly ubuntu build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,40 @@
+on:
+  workflow_dispatch:
+    branches:
+      - master
+    schedule:
+      - cron: '5 0 * * *' # build every day at 12:05AM
+
+name: Nightly build
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    container: ${{ format('cclnd/cctools-env:x86_64-{0}', matrix.os-name) }}
+    timeout-minutes: 30
+    env:
+      CCTOOLS_OUTPUT: ${{ format('cctools-{0}-x86_64-{1}.tar.gz', 'nightly', matrix.os-name) }}
+      CCTOOLS_DOCKER_GITHUB: yes
+    strategy: 
+      matrix:
+        os-name: ['ubuntu20.04']
+    steps:
+      - name: checkout CCTools from main head
+        uses: actions/checkout@v2
+      - name: build
+        run: ${GITHUB_WORKSPACE}/packaging/scripts/build.sh
+      - name: deploy
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: /tmp/${{ env.CCTOOLS_OUTPUT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          allowUpdates: true
+          artifactContentType: application/gzip
+          draft: false
+          omitBody: true
+          omitBodyDuringUpdate: true
+          prerelease: true
+          replacesArtifacts: true
+          commit: HEAD
+          tag: nightly-build
+


### PR DESCRIPTION
The idea is to generate binaries (e.g. parrot with cvmfs and bxgrid)
that we can test in the cctools-packaging-test.