### PR TITLE
No version in mds manuals

### DIFF
--- a/doc/man/m4/allpairs_multicore.m4
+++ b/doc/man/m4/allpairs_multicore.m4
@@ -41,11 +41,7 @@ SECTION(EXAMPLES)
 
 Let's suppose you have a whole lot of files that you want to compare all to
 each other, named CODE(a), CODE(b), CODE(c), and so on. Suppose that you also
-<<<<<<< HEAD
 have a program named CODE(compareit)) that when invoked as CODE(compareit a b)
-=======
-have a program namedCODE(compareit)) that when invoked as CODE(compareit a b)
->>>>>>> 45cdc6826... rebuild pages
 will compare files CODE(a) and CODE(b) and produce some output summarizing the
 difference between the two, like this:
 

--- a/doc/man/manual_md.h
+++ b/doc/man/manual_md.h
@@ -38,4 +38,4 @@ define(OPTIONS_END,LIST_END)
 define(LONGCODE_BEGIN,changequote([,])[changequote([,])```changequote]changequote)
 define(LONGCODE_END,changequote([,])[changequote([,])```changequote]changequote)
 
-define(FOOTER,CCTools CCTOOLS_VERSION)dnl
+define(FOOTER,CCTools)dnl

--- a/doc/man/md/allpairs_master.md
+++ b/doc/man/md/allpairs_master.md
@@ -151,4 +151,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [allpairs_multicore(1)](allpairs_multicore.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/allpairs_multicore.md
+++ b/doc/man/md/allpairs_multicore.md
@@ -63,7 +63,7 @@ On success, returns zero.  On failure, returns non-zero.
 
 Let's suppose you have a whole lot of files that you want to compare all to
 each other, named **a**, **b**, **c**, and so on. Suppose that you also
-have a program namedCODE(compareit)) that when invoked as **compareit a b**
+have a program named **compareit**) that when invoked as **compareit a b**
 will compare files **a** and **b** and produce some output summarizing the
 difference between the two, like this:
 
