### PR TITLE
Parrot: Remove unspecific test case.

### DIFF
--- a/parrot/test/TR_parrot_dir.sh
+++ b/parrot/test/TR_parrot_dir.sh
@@ -65,11 +65,18 @@ int main (int argc, char *argv[])
 	check(-1 ==, fd = open("foo", O_RDWR));
 	check(EISDIR ==, errno);
 
+/*
+This test is exercising behavior that is unspecified in POSIX,
+and seems to vary between versions of Linux.
+*/
+
+    /*
 	check(0 <=, fd = open("foo/bar", O_CREAT|O_DIRECTORY, S_IRUSR|S_IWUSR));
 	CATCHUNIX(fstat(fd, &info));
 	check(!!, S_ISREG(info.st_mode));
 	CATCHUNIX(close(fd));
 	CATCHUNIX(unlink("foo/bar"));
+    */
 
 	CATCHUNIX(fd = open("foo/bar", O_WRONLY|O_CREAT|O_TRUNC, S_IRUSR|S_IWUSR));
 	CATCHUNIX(close(fd));


### PR DESCRIPTION
cctools builds via spack are failing due to test `TR_parrot_dir.sh`. This test is exercising a corner case of POSIX `open(name,O_DIRECTORY|O_CREAT,mode)` that seems to be unspecified and varies between Linux kernels.  Removing that part of the test case.