### PR TITLE
wq: work_queue_wait_for_tag

### DIFF
--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -1733,7 +1733,20 @@ class WorkQueue(object):
     #                   before returning.  Use an integer to set the timeout or the constant @ref
     #                   WORK_QUEUE_WAITFORTASK to block until a task has completed.
     def wait(self, timeout=WORK_QUEUE_WAITFORTASK):
-        task_pointer = work_queue_wait(self._work_queue, timeout)
+        return self.wait_for_tag(None, timeout)
+
+    ##
+    # Similar to @ref wait, but guarantees that the returned task has the
+    # specified tag.
+    #
+    # This call will block until the timeout has elapsed.
+    #
+    # @param self       Reference to the current work queue object.
+    # @param tag        Desired tag. If None, then it is equivalent to self.wait(timeout)
+    # @param timeout    The number of seconds to wait for a completed task
+    #                   before returning.
+    def wait_for_tag(self, tag, timeout=WORK_QUEUE_WAITFORTASK):
+        task_pointer = work_queue_wait_for_tag(self._work_queue, tag, timeout)
         if task_pointer:
             task = self._task_table[int(task_pointer.taskid)]
             del self._task_table[task_pointer.taskid]

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -6234,7 +6234,11 @@ static void print_password_warning( struct work_queue *q )
 
 struct work_queue_task *work_queue_wait(struct work_queue *q, int timeout)
 {
+	return work_queue_wait_for_tag(q, NULL, timeout);
+}
 
+struct work_queue_task *work_queue_wait_for_tag(struct work_queue *q, const char *tag, int timeout)
+{
 	if(timeout == 0) {
 		// re-establish old, if unintended behavior, where 0 would wait at
 		// least a second. With 0, we would like the loop to be executed at
@@ -6248,7 +6252,7 @@ struct work_queue_task *work_queue_wait(struct work_queue *q, int timeout)
 		timeout = 5;
 	}
 
-	return work_queue_wait_internal(q, timeout, NULL, NULL);
+	return work_queue_wait_internal(q, timeout, NULL, NULL, tag);
 }
 
 /* return number of workers that failed */
@@ -6379,7 +6383,7 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 		if (t == NULL)
 		{
 			if(tag) {
-				t = task_state_any_with_tag(q, WORK_QUEUE_TASK_RETRIEVED);
+				t = task_state_any_with_tag(q, WORK_QUEUE_TASK_RETRIEVED, tag);
 			} else {
 				t = task_state_any(q, WORK_QUEUE_TASK_RETRIEVED);
 			}

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -6036,6 +6036,20 @@ static struct work_queue_task *task_state_any(struct work_queue *q, work_queue_t
 	return NULL;
 }
 
+static struct work_queue_task *task_state_any_with_tag(struct work_queue *q, work_queue_task_state_t state, const char *tag) {
+	struct work_queue_task *t;
+	uint64_t taskid;
+
+	itable_firstkey(q->tasks);
+	while( itable_nextkey(q->tasks, &taskid, (void **) &t) ) {
+		if( task_state_is(q, taskid, state) && tasktag_comparator((void *) t, (void *) tag)) {
+			return t;
+		}
+	}
+
+	return NULL;
+}
+
 static int task_state_count(struct work_queue *q, const char *category, work_queue_task_state_t state) {
 	struct work_queue_task *t;
 	uint64_t taskid;

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -6337,7 +6337,8 @@ static int connect_new_workers(struct work_queue *q, int stoptime, int max_new_w
 }
 
 
-struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeout, struct link *foreman_uplink, int *foreman_uplink_active)
+struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeout, struct link *foreman_uplink, int *foreman_uplink_active, const char *tag)
+{
 /*
    - compute stoptime
    S time left?                              No:  return null
@@ -6353,7 +6354,6 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
    - queue empty?                            Yes: return null
    - go to S
 */
-{
 	int events = 0;
 
 	// account for time we spend outside work_queue_wait
@@ -6378,7 +6378,11 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 		// task completed?
 		if (t == NULL)
 		{
-			t = task_state_any(q, WORK_QUEUE_TASK_RETRIEVED);
+			if(tag) {
+				t = task_state_any_with_tag(q, WORK_QUEUE_TASK_RETRIEVED);
+			} else {
+				t = task_state_any(q, WORK_QUEUE_TASK_RETRIEVED);
+			}
 			if(t) {
 				change_task_state(q, t, WORK_QUEUE_TASK_DONE);
 

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4354,16 +4354,21 @@ static int abort_drained_workers(struct work_queue *q) {
 }
 
 
-//comparator function for checking if a task matches given tag.
+//comparator function for checking if a task matches a given tag.
 static int tasktag_comparator(void *t, const void *r) {
 
 	struct work_queue_task *task_in_queue = t;
 	const char *tasktag = r;
 
-	if (task_in_queue->tag && !strcmp(task_in_queue->tag, tasktag)) {
+	if(!task_in_queue->tag && !tasktag) {
 		return 1;
 	}
-	return 0;
+
+	if(!task_in_queue->tag || !tasktag) {
+		return 0;
+	}
+
+	return !strcmp(task_in_queue->tag, tasktag);
 }
 
 

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -786,6 +786,16 @@ If the task could not, then the <tt>result</tt> field will be non-zero and the
 */
 struct work_queue_task *work_queue_wait(struct work_queue *q, int timeout);
 
+
+/** Wait for a task with a given task to complete.
+Similar to @ref work_queue_wait, but guarantees that the returned task has the specified tag.
+@param q A work queue object.
+@param tag The desired tag. If NULL, then tasks are returned regardless of their tag.
+@param timeout The number of seconds to wait for a completed task before returning.  Use an integer time to set the timeout or the constant @ref WORK_QUEUE_WAITFORTASK to block until a task has completed.
+@returns A completed task description, or null if the queue is empty, or the timeout was reached without a completed task, or there is completed child process (call @ref process_wait to retrieve the status of the completed child process).
+*/
+struct work_queue_task *work_queue_wait_for_tag(struct work_queue *q, const char *tag, int timeout);
+
 /** Determine whether the queue is 'hungry' for more tasks.
 While the Work Queue can handle a very large number of tasks,
 it runs most efficiently when the number of tasks is slightly

--- a/work_queue/src/work_queue_internal.h
+++ b/work_queue/src/work_queue_internal.h
@@ -21,7 +21,7 @@ struct work_queue_file {
 	char *cached_name;	// name on remote machine in cached directory.
 };
 
-struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeout, struct link *foreman_uplink, int *foreman_uplink_active);
+struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeout, struct link *foreman_uplink, int *foreman_uplink_active, const char *tag);
 
 /* Adds (arithmetically) all the workers resources (cores, memory, disk) */
 void aggregate_workers_resources( struct work_queue *q, struct work_queue_resources *r, struct hash_table *categories );

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1983,7 +1983,7 @@ static void foreman_for_manager(struct link *manager) {
 		}
 		prev_num_workers = curr_num_workers;
 
-		task = work_queue_wait_internal(foreman_q, foreman_internal_timeout, manager, &manager_active);
+		task = work_queue_wait_internal(foreman_q, foreman_internal_timeout, manager, &manager_active, NULL);
 
 		if(task) {
 			struct work_queue_process *p;

--- a/work_queue/test/TR_work_queue_tag.sh
+++ b/work_queue/test/TR_work_queue_tag.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -e
+
+. ../../dttools/test/test_runner_common.sh
+
+python=${CCTOOLS_PYTHON_TEST_EXEC}
+python_dir=${CCTOOLS_PYTHON_TEST_DIR}
+
+STATUS_FILE=wq.status
+PORT_FILE=wq.port
+
+
+check_needed()
+{
+	[ -n "${python}" ] || return 1
+}
+
+prepare()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+
+	return 0
+}
+
+run()
+{
+	# send wq to the background, saving its exit status.
+	(PYTHONPATH=$(pwd)/../src/bindings/${python_dir} ${python} wq_test_tag.py $PORT_FILE; echo $? > $STATUS_FILE) &
+
+	# wait at most 5 seconds for wq to find a port.
+	wait_for_file_creation $PORT_FILE 5
+
+	run_local_worker $PORT_FILE worker.log
+
+	# wait for wq to exit.
+	wait_for_file_creation $STATUS_FILE 5
+
+	# retrieve wq exit status
+	status=$(cat $STATUS_FILE)
+	if [ $status -ne 0 ]
+	then
+		exit 1
+	fi
+
+	exit 0
+}
+
+clean()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+
+	exit 0
+}
+
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/work_queue/test/wq_test_tag.py
+++ b/work_queue/test/wq_test_tag.py
@@ -1,0 +1,43 @@
+#! /usr/bin/env python
+
+# work queue python binding tests
+# tests for missing/recursive inputs/outputs.
+
+import sys
+import work_queue as wq
+
+port_file = None
+try:
+    port_file = sys.argv[1]
+except IndexError:
+    sys.stderr.write("Usage: {} PORTFILE\n".format(sys.argv[0]))
+    raise
+
+desired_tag_order = "7 5 9 6 3 8 2 1".split()
+alpha_order = sorted(desired_tag_order)
+done_order = []
+
+q = wq.WorkQueue(port=0, debug_log='lala.log')
+with open(port_file, 'w') as f:
+    print('Writing port {port} to file {file}'.format(port=q.port, file=port_file))
+    f.write(str(q.port))
+print(wq.__file__)
+
+for tag in alpha_order:
+    t = wq.Task("/bin/echo hello tag {}".format(tag))
+    t.specify_tag(tag)
+    q.submit(t)
+
+for tag in desired_tag_order:
+    while not q.empty():
+        t = q.wait_for_tag(tag, 10)
+        if t:
+            done_order.append(t.tag)
+            break
+
+print("desired order: {}".format(desired_tag_order))
+print("returned order: {}".format(done_order))
+
+correct_order = all(map(lambda pair: pair[0] == pair[1], zip(desired_tag_order, done_order)))
+if not correct_order or (len(done_order) != len(desired_tag_order)):
+    raise Exception("Incorrect order")


### PR DESCRIPTION
For #2737.

Decided to modify `work_queue_wait_internal` directly, as that allows us to use the RETRIEVED state for tasks with the incorrect tag. Otherwise we would need to add another state, or maintain a list of done tasks.

Asking for the NULL (None) tasks means to wait for any task (e.g. q.wait_for_tag(None, time) == q.wait(time))