### PR TITLE
WQ run time fixes

### DIFF
--- a/doc/manuals/work_queue/index.md
+++ b/doc/manuals/work_queue/index.md
@@ -636,7 +636,8 @@ $t->specify_cores(1)      # task needs one core
 $t->specify_memory(1024)  # task needs 1024 MB of memory
 $t->specify_disk(4096)    # task needs 4096 MB of disk space
 $t->specify_gpus(0)       # task does not need a gpu
-#specifying running time is not yet supported in perl
+$t->specify_running_time_max(100)  # task is allowed to run in 100 seconds
+$t->specify_running_time_min(10)   # task needs at least 10 seconds to run
 ```
 
 When all cores, memory, and disk are specified, Work Queue will simply fit as

--- a/doc/manuals/work_queue/index.md
+++ b/doc/manuals/work_queue/index.md
@@ -627,8 +627,8 @@ t.specify_cores(1)                     # task needs one core
 t.specify_memory(1024)                 # task needs 1024 MB of memory
 t.specify_disk(4096)                   # task needs 4096 MB of disk space
 t.specify_gpus(0)                      # task does not need a gpu
-t.specify_running_time_max(100000000)  # task is allowed to run in 100 seconds
-t.specify_running_time_min(10000000)   # task needs at least 10 seconds to run
+t.specify_running_time_max(100)        # task is allowed to run in 100 seconds
+t.specify_running_time_min(10)         # task needs at least 10 seconds to run
 ```
 
 ```perl

--- a/work_queue/src/bindings/perl/Work_Queue/Task.pm
+++ b/work_queue/src/bindings/perl/Work_Queue/Task.pm
@@ -259,6 +259,15 @@ sub specify_running_time {
 	return work_queue_task_specify_running_time($self->{_task}, $useconds);
 }
 
+sub specify_running_time_max {
+	my ($self, $seconds) = @_;
+	return work_queue_task_specify_running_time_max($self->{_task}, $seconds);
+}
+
+sub specify_running_time_min {
+	my ($self, $seconds) = @_;
+	return work_queue_task_specify_running_time_min($self->{_task}, $seconds);
+}
 sub specify_priority {
 	my ($self, $priority) = @_;
 	return work_queue_task_specify_priority($self->{_task}, $priority);
@@ -937,14 +946,44 @@ Number of microseconds.
 
 =head3 C<specify_running_time>
 
-Indicate the maximum running time for a task in a worker (relative to when the
-task starts to run).  If less than 1, or not specified, no limit is imposed.
+Indicate the maximum running time (in microseconds) for a task in a worker
+(relative to when the task starts to run).  If less than 1, or not specified,
+no limit is imposed.
+Note: Same as specify_running_time_max, but specified in microseconds. Kept for
+backwards compatibility.
 
 =over 12
 
 =item useconds
 
 Number of microseconds.
+
+=back
+
+=head3 C<specify_running_time_max>
+
+Indicate the maximum running time (in seconds) for a task in a worker (relative to when the
+task starts to run).  If less than 1, or not specified, no limit is imposed.
+
+=over 12
+
+=item seconds
+
+Number of seconds.
+
+=back
+
+
+=head3 C<specify_running_time_min>
+
+Indicate the minimum running time (in seconds) the task needs (relative to when the
+task starts to run).  If less than 1, or not specified, no minimum time is defined.
+
+=over 12
+
+=item seconds
+
+Number of seconds.
 
 =back
 

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -403,24 +403,25 @@ class Task(object):
     def specify_end_time(self, useconds):
         return work_queue_task_specify_end_time(self._task, int(useconds))
 
-    # Indicate the maximum running time for a task in a worker (relative to
-    # when the task starts to run).  If less than 1, or not specified, no limit
-    # is imposed.
+    # Indicate the maximum running time (in microseconds) for a task in a
+    # worker (relative to when the task starts to run).  If less than 1, or not
+    # specified, no limit is imposed.
+    # Note: It has the same effect that specify_running_time_max, but specified
+    # in microseconds. Kept for backwards compatibility.
     def specify_running_time(self, useconds):
         return work_queue_task_specify_running_time(self._task, int(useconds))
 
-    # Indicate the maximum running time for a task in a worker (relative to
-    # when the task starts to run).  If less than 1, or not specified, no limit
-    # is imposed.
-    # Note: same effect as specify_running_time for backwards compatibility
-    def specify_running_time_max(self, useconds):
-        return work_queue_task_specify_running_time_max(self._task, int(useconds))
+    # Indicate the maximum running time (in seconds) for a task in a worker
+    # (relative to when the task starts to run).  If less than 1, or not
+    # specified, no limit is imposed.
+    def specify_running_time_max(self, seconds):
+        return work_queue_task_specify_running_time_max(self._task, int(seconds))
 
-    # Indicate the minimum running time for a task in a worker (relative to
-    # when the task starts to run).  If less than 1, or not specified, no limit
-    # is imposed.
-    def specify_running_time_min(self, useconds):
-        return work_queue_task_specify_running_time_min(self._task, int(useconds))
+    # Indicate the minimum running time (in seconds) for a task in a worker
+    # (relative to when the task starts to run).  If less than 1, or not
+    # specified, no limit is imposed.
+    def specify_running_time_min(self, seconds):
+        return work_queue_task_specify_running_time_min(self._task, int(seconds))
 
     ##
     # Set this environment variable before running the task.

--- a/work_queue/test/wq_test.py
+++ b/work_queue/test/wq_test.py
@@ -149,14 +149,14 @@ report_task(t, wq.WORK_QUEUE_RESULT_OUTPUT_MISSING, 0)
 
 # should succeed in the alloted time
 t = wq.Task("/bin/sleep 1")
-t.specify_running_time(10 * 1e6)
+t.specify_running_time_max(10)
 q.submit(t)
 t = q.wait(5)
 report_task(t, wq.WORK_QUEUE_RESULT_SUCCESS, 0)
 
 # should fail in the alloted time
 t = wq.Task("/bin/sleep 10")
-t.specify_running_time(1 * 1e6)
+t.specify_running_time_max(1)
 q.submit(t)
 t = q.wait(20)
 report_task(t, wq.WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME, 9)


### PR DESCRIPTION
Minor fixes to specify_running_time_{max,min}:
- adds perl bindings
- updates docs to seconds
- updates test to use specify_running_time_max