### PR TITLE
WQ: Add Minimum Time as a Resource

### DIFF
--- a/doc/manuals/work_queue/index.md
+++ b/doc/manuals/work_queue/index.md
@@ -616,15 +616,19 @@ Both memory and disk are specified in `MB`.
 
 ### Specifying Task Resources
 
-To run several task in a worker, every task must have a description of the
-resources it uses, in terms of cores, memory, disk, and gpus. These resources
-can be specified as in the following example:
+To run several tasks in a worker, every task must have a description of the
+resources it uses, in terms of cores, memory, disk, and gpus. While time is 
+not exactly a type of resource, specifying the running time of tasks can 
+often be helpful to map tasks to workers. These resources can be specified 
+as in the following example:
 
 ```python
-t.specify_cores(1)      # task needs one core
-t.specify_memory(1024)  # task needs 1024 MB of memory
-t.specify_disk(4096)    # task needs 4096 MB of disk space
-t.specify_gpus(0)       # task does not need a gpu
+t.specify_cores(1)                     # task needs one core
+t.specify_memory(1024)                 # task needs 1024 MB of memory
+t.specify_disk(4096)                   # task needs 4096 MB of disk space
+t.specify_gpus(0)                      # task does not need a gpu
+t.specify_running_time_max(100000000)  # task is allowed to run in 100 seconds
+t.specify_running_time_min(10000000)   # task needs at least 10 seconds to run
 ```
 
 ```perl
@@ -632,11 +636,17 @@ $t->specify_cores(1)      # task needs one core
 $t->specify_memory(1024)  # task needs 1024 MB of memory
 $t->specify_disk(4096)    # task needs 4096 MB of disk space
 $t->specify_gpus(0)       # task does not need a gpu
+#specifying running time is not yet supported in perl
 ```
 
 When all cores, memory, and disk are specified, Work Queue will simply fit as
 many tasks as possible without going above the resources available at a
-particular worker.
+particular worker. When the maximum running time is specified, Work Queue will
+kill any task that has its running time is higher than the maximum running 
+time. The minimum running time, if specified, helps Work Queue decide which 
+worker best fits which task. Specifying tasks' running time is especially 
+helpful in clusters where workers may have a hard threshold of their running 
+time.
 
 When some of the resources are left unspecified, then Work Queue tries to find
 some reasonable defaults as follows:

--- a/doc/manuals/work_queue/index.md
+++ b/doc/manuals/work_queue/index.md
@@ -642,11 +642,10 @@ $t->specify_gpus(0)       # task does not need a gpu
 When all cores, memory, and disk are specified, Work Queue will simply fit as
 many tasks as possible without going above the resources available at a
 particular worker. When the maximum running time is specified, Work Queue will
-kill any task that has its running time is higher than the maximum running 
-time. The minimum running time, if specified, helps Work Queue decide which 
-worker best fits which task. Specifying tasks' running time is especially 
-helpful in clusters where workers may have a hard threshold of their running 
-time.
+kill any task that exceeds their maximum running time. The minimum running time, 
+if specified, helps Work Queue decide which worker best fits which task. 
+Specifying tasks' running time is especially helpful in clusters where workers 
+may have a hard threshold of their running time.
 
 When some of the resources are left unspecified, then Work Queue tries to find
 some reasonable defaults as follows:

--- a/doc/manuals/work_queue/index.md
+++ b/doc/manuals/work_queue/index.md
@@ -642,7 +642,7 @@ $t->specify_gpus(0)       # task does not need a gpu
 When all cores, memory, and disk are specified, Work Queue will simply fit as
 many tasks as possible without going above the resources available at a
 particular worker. When the maximum running time is specified, Work Queue will
-kill any task that exceeds their maximum running time. The minimum running time, 
+kill any task that exceeds its maximum running time. The minimum running time, 
 if specified, helps Work Queue decide which worker best fits which task. 
 Specifying tasks' running time is especially helpful in clusters where workers 
 may have a hard threshold of their running time.

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -401,13 +401,13 @@ class Task(object):
     # This is useful, for example, when the task uses certificates that expire.
     # If less than 1, or not specified, no limit is imposed.
     def specify_end_time(self, useconds):
