### PR TITLE
Starch small fixes

### DIFF
--- a/makeflow/example/starch-example.config
+++ b/makeflow/example/starch-example.config
@@ -1,0 +1,27 @@
+# Example of a starch command configuration. 
+# Create a self-contained package to run the command `date` using the timezone
+# specified in starch-example.env with:
+#
+# starch -C starch-example.config date.sfx
+# ./date.sfx
+#
+
+[starch]
+# command to execute when executing the resulting starch package
+command = date
+
+# comma-separated list of executables to include in the package. If not an
+# absolute path, then they musth be found in PATH
+executables = /bin/date
+
+# comma-separated list of dynamically linked libraries (e.g. *.so files) to
+# include in the package
+libraries = 
+
+# comma-separated list of sh files to be sourced before the command's
+# execution. Useful to export necessary environment variables.
+environments = starch-example.env
+
+# comma-separated list of mappings of PACKAGE_PATH:HOST_PATH of files to include
+# in the package.
+data = my_data/motd:/etc/motd

--- a/makeflow/example/starch-example.env
+++ b/makeflow/example/starch-example.env
@@ -1,0 +1,1 @@
+export TZ=Australia/Melbourne

--- a/makeflow/src/starch
+++ b/makeflow/src/starch
@@ -156,6 +156,19 @@ fi
 
 SFX_DEFAULT_COMMAND=%s
 
+if [ "$1" = "--sfx-help" ]
+then
+    echo starch package options:
+    echo executing the sfx file by itself executes the command ${SFX_DEFAULT_COMMAND}
+    echo
+    echo environment variables to set packages options:
+    echo SFX_EXEC=CMD        Execute CMD instead of the default.
+    echo SFX_EXTRACT_ONLY=1  Extract package, but do not run a command.
+    echo SFX_KEEP=1          Do not remove extracted package when command finishes.
+    echo SFX_DIR=DIR         Extract to DIR, instead of a temporary directory. Implies SFX_KEEP=1
+    exit 0
+fi
+
 if [ -z "$SFX_EXEC" ]
 then
     SFX_EXEC="${SFX_DEFAULT_COMMAND}"

--- a/makeflow/src/starch
+++ b/makeflow/src/starch
@@ -391,11 +391,14 @@ def parse_command_line_options():
             options.command = config.safe_get('starch', 'command', '')
 
     if not options.executables:
-        logging.error('no executables specified')
+        logging.error('At least one executable should be specified with -x')
+        parser.print_help()
+        sys.exit(1)
+
 
     if not options.command:
         options.command = os.path.basename(options.executables[0])
-        logging.warn('no command specified, so using: %s' % options.command)
+        logging.warn('no command specified with -c, using: %s' % options.command)
 
     logging.debug('command ... ' + options.command)
 
@@ -403,7 +406,6 @@ def parse_command_line_options():
                     options.data, options.environments, options.command
 
 # Main execution
-
 if __name__ == '__main__':
     create_sfx(*parse_command_line_options())
 

--- a/makeflow/src/starch
+++ b/makeflow/src/starch
@@ -92,6 +92,8 @@ extract() {
 }
 
 run() {
+    # make the extraction directory easily available in run.sh
+    export SFX_DIR
     $SFX_DIR/run.sh "$@"
     SFX_EXIT_STATUS=$?
 }

--- a/makeflow/src/starch
+++ b/makeflow/src/starch
@@ -153,7 +153,15 @@ if [ -d "$SFX_DIR/lib" ]; then
         fi
     fi
 fi
-%s "$@"
+
+SFX_DEFAULT_COMMAND=%s
+
+if [ -z "$SFX_EXEC" ]
+then
+    SFX_EXEC="${SFX_DEFAULT_COMMAND}"
+fi
+
+${SFX_EXEC} "$@"
 '''
 
 # Create SFX
@@ -329,7 +337,6 @@ def autodetect_libraries_darwin(executable):
     return libs
 
 # Configuration Parser
-
 class StarchConfigParser(ConfigParser):
     def safe_get(self, section, name, default = None):
         try:
@@ -338,7 +345,6 @@ class StarchConfigParser(ConfigParser):
             return default
 
 # Parse commandline options
-
 def parse_command_line_options():
     global STARCH_AUTODETECT
     global STARCH_PLATFORM

--- a/makeflow/src/starch
+++ b/makeflow/src/starch
@@ -154,12 +154,11 @@ if [ -d "$SFX_DIR/lib" ]; then
     fi
 fi
 
-SFX_DEFAULT_COMMAND=%s
-
 if [ "$1" = "--sfx-help" ]
 then
     echo starch package options:
-    echo executing the sfx file by itself executes the command ${SFX_DEFAULT_COMMAND}
+    echo executing the sfx file by itself executes the command:
+    echo  "{cmd}"   
     echo
     echo environment variables to set packages options:
     echo SFX_EXEC=CMD        Execute CMD instead of the default.
@@ -169,12 +168,12 @@ then
     exit 0
 fi
 
-if [ -z "$SFX_EXEC" ]
+if [ -n "$SFX_EXEC" ]
 then
-    SFX_EXEC="${SFX_DEFAULT_COMMAND}"
+    $SFX_EXEC "$@"
+else
+    {cmd} "$@"
 fi
-
-${SFX_EXEC} "$@"
 '''
 
 # Create SFX
@@ -227,7 +226,7 @@ def create_sfx(sfx_path, executables, libraries, data, environments, command):
         archive.addfile(env_info, open(real_path, 'rb'))
 
     run_info = TarInfo('run.sh')
-    run_info_data  = RUN_SH % command
+    run_info_data  = RUN_SH.format(cmd=command)
     run_info.mode  = int('755', 8)
     run_info.mtime = time()
     run_info.size  = len(run_info_data)

--- a/makeflow/test/TR_starch_extract_and_remove.sh
+++ b/makeflow/test/TR_starch_extract_and_remove.sh
@@ -7,13 +7,13 @@ tarfile=starch.tar.gz
 
 prepare()
 {
-	cd ..; tar czvf $tarfile src; cd -; mv ../$tarfile .
+	(cd .. && tar czvf $tarfile src) && mv ../$tarfile .
 	exit 0
 }
 
 run()
 {
-	../src/starch -v -x tar -x rm -c 'tar_test() { for f in $@; do if ! tar xvf $f; then exit 1; fi ; done; rm $@; }; tar_test' $sfxfile
+	../src/starch -v -x tar -x rm -c 'tar_test() { for f in "$@"; do if ! tar xvf $f; then exit 1; fi ; done; }; tar_test' $sfxfile
 	exec ./$sfxfile $tarfile
 }
 


### PR DESCRIPTION
- Adds configuration example
- Adds --sfx-help to show relevant environment variables
- Adds SFX_EXEC env var to change which command to execute (if multiple commands in the package.) E.g:

```sh
starch -x date -x uname -c date example.sfx
./example.sfx
    Mon Jan 10 11:12:02 EST 2022
    
SFX_EXEC=uname ./example.sfx
    Linux
```

    
This also useful to run a shell with all the PATH and LD_LIBRARY_PATH variables set correctly to run a set of commands:

```sh
SFX_EXEC=/bin/sh ./example.sfx
sh$ which date
/home/myuser/example.sfx.27441.dir/bin/date
```

(wip: updating readthedocs)