### PR TITLE
Small fixes for over-commitment to workers

### DIFF
--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -1669,8 +1669,7 @@ class WorkQueue(object):
     #
     # @param self  Reference to the current work queue object.
     # @param name  The name fo the parameter to tune. Can be one of following:
-    # - "asynchrony-multiplier" Treat each worker as having (actual_cores * multiplier) total cores. (default = 1.0)
-    # - "asynchrony-modifier" Treat each worker as having an additional "modifier" cores. (default=0)
+    # - "resource-submit-multiplier" Treat each worker as having ({cores,memory,gpus} * multiplier) when submitting tasks. This allows for tasks to wait at a worker rather than the manager. (default = 1.0)
     # - "min-transfer-timeout" Set the minimum number of seconds to wait for files to be transferred to or from a worker. (default=10)
     # - "foreman-transfer-timeout" Set the minimum number of seconds to wait for files to be transferred to or from a foreman. (default=3600)
     # - "transfer-outlier-factor" Transfer that are this many times slower than the average will be aborted.  (default=10x)

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -6472,10 +6472,10 @@ int work_queue_hungry(struct work_queue *q)
 	int64_t workers_total_avail_disk 	= 0;
 	int64_t workers_total_avail_gpus 	= 0;
 
-	workers_total_avail_cores 	= q->stats->total_cores - q->stats->committed_cores;
-	workers_total_avail_memory 	= q->stats->total_memory - q->stats->committed_memory;
-	workers_total_avail_disk 	= q->stats->total_disk - q->stats->committed_disk;
-	workers_total_avail_gpus	= q->stats->total_gpus - q->stats->committed_gpus;
+	workers_total_avail_cores 	= overcommitted_resource_total(q, q->stats->total_cores) - q->stats->committed_cores;
+	workers_total_avail_memory 	= overcommitted_resource_total(q, q->stats->total_memory) - q->stats->committed_memory;
+	workers_total_avail_gpus	= overcommitted_resource_total(q, q->stats->total_gpus) - q->stats->committed_gpus;
+	workers_total_avail_disk 	= q->stats->total_disk - q->stats->committed_disk; //never overcommit disk
 
 	//get required resources (cores, memory, disk, gpus) of one waiting task
 	int64_t ready_task_cores 	= 0;

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -3742,23 +3742,24 @@ static int check_hand_against_task(struct work_queue *q, struct work_queue_worke
 		}
 	}
 
-	struct rmsummary *limits = task_worker_box_size(q, w, t);
+	struct rmsummary *l = task_worker_box_size(q, w, t);
+	struct work_queue_resources *r = w->resources;
 
 	int ok = 1;
 
-	if(w->resources->cores.inuse + limits->cores > overcommitted_resource_total(q, w->resources->cores.total)) {
+	if(r->disk.inuse + l->disk > r->disk.total) { /* No overcommit disk */
 		ok = 0;
 	}
 
-	if(w->resources->memory.inuse + limits->memory > overcommitted_resource_total(q, w->resources->memory.total)) {
+	if((l->cores > r->cores.total) || (r->cores.inuse + l->cores > overcommitted_resource_total(q, r->cores.total))) {
 		ok = 0;
 	}
 
-	if(w->resources->disk.inuse + limits->disk > w->resources->disk.total) { /* No overcommit disk */
+	if((l->memory > r->memory.total) || (r->memory.inuse + l->memory > overcommitted_resource_total(q, r->memory.total))) {
 		ok = 0;
 	}
 
-	if(w->resources->gpus.inuse + limits->gpus > overcommitted_resource_total(q, w->resources->gpus.total)) {
+	if((l->gpus > r->gpus.total) || (r->gpus.inuse + l->gpus > overcommitted_resource_total(q, r->gpus.total))) {
 		ok = 0;
 	}
 
@@ -3778,7 +3779,7 @@ static int check_hand_against_task(struct work_queue *q, struct work_queue_worke
 		}
 	}
 
-	rmsummary_delete(limits);
+	rmsummary_delete(l);
 
 	if(t->features) {
 		if(!w->features)

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -1044,8 +1044,7 @@ void work_queue_manager_preferred_connection(struct work_queue *q, const char *p
 /** Tune advanced parameters for work queue.
 @param q A work queue object.
 @param name The name of the parameter to tune
- - "asynchrony-multiplier" Treat each worker as having (actual_cores * multiplier) total cores. (default = 1.0)
- - "asynchrony-modifier" Treat each worker as having an additional "modifier" cores. (default=0)
+ - "resource-submit-multiplier" Treat each worker as having ({cores,memory,gpus} * multiplier) when submitting tasks. This allows for tasks to wait at a worker rather than the manager. (default = 1.0)
  - "min-transfer-timeout" Set the minimum number of seconds to wait for files to be transferred to or from a worker. (default=10)
  - "foreman-transfer-timeout" Set the minimum number of seconds to wait for files to be transferred to or from a foreman. (default=3600)
  - "transfer-outlier-factor" Transfer that are this many times slower than the average will be aborted.  (default=10x)


### PR DESCRIPTION
Changes the name of `asynchrony-multiplier` to `resource-submit-multiplier` tune parameter.  This factor (default to 1) is applied to cores, memory and gpus when deciding if a task should be sent to a worker. The idea is to allow for tasks to wait at workers.

This pr also fixes an old bug where a task was sent to a worker because of the apparent resources given `asynchrony-multiplier`, but the task would not be able to run because of the actual worker resources.

It also eliminates asynchrony-modifier, as it only had an effect for the old unlabeled tasks before work queue managed resources.

Lastly, it makes work_queue_hungry take into account the over-commitment. 