### PR TITLE
wq: adds by_apparent_ip mode

### DIFF
--- a/doc/man/m4/work_queue_worker.m4
+++ b/doc/man/m4/work_queue_worker.m4
@@ -70,6 +70,7 @@ OPTION_ARG_LONG(disk, mb)Manually set the amount of disk space (in MB) reported 
 OPTION_ARG_LONG(wall-time, s)Set the maximum number of seconds the worker may be active.
 OPTION_ARG_LONG(feature, feature)Specifies a user-defined feature the worker provides (option can be repeated).
 OPTION_ARG_LONG(volatility, chance)Set the percent chance per minute that the worker will shut down (simulates worker failures, for testing only).
+OPTION_ARG_LONG(connection-mode, mode)When using -M, override manager preference to resolve its address. One of by_ip, by_hostname, or by_apparent_ip. Default is set by manager.
 OPTIONS_END
 
 SECTION(FOREMAN MODE)

--- a/doc/man/md/work_queue_worker.md
+++ b/doc/man/md/work_queue_worker.md
@@ -92,6 +92,7 @@ grid or cloud computing environments such as SGE, PBS, SLURM, and HTCondor using
 - **--wall-time=_&lt;s&gt;_**<br />Set the maximum number of seconds the worker may be active.
 - **--feature=_&lt;feature&gt;_**<br />Specifies a user-defined feature the worker provides (option can be repeated).
 - **--volatility=_&lt;chance&gt;_**<br />Set the percent chance per minute that the worker will shut down (simulates worker failures, for testing only).
+- **--connection-mode=_&lt;mode&gt;_**<br />When using -M, override manager preference to resolve its address. One of by_ip, by_hostname, or by_apparent_ip. Default is set by manager.
 
 
 ## FOREMAN MODE

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -1326,7 +1326,7 @@ class WorkQueue(object):
     # server.
     #
     # @param self Reference to the current work queue object.
-    # @param mode An string to indicate using 'by_ip' or a 'by_hostname'.
+    # @param mode An string to indicate using 'by_ip', 'by_hostname' or 'by_apparent_ip'.
     def specify_manager_preferred_connection(self, mode):
         return work_queue_manager_preferred_connection(self._work_queue, mode)
 

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -1320,8 +1320,10 @@ class WorkQueue(object):
 
     ##
     # Set the preference for using hostname over IP address to connect.
-    # 'by_ip' uses IP address (standard behavior), or 'by_hostname' to use the
-    # hostname at the manager.
+    # 'by_ip' uses IP addresses from the network interfaces of the manager
+    # (standard behavior), 'by_hostname' to use the hostname at the manager, or
+    # 'by_apparent_ip' to use the address of the manager as seen by the catalog
+    # server.
     #
     # @param self Reference to the current work queue object.
     # @param mode An string to indicate using 'by_ip' or a 'by_hostname'.

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -195,7 +195,7 @@ struct work_queue {
 	int keepalive_timeout;
 	timestamp_t link_poll_end;	//tracks when we poll link; used to timeout unacknowledged keepalive checks
 
-    char *manager_preferred_connection; 
+    char *manager_preferred_connection;
 
 	int monitor_mode;
 	FILE *monitor_file;
@@ -6702,6 +6702,12 @@ void work_queue_specify_keepalive_timeout(struct work_queue *q, int timeout)
 void work_queue_manager_preferred_connection(struct work_queue *q, const char *preferred_connection)
 {
 	free(q->manager_preferred_connection);
+	assert(preferred_connection);
+
+	if(strcmp(preferred_connection, "by_ip") && strcmp(preferred_connection, "by_hostname") && strcmp(preferred_connection, "by_apparent_ip")) {
+		fatal("manager_preferred_connection should be one of: by_ip, by_hostname, by_apparent_ip");
+	}
+
 	q->manager_preferred_connection = xxstrdup(preferred_connection);
 }
 

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -1035,7 +1035,7 @@ void work_queue_specify_keepalive_interval(struct work_queue *q, int interval);
 void work_queue_specify_keepalive_timeout(struct work_queue *q, int timeout);
 
 /** Set the preference for using hostname over IP address to connect.
-'by_ip' uses IP address (standard behavior), or 'by_hostname' to use the hostname at the manager.
+'by_ip' uses IP addresses from the network interfaces of the manager (standard behavior), 'by_hostname' to use the hostname at the manager, or 'by_apparent_ip' to use the address of the manager as seen by the catalog server.
 @param q A work queue object.
 @param preferred_connection An string to indicate using 'by_ip' or a 'by_hostname'.
 */

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -2500,6 +2500,10 @@ static void show_help(const char *cmd)
 	printf( " %-30s Use loop devices for task sandboxes (default=disabled, requires root access).\n", "--disk-allocation");
 	printf( " %-30s Specifies a user-defined feature the worker provides. May be specified several times.\n", "--feature");
 	printf( " %-30s Set the maximum number of seconds the worker may be active. (in s).\n", "--wall-time=<s>");
+
+	printf( " %-30s When using -M, override manager preference to resolve its address.\n", "--connection-mode");
+	printf( " %-30s One of by_ip, by_hostname, or by_apparent_ip. Default is set by manager.\n", "");
+
 	printf( " %-30s Forbid the use of symlinks for cache management.\n", "--disable-symlinks");
 	printf(" %-30s Single-shot mode -- quit immediately after disconnection.\n", "--single-shot");
 	printf( " %-30s Set the percent chance per minute that the worker will shut down (simulates worker failures, for testing only).\n", "--volatility=<chance>");


### PR DESCRIPTION
ignores the list of interfaces and directly tries to connect to the
manager address the catalog observes.

This is the original work queue behaviour from years ago, and it was
already present as a fallback from when a manager did not report a list
of interfaces.