### PR TITLE
remove antigravity from PONCHO example

### DIFF
--- a/doc/manuals/poncho/index.md
+++ b/doc/manuals/poncho/index.md
@@ -19,8 +19,6 @@ Suppose you have a Python program `example.py` like this:
 import os
 import sys
 import pickle
-
-import antigravity
 import matplotlib
 
 


### PR DESCRIPTION
antigravity in the example caused an issue where the xkcd program would open when ran as mentioned in #2663