@@ -110,4 +110,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [allpairs_master(1)](allpairs_master.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/catalog_query.md
+++ b/doc/man/md/catalog_query.md
@@ -78,4 +78,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [catalog_server(1)](catalog_server.md)  [catalog_update(1)](catalog_update.md)  [catalog_query(1)](catalog_query.md)  [chirp_status(1)](chirp_status.md)  [work_queue_status(1)](work_queue_status.md)   [deltadb_query(1)](deltadb_query.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/catalog_server.md
+++ b/doc/man/md/catalog_server.md
@@ -103,4 +103,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [catalog_server(1)](catalog_server.md)  [catalog_update(1)](catalog_update.md)  [catalog_query(1)](catalog_query.md)  [chirp_status(1)](chirp_status.md)  [work_queue_status(1)](work_queue_status.md)   [deltadb_query(1)](deltadb_query.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/catalog_update.md
+++ b/doc/man/md/catalog_update.md
@@ -107,4 +107,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [catalog_server(1)](catalog_server.md)  [catalog_update(1)](catalog_update.md)  [catalog_query(1)](catalog_query.md)  [chirp_status(1)](chirp_status.md)  [work_queue_status(1)](work_queue_status.md)   [deltadb_query(1)](deltadb_query.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/chirp.md
+++ b/doc/man/md/chirp.md
@@ -134,4 +134,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [chirp(1)](chirp.md)  [chirp_status(1)](chirp_status.md)  [chirp_fuse(1)](chirp_fuse.md)  [chirp_get(1)](chirp_get.md)  [chirp_put(1)](chirp_put.md)  [chirp_stream_files(1)](chirp_stream_files.md)  [chirp_distribute(1)](chirp_distribute.md)  [chirp_benchmark(1)](chirp_benchmark.md)  [chirp_server(1)](chirp_server.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/chirp_benchmark.md
+++ b/doc/man/md/chirp_benchmark.md
@@ -72,4 +72,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [chirp(1)](chirp.md)  [chirp_status(1)](chirp_status.md)  [chirp_fuse(1)](chirp_fuse.md)  [chirp_get(1)](chirp_get.md)  [chirp_put(1)](chirp_put.md)  [chirp_stream_files(1)](chirp_stream_files.md)  [chirp_distribute(1)](chirp_distribute.md)  [chirp_benchmark(1)](chirp_benchmark.md)  [chirp_server(1)](chirp_server.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/chirp_distribute.md
+++ b/doc/man/md/chirp_distribute.md
@@ -104,4 +104,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [chirp(1)](chirp.md)  [chirp_status(1)](chirp_status.md)  [chirp_fuse(1)](chirp_fuse.md)  [chirp_get(1)](chirp_get.md)  [chirp_put(1)](chirp_put.md)  [chirp_stream_files(1)](chirp_stream_files.md)  [chirp_distribute(1)](chirp_distribute.md)  [chirp_benchmark(1)](chirp_benchmark.md)  [chirp_server(1)](chirp_server.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/chirp_fuse.md
+++ b/doc/man/md/chirp_fuse.md
@@ -97,4 +97,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [chirp(1)](chirp.md)  [chirp_status(1)](chirp_status.md)  [chirp_fuse(1)](chirp_fuse.md)  [chirp_get(1)](chirp_get.md)  [chirp_put(1)](chirp_put.md)  [chirp_stream_files(1)](chirp_stream_files.md)  [chirp_distribute(1)](chirp_distribute.md)  [chirp_benchmark(1)](chirp_benchmark.md)  [chirp_server(1)](chirp_server.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/chirp_get.md
+++ b/doc/man/md/chirp_get.md
@@ -83,4 +83,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [chirp(1)](chirp.md)  [chirp_status(1)](chirp_status.md)  [chirp_fuse(1)](chirp_fuse.md)  [chirp_get(1)](chirp_get.md)  [chirp_put(1)](chirp_put.md)  [chirp_stream_files(1)](chirp_stream_files.md)  [chirp_distribute(1)](chirp_distribute.md)  [chirp_benchmark(1)](chirp_benchmark.md)  [chirp_server(1)](chirp_server.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/chirp_put.md
+++ b/doc/man/md/chirp_put.md
@@ -84,4 +84,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [chirp(1)](chirp.md)  [chirp_status(1)](chirp_status.md)  [chirp_fuse(1)](chirp_fuse.md)  [chirp_get(1)](chirp_get.md)  [chirp_put(1)](chirp_put.md)  [chirp_stream_files(1)](chirp_stream_files.md)  [chirp_distribute(1)](chirp_distribute.md)  [chirp_benchmark(1)](chirp_benchmark.md)  [chirp_server(1)](chirp_server.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/chirp_server.md
+++ b/doc/man/md/chirp_server.md
@@ -116,4 +116,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [chirp(1)](chirp.md)  [chirp_status(1)](chirp_status.md)  [chirp_fuse(1)](chirp_fuse.md)  [chirp_get(1)](chirp_get.md)  [chirp_put(1)](chirp_put.md)  [chirp_stream_files(1)](chirp_stream_files.md)  [chirp_distribute(1)](chirp_distribute.md)  [chirp_benchmark(1)](chirp_benchmark.md)  [chirp_server(1)](chirp_server.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/chirp_server_hdfs.md
+++ b/doc/man/md/chirp_server_hdfs.md
@@ -77,4 +77,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [chirp(1)](chirp.md)  [chirp_status(1)](chirp_status.md)  [chirp_fuse(1)](chirp_fuse.md)  [chirp_get(1)](chirp_get.md)  [chirp_put(1)](chirp_put.md)  [chirp_stream_files(1)](chirp_stream_files.md)  [chirp_distribute(1)](chirp_distribute.md)  [chirp_benchmark(1)](chirp_benchmark.md)  [chirp_server(1)](chirp_server.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/chirp_status.md
+++ b/doc/man/md/chirp_status.md
@@ -108,4 +108,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [chirp(1)](chirp.md)  [chirp_status(1)](chirp_status.md)  [chirp_fuse(1)](chirp_fuse.md)  [chirp_get(1)](chirp_get.md)  [chirp_put(1)](chirp_put.md)  [chirp_stream_files(1)](chirp_stream_files.md)  [chirp_distribute(1)](chirp_distribute.md)  [chirp_benchmark(1)](chirp_benchmark.md)  [chirp_server(1)](chirp_server.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/chirp_stream_files.md
+++ b/doc/man/md/chirp_stream_files.md
@@ -96,4 +96,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [chirp(1)](chirp.md)  [chirp_status(1)](chirp_status.md)  [chirp_fuse(1)](chirp_fuse.md)  [chirp_get(1)](chirp_get.md)  [chirp_put(1)](chirp_put.md)  [chirp_stream_files(1)](chirp_stream_files.md)  [chirp_distribute(1)](chirp_distribute.md)  [chirp_benchmark(1)](chirp_benchmark.md)  [chirp_server(1)](chirp_server.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/chroot_package_run.md
+++ b/doc/man/md/chroot_package_run.md
@@ -98,4 +98,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [parrot_run(1)](parrot_run.md) [parrot_cp(1)](parrot_cp.md) [parrot_getacl(1)](parrot_getacl.md)  [parrot_setacl(1)](parrot_setacl.md)  [parrot_mkalloc(1)](parrot_mkalloc.md)  [parrot_lsalloc(1)](parrot_lsalloc.md)  [parrot_locate(1)](parrot_locate.md)  [parrot_timeout(1)](parrot_timeout.md)  [parrot_whoami(1)](parrot_whoami.md)  [parrot_mount(1)](parrot_mount.md)  [parrot_md5(1)](parrot_md5.md)  [parrot_package_create(1)](parrot_package_create.md)  [parrot_package_run(1)](parrot_package_run.md)  [chroot_package_run(1)](chroot_package_run.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/condor_submit_makeflow.md
+++ b/doc/man/md/condor_submit_makeflow.md
@@ -60,4 +60,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [makeflow(1)](makeflow.md) [makeflow_monitor(1)](makeflow_monitor.md) [makeflow_analyze(1)](makeflow_analyze.md) [makeflow_viz(1)](makeflow_viz.md) [makeflow_graph_log(1)](makeflow_graph_log.md) [starch(1)](starch.md) [makeflow_ec2_setup(1)](makeflow_ec2_setup.md) [makeflow_ec2_cleanup(1)](makeflow_ec2_cleanup.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/condor_submit_workers.md
+++ b/doc/man/md/condor_submit_workers.md
@@ -104,4 +104,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [work_queue_worker(1)](work_queue_worker.md) [work_queue_status(1)](work_queue_status.md) [work_queue_factory(1)](work_queue_factory.md) [condor_submit_workers(1)](condor_submit_workers.md) [sge_submit_workers(1)](sge_submit_workers.md) [torque_submit_workers(1)](torque_submit_workers.md) 
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/confuga.md
+++ b/doc/man/md/confuga.md
@@ -225,4 +225,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [chirp(1)](chirp.md)  [chirp_status(1)](chirp_status.md)  [chirp_fuse(1)](chirp_fuse.md)  [chirp_get(1)](chirp_get.md)  [chirp_put(1)](chirp_put.md)  [chirp_stream_files(1)](chirp_stream_files.md)  [chirp_distribute(1)](chirp_distribute.md)  [chirp_benchmark(1)](chirp_benchmark.md)  [chirp_server(1)](chirp_server.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/confuga_adm.md
+++ b/doc/man/md/confuga_adm.md
@@ -77,4 +77,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 ## SEE ALSO
 [confuga(1)](confuga.md)
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/deltadb_query.md
+++ b/doc/man/md/deltadb_query.md
@@ -148,4 +148,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [catalog_server(1)](catalog_server.md)  [catalog_update(1)](catalog_update.md)  [catalog_query(1)](catalog_query.md)  [chirp_status(1)](chirp_status.md)  [work_queue_status(1)](work_queue_status.md)   [deltadb_query(1)](deltadb_query.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/disk_allocator.md
+++ b/doc/man/md/disk_allocator.md
@@ -68,4 +68,4 @@ disk_allocator delete /tmp/test
 
 The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of Notre Dame.  This software is distributed under the GNU General Public License.  See the file COPYING for details.
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/make_growfs.md
+++ b/doc/man/md/make_growfs.md
@@ -89,4 +89,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [parrot_run(1)](parrot_run.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/makeflow.md
+++ b/doc/man/md/makeflow.md
@@ -333,4 +333,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [makeflow(1)](makeflow.md) [makeflow_monitor(1)](makeflow_monitor.md) [makeflow_analyze(1)](makeflow_analyze.md) [makeflow_viz(1)](makeflow_viz.md) [makeflow_graph_log(1)](makeflow_graph_log.md) [starch(1)](starch.md) [makeflow_ec2_setup(1)](makeflow_ec2_setup.md) [makeflow_ec2_cleanup(1)](makeflow_ec2_cleanup.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/makeflow_amazon_batch_cleanup.md
+++ b/doc/man/md/makeflow_amazon_batch_cleanup.md
@@ -64,4 +64,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [makeflow(1)](makeflow.md) [makeflow_monitor(1)](makeflow_monitor.md) [makeflow_analyze(1)](makeflow_analyze.md) [makeflow_viz(1)](makeflow_viz.md) [makeflow_graph_log(1)](makeflow_graph_log.md) [starch(1)](starch.md) [makeflow_ec2_setup(1)](makeflow_ec2_setup.md) [makeflow_ec2_cleanup(1)](makeflow_ec2_cleanup.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/makeflow_amazon_batch_setup.md
+++ b/doc/man/md/makeflow_amazon_batch_setup.md
@@ -90,4 +90,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [makeflow(1)](makeflow.md) [makeflow_monitor(1)](makeflow_monitor.md) [makeflow_analyze(1)](makeflow_analyze.md) [makeflow_viz(1)](makeflow_viz.md) [makeflow_graph_log(1)](makeflow_graph_log.md) [starch(1)](starch.md) [makeflow_ec2_setup(1)](makeflow_ec2_setup.md) [makeflow_ec2_cleanup(1)](makeflow_ec2_cleanup.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/makeflow_analyze.md
+++ b/doc/man/md/makeflow_analyze.md
@@ -63,4 +63,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [makeflow(1)](makeflow.md) [makeflow_monitor(1)](makeflow_monitor.md) [makeflow_analyze(1)](makeflow_analyze.md) [makeflow_viz(1)](makeflow_viz.md) [makeflow_graph_log(1)](makeflow_graph_log.md) [starch(1)](starch.md) [makeflow_ec2_setup(1)](makeflow_ec2_setup.md) [makeflow_ec2_cleanup(1)](makeflow_ec2_cleanup.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/makeflow_blast.md
+++ b/doc/man/md/makeflow_blast.md
@@ -68,4 +68,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [makeflow(1)](makeflow.md) [makeflow_monitor(1)](makeflow_monitor.md) [makeflow_analyze(1)](makeflow_analyze.md) [makeflow_viz(1)](makeflow_viz.md) [makeflow_graph_log(1)](makeflow_graph_log.md) [starch(1)](starch.md) [makeflow_ec2_setup(1)](makeflow_ec2_setup.md) [makeflow_ec2_cleanup(1)](makeflow_ec2_cleanup.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/makeflow_ec2_cleanup.md
+++ b/doc/man/md/makeflow_ec2_cleanup.md
@@ -64,4 +64,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [makeflow(1)](makeflow.md) [makeflow_monitor(1)](makeflow_monitor.md) [makeflow_analyze(1)](makeflow_analyze.md) [makeflow_viz(1)](makeflow_viz.md) [makeflow_graph_log(1)](makeflow_graph_log.md) [starch(1)](starch.md) [makeflow_ec2_setup(1)](makeflow_ec2_setup.md) [makeflow_ec2_cleanup(1)](makeflow_ec2_cleanup.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/makeflow_ec2_setup.md
+++ b/doc/man/md/makeflow_ec2_setup.md
@@ -72,4 +72,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [makeflow(1)](makeflow.md) [makeflow_monitor(1)](makeflow_monitor.md) [makeflow_analyze(1)](makeflow_analyze.md) [makeflow_viz(1)](makeflow_viz.md) [makeflow_graph_log(1)](makeflow_graph_log.md) [starch(1)](starch.md) [makeflow_ec2_setup(1)](makeflow_ec2_setup.md) [makeflow_ec2_cleanup(1)](makeflow_ec2_cleanup.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/makeflow_graph_log.md
+++ b/doc/man/md/makeflow_graph_log.md
@@ -60,4 +60,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [makeflow(1)](makeflow.md) [makeflow_monitor(1)](makeflow_monitor.md) [makeflow_analyze(1)](makeflow_analyze.md) [makeflow_viz(1)](makeflow_viz.md) [makeflow_graph_log(1)](makeflow_graph_log.md) [starch(1)](starch.md) [makeflow_ec2_setup(1)](makeflow_ec2_setup.md) [makeflow_ec2_cleanup(1)](makeflow_ec2_cleanup.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/makeflow_linker.md
+++ b/doc/man/md/makeflow_linker.md
@@ -77,4 +77,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 -  [makeflow(1)](makeflow.md) perl(1), python(1), ldd(1)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/makeflow_monitor.md
+++ b/doc/man/md/makeflow_monitor.md
@@ -81,4 +81,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [makeflow(1)](makeflow.md) [makeflow_monitor(1)](makeflow_monitor.md) [makeflow_analyze(1)](makeflow_analyze.md) [makeflow_viz(1)](makeflow_viz.md) [makeflow_graph_log(1)](makeflow_graph_log.md) [starch(1)](starch.md) [makeflow_ec2_setup(1)](makeflow_ec2_setup.md) [makeflow_ec2_cleanup(1)](makeflow_ec2_cleanup.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/makeflow_mpi_starter.md
+++ b/doc/man/md/makeflow_mpi_starter.md
@@ -99,4 +99,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 
 SEE_ALSO_WORKQUEUE
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/makeflow_status.md
+++ b/doc/man/md/makeflow_status.md
@@ -67,4 +67,4 @@ Retrieving reports related to project "awesome"
 
 The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of Notre Dame.  This software is distributed under the GNU General Public License.  See the file COPYING for details.
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/makeflow_viz.md
+++ b/doc/man/md/makeflow_viz.md
@@ -98,4 +98,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [makeflow(1)](makeflow.md) [makeflow_monitor(1)](makeflow_monitor.md) [makeflow_analyze(1)](makeflow_analyze.md) [makeflow_viz(1)](makeflow_viz.md) [makeflow_graph_log(1)](makeflow_graph_log.md) [starch(1)](starch.md) [makeflow_ec2_setup(1)](makeflow_ec2_setup.md) [makeflow_ec2_cleanup(1)](makeflow_ec2_cleanup.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/maker_wq.md
+++ b/doc/man/md/maker_wq.md
@@ -60,4 +60,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 
 ## SEE ALSO
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/parrot_cp.md
+++ b/doc/man/md/parrot_cp.md
@@ -86,4 +86,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [parrot_run(1)](parrot_run.md) [parrot_cp(1)](parrot_cp.md) [parrot_getacl(1)](parrot_getacl.md)  [parrot_setacl(1)](parrot_setacl.md)  [parrot_mkalloc(1)](parrot_mkalloc.md)  [parrot_lsalloc(1)](parrot_lsalloc.md)  [parrot_locate(1)](parrot_locate.md)  [parrot_timeout(1)](parrot_timeout.md)  [parrot_whoami(1)](parrot_whoami.md)  [parrot_mount(1)](parrot_mount.md)  [parrot_md5(1)](parrot_md5.md)  [parrot_package_create(1)](parrot_package_create.md)  [parrot_package_run(1)](parrot_package_run.md)  [chroot_package_run(1)](chroot_package_run.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/parrot_getacl.md
+++ b/doc/man/md/parrot_getacl.md
@@ -57,4 +57,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [parrot_run(1)](parrot_run.md) [parrot_cp(1)](parrot_cp.md) [parrot_getacl(1)](parrot_getacl.md)  [parrot_setacl(1)](parrot_setacl.md)  [parrot_mkalloc(1)](parrot_mkalloc.md)  [parrot_lsalloc(1)](parrot_lsalloc.md)  [parrot_locate(1)](parrot_locate.md)  [parrot_timeout(1)](parrot_timeout.md)  [parrot_whoami(1)](parrot_whoami.md)  [parrot_mount(1)](parrot_mount.md)  [parrot_md5(1)](parrot_md5.md)  [parrot_package_create(1)](parrot_package_create.md)  [parrot_package_run(1)](parrot_package_run.md)  [chroot_package_run(1)](chroot_package_run.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/parrot_locate.md
+++ b/doc/man/md/parrot_locate.md
@@ -82,4 +82,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [parrot_run(1)](parrot_run.md) [parrot_cp(1)](parrot_cp.md) [parrot_getacl(1)](parrot_getacl.md)  [parrot_setacl(1)](parrot_setacl.md)  [parrot_mkalloc(1)](parrot_mkalloc.md)  [parrot_lsalloc(1)](parrot_lsalloc.md)  [parrot_locate(1)](parrot_locate.md)  [parrot_timeout(1)](parrot_timeout.md)  [parrot_whoami(1)](parrot_whoami.md)  [parrot_mount(1)](parrot_mount.md)  [parrot_md5(1)](parrot_md5.md)  [parrot_package_create(1)](parrot_package_create.md)  [parrot_package_run(1)](parrot_package_run.md)  [chroot_package_run(1)](chroot_package_run.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/parrot_lsalloc.md
+++ b/doc/man/md/parrot_lsalloc.md
@@ -82,4 +82,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [parrot_run(1)](parrot_run.md) [parrot_cp(1)](parrot_cp.md) [parrot_getacl(1)](parrot_getacl.md)  [parrot_setacl(1)](parrot_setacl.md)  [parrot_mkalloc(1)](parrot_mkalloc.md)  [parrot_lsalloc(1)](parrot_lsalloc.md)  [parrot_locate(1)](parrot_locate.md)  [parrot_timeout(1)](parrot_timeout.md)  [parrot_whoami(1)](parrot_whoami.md)  [parrot_mount(1)](parrot_mount.md)  [parrot_md5(1)](parrot_md5.md)  [parrot_package_create(1)](parrot_package_create.md)  [parrot_package_run(1)](parrot_package_run.md)  [chroot_package_run(1)](chroot_package_run.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/parrot_md5.md
+++ b/doc/man/md/parrot_md5.md
@@ -65,4 +65,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [parrot_run(1)](parrot_run.md) [parrot_cp(1)](parrot_cp.md) [parrot_getacl(1)](parrot_getacl.md)  [parrot_setacl(1)](parrot_setacl.md)  [parrot_mkalloc(1)](parrot_mkalloc.md)  [parrot_lsalloc(1)](parrot_lsalloc.md)  [parrot_locate(1)](parrot_locate.md)  [parrot_timeout(1)](parrot_timeout.md)  [parrot_whoami(1)](parrot_whoami.md)  [parrot_mount(1)](parrot_mount.md)  [parrot_md5(1)](parrot_md5.md)  [parrot_package_create(1)](parrot_package_create.md)  [parrot_package_run(1)](parrot_package_run.md)  [chroot_package_run(1)](chroot_package_run.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/parrot_mkalloc.md
+++ b/doc/man/md/parrot_mkalloc.md
@@ -78,4 +78,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [parrot_run(1)](parrot_run.md) [parrot_cp(1)](parrot_cp.md) [parrot_getacl(1)](parrot_getacl.md)  [parrot_setacl(1)](parrot_setacl.md)  [parrot_mkalloc(1)](parrot_mkalloc.md)  [parrot_lsalloc(1)](parrot_lsalloc.md)  [parrot_locate(1)](parrot_locate.md)  [parrot_timeout(1)](parrot_timeout.md)  [parrot_whoami(1)](parrot_whoami.md)  [parrot_mount(1)](parrot_mount.md)  [parrot_md5(1)](parrot_md5.md)  [parrot_package_create(1)](parrot_package_create.md)  [parrot_package_run(1)](parrot_package_run.md)  [chroot_package_run(1)](chroot_package_run.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/parrot_mount.md
+++ b/doc/man/md/parrot_mount.md
@@ -69,4 +69,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [parrot_run(1)](parrot_run.md) [parrot_cp(1)](parrot_cp.md) [parrot_getacl(1)](parrot_getacl.md)  [parrot_setacl(1)](parrot_setacl.md)  [parrot_mkalloc(1)](parrot_mkalloc.md)  [parrot_lsalloc(1)](parrot_lsalloc.md)  [parrot_locate(1)](parrot_locate.md)  [parrot_timeout(1)](parrot_timeout.md)  [parrot_whoami(1)](parrot_whoami.md)  [parrot_mount(1)](parrot_mount.md)  [parrot_md5(1)](parrot_md5.md)  [parrot_package_create(1)](parrot_package_create.md)  [parrot_package_run(1)](parrot_package_run.md)  [chroot_package_run(1)](chroot_package_run.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/parrot_namespace.md
+++ b/doc/man/md/parrot_namespace.md
@@ -81,4 +81,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [parrot_run(1)](parrot_run.md) [parrot_cp(1)](parrot_cp.md) [parrot_getacl(1)](parrot_getacl.md)  [parrot_setacl(1)](parrot_setacl.md)  [parrot_mkalloc(1)](parrot_mkalloc.md)  [parrot_lsalloc(1)](parrot_lsalloc.md)  [parrot_locate(1)](parrot_locate.md)  [parrot_timeout(1)](parrot_timeout.md)  [parrot_whoami(1)](parrot_whoami.md)  [parrot_mount(1)](parrot_mount.md)  [parrot_md5(1)](parrot_md5.md)  [parrot_package_create(1)](parrot_package_create.md)  [parrot_package_run(1)](parrot_package_run.md)  [chroot_package_run(1)](chroot_package_run.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/parrot_package_create.md
+++ b/doc/man/md/parrot_package_create.md
@@ -100,4 +100,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [Parrot User Manual]("../parrot.html")
 - [parrot_run(1)](parrot_run.md) [parrot_cp(1)](parrot_cp.md) [parrot_getacl(1)](parrot_getacl.md)  [parrot_setacl(1)](parrot_setacl.md)  [parrot_mkalloc(1)](parrot_mkalloc.md)  [parrot_lsalloc(1)](parrot_lsalloc.md)  [parrot_locate(1)](parrot_locate.md)  [parrot_timeout(1)](parrot_timeout.md)  [parrot_whoami(1)](parrot_whoami.md)  [parrot_mount(1)](parrot_mount.md)  [parrot_md5(1)](parrot_md5.md)  [parrot_package_create(1)](parrot_package_create.md)  [parrot_package_run(1)](parrot_package_run.md)  [chroot_package_run(1)](chroot_package_run.md)
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/parrot_package_run.md
+++ b/doc/man/md/parrot_package_run.md
@@ -98,4 +98,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [parrot_run(1)](parrot_run.md) [parrot_cp(1)](parrot_cp.md) [parrot_getacl(1)](parrot_getacl.md)  [parrot_setacl(1)](parrot_setacl.md)  [parrot_mkalloc(1)](parrot_mkalloc.md)  [parrot_lsalloc(1)](parrot_lsalloc.md)  [parrot_locate(1)](parrot_locate.md)  [parrot_timeout(1)](parrot_timeout.md)  [parrot_whoami(1)](parrot_whoami.md)  [parrot_mount(1)](parrot_mount.md)  [parrot_md5(1)](parrot_md5.md)  [parrot_package_create(1)](parrot_package_create.md)  [parrot_package_run(1)](parrot_package_run.md)  [chroot_package_run(1)](chroot_package_run.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/parrot_run.md
+++ b/doc/man/md/parrot_run.md
@@ -151,4 +151,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [parrot_run(1)](parrot_run.md) [parrot_cp(1)](parrot_cp.md) [parrot_getacl(1)](parrot_getacl.md)  [parrot_setacl(1)](parrot_setacl.md)  [parrot_mkalloc(1)](parrot_mkalloc.md)  [parrot_lsalloc(1)](parrot_lsalloc.md)  [parrot_locate(1)](parrot_locate.md)  [parrot_timeout(1)](parrot_timeout.md)  [parrot_whoami(1)](parrot_whoami.md)  [parrot_mount(1)](parrot_mount.md)  [parrot_md5(1)](parrot_md5.md)  [parrot_package_create(1)](parrot_package_create.md)  [parrot_package_run(1)](parrot_package_run.md)  [chroot_package_run(1)](chroot_package_run.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/parrot_setacl.md
+++ b/doc/man/md/parrot_setacl.md
@@ -58,4 +58,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [parrot_run(1)](parrot_run.md) [parrot_cp(1)](parrot_cp.md) [parrot_getacl(1)](parrot_getacl.md)  [parrot_setacl(1)](parrot_setacl.md)  [parrot_mkalloc(1)](parrot_mkalloc.md)  [parrot_lsalloc(1)](parrot_lsalloc.md)  [parrot_locate(1)](parrot_locate.md)  [parrot_timeout(1)](parrot_timeout.md)  [parrot_whoami(1)](parrot_whoami.md)  [parrot_mount(1)](parrot_mount.md)  [parrot_md5(1)](parrot_md5.md)  [parrot_package_create(1)](parrot_package_create.md)  [parrot_package_run(1)](parrot_package_run.md)  [chroot_package_run(1)](chroot_package_run.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/parrot_timeout.md
+++ b/doc/man/md/parrot_timeout.md
@@ -75,4 +75,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [parrot_run(1)](parrot_run.md) [parrot_cp(1)](parrot_cp.md) [parrot_getacl(1)](parrot_getacl.md)  [parrot_setacl(1)](parrot_setacl.md)  [parrot_mkalloc(1)](parrot_mkalloc.md)  [parrot_lsalloc(1)](parrot_lsalloc.md)  [parrot_locate(1)](parrot_locate.md)  [parrot_timeout(1)](parrot_timeout.md)  [parrot_whoami(1)](parrot_whoami.md)  [parrot_mount(1)](parrot_mount.md)  [parrot_md5(1)](parrot_md5.md)  [parrot_package_create(1)](parrot_package_create.md)  [parrot_package_run(1)](parrot_package_run.md)  [chroot_package_run(1)](chroot_package_run.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/parrot_whoami.md
+++ b/doc/man/md/parrot_whoami.md
@@ -73,4 +73,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [parrot_run(1)](parrot_run.md) [parrot_cp(1)](parrot_cp.md) [parrot_getacl(1)](parrot_getacl.md)  [parrot_setacl(1)](parrot_setacl.md)  [parrot_mkalloc(1)](parrot_mkalloc.md)  [parrot_lsalloc(1)](parrot_lsalloc.md)  [parrot_locate(1)](parrot_locate.md)  [parrot_timeout(1)](parrot_timeout.md)  [parrot_whoami(1)](parrot_whoami.md)  [parrot_mount(1)](parrot_mount.md)  [parrot_md5(1)](parrot_md5.md)  [parrot_package_create(1)](parrot_package_create.md)  [parrot_package_run(1)](parrot_package_run.md)  [chroot_package_run(1)](chroot_package_run.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/pbs_submit_workers.md
+++ b/doc/man/md/pbs_submit_workers.md
@@ -87,4 +87,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [work_queue_worker(1)](work_queue_worker.md) [work_queue_status(1)](work_queue_status.md) [work_queue_factory(1)](work_queue_factory.md) [condor_submit_workers(1)](condor_submit_workers.md) [sge_submit_workers(1)](sge_submit_workers.md) [torque_submit_workers(1)](torque_submit_workers.md) 
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/poncho_package_analyze.md
+++ b/doc/man/md/poncho_package_analyze.md
@@ -83,5 +83,5 @@ This includes other modules within the CWD or in user-written packages.
 
 The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of Notre Dame.  This software is distributed under the GNU General Public License.  See the file COPYING for details.
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools
 

--- a/doc/man/md/poncho_package_create.md
+++ b/doc/man/md/poncho_package_create.md
@@ -57,4 +57,4 @@ This will create an example_venv.tar.gz environment tarball within the current w
 
 The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of Notre Dame.  This software is distributed under the GNU General Public License.  See the file COPYING for details.
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/poncho_package_run.md
+++ b/doc/man/md/poncho_package_run.md
@@ -72,4 +72,4 @@ The previous command will run faster the second time it is executed, as the envi
 
 The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of Notre Dame.  This software is distributed under the GNU General Public License.  See the file COPYING for details.
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/replica_exchange.md
+++ b/doc/man/md/replica_exchange.md
@@ -93,4 +93,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [work_queue_worker(1)](work_queue_worker.md) [work_queue_status(1)](work_queue_status.md) [work_queue_factory(1)](work_queue_factory.md) [condor_submit_workers(1)](condor_submit_workers.md) [sge_submit_workers(1)](sge_submit_workers.md) [torque_submit_workers(1)](torque_submit_workers.md) 
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/resource_monitor.md
+++ b/doc/man/md/resource_monitor.md
@@ -366,4 +366,4 @@ snapshot everytime the file **please-take-a-snapshot** is created:
 
 The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of Notre Dame.  This software is distributed under the GNU General Public License.  See the file COPYING for details.
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/sand_align_kernel.md
+++ b/doc/man/md/sand_align_kernel.md
@@ -83,4 +83,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [sand_filter_master(1)](sand_filter_master.md)  [sand_filter_kernel(1)](sand_filter_kernel.md)  [sand_align_master(1)](sand_align_master.md)  [sand_align_kernel(1)](sand_align_kernel.md)  [sand_compress_reads(1)](sand_compress_reads.md)  [sand_uncompress_reads(1)](sand_uncompress_reads.md)  [work_queue_worker(1)](work_queue_worker.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/sand_align_master.md
+++ b/doc/man/md/sand_align_master.md
@@ -88,4 +88,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [sand_filter_master(1)](sand_filter_master.md)  [sand_filter_kernel(1)](sand_filter_kernel.md)  [sand_align_master(1)](sand_align_master.md)  [sand_align_kernel(1)](sand_align_kernel.md)  [sand_compress_reads(1)](sand_compress_reads.md)  [sand_uncompress_reads(1)](sand_uncompress_reads.md)  [work_queue_worker(1)](work_queue_worker.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/sand_compress_reads.md
+++ b/doc/man/md/sand_compress_reads.md
@@ -73,4 +73,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [sand_filter_master(1)](sand_filter_master.md)  [sand_filter_kernel(1)](sand_filter_kernel.md)  [sand_align_master(1)](sand_align_master.md)  [sand_align_kernel(1)](sand_align_kernel.md)  [sand_compress_reads(1)](sand_compress_reads.md)  [sand_uncompress_reads(1)](sand_uncompress_reads.md)  [work_queue_worker(1)](work_queue_worker.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/sand_filter_kernel.md
+++ b/doc/man/md/sand_filter_kernel.md
@@ -80,4 +80,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [sand_filter_master(1)](sand_filter_master.md)  [sand_filter_kernel(1)](sand_filter_kernel.md)  [sand_align_master(1)](sand_align_master.md)  [sand_align_kernel(1)](sand_align_kernel.md)  [sand_compress_reads(1)](sand_compress_reads.md)  [sand_uncompress_reads(1)](sand_uncompress_reads.md)  [work_queue_worker(1)](work_queue_worker.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/sand_filter_master.md
+++ b/doc/man/md/sand_filter_master.md
@@ -94,4 +94,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [sand_filter_master(1)](sand_filter_master.md)  [sand_filter_kernel(1)](sand_filter_kernel.md)  [sand_align_master(1)](sand_align_master.md)  [sand_align_kernel(1)](sand_align_kernel.md)  [sand_compress_reads(1)](sand_compress_reads.md)  [sand_uncompress_reads(1)](sand_uncompress_reads.md)  [work_queue_worker(1)](work_queue_worker.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/sand_uncompress_reads.md
+++ b/doc/man/md/sand_uncompress_reads.md
@@ -70,4 +70,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [sand_filter_master(1)](sand_filter_master.md)  [sand_filter_kernel(1)](sand_filter_kernel.md)  [sand_align_master(1)](sand_align_master.md)  [sand_align_kernel(1)](sand_align_kernel.md)  [sand_compress_reads(1)](sand_compress_reads.md)  [sand_uncompress_reads(1)](sand_uncompress_reads.md)  [work_queue_worker(1)](work_queue_worker.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/sge_submit_workers.md
+++ b/doc/man/md/sge_submit_workers.md
@@ -96,4 +96,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [work_queue_worker(1)](work_queue_worker.md) [work_queue_status(1)](work_queue_status.md) [work_queue_factory(1)](work_queue_factory.md) [condor_submit_workers(1)](condor_submit_workers.md) [sge_submit_workers(1)](sge_submit_workers.md) [torque_submit_workers(1)](torque_submit_workers.md) 
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/slurm_submit_workers.md
+++ b/doc/man/md/slurm_submit_workers.md
@@ -86,4 +86,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [work_queue_worker(1)](work_queue_worker.md) [work_queue_status(1)](work_queue_status.md) [work_queue_factory(1)](work_queue_factory.md) [condor_submit_workers(1)](condor_submit_workers.md) [sge_submit_workers(1)](sge_submit_workers.md) [torque_submit_workers(1)](torque_submit_workers.md) 
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/split_fasta.md
+++ b/doc/man/md/split_fasta.md
@@ -61,4 +61,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [makeflow(1)](makeflow.md) [makeflow_monitor(1)](makeflow_monitor.md) [makeflow_analyze(1)](makeflow_analyze.md) [makeflow_viz(1)](makeflow_viz.md) [makeflow_graph_log(1)](makeflow_graph_log.md) [starch(1)](starch.md) [makeflow_ec2_setup(1)](makeflow_ec2_setup.md) [makeflow_ec2_cleanup(1)](makeflow_ec2_cleanup.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/starch.md
+++ b/doc/man/md/starch.md
@@ -158,4 +158,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [makeflow(1)](makeflow.md) [makeflow_monitor(1)](makeflow_monitor.md) [makeflow_analyze(1)](makeflow_analyze.md) [makeflow_viz(1)](makeflow_viz.md) [makeflow_graph_log(1)](makeflow_graph_log.md) [starch(1)](starch.md) [makeflow_ec2_setup(1)](makeflow_ec2_setup.md) [makeflow_ec2_cleanup(1)](makeflow_ec2_cleanup.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/torque_submit_workers.md
+++ b/doc/man/md/torque_submit_workers.md
@@ -87,4 +87,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [work_queue_worker(1)](work_queue_worker.md) [work_queue_status(1)](work_queue_status.md) [work_queue_factory(1)](work_queue_factory.md) [condor_submit_workers(1)](condor_submit_workers.md) [sge_submit_workers(1)](sge_submit_workers.md) [torque_submit_workers(1)](torque_submit_workers.md) 
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/wavefront_master.md
+++ b/doc/man/md/wavefront_master.md
@@ -144,4 +144,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [sge_submit_workers(1)](sge_submit_workers.md)
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/weaver.md
+++ b/doc/man/md/weaver.md
@@ -113,4 +113,4 @@ Please refer to **cctools/doc/weaver_examples** for further information.
 
 The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of Notre Dame.  This software is distributed under the GNU General Public License.  See the file COPYING for details.
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/work_queue_factory.md
+++ b/doc/man/md/work_queue_factory.md
@@ -222,4 +222,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [work_queue_worker(1)](work_queue_worker.md) [work_queue_status(1)](work_queue_status.md) [work_queue_factory(1)](work_queue_factory.md) [condor_submit_workers(1)](condor_submit_workers.md) [sge_submit_workers(1)](sge_submit_workers.md) [torque_submit_workers(1)](torque_submit_workers.md) 
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/work_queue_graph_log.md
+++ b/doc/man/md/work_queue_graph_log.md
@@ -102,4 +102,4 @@ Specify gnuplot path:
 
 The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of Notre Dame.  This software is distributed under the GNU General Public License.  See the file COPYING for details.
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/work_queue_pool.md
+++ b/doc/man/md/work_queue_pool.md
@@ -41,4 +41,4 @@ please see that man page for details.
 - [work_queue_worker(1)](work_queue_worker.md) [work_queue_status(1)](work_queue_status.md) [work_queue_factory(1)](work_queue_factory.md) [condor_submit_workers(1)](condor_submit_workers.md) [sge_submit_workers(1)](sge_submit_workers.md) [torque_submit_workers(1)](torque_submit_workers.md) 
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/work_queue_status.md
+++ b/doc/man/md/work_queue_status.md
@@ -174,4 +174,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [work_queue_worker(1)](work_queue_worker.md) [work_queue_status(1)](work_queue_status.md) [work_queue_factory(1)](work_queue_factory.md) [condor_submit_workers(1)](condor_submit_workers.md) [sge_submit_workers(1)](sge_submit_workers.md) [torque_submit_workers(1)](torque_submit_workers.md) 
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools

--- a/doc/man/md/work_queue_worker.md
+++ b/doc/man/md/work_queue_worker.md
@@ -139,4 +139,4 @@ The Cooperative Computing Tools are Copyright (C) 2005-2021 The University of No
 - [work_queue_worker(1)](work_queue_worker.md) [work_queue_status(1)](work_queue_status.md) [work_queue_factory(1)](work_queue_factory.md) [condor_submit_workers(1)](condor_submit_workers.md) [sge_submit_workers(1)](sge_submit_workers.md) [torque_submit_workers(1)](torque_submit_workers.md) 
 
 
-CCTools 8.0.0 DEVELOPMENT
+CCTools


### PR DESCRIPTION
Since the manuals are build and included with the source, the version string was always a mismatch between the stable and master branch.
