### PR TITLE
Compute peak cores less aggressively

### DIFF
--- a/dttools/src/rmsummary.c
+++ b/dttools/src/rmsummary.c
@@ -129,13 +129,13 @@ int rmsummary_to_internal_unit(const char *field, double input_number, int64_t *
 	}
 
 	if(strcmp(field, "cores") == 0) {
-		/* hack to eliminate noise. we do not round up unless more than %10 of
+		/* hack to eliminate noise. we do not round up unless more than %25 of
 		 * the additional core is used. */
 
 		double raw   = MAX(1.0, input_number);
 		double floor = trunc(raw);
 
-		if(raw - floor < 0.1) {
+		if(raw - floor < 0.25) {
 			input_number = floor;
 		}
 	}

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -899,7 +899,7 @@ struct peak_cores_sample {
 double peak_cores(int64_t wall_time, int64_t cpu_time) {
 	static struct list *samples = NULL;
 
-	int64_t max_separation = (60 + 2*interval)*USECOND; /* at least one minute and a complete interval */
+	int64_t max_separation = (180 + 2*interval)*USECOND; /* at least three minutes and a complete interval */
 
 	if(!samples) {
 		samples = list_create();
@@ -1524,7 +1524,6 @@ struct rmsummary *rmonitor_final_usage_tree(void)
 
 	/* we do not use peak_cores here, as we may have missed some threads which
 	 * make cpu_time quite jumpy. */
-	
 	if(tr_usg->wall_time > 0) {
 		int64_t tmp_output;
 		rmsummary_to_internal_unit("cores", ((double) tr_usg->cpu_time)/tr_usg->wall_time, &tmp_output, "cores");


### PR DESCRIPTION
- peak cores computed over three-minute windows rather than one minute.
- fuzzy limit increased to 0.25 cores, rather than 0.1 cores.