### PR TITLE
use debug D_NOTICE to print wq password warning.

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -6102,9 +6102,9 @@ static void print_password_warning( struct work_queue *q )
 
 	if(did_password_warning) return;
 
-		if(!q->password && q->name) {
-			fprintf(stderr,"warning: this work queue manager is visible to the public.\n");
-			fprintf(stderr,"warning: you should set a password with the --password option.\n");
+	if(!q->password && q->name) {
+		debug(D_NOTICE|D_WQ, "warning: this work queue manager is visible to the public.\n");
+		debug(D_NOTICE|D_WQ, "warning: you should set a password with the --password option.\n");
 		did_password_warning = 1;
 	}
 }


### PR DESCRIPTION
Forcing it with fprintf to stderr may cause noise in applications that
do not expect output in stderr. (E.g., progress bars in coffea.)