### PR TITLE
Nix fixes

### DIFF
--- a/configure
+++ b/configure
@@ -95,7 +95,7 @@ ccompiler=${CC:-gcc}
 cxxcompiler=${CXX:-g++}
 linker="${ccompiler}"
 
-ccflags="${CFLAGS} -D__EXTENSIONS__ -D_LARGEFILE64_SOURCE -D__LARGE64_FILES -Wall -Wextra -fPIC"
+ccflags="${CFLAGS} -D__EXTENSIONS__ -D_LARGEFILE64_SOURCE -D__LARGE64_FILES -Wall -Wextra -Wno-unused-result -fPIC"
 c_only_flags="-std=c99"
 
 config_zlib_path=yes

--- a/dttools/src/libforce_halt_enospc.c
+++ b/dttools/src/libforce_halt_enospc.c
@@ -44,7 +44,7 @@ int open(const char *path, int flags, ...)
 			fprintf(stderr, "OPEN ERROR: device capacity reached.\n");
 			return fd;
 		}
-		err_fd = open(filename, O_RDWR | O_CREAT);
+		err_fd = original_open(filename, O_RDWR | O_CREAT);
 		if(err_fd < 0) { fprintf(stderr, "OPEN ERROR: could not alert resource management system that loop device is full.\n"); }
 		fprintf(stderr, "OPEN ERROR: device capacity reached.\n");
 		return fd;

--- a/parrot/src/pfs_critical.h
+++ b/parrot/src/pfs_critical.h
@@ -10,7 +10,20 @@ See the file COPYING for details.
 
 #include <signal.h>
 
-#define CRITICAL_BEGIN sigsetmask(sigmask(SIGIO)|sigmask(SIGINT)|sigmask(SIGHUP)|sigmask(SIGCHLD)|sigmask(SIGPIPE));
-#define CRITICAL_END sigsetmask(sigmask(SIGPIPE));
+#define CRITICAL_BEGIN {\
+    sigset_t s;\
+    sigaddset(&s, SIGIO);\
+    sigaddset(&s, SIGINT);\
+    sigaddset(&s, SIGHUP);\
+    sigaddset(&s, SIGCHLD);\
+    sigaddset(&s, SIGPIPE);\
+    sigprocmask(SIG_SETMASK, &s, NULL);\
+}
+
+#define CRITICAL_END {\
+    sigset_t s;\
+    sigaddset(&s, SIGPIPE);\
+    sigprocmask(SIG_SETMASK, &s, NULL);\
+}
 
 #endif

--- a/parrot/src/pfs_process.cc
+++ b/parrot/src/pfs_process.cc
@@ -67,7 +67,12 @@ void pfs_process_kill_everyone( int sig )
 	debug(D_NOTICE,"sending myself %d (%s), goodbye!",sig,string_signal(sig));
 	while(1) {
 		signal(sig,SIG_DFL);
-		sigsetmask(~sigmask(sig));
+
+		sigset_t s;
+		sigfillset(&s);
+		sigdelset(&s, sig);
+		sigprocmask(SIG_SETMASK, &s, NULL);\
+
 		kill(getpid(),sig);
 		kill(getpid(),SIGKILL);
 	}


### PR DESCRIPTION
@dthain: The most important is the change from sigsetmask to sigprocmask. sigsetmask has been deprecated and it causes an error with pedantic compile options.

(For #2326. Note that the compiler versions are ok with conda, but not with nix. I assume nix is setting more pedantic compilation options. )