### PR TITLE
move jx_{canonicalize,merge}_test to their own .c

### DIFF
--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -184,7 +184,7 @@ PROGRAMS = $(MOST_PROGRAMS) catalog_query
 
 SCRIPTS = cctools_gpu_autodetect
 TARGETS = $(LIBRARIES) $(PRELOAD_LIBRARIES) $(PROGRAMS) $(TEST_PROGRAMS)
-TEST_PROGRAMS = auth_test disk_alloc_test jx_test microbench multirun jx_count_obj_test histogram_test category_test jx_binary_test mq_poll_test mq_wait_test mq_store_test
+TEST_PROGRAMS = auth_test disk_alloc_test jx_test microbench multirun jx_count_obj_test jx_canonicalize_test jx_merge_test histogram_test category_test jx_binary_test mq_poll_test mq_wait_test mq_store_test
 
 all: $(TARGETS) catalog_query
 

--- a/dttools/src/jx_canonicalize_test.c
+++ b/dttools/src/jx_canonicalize_test.c
@@ -1,0 +1,102 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jx.h"
+#include "jx_canonicalize.h"
+
+
+int main(int argc, char **argv) {
+	char *s;
+
+	struct jx *x_null = jx_null();
+	struct jx *x_true = jx_boolean(1);
+	struct jx *x_false = jx_boolean(0);
+	struct jx *x_integer = jx_integer(42);
+	struct jx *x_double = jx_double(42);
+	struct jx *x_string = jx_string("s");
+	struct jx *x_string2 = jx_string("t");
+	struct jx *x_symbol = jx_symbol("sym");
+	struct jx *x_array = jx_array(NULL);
+	struct jx *x_object = jx_object(NULL);
+
+	s = jx_canonicalize(x_null);
+	assert(s);
+	assert(!strcmp(s, "null"));
+
+	s = jx_canonicalize(x_true);
+	assert(s);
+	assert(!strcmp(s, "true"));
+
+	s = jx_canonicalize(x_false);
+	assert(s);
+	assert(!strcmp(s, "false"));
+
+	s = jx_canonicalize(x_integer);
+	assert(s);
+	assert(!strcmp(s, "42"));
+
+	s = jx_canonicalize(x_double);
+	assert(s);
+	assert(!strcmp(s, "4.200000e+01"));
+
+	s = jx_canonicalize(x_string);
+	assert(s);
+	assert(!strcmp(s, "\"s\""));
+
+	s = jx_canonicalize(x_symbol);
+	assert(!s);
+
+	s = jx_canonicalize(x_array);
+	assert(s);
+	assert(!strcmp(s, "[]"));
+
+	jx_array_append(x_array, x_null);
+	jx_array_append(x_array, x_string);
+	jx_array_append(x_array, x_string2);
+	jx_array_append(x_array, x_integer);
+	jx_array_append(x_array, x_string);
+	s = jx_canonicalize(x_array);
+	assert(s);
+	assert(!strcmp(s, "[null,\"s\",\"t\",42,\"s\"]"));
+
+	jx_array_append(x_array, x_symbol);
+	s = jx_canonicalize(x_array);
+	assert(!s);
+
+	s = jx_canonicalize(x_object);
+	assert(s);
+	assert(!strcmp(s, "{}"));
+
+	jx_insert(x_object, x_string, x_integer);
+	jx_insert(x_object, x_string2, x_null);
+	s = jx_canonicalize(x_object);
+	assert(s);
+	assert(!strcmp(s, "{\"s\":42,\"t\":null}"));
+
+	x_object = jx_object(NULL);
+	jx_insert(x_object, x_string2, x_null);
+	jx_insert(x_object, x_string, x_integer);
+	s = jx_canonicalize(x_object);
+	assert(s);
+	assert(!strcmp(s, "{\"s\":42,\"t\":null}"));
+
+	jx_insert(x_object, x_string, x_true);
+	s = jx_canonicalize(x_object);
+	assert(!s);
+
+	x_object = jx_object(NULL);
+	jx_insert(x_object, x_integer, x_false);
+	s = jx_canonicalize(x_object);
+	assert(!s);
+
+	x_object = jx_object(NULL);
+	jx_insert(x_object, x_string, x_symbol);
+	s = jx_canonicalize(x_object);
+	assert(!s);
+
+	return 0;
+}
+
+// vim: set noexpandtab tabstop=4:

