### PR TITLE
adds work_queue_task_specify_start_time_min

### DIFF
--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -423,6 +423,11 @@ class Task(object):
     def specify_end_time(self, useconds):
         return work_queue_task_specify_end_time(self._task, int(useconds))
 
+    # Indicate the minimum start time (absolute, in microseconds from the Epoch) of this task.
+    # If less than 1, or not specified, no limit is imposed.
+    def specify_start_time_min(self, useconds):
+        return work_queue_task_specify_start_time_min(self._task, int(useconds))
+
     # Indicate the maximum running time (in microseconds) for a task in a
     # worker (relative to when the task starts to run).  If less than 1, or not
     # specified, no limit is imposed.

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4113,9 +4113,14 @@ static int send_one_task( struct work_queue *q )
 	struct work_queue_task *t;
 	struct work_queue_worker *w;
 
+	timestamp_t now = timestamp_get();
+
 	// Consider each task in the order of priority:
 	list_first_item(q->ready_list);
 	while( (t = list_next_item(q->ready_list))) {
+
+		// Skip task if min requested start time not met.
+		if(t->resources_requested->start > now) continue;
 
 		// Find the best worker for the task at the head of the list
 		w = find_best_worker(q,t);
@@ -4598,6 +4603,18 @@ void work_queue_task_specify_end_time( struct work_queue_task *t, int64_t usecon
 	else
 	{
 		t->resources_requested->end = DIV_INT_ROUND_UP(useconds, ONE_SECOND);
+	}
+}
+
+void work_queue_task_specify_start_time_min( struct work_queue_task *t, int64_t useconds )
+{
+	if(useconds < 1)
+	{
+		t->resources_requested->start = -1;
+	}
+	else
+	{
+		t->resources_requested->start = DIV_INT_ROUND_UP(useconds, ONE_SECOND);
 	}
 }
 

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -498,6 +498,14 @@ This is useful, for example, when the task uses certificates that expire.
 
 void work_queue_task_specify_end_time( struct work_queue_task *t, int64_t useconds );
 
+/** Specify the minimum start time allowed for the task (in microseconds since the
+ * Epoch). If less than 1, then no minimum start time is specified (this is the default).
+@param t A task object.
+@param useconds Number of useconds since the Epoch.
+*/
+
+void work_queue_task_specify_start_time_min( struct work_queue_task *t, int64_t useconds );
+
 /** Specify the maximum time (in microseconds) the task is allowed to run in a
  * worker. This time is accounted since the the moment the task starts to run
  * in a worker.  If less than 1, then no maximum time is specified (this is the default).


### PR DESCRIPTION
This defines a minimum start time (usecs from epoch) before which the
task should not be submitted to workers.