### PR TITLE
Added delayed_wait parameter to alter work_queue loop

### DIFF
--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -1701,6 +1701,7 @@ class WorkQueue(object):
     # - "category-steady-n-tasks" Set the number of tasks considered when computing category buckets.
     # - "hungry-minimum" Mimimum number of tasks to consider queue not hungry. (default=10)
     # - "wait-for-workers" Mimimum number of workers to connect before starting dispatching tasks. (default=0)
+    # - "delayed-wait" Parameter to alter how work_queue_wait works. If set to 0, work_queue_wait breaks out of the while loop whenever a task changes to WORK_QUEUE_TASK_DONE. If set to 1, work_queue_wait does not break, but continues recieving and dispatching tasks. This occurs until no task is sent or recieved, at which case it breaks out of the while loop. (default=0)
     # @param value The value to set the parameter to.
     # @return 0 on succes, -1 on failure.
     #

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -1701,7 +1701,7 @@ class WorkQueue(object):
     # - "category-steady-n-tasks" Set the number of tasks considered when computing category buckets.
     # - "hungry-minimum" Mimimum number of tasks to consider queue not hungry. (default=10)
     # - "wait-for-workers" Mimimum number of workers to connect before starting dispatching tasks. (default=0)
-    # - "delayed-wait" Parameter to alter how work_queue_wait works. If set to 0, work_queue_wait breaks out of the while loop whenever a task changes to WORK_QUEUE_TASK_DONE. If set to 1, work_queue_wait does not break, but continues recieving and dispatching tasks. This occurs until no task is sent or recieved, at which case it breaks out of the while loop. (default=0)
+    # - "wait_retrieve_many" Parameter to alter how work_queue_wait works. If set to 0, work_queue_wait breaks out of the while loop whenever a task changes to WORK_QUEUE_TASK_DONE (wait_retrieve_one mode). If set to 1, work_queue_wait does not break, but continues recieving and dispatching tasks. This occurs until no task is sent or recieved, at which case it breaks out of the while loop (wait_retrieve_many mode). (default=0)
     # @param value The value to set the parameter to.
     # @return 0 on succes, -1 on failure.
     #

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -6317,32 +6317,31 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 	while( (stoptime == 0) || (time(0) < stoptime) ) {
 
 		BEGIN_ACCUM_TIME(q, time_internal);
-		// keep track of whether a task has been sent and recieved
+		// keep track of whether a task has been sent or recieved
 		int task_event = 0;
 		// task completed?
 		if (t == NULL)
 		{
 			t = task_state_any(q, WORK_QUEUE_TASK_RETRIEVED);
-		}
-		if(t) {
-			change_task_state(q, t, WORK_QUEUE_TASK_DONE);
+			if(t) {
+				change_task_state(q, t, WORK_QUEUE_TASK_DONE);
 
-			if( t->result != WORK_QUEUE_RESULT_SUCCESS )
-			{
-				q->stats->tasks_failed++;
-			}
+				if( t->result != WORK_QUEUE_RESULT_SUCCESS )
+				{
+					q->stats->tasks_failed++;
+				}
 
-			// return completed task (t) to the user. We do not return right
-			// away, and instead break out of the loop to correctly update the
-			// queue time statistics.
-			events++;
-			END_ACCUM_TIME(q, time_internal);
-			if (!q->delayed_wait)
-			{
-				break;
+				// return completed task (t) to the user. We do not return right
+				// away, and instead break out of the loop to correctly update the
+				// queue time statistics.
+				events++;
+				END_ACCUM_TIME(q, time_internal);
 			}
 		}
-
+		if (t && !q->delayed_wait)
+		{
+			break;
+		}
 		 // update catalog if appropriate
 		if(q->name) {
 			update_catalog(q, foreman_uplink, 0);

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -215,7 +215,7 @@ struct work_queue {
 	int tlq_port;
 	char *tlq_url;
 
-	int delayed_wait;
+	int wait_retrieve_many;
 };
 
 struct work_queue_worker {
@@ -6338,7 +6338,7 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 				END_ACCUM_TIME(q, time_internal);
 			}
 		}
-		if (t && !q->delayed_wait)
+		if (t && !q->wait_retrieve_many)
 		{
 			break;
 		}
@@ -6468,7 +6468,7 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 		if(foreman_uplink) {
 			break;
 		}
-		if (!task_event && q->delayed_wait)
+		if (!task_event && q->wait_retrieve_many)
 		{
 			break;
 		}
@@ -6783,8 +6783,8 @@ int work_queue_tune(struct work_queue *q, const char *name, double value)
 	} else if(!strcmp(name, "wait-for-workers")) {
 		q->wait_for_workers = MAX(0, (int)value);
 
-	} else if(!strcmp(name, "delayed-wait")){
-		q->delayed_wait = MAX(0, (int)value);
+	} else if(!strcmp(name, "wait_retrieve_many")){
+		q->wait_retrieve_many = MAX(0, (int)value);
 
 	} else {
 		debug(D_NOTICE|D_WQ, "Warning: tuning parameter \"%s\" not recognized\n", name);

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -6469,7 +6469,7 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 		if(foreman_uplink) {
 			break;
 		}
-		if (!task_event)
+		if (!task_event && q->delayed_wait)
 		{
 			break;
 		}

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -1065,7 +1065,7 @@ void work_queue_manager_preferred_connection(struct work_queue *q, const char *p
  - "category-steady-n-tasks" Set the number of tasks considered when computing category buckets.
  - "hungry-minimum" Mimimum number of tasks to consider queue not hungry. (default=10)
  - "wait-for-workers" Mimimum number of workers to connect before starting dispatching tasks. (default=0)
- - "delayed-wait" Parameter to alter how work_queue_wait works. If set to 0, work_queue_wait breaks out of the while loop whenever a task changes to WORK_QUEUE_TASK_DONE. If set to 1, work_queue_wait does not break, but continues recieving and dispatching tasks. This occurs until no task is sent or recieved, at which case it breaks out of the while loop. (default=0)
+ - "wait_retrieve_many" Parameter to alter how work_queue_wait works. If set to 0, work_queue_wait breaks out of the while loop whenever a task changes to WORK_QUEUE_TASK_DONE (wait_retrieve_one mode). If set to 1, work_queue_wait does not break, but continues recieving and dispatching tasks. This occurs until no task is sent or recieved, at which case it breaks out of the while loop (wait_retrieve_many mode). (default=0)
 @param value The value to set the parameter to.
 @return 0 on succes, -1 on failure.
 */

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -1065,6 +1065,7 @@ void work_queue_manager_preferred_connection(struct work_queue *q, const char *p
  - "category-steady-n-tasks" Set the number of tasks considered when computing category buckets.
  - "hungry-minimum" Mimimum number of tasks to consider queue not hungry. (default=10)
  - "wait-for-workers" Mimimum number of workers to connect before starting dispatching tasks. (default=0)
+ - "delayed-wait" Parameter to alter how work_queue_wait works. If set to 0, work_queue_wait breaks out of the while loop whenever a task changes to WORK_QUEUE_TASK_DONE. If set to 1, work_queue_wait does not break, but continues recieving and dispatching tasks. This occurs until no task is sent or recieved, at which case it breaks out of the while loop. (default=0)
 @param value The value to set the parameter to.
 @return 0 on succes, -1 on failure.
 */


### PR DESCRIPTION
Pull request for #2691
Added a delayed_wait paramter to work_queue_tune that, if enabled, alters the function of the main work_queue_wait loop. The loop now only breaks if we fail to send or receive a task, and not only if one task changed to WORK_QUEUE_TASK_DONE.