### PR TITLE
add tune parameter: wait-for-workers

### DIFF
--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -1057,6 +1057,7 @@ void work_queue_manager_preferred_connection(struct work_queue *q, const char *p
  - "long-timeout" Set the minimum timeout when sending a brief message to a foreman. (default=1h)
  - "category-steady-n-tasks" Set the number of tasks considered when computing category buckets.
  - "hungry-minimum" Mimimum number of tasks to consider queue not hungry. (default=10)
+ - "wait-for-workers" Mimimum number of workers to connect before starting dispatching tasks. (default=0)
 @param value The value to set the parameter to.
 @return 0 on succes, -1 on failure.
 */


### PR DESCRIPTION
It is an int. No task is submitted to workers until wait-for-workers
number of workers connected is reached. After this, wait-for-workers is
reset to 0. Useful for testing, not for regular production.