### PR TITLE
work queue: improve task submission time

### DIFF
--- a/dttools/src/list.c
+++ b/dttools/src/list.c
@@ -590,7 +590,7 @@ void list_push_priority(struct list *list, list_priority_t p, void *item) {
 	void *i = NULL;
 	struct list_cursor *cur = list_cursor_create(list);
 	for (list_seek(cur, 0); list_get(cur, &i); list_next(cur)) {
-			if (p(i) < p(item)) {
+			if (p(i) <= p(item)) {
 				list_insert(cur, item);
 				break;
 			}

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -5609,12 +5609,9 @@ void work_queue_delete(struct work_queue *q)
 			fclose(q->transactions_logfile);
 		}
 
-
-		if(q->measured_local_resources)
-			rmsummary_delete(q->measured_local_resources);
-
-		if(q->current_max_worker)
-			rmsummary_delete(q->current_max_worker);
+		rmsummary_delete(q->measured_local_resources);
+		rmsummary_delete(q->current_max_worker);
+		rmsummary_delete(q->max_task_resources_requested);
 
 		free(q);
 	}

--- a/work_queue/src/work_queue_status.c
+++ b/work_queue/src/work_queue_status.c
@@ -96,7 +96,7 @@ static struct jx_table worker_headers[] = {
 
 static struct jx_table workers_able_headers[] = {
 {"category",      "CATEGORY",     JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_LEFT,  -12},
-{"tasks_running", "RUNNING",      JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 10},
+{"tasks_on_workers", "DISPATCHED",      JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 10},
 {"tasks_waiting", "WAITING",      JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 10},
 {"workers_able",  "FIT-WORKERS",  JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 12},
 {"max_cores",     "MAX-CORES",    JX_TABLE_MODE_PLAIN, JX_TABLE_ALIGN_RIGHT, 10},


### PR DESCRIPTION
As observed by @BarrySlyDelgado, work_queue_submit_task was noticeably slower than expected in the python bindings. This pr makes the submission more efficient by:

- Inserting a task into the queue as soon as its priority allows, rather than prioritize previously submitted tasks.
- Batch log stats requests together, rather than write stats on each submission.
- Keep max resources seen per queue in a field, rather than recompute it each time.