### PR TITLE
Add recurse option to serialization

### DIFF
--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -961,7 +961,7 @@ class PythonTask(Task):
 
     def _serialize_python_function(self, func, *args):
         with open(self._func_file, 'wb') as wf:
-            dill.dump(func, wf)
+            dill.dump(func, wf, recurse=True)
         with open(self._args_file, 'wb') as wf:
             dill.dump([*args], wf)
 

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -963,7 +963,7 @@ class PythonTask(Task):
         with open(self._func_file, 'wb') as wf:
             dill.dump(func, wf, recurse=True)
         with open(self._args_file, 'wb') as wf:
-            dill.dump([*args], wf)
+            dill.dump([*args], wf, recurse=True)
 
 
     def _python_function_command(self):


### PR DESCRIPTION
The default recurse option using dill is false. Thus, previously, if a user used PythonTask for serialization, any sub functions would not be included in the. This would fix that.