### PR TITLE
add debug switch to TR_work_queue_allocations.sh

### DIFF
--- a/work_queue/test/TR_work_queue_allocations.sh
+++ b/work_queue/test/TR_work_queue_allocations.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -ex
 
 . ../../dttools/test/test_runner_common.sh
 


### PR DESCRIPTION
The test succeeds running locally on cclmac02. Adding `set -x` as we are not getting any output when the test fails with the github action.