### PR TITLE
WQ Abstractions: Tree Reduce

### DIFF
--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -1799,26 +1799,7 @@ class WorkQueue(object):
     # @param seq        The seq that will be reduced
     # @param chunk_size The number of elements per Task (for tree reduc, must be greater than 1)
 
-    def tree_reduce(self, fn, seq, iter_size, chunk_size=2):
-        def reduce(fn, iter_size, seq):
-            ''' Serializable tree reduce function '''    
-            while len(seq) > 1:
-                results = []
-                for i in range(len(seq)//iter_size):
-                    s = i*iter_size
-                    e = s + iter_size
-                    if e < len(seq):
-                        results.append(fn(seq[s:e]))
-                    else:
-                        results.append(fn(seq[s:]))
-
-                if len(seq) % 2 == 1:
-                    results.append(seq[-1])
-                
-                seq = results
-    
-            return seq[0]
-
+    def tree_reduce(self, fn, seq, chunk_size=2): 
 
         # parallel function
         tasks = {}
@@ -1833,9 +1814,9 @@ class WorkQueue(object):
                 end = start + chunk_size
 
                 if end > len(seq):
-                    p_task = PythonTask(reduce, fn, iter_size, seq[start:])
+                    p_task = PythonTask(fn, seq[start:])
                 else:
-                    p_task = PythonTask(reduce, fn, iter_size, seq[start:end])
+                    p_task = PythonTask(fn, seq[start:end])
 
                 self.submit(p_task)
                 tasks[p_task.id] = i


### PR DESCRIPTION
work in progress, but I believe it is close to done, as it works, and bigger chunks seem to be faster. Need to do an actual timed test with large data. 

For breaking up into tasks, associative operations work no matter how you break up the data, but operations like divison will change based on the size. The way I tried to fix this was by only breaking up the data in powers of 2, this way breaking up the tasks is the same as doing it as one big task. However, I am not sure if this is the best way, and there would be a gap between the requested chunk_size and the used one