### PR TITLE
wq: add API call to translate task result from integer to string

### DIFF
--- a/work_queue/src/bindings/perl/Work_Queue/Task.pm
+++ b/work_queue/src/bindings/perl/Work_Queue/Task.pm
@@ -315,6 +315,11 @@ sub result {
 	return $self->{_task}->{result};
 }
 
+sub result_str {
+	my ($self) = @_;
+	return work_queuec::work_queue_result_str($self->{_task}->{result});
+}
+
 sub total_submissions {
 	my ($self) = @_;
 	return $self->{_task}->{total_submissions};
@@ -1017,9 +1022,13 @@ after the task completes execution.
 
 =head3 C<result>
 
-Get the result of the task (successful, failed return_status, missing input file, missing output file).
+Get the result of the task as in integer (successful, failed return_status, missing input file, missing output file).
 
 Must be called only after the task completes execution.
+
+=head3 C<result_str>
+
+Returns a string that explains the result of a task. (SUCCESS, INPUT_MISS, OUTPUT_MISS, etc.)
 
 =head3 C<total_submissions>
 

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -488,17 +488,31 @@ class Task(object):
         return self._task.return_status
 
     ##
-    # Get the result of the task, such as successful, missing file, etc.
+    # Get the result of the task as an integer code, such as successful, missing file, etc.
     # See @ref work_queue_result_t for possible values.  Must be called only
     # after the task completes execution.
     # @a Note: This is defined using property decorator. So it must be called without parentheses
     # (). For example:
     # @code
     # >>> print t.result
+    # 0
     # @endcode
     @property
     def result(self):
         return self._task.result
+
+    ##
+    # Return a string that explains the result of a task.
+    # Must be called only after the task completes execution.
+    # @a Note: This is defined using property decorator. So it must be called without parentheses
+    # (). For example:
+    # @code
+    # >>> print t.result_str
+    # 'SUCCESS'
+    # @endcode
+    @property
+    def result_str(self):
+        return work_queue_result_str(self._task.result)
 
     ##
     # Get the number of times the task has been resubmitted internally.

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -279,7 +279,6 @@ static void push_task_to_ready_list( struct work_queue *q, struct work_queue_tas
 static work_queue_task_state_t change_task_state( struct work_queue *q, struct work_queue_task *t, work_queue_task_state_t new_state);
 
 const char *task_state_str(work_queue_task_state_t state);
-const char *task_result_str(work_queue_result_t result);
 
 /* 1, 0 whether t is in state */
 static int task_state_is( struct work_queue *q, uint64_t taskid, work_queue_task_state_t state);
@@ -5847,7 +5846,7 @@ static int task_in_terminal_state(struct work_queue *q, struct work_queue_task *
 	return 0;
 }
 
-const char *task_result_str(work_queue_result_t result) {
+const char *work_queue_result_str(work_queue_result_t result) {
 	const char *str;
 
 	switch(result) {
@@ -7002,7 +7001,7 @@ static void write_transaction_task(struct work_queue *q, struct work_queue_task 
 	} else if(state == WORK_QUEUE_TASK_CANCELED) {
 			/* do not add any info */
 	} else if(state == WORK_QUEUE_TASK_RETRIEVED || state == WORK_QUEUE_TASK_DONE) {
-		buffer_printf(&B, " %s ", task_result_str(t->result));
+		buffer_printf(&B, " %s ", work_queue_result_str(t->result));
 		buffer_printf(&B, " %d ", t->return_status);
 
 		if(t->resources_measured) {

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -1073,6 +1073,12 @@ void work_queue_specify_category_first_allocation_guess(struct work_queue *q,  c
 void work_queue_initialize_categories(struct work_queue *q, struct rmsummary *max, const char *summaries_file);
 
 
+/** Explain result codes from tasks.
+@param result Result from a task returned by @ref work_queue_wait.
+@return String representation of task result code.
+*/
+const char *work_queue_result_str(work_queue_result_t result);
+
 //@}
 
 /** @name Functions - Deprecated */

--- a/work_queue/test/wq_test.py
+++ b/work_queue/test/wq_test.py
@@ -21,45 +21,6 @@ def cleanup():
     shutil.rmtree(test_dir)
 atexit.register(cleanup)
 
-def result_to_string(result):
-    if result == wq.WORK_QUEUE_RESULT_SUCCESS:
-        return 'success'
-
-    if result == wq.WORK_QUEUE_RESULT_INPUT_MISSING:
-        return 'input missing'
-
-    if result == wq.WORK_QUEUE_RESULT_OUTPUT_MISSING:
-        return 'output missing'
-
-    if result == wq.WORK_QUEUE_RESULT_SIGNAL:
-        return 'signal'
-
-    if result == wq.WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION:
-        return 'resource exhaustion'
-
-    if result == wq.WORK_QUEUE_RESULT_TASK_TIMEOUT:
-        return 'resource exhaustion'
-
-    if result == wq.WORK_QUEUE_RESULT_UNKNOWN:
-        return 'unknown'
-
-    if result == wq.WORK_QUEUE_RESULT_FORSAKEN:
-        return 'forsaken'
-
-    if result == wq.WORK_QUEUE_RESULT_MAX_RETRIES:
-        return 'maximum retries'
-
-    if result == wq.WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME:
-        return 'maximum runtime'
-
-    if result == wq.WORK_QUEUE_RESULT_DISK_ALLOC_FULL:
-        return 'disk allocation full'
-
-    if result == wq.WORK_QUEUE_RESULT_RMONITOR_ERROR:
-        return 'resource monitor error'
-
-    return 'invalid result'
-
 def report_task(task, expected_result, expected_exit_code, expected_outpus=None):
     error = False
     print("\nTask '{command}' report:".format(command=t.command))
@@ -67,13 +28,13 @@ def report_task(task, expected_result, expected_exit_code, expected_outpus=None)
         error = True
         print("It was not completed by a worker.")
     else:
-        print("result: {result}".format(result=result_to_string(t.result)))
+        print("result: {as_str} {as_int}".format(as_str=t.result_str, as_int=t.result))
         print("exit code: {status}".format(status=t.return_status))
         if t.output:
             print("stderr:\n+++\n{stderr}---".format(stderr=t.output))
         if task.result != expected_result:
             error = True
-            print("Should have finished with result '{result}', but got '{real}'.".format(result=result_to_string(expected_result), real=result_to_string(task.result)))
+            print("Should have finished with result '{result}', but got '{real}'.".format(result=expected_result, real=task.result))
         elif task.return_status != expected_exit_code:
             error = True
             print("Should have finished with exit_code {status}, but got {real}.".format(status=str(expected_exit_code), real=str(task.return_status)))


### PR DESCRIPTION
This like a perror but for work_queue_result_task_t. For debugging and user interaction it is more helpful to see for example a 'INPUT_MISS" rather than the integer 1.