-        return work_queue_task_specify_end_time(self._task, useconds)
+        return work_queue_task_specify_end_time(self._task, int(useconds))
 
     # Indicate the maximum running time for a task in a worker (relative to
     # when the task starts to run).  If less than 1, or not specified, no limit
     # is imposed.
     def specify_running_time(self, useconds):
-        return work_queue_task_specify_running_time(self._task, useconds)
+        return work_queue_task_specify_running_time(self._task, int(useconds))
 
     ##
     # Set this environment variable before running the task.

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -409,6 +409,19 @@ class Task(object):
     def specify_running_time(self, useconds):
         return work_queue_task_specify_running_time(self._task, int(useconds))
 
+    # Indicate the maximum running time for a task in a worker (relative to
+    # when the task starts to run).  If less than 1, or not specified, no limit
+    # is imposed.
+    # Note: same effect as specify_running_time for backwards compatibility
+    def specify_running_time_max(self, useconds):
+        return work_queue_task_specify_running_time_max(self._task, int(useconds))
+
+    # Indicate the minimum running time for a task in a worker (relative to
+    # when the task starts to run).  If less than 1, or not specified, no limit
+    # is imposed.
+    def specify_running_time_min(self, useconds):
+        return work_queue_task_specify_running_time_min(self._task, int(useconds))
+
     ##
     # Set this environment variable before running the task.
     # If value is None, then variable is unset.

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -244,7 +244,7 @@ struct work_queue_worker {
 	timestamp_t start_time;
 	timestamp_t last_msg_recv_time;
 	timestamp_t last_update_msg_time;
-	long long int end_time;
+	int64_t end_time;
 };
 
 struct work_queue_task_report {
@@ -636,7 +636,7 @@ work_queue_msg_code_t process_info(struct work_queue *q, struct work_queue_worke
 		w->workerid = xxstrdup(value);
 		write_transaction_worker(q, w, 0, 0);
 	} else if(string_prefix_is(field, "worker-end-time")) {
-		w->end_time = atoll(value);	
+		w->end_time = MAX(0, atoll(value));
 	}
 
 	//Note we always mark info messages as processed, as they are optional.
@@ -1035,6 +1035,7 @@ static void add_worker(struct work_queue *q)
 	w->current_tasks_boxes = itable_create(0);
 	w->finished_tasks = 0;
 	w->start_time = timestamp_get();
+	w->end_time = -1;
 
 	w->last_update_msg_time = w->start_time;
 

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -3719,6 +3719,11 @@ static int check_hand_against_task(struct work_queue *q, struct work_queue_worke
 	if(w->resources->gpus.inuse + limits->gpus > overcommitted_resource_total(q, w->resources->gpus.total, 0)) {
 		ok = 0;
 	}
+		
+	//if the wall time for the worker is specified and there's not enough time for the task, then not ok
+	if(w->resources->time_left != -1 && w->resources->time_left < t->resources_requested->wall_time){
+		ok = 0;
+	}
 
 	rmsummary_delete(limits);
 

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4591,20 +4591,20 @@ void work_queue_task_specify_running_time( struct work_queue_task *t, int64_t us
 	}
 }
 
-void work_queue_task_specify_running_time_max( struct work_queue_task *t, int64_t useconds )
+void work_queue_task_specify_running_time_max( struct work_queue_task *t, int64_t seconds )
 {
-	work_queue_task_specify_running_time(t, useconds);
+	work_queue_task_specify_running_time(t, 1000000*seconds); 	//convert to useconds for backward compat
 }
 
-void work_queue_task_specify_running_time_min( struct work_queue_task *t, int64_t useconds )
+void work_queue_task_specify_running_time_min( struct work_queue_task *t, int64_t seconds )
 {
-	if(useconds < 1)
+	if(seconds < 1)
 	{
 		t->min_running_time = -1;
 	}
 	else
 	{
-		t->min_running_time = useconds;
+		t->min_running_time = 1000000*seconds;					//convert to useconds for backward compat
 	}	
 }
 

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -3731,10 +3731,10 @@ static int check_hand_against_task(struct work_queue *q, struct work_queue_worke
 
 	//if wall time for worker is specified and there's not enough time for task, then not ok
 	if(w->end_time > 0){
-		if(t->resources_requested->wall_time > 0 && w->end_time < timestamp_get() + t->resources_requested->wall_time){
+		if(t->resources_requested->wall_time > 0 && ((uint64_t) w->end_time) < timestamp_get() + t->resources_requested->wall_time){
 			ok = 0;
 		}
-		if(t->resources_requested->end > 0 && w->end_time < t->resources_requested->end) {
+		if(t->resources_requested->end > 0 && ((uint64_t) w->end_time) < t->resources_requested->end) {
 			ok = 0;
 		}
 	}

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -3723,22 +3723,21 @@ static int check_hand_against_task(struct work_queue *q, struct work_queue_worke
 	if(w->resources->gpus.inuse + limits->gpus > overcommitted_resource_total(q, w->resources->gpus.total, 0)) {
 		ok = 0;
 	}
-	
-	//if worker's end time is unreceived(= 0)
-	if(w->end_time == 0){
+
+	//if worker's end time has not been received
+	if(w->end_time < 0){
 		ok = 0;
 	}
-		
+
 	//if wall time for worker is specified and there's not enough time for task, then not ok
 	if(w->end_time > 0){
-		//wall time of task is in micro-seconds, so must be divided by 1000000
-		if(t->resources_requested->wall_time > 0 && w->end_time < time(0) + t->resources_requested->wall_time/1000000){
+		if(t->resources_requested->wall_time > 0 && w->end_time < timestamp_get() + t->resources_requested->wall_time){
 			ok = 0;
 		}
 		if(t->resources_requested->end > 0 && w->end_time < t->resources_requested->end) {
 			ok = 0;
 		}
-	} 
+	}
 
 	rmsummary_delete(limits);
 

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -3722,18 +3722,22 @@ static int check_hand_against_task(struct work_queue *q, struct work_queue_worke
 	if(w->resources->gpus.inuse + limits->gpus > overcommitted_resource_total(q, w->resources->gpus.total, 0)) {
 		ok = 0;
 	}
+	
+	//if worker's end time is unreceived(= 0)
+	if(w->end_time == 0){
+		ok = 0;
+	}
 		
 	//if wall time for worker is specified and there's not enough time for task, then not ok
 	if(w->end_time > 0){
-		if(t->resources_requested->wall_time > 0){
-			if(w->end_time < time(0) + t->resources_requested->wall_time) {
-				ok = 0;
-			}
+		//wall time of task is in micro-seconds, so must be divided by 1000000
+		if(t->resources_requested->wall_time > 0 && w->end_time < time(0) + t->resources_requested->wall_time/1000000){
+			ok = 0;
+		}
+		if(t->resources_requested->end > 0 && w->end_time < t->resources_requested->end) {
+			ok = 0;
 		}
 	} 
-	else if(w->end_time < t->resources_requested->end){
-		ok = 0;
-	}
 
 	rmsummary_delete(limits);
 

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -3723,13 +3723,10 @@ static int check_hand_against_task(struct work_queue *q, struct work_queue_worke
 		ok = 0;
 	}
 		
-	//if the wall time for the worker is specified and there's not enough time for the task, then not ok
-	if(w->end_time){
+	//if wall time for worker is specified and there's not enough time for task, then not ok
+	if(w->end_time > 0){
 		if(t->resources_requested->wall_time > 0){
-			if(w->end_time - time(0) > t->resources_requested->wall_time) {
-				ok = 1;
-			}
-			else{
+			if(w->end_time < time(0) + t->resources_requested->wall_time) {
 				ok = 0;
 			}
 		}

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -154,6 +154,8 @@ struct work_queue_task {
 	timestamp_t time_when_done;         /**< The time at which the task is mark as retrieved, after transfering output files and other final processing. */
 
 	int disk_allocation_exhausted;                        /**< Non-zero if a task filled its loop device allocation, zero otherwise. */
+	
+	int64_t min_running_time;
 
 	timestamp_t time_when_commit_start; /**< The time when the task starts to be transfered to a worker. */
 	timestamp_t time_when_commit_end;   /**< The time when the task is completely transfered to a worker. */
@@ -500,6 +502,23 @@ void work_queue_task_specify_end_time( struct work_queue_task *t, int64_t usecon
 */
 
 void work_queue_task_specify_running_time( struct work_queue_task *t, int64_t useconds );
+
+/** Specify the maximum time (in microseconds) the task is allowed to run in a worker.
+ * This time is accounted since the moment the task starts to run in a worker.
+ * If less than 1, then no maximum time is specified (this is the default).
+ * Note: same effect as work_queue_task_specify_running_time.
+@param t A task object.
+@param useconds Maximum number of seconds the task may run in a worker.
+*/
+void work_queue_task_specify_running_time_max( struct work_queue_task *t, int64_t useconds );
+
+/** Specify the minimum time (in microseconds) the task is expected to run in a worker.
+ * This time is accounted since the moment the task starts to run in a worker.
+ * If less than 1, then no minimum time is specified (this is the default).
+@param t A task object.
+@param useconds Minimum number of seconds the task may run in a worker.
+*/
+void work_queue_task_specify_running_time_min( struct work_queue_task *t, int64_t useconds );
 
 /** Attach a user defined string tag to the task.
 This field is not interpreted by the work queue, but is provided for the user's convenience

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -503,22 +503,22 @@ void work_queue_task_specify_end_time( struct work_queue_task *t, int64_t usecon
 
 void work_queue_task_specify_running_time( struct work_queue_task *t, int64_t useconds );
 
-/** Specify the maximum time (in microseconds) the task is allowed to run in a worker.
+/** Specify the maximum time (in seconds) the task is allowed to run in a worker.
  * This time is accounted since the moment the task starts to run in a worker.
  * If less than 1, then no maximum time is specified (this is the default).
  * Note: same effect as work_queue_task_specify_running_time.
 @param t A task object.
-@param useconds Maximum number of seconds the task may run in a worker.
+@param seconds Maximum number of seconds the task may run in a worker.
 */
-void work_queue_task_specify_running_time_max( struct work_queue_task *t, int64_t useconds );
+void work_queue_task_specify_running_time_max( struct work_queue_task *t, int64_t seconds );
 
-/** Specify the minimum time (in microseconds) the task is expected to run in a worker.
+/** Specify the minimum time (in seconds) the task is expected to run in a worker.
  * This time is accounted since the moment the task starts to run in a worker.
  * If less than 1, then no minimum time is specified (this is the default).
 @param t A task object.
-@param useconds Minimum number of seconds the task may run in a worker.
+@param seconds Minimum number of seconds the task may run in a worker.
 */
-void work_queue_task_specify_running_time_min( struct work_queue_task *t, int64_t useconds );
+void work_queue_task_specify_running_time_min( struct work_queue_task *t, int64_t seconds );
 
 /** Attach a user defined string tag to the task.
 This field is not interpreted by the work queue, but is provided for the user's convenience

--- a/work_queue/src/work_queue_resources.h
+++ b/work_queue/src/work_queue_resources.h
@@ -19,6 +19,7 @@ struct work_queue_resource {
 
 struct work_queue_resources {
 	int64_t tag;                       // Identifies the resource snapshot.
+	time_t time_left;			   	   // Marks the time left for work queue workers
 	struct work_queue_resource workers;
 	struct work_queue_resource disk;
 	struct work_queue_resource cores;

--- a/work_queue/src/work_queue_resources.h
+++ b/work_queue/src/work_queue_resources.h
@@ -19,7 +19,6 @@ struct work_queue_resource {
 
 struct work_queue_resources {
 	int64_t tag;                       // Identifies the resource snapshot.
-	time_t time_left;			   	   // Marks the time left for work queue workers
 	struct work_queue_resource workers;
 	struct work_queue_resource disk;
 	struct work_queue_resource cores;

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -380,6 +380,14 @@ static void send_resource_update(struct link *manager)
 		total_resources->disk.total    = MAX(0, local_resources->disk.total);
 		total_resources->disk.largest  = MAX(0, local_resources->disk.largest);
 		total_resources->disk.smallest = MAX(0, local_resources->disk.smallest);
+		
+		//if workers are set to expire at some time, send the amount of time left to manager
+		if(manual_wall_time_option != 0) {
+			total_resources->time_left = worker_start_time + manual_wall_time_option - time(0);
+		}
+		else {
+			total_resources->time_left = -1;
+		}
 	}
 
 	work_queue_resources_send(manager,total_resources,stoptime);

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -114,7 +114,7 @@ static int init_backoff_interval = 1;
 static int max_backoff_interval = 60;
 
 // Absolute end time for worker, worker is killed after this point.
-static time_t end_time = -1;
+static timestamp_t end_time = 0;
 
 // Chance that a worker will decide to shut down each minute without warning, to simulate failure.
 static double worker_volatility = 0.0;
@@ -1803,7 +1803,7 @@ static int enforce_worker_limits(struct link *manager) {
 If 0, the worker has less resources than promised. 1 otherwise.
 */
 static int enforce_worker_promises(struct link *manager) {
-	if(end_time > 0 && timestamp_get() > end_time) {
+	if(end_time > 0 && timestamp_get() > ((uint64_t) end_time)) {
 		warn(D_NOTICE, "work_queue_worker: reached the wall time limit %"PRIu64" s\n", (uint64_t) manual_wall_time_option);
 		if(manager) {
 			send_manager_message(manager, "info wall_time_exhausted %"PRIu64"\n", (uint64_t) manual_wall_time_option);

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -114,7 +114,7 @@ static int init_backoff_interval = 1;
 static int max_backoff_interval = 60;
 
 // Absolute end time for worker, worker is killed after this point.
-static time_t end_time = 0;
+static time_t end_time = -1;
 
 // Chance that a worker will decide to shut down each minute without warning, to simulate failure.
 static double worker_volatility = 0.0;
@@ -387,9 +387,6 @@ static void send_resource_update(struct link *manager)
 		//if workers are set to expire in some time, send the expiration time to manager
 		if(manual_wall_time_option > 0) {
 			end_time = worker_start_time + manual_wall_time_option;
-		}
-		else {
-			end_time = 0;
 		}
 	}
 

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -159,7 +159,7 @@ static char *workspace;
 static char *os_name = NULL;
 static char *arch_name = NULL;
 static char *user_specified_workdir = NULL;
-static time_t worker_start_time = 0;
+static timestamp_t worker_start_time = 0;
 
 static struct work_queue_watcher * watcher = 0;
 
@@ -386,7 +386,7 @@ static void send_resource_update(struct link *manager)
 
 		//if workers are set to expire in some time, send the expiration time to manager
 		if(manual_wall_time_option > 0) {
-			end_time = worker_start_time + manual_wall_time_option;
+			end_time = worker_start_time + (manual_wall_time_option * 1e6);
 		}
 	}
 
@@ -1803,7 +1803,7 @@ static int enforce_worker_limits(struct link *manager) {
 If 0, the worker has less resources than promised. 1 otherwise.
 */
 static int enforce_worker_promises(struct link *manager) {
-	if(end_time > 0 && time(0) > end_time) {
+	if(end_time > 0 && timestamp_get() > end_time) {
 		warn(D_NOTICE, "work_queue_worker: reached the wall time limit %"PRIu64" s\n", (uint64_t) manual_wall_time_option);
 		if(manager) {
 			send_manager_message(manager, "info wall_time_exhausted %"PRIu64"\n", (uint64_t) manual_wall_time_option);
@@ -2573,7 +2573,7 @@ int main(int argc, char *argv[])
 
 	features = hash_table_create(4, 0);
 
-	worker_start_time = time(0);
+	worker_start_time = timestamp_get();
 
 	set_worker_id();
 

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -383,7 +383,7 @@ static void send_resource_update(struct link *manager)
 		total_resources->disk.total    = MAX(0, local_resources->disk.total);
 		total_resources->disk.largest  = MAX(0, local_resources->disk.largest);
 		total_resources->disk.smallest = MAX(0, local_resources->disk.smallest);
-		
+
 		//if workers are set to expire in some time, send the expiration time to manager
 		if(manual_wall_time_option > 0) {
 			end_time = worker_start_time + manual_wall_time_option;
@@ -2743,6 +2743,10 @@ int main(int argc, char *argv[])
 			break;
 		case LONG_OPT_WALL_TIME:
 			manual_wall_time_option = atoi(optarg);
+			if(manual_wall_time_option < 1) {
+				manual_wall_time_option = 0;
+				warn(D_NOTICE, "Ignoring --wall-time, a positive integer is expected.");
+			}
 			break;
 		case LONG_OPT_DISABLE_SYMLINKS:
 			symlinks_enabled = 0;

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1601,7 +1601,7 @@ static void enforce_processes_max_running_time() {
 		if(p->task->resources_requested->wall_time < 1)
 			continue;
 
-		if(now < p->execution_start + p->task->resources_requested->wall_time) {
+		if(now > p->execution_start + p->task->resources_requested->wall_time) {
 			debug(D_WQ,"Task %d went over its running time limit: %s > %s\n",
 					p->task->taskid,
 					rmsummary_resource_to_str("wall_time", now - p->execution_start, 1),

--- a/work_queue/test/wq_test.py
+++ b/work_queue/test/wq_test.py
@@ -10,6 +10,7 @@ import os
 import os.path as path
 import shutil
 import stat
+import time
 
 import work_queue as wq
 
@@ -146,4 +147,31 @@ q.submit(t)
 t = q.wait(5)
 report_task(t, wq.WORK_QUEUE_RESULT_OUTPUT_MISSING, 0)
 
+# should succeed in the alloted time
+t = wq.Task("/bin/sleep 1")
+t.specify_running_time(10 * 1e6)
+q.submit(t)
+t = q.wait(5)
+report_task(t, wq.WORK_QUEUE_RESULT_SUCCESS, 0)
+
+# should fail in the alloted time
+t = wq.Task("/bin/sleep 10")
+t.specify_running_time(1 * 1e6)
+q.submit(t)
+t = q.wait(20)
+report_task(t, wq.WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME, 9)
+
+# should run in the alloted absolute time
+t = wq.Task("/bin/sleep 1")
+t.specify_end_time((time.time() + 5) * 1e6)
+q.submit(t)
+t = q.wait(5)
+report_task(t, wq.WORK_QUEUE_RESULT_SUCCESS, 0)
+
+# should fail in the alloted absolute time
+t = wq.Task("/bin/sleep 10")
+t.specify_end_time((time.time() + 2) * 1e6)
+q.submit(t)
+t = q.wait(20)
+report_task(t, wq.WORK_QUEUE_RESULT_TASK_TIMEOUT, 9)
 


### PR DESCRIPTION
**Modifications:**
Line 3722 to 3726 in `work_queue.c` checks whether a worker has enough time for a task.
Line 22 in `work_queue_resources.h` adds time to the `work_queue_resources` structure.
Line 383 to 390 in `work_queue_worker.c`updates the manager on the time a worker has left.

**Diagnosis:**
When code is compiled and run with the example WQ program in the [docs](https://cctools.readthedocs.io/en/latest/work_queue/) (this program needs to add a call to `work_queue_task_specify_running_time` for the issue to appear), it seems that `work_queue_worker` is stuck in a loop starting at line 2962 in `work_queue_worker.c`. The main reason for this is that line 2979 in `work_queue_worker.c` returns the variable `result ` with a value of 0. A deeper dive into function `serve_manager_by_hostport_list` doesn't give much information though.