### PR TITLE
wq: wait do one of each

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -6425,14 +6425,6 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 			}
 		}
 
-		// return if queue is empty.
-		BEGIN_ACCUM_TIME(q, time_internal);
-		int done = !task_state_any(q, WORK_QUEUE_TASK_RUNNING) && !task_state_any(q, WORK_QUEUE_TASK_READY) && !task_state_any(q, WORK_QUEUE_TASK_WAITING_RETRIEVAL) && !(foreman_uplink);
-		END_ACCUM_TIME(q, time_internal);
-
-		if(done)
-			break;
-
 		/* if we got here, no events were triggered. we set the busy_waiting
 		 * flag so that link_poll waits for some time the next time around. */
 		q->busy_waiting_flag = 1;

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -6270,16 +6270,15 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 /*
    - compute stoptime
    S time left?                              No:  return null
-   - task completed?                         Yes: return completed task to user
    - update catalog if appropiate
    - retrieve workers status messages
-   - tasks waiting to be retrieved?          Yes: retrieve one task and go to S.
-   - tasks waiting to be dispatched?         Yes: dispatch one task and go to S.
+   - tasks waiting to be retrieved?          Yes: retrieve one task.
+   - tasks waiting to be dispatched?         Yes: dispatch one task.
    - send keepalives to appropiate workers
    - fast-abort workers
    - if new workers, connect n of them
-   - expired tasks?                          Yes: mark expired tasks as retrieved and go to S.
-   - queue empty?                            Yes: return null
+   - expired tasks?                          Yes: mark expired tasks as retrieved.
+   - task completed?                         Yes: return completed task to user
    - go to S
 */
 {

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -297,9 +297,8 @@ struct work_queue_stats {
 
     double manager_load;      /**< In the range of [0,1]. If close to 1, then
                                 the manager is at full load and spends most
-                                of its time sending and receiving taks, and
-                                thus cannot accept connections from new
-                                workers. If close to 0, the manager is spending
+                                of its time sending and receiving taks.
+                                If close to 0, the manager is spending
                                 most of its time waiting for something to happen. */
 
 	/**< deprecated fields: */


### PR DESCRIPTION
Changes wq wait internal so that connect new workers and submit tasks get executed at least once per call. This has some consequences:

- allows to connect workers when the queue is empty, targeting workflows that submit tasks according to the resources available.
- work_queue_status connecting directly to the manager is ensured to succeed (unless there are very large tasks transfers). Before, a status call would only be processed when the manager did not have anything to do, which was seldom the case when running hundreds of tasks and workers.
- a task is submitted as soon as one is retrieved. This means that the number of tasks running on workers does not decrease as long as there are tasks waiting. However, in steady state, this means that more tasks may have results computed waiting at the workers. In stable environments this is more efficient, as results can be retrieved while new tasks start to run, but in environments with high eviction some results may be lost and they will need to be recomputed.  
