### PR TITLE
Fix time units

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4589,13 +4589,13 @@ void work_queue_task_specify_running_time( struct work_queue_task *t, int64_t us
 	}
 	else
 	{
-		t->resources_requested->wall_time = useconds;
+		t->resources_requested->wall_time = DIV_INT_ROUND_UP(useconds, ONE_SECOND);
 	}
 }
 
 void work_queue_task_specify_running_time_max( struct work_queue_task *t, int64_t seconds )
 {
-	work_queue_task_specify_running_time(t, 1000000*seconds); 	//convert to useconds for backward compat
+	work_queue_task_specify_running_time(t, seconds);
 }
 
 void work_queue_task_specify_running_time_min( struct work_queue_task *t, int64_t seconds )

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -3731,13 +3731,14 @@ static int check_hand_against_task(struct work_queue *q, struct work_queue_worke
 
 	//if wall time for worker is specified and there's not enough time for task, then not ok
 	if(w->end_time > 0){
-		if(t->resources_requested->wall_time > 0 && w->end_time - (int64_t) timestamp_get() < t->resources_requested->wall_time){
+		double current_time = timestamp_get() / ONE_SECOND;
+		if(t->resources_requested->wall_time > 0 && w->end_time - current_time < t->resources_requested->wall_time){
 			ok = 0;
 		}
 		if(t->resources_requested->end > 0 && w->end_time < t->resources_requested->end) {
 			ok = 0;
 		}
-		if(t->min_running_time > 0 && w->end_time - (int64_t) timestamp_get() < t->min_running_time){
+		if(t->min_running_time > 0 && w->end_time - current_time < t->min_running_time){
 			ok = 0;
 		}
 	}
@@ -4604,7 +4605,7 @@ void work_queue_task_specify_running_time_min( struct work_queue_task *t, int64_
 	}
 	else
 	{
-		t->min_running_time = 1000000*seconds;					//convert to useconds for backward compat
+		t->min_running_time = seconds;
 	}
 }
 

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -155,8 +155,9 @@ struct work_queue_task {
 
 	int disk_allocation_exhausted;                        /**< Non-zero if a task filled its loop device allocation, zero otherwise. */
 
-	int64_t min_running_time;
+	int64_t min_running_time;           /**< Minimum time (in seconds) the task needs to run. (see work_queue_worker --wall-time)*/
 
+    /**< All fields of the form time_* in microseconds. */
 	timestamp_t time_when_commit_start; /**< The time when the task starts to be transfered to a worker. */
 	timestamp_t time_when_commit_end;   /**< The time when the task is completely transfered to a worker. */
 

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -506,7 +506,7 @@ static void report_worker_ready( struct link *manager )
 	send_features(manager);
 	send_tlq_config(manager);
 	send_keepalive(manager, 1);
-	send_manager_message(manager, "info worker-end-time %lld\n", DIV_INT_ROUND_UP(end_time, ONE_SECOND));
+	send_manager_message(manager, "info worker-end-time %" PRId64 "\n", (int64_t) DIV_INT_ROUND_UP(end_time, USECOND));
 }
 
 
@@ -700,7 +700,7 @@ static void expire_procs_running() {
 	struct work_queue_process *p;
 	uint64_t pid;
 
-	double current_time = timestamp_get() / ONE_SECOND;
+	double current_time = timestamp_get() / USECOND;
 
 	itable_firstkey(procs_running);
 	while(itable_nextkey(procs_running, (uint64_t*)&pid, (void**)&p)) {
@@ -1008,7 +1008,7 @@ static int do_task( struct link *manager, int taskid, time_t stoptime )
 		} else if(sscanf(line,"gpus %" PRId64,&n)) {
 			work_queue_task_specify_gpus(task, n);
 		} else if(sscanf(line,"wall_time %" PRIu64,&nt)) {
-			work_queue_task_specify_running_time(task, nt);
+			work_queue_task_specify_running_time_max(task, nt);
 		} else if(sscanf(line,"end_time %" PRIu64,&nt)) {
 			work_queue_task_specify_end_time(task, nt * USECOND); //end_time needs it usecs
 		} else if(sscanf(line,"env %d",&length)==1) {
@@ -1598,10 +1598,10 @@ static void enforce_processes_max_running_time() {
 		if(p->task->resources_requested->wall_time < 1)
 			continue;
 
-		if(now > p->execution_start + p->task->resources_requested->wall_time) {
+		if(now > p->execution_start + (1e6 * p->task->resources_requested->wall_time)) {
 			debug(D_WQ,"Task %d went over its running time limit: %s > %s\n",
 					p->task->taskid,
-					rmsummary_resource_to_str("wall_time", now - p->execution_start, 1),
+					rmsummary_resource_to_str("wall_time", (now - p->execution_start)/1e6, 1),
 					rmsummary_resource_to_str("wall_time", p->task->resources_requested->wall_time, 1));
 			p->task_status = WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME;
 			kill(pid, SIGKILL);


### PR DESCRIPTION
Move end_time and wall_time to seconds, to match the new rmsummary.