### PR TITLE
wq worker: cleanup workspace after complete disconnect from manager

### DIFF
--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -2238,9 +2238,10 @@ static int serve_manager_by_hostport( const char *host, int port, const char *ve
 	last_task_received     = 0;
 	results_to_be_sent_msg = 0;
 
-	workspace_cleanup();
 	disconnect_manager(manager);
 	printf("disconnected from manager %s:%d\n", host, port );
+
+	workspace_cleanup();
 
 	return 1;
 }


### PR DESCRIPTION
Otherwise, there was a race condition where a task could produce a file
between the removal of the workspace and the termination of the task.
This issue only happened for tasks that wrote files in the workspace
outside their sandbox. (Which breaks the wq task abstraction and
shouldn't really happen but for very special conditions.)