### PR TITLE
wall_time should not be considered when matching workers

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -3733,9 +3733,6 @@ static int check_hand_against_task(struct work_queue *q, struct work_queue_worke
 	//if wall time for worker is specified and there's not enough time for task, then not ok
 	if(w->end_time > 0){
 		double current_time = timestamp_get() / ONE_SECOND;
-		if(t->resources_requested->wall_time > 0 && w->end_time - current_time < t->resources_requested->wall_time){
-			ok = 0;
-		}
 		if(t->resources_requested->end > 0 && w->end_time < t->resources_requested->end) {
 			ok = 0;
 		}


### PR DESCRIPTION
Only min_time should be considered, as wall_time is a maximum time of
the task itself.