### PR TITLE
wq factory: allow abort while sleep

### DIFF
--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -1017,7 +1017,14 @@ static void mainloop( struct batch_queue *queue )
 		delete_projects_list(managers_list);
 		delete_projects_list(foremen_list);
 
-		sleep(factory_period);
+		int sleep_seconds = 0;
+		while(sleep_seconds < factory_period) {
+			if(abort_flag) {
+				break;
+			}
+			sleep_seconds += 1;
+			sleep(1);
+		}
 	}
 
 	printf("removing %d workers...\n",itable_size(job_table));


### PR DESCRIPTION
This commit checks abort_flag each second the factory sleeps. This
allows a much faster response when using the factory with PythonTask.

The previous behaviour made the factory sleep for a whole period before
checking the abort_flag. Fast executing PythonTask would then have a 30s
overhead when using the 'with workers:' syntax.