--- a/dttools/src/jx_merge_test.c
+++ b/dttools/src/jx_merge_test.c
@@ -1,0 +1,77 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jx.h"
+#include "jx_parse.h"
+
+int main(int argc, char **argv) {
+	struct jx *a;
+	struct jx *b;
+	struct jx *c;
+	struct jx *r;
+	struct jx *s;
+	struct jx *t;
+
+	a = jx_object(NULL);
+	jx_insert(a, jx_string("k"), jx_integer(5));
+	jx_insert(a, jx_string("e"), jx_integer(6));
+	jx_insert(a, jx_string("y"), jx_integer(7));
+
+	b = jx_object(NULL);
+
+	c = jx_object(NULL);
+	jx_insert(c, jx_string("x"), jx_integer(2));
+	jx_insert(c, jx_string("x"), jx_integer(3));
+
+
+	t = jx_parse_string("{\"k\": 5, \"e\": 6, \"y\": 7}");
+
+	s = jx_merge(a, NULL);
+	assert(jx_equals(s, t));
+	jx_delete(s);
+
+	s = jx_merge(a, b, NULL);
+	assert(jx_equals(s, t));
+	jx_delete(s);
+
+	s = jx_merge(b, a, NULL);
+	assert(jx_equals(s, t));
+	jx_delete(s);
+
+	jx_delete(t);
+
+	t = jx_integer(3);
+	s = jx_lookup(c, "x");
+	assert(jx_equals(s, t));
+	jx_delete(t);
+
+	r = jx_merge(c, NULL);
+	s = jx_lookup(r, "x");
+	t = jx_integer(2);
+	// probably not desirable...
+	assert(jx_equals(s, t));
+	jx_delete(r);
+	jx_delete(t);
+
+	s = jx_merge(a, b, c, NULL);
+	t = jx_parse_string("{\"x\":2,\"k\":5,\"e\":6,\"y\":7}");
+	assert(jx_equals(s, t));
+	jx_delete(s);
+	jx_delete(t);
+
+	s = jx_merge(a, c, a, NULL);
+	t = jx_parse_string("{\"k\":5,\"e\":6,\"y\":7,\"x\":2}");
+	assert(jx_equals(s, t));
+	jx_delete(s);
+	jx_delete(t);
+
+	jx_delete(a);
+	jx_delete(b);
+	jx_delete(c);
+
+	return 0;
+}
+
+// vim: set noexpandtab tabstop=4:

--- a/dttools/test/TR_jx_canonicalize.sh
+++ b/dttools/test/TR_jx_canonicalize.sh
@@ -2,124 +2,20 @@
 
 . ../../dttools/test/test_runner_common.sh
 
-exe="canonical.test"
+exe="../src/jx_canonicalize_test"
 
 prepare()
 {
-	${CC} -g -o "$exe" -I ../src/ -x c - -x none ../src/libdttools.a -lm ${CCTOOLS_EXTERNAL_LINKAGE} <<EOF
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-#include "jx.h"
-#include "jx_canonicalize.h"
-
-
-int main(int argc, char **argv) {
-	char *s;
-
-	struct jx *x_null = jx_null();
-	struct jx *x_true = jx_boolean(1);
-	struct jx *x_false = jx_boolean(0);
-	struct jx *x_integer = jx_integer(42);
-	struct jx *x_double = jx_double(42);
-	struct jx *x_string = jx_string("s");
-	struct jx *x_string2 = jx_string("t");
-	struct jx *x_symbol = jx_symbol("sym");
-	struct jx *x_array = jx_array(NULL);
-	struct jx *x_object = jx_object(NULL);
-
-	s = jx_canonicalize(x_null);
-	assert(s);
-	assert(!strcmp(s, "null"));
-
-	s = jx_canonicalize(x_true);
-	assert(s);
-	assert(!strcmp(s, "true"));
-
-	s = jx_canonicalize(x_false);
-	assert(s);
-	assert(!strcmp(s, "false"));
-
-	s = jx_canonicalize(x_integer);
-	assert(s);
-	assert(!strcmp(s, "42"));
-
-	s = jx_canonicalize(x_double);
-	assert(s);
-	assert(!strcmp(s, "4.200000e+01"));
-
-	s = jx_canonicalize(x_string);
-	assert(s);
-	assert(!strcmp(s, "\"s\""));
-
-	s = jx_canonicalize(x_symbol);
-	assert(!s);
-
-	s = jx_canonicalize(x_array);
-	assert(s);
-	assert(!strcmp(s, "[]"));
-
-	jx_array_append(x_array, x_null);
-	jx_array_append(x_array, x_string);
-	jx_array_append(x_array, x_string2);
-	jx_array_append(x_array, x_integer);
-	jx_array_append(x_array, x_string);
-	s = jx_canonicalize(x_array);
-	assert(s);
-	assert(!strcmp(s, "[null,\"s\",\"t\",42,\"s\"]"));
-
-	jx_array_append(x_array, x_symbol);
-	s = jx_canonicalize(x_array);
-	assert(!s);
-
-	s = jx_canonicalize(x_object);
-	assert(s);
-	assert(!strcmp(s, "{}"));
-
-	jx_insert(x_object, x_string, x_integer);
-	jx_insert(x_object, x_string2, x_null);
-	s = jx_canonicalize(x_object);
-	assert(s);
-	assert(!strcmp(s, "{\"s\":42,\"t\":null}"));
-
-	x_object = jx_object(NULL);
-	jx_insert(x_object, x_string2, x_null);
-	jx_insert(x_object, x_string, x_integer);
-	s = jx_canonicalize(x_object);
-	assert(s);
-	assert(!strcmp(s, "{\"s\":42,\"t\":null}"));
-
-	jx_insert(x_object, x_string, x_true);
-	s = jx_canonicalize(x_object);
-	assert(!s);
-
-	x_object = jx_object(NULL);
-	jx_insert(x_object, x_integer, x_false);
-	s = jx_canonicalize(x_object);
-	assert(!s);
-
-	x_object = jx_object(NULL);
-	jx_insert(x_object, x_string, x_symbol);
-	s = jx_canonicalize(x_object);
-	assert(!s);
-
-	return 0;
-}
-EOF
-	return $?
+	return 0
 }
 
 run()
 {
-	./"$exe"
-	return $?
+	exec "$exe"
 }
 
 clean()
 {
-	rm -f "$exe"
 	return 0
 }
 

--- a/dttools/test/TR_jx_merge.sh
+++ b/dttools/test/TR_jx_merge.sh
@@ -2,99 +2,20 @@
 
 . ../../dttools/test/test_runner_common.sh
 
-exe="merge.test"
+exe="../src/jx_merge_test"
 
 prepare()
 {
-	${CC} -g -o "$exe" -I ../src/ -x c - -x none ../src/libdttools.a ${CCTOOLS_EXTERNAL_LINKAGE} <<EOF
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-#include "jx.h"
-#include "jx_parse.h"
-
-int main(int argc, char **argv) {
-	struct jx *a;
-	struct jx *b;
-	struct jx *c;
-	struct jx *r;
-	struct jx *s;
-	struct jx *t;
-
-	a = jx_object(NULL);
-	jx_insert(a, jx_string("k"), jx_integer(5));
-	jx_insert(a, jx_string("e"), jx_integer(6));
-	jx_insert(a, jx_string("y"), jx_integer(7));
-
-	b = jx_object(NULL);
-
-	c = jx_object(NULL);
-	jx_insert(c, jx_string("x"), jx_integer(2));
-	jx_insert(c, jx_string("x"), jx_integer(3));
-
-
-	t = jx_parse_string("{\"k\": 5, \"e\": 6, \"y\": 7}");
-
-	s = jx_merge(a, NULL);
-	assert(jx_equals(s, t));
-	jx_delete(s);
-
-	s = jx_merge(a, b, NULL);
-	assert(jx_equals(s, t));
-	jx_delete(s);
-
-	s = jx_merge(b, a, NULL);
-	assert(jx_equals(s, t));
-	jx_delete(s);
-
-	jx_delete(t);
-
-	t = jx_integer(3);
-	s = jx_lookup(c, "x");
-	assert(jx_equals(s, t));
-	jx_delete(t);
-
-	r = jx_merge(c, NULL);
-	s = jx_lookup(r, "x");
-	t = jx_integer(2);
-	// probably not desirable...
-	assert(jx_equals(s, t));
-	jx_delete(r);
-	jx_delete(t);
-
-	s = jx_merge(a, b, c, NULL);
-	t = jx_parse_string("{\"x\":2,\"k\":5,\"e\":6,\"y\":7}");
-	assert(jx_equals(s, t));
-	jx_delete(s);
-	jx_delete(t);
-
-	s = jx_merge(a, c, a, NULL);
-	t = jx_parse_string("{\"k\":5,\"e\":6,\"y\":7,\"x\":2}");
-	assert(jx_equals(s, t));
-	jx_delete(s);
-	jx_delete(t);
-
-	jx_delete(a);
-	jx_delete(b);
-	jx_delete(c);
-
-	return 0;
-}
-EOF
-	return $?
+	return 0
 }
 
 run()
 {
-	./"$exe"
-	return $?
+	exec "$exe"
 }
 
 clean()
 {
-	rm -f "$exe"
 	return 0
 }
 


### PR DESCRIPTION
otherwise we have to reproduce the linking rules inside the TR_*.sh
files, and they may link to a different version of shared libraries than
the rest of the binaries.