### PR TITLE
Custom class ads for condor_submit_workers

### DIFF
--- a/doc/man/m4/condor_submit_workers.m4
+++ b/doc/man/m4/condor_submit_workers.m4
@@ -40,11 +40,21 @@ OPTION_TRIPLET(-z, disk-threshold, size)Set available disk space threshold (in M
 OPTION_TRIPLET(-A, arch, arch)Set architecture string for the worker to report to manager instead of the value in uname.
 OPTION_TRIPLET(-O, os, os)Set operating system string for the worker to report to manager instead of the value in uname.
 OPTION_TRIPLET(-s, workdir, path)Set the location for creating the working directory of the worker.
-OPTION_TRIPLET(-P,--password, file)Password file to authenticate workers to manager.
+OPTION_TRIPLET(-P, password, file)Password file to authenticate workers to manager.
+OPTION_TRIPLET(-E, worker-options, <str>)Extra options passed to work_queue_worker
+
 OPTION_PAIR(--cores, cores)Set the number of cores each worker should use (0=auto). (default=1)
 OPTION_PAIR(--memory, size)Manually set the amonut of memory (in MB) reported by this worker.
 OPTION_PAIR(--disk, size)Manually set the amount of disk (in MB) reported by this worker.
+
+OPTION_TRIPLET(-r,requirements,<reqs>)Condor requirements expression.
+OPTION_PAIR(--class-ad,<ad>)Extra condor class ad. May be specified multiple times.
+OPTION_ITEM(`--autosize')Condor will automatically size the worker to the slot.
+OPTION_PAIR(--docker-universe,<image>)Run worker inside <image> using condor's docker universe
+
 OPTION_ITEM(`-h,--help')Show help message.
+
+
 OPTIONS_END
 
 SECTION(EXIT STATUS)

--- a/doc/man/md/condor_submit_workers.md
+++ b/doc/man/md/condor_submit_workers.md
@@ -62,11 +62,21 @@ the catalog server by specifying the name of the work queue using the --manager-
 - **-A --arch <arch>** Set architecture string for the worker to report to manager instead of the value in uname.
 - **-O --os <os>** Set operating system string for the worker to report to manager instead of the value in uname.
 - **-s --workdir <path>** Set the location for creating the working directory of the worker.
-- **-P ----password <file>** Password file to authenticate workers to manager.
+- **-P --password <file>** Password file to authenticate workers to manager.
+- **-E --worker-options <<str>>** Extra options passed to work_queue_worker
+
 - **--cores cores** Set the number of cores each worker should use (0=auto). (default=1)
 - **--memory size** Manually set the amonut of memory (in MB) reported by this worker.
 - **--disk size** Manually set the amount of disk (in MB) reported by this worker.
+
+- **-r --requirements <<reqs>>** Condor requirements expression.
+- **--class-ad <ad>** Extra condor class ad. May be specified multiple times.
+- **--autosize** Condor will automatically size the worker to the slot.
+- **--docker-universe <image>** Run worker inside <image> using condor's docker universe
+
 - **-h,--help** Show help message.
+
+
 
 
 ## EXIT STATUS

--- a/work_queue/src/condor_submit_workers
+++ b/work_queue/src/condor_submit_workers
@@ -13,6 +13,7 @@ fi
 show_help()
 {
 	echo "  -r,--requirements <reqs>  Condor requirements expression."
+	echo "  --class-ad <ad>           Extra condor class ad. May be specified multiple times."
 	echo "  --autosize                Condor will automatically size the worker to the slot."
     echo "  --docker-universe <image> Run worker inside <image> using condor's docker universe"
 }
@@ -22,6 +23,7 @@ show_help()
 # The user can still add their own expression via the -r option.
 
 requirements=""
+class_ads=""
 transfer_input_files="work_queue_worker, cctools_gpu_autodetect"
 
 parse_arguments()
@@ -42,6 +44,11 @@ parse_arguments()
 			-r|--requirements)
 			shift
 			requirements="$requirements $1"
+			;;
+
+			--class-ad)
+			shift
+			class_ads="$class_ads\n$1"
 			;;
 
 			--autosize)
@@ -103,6 +110,8 @@ output = worker.\$(PROCESS).output
 error = worker.\$(PROCESS).error
 log = workers.log
 +JobMaxSuspendTime = 0
+
+$(printf ${class_ads})
 
 # Some programs assume some variables are set, like HOME, so we export the
 # environment variables with the job.  Comment the next line if you do not want


### PR DESCRIPTION
Adds --class-ad to specify custom class ads when submitting workers to condor.

NDCMS use case:
```sh
condor_submit_workers ... --class-ad "+IsExpressJob" ...
```