### PR TITLE
batch cluster: remove space between value and memory unit

### DIFF
--- a/batch_job/src/batch_job_cluster.c
+++ b/batch_job/src/batch_job_cluster.c
@@ -134,14 +134,14 @@ static char *cluster_set_resource_string(struct batch_queue *q, const struct rms
 	if(q->type == BATCH_QUEUE_TYPE_TORQUE || q->type == BATCH_QUEUE_TYPE_PBS){
 		buffer_printf(&cluster_resources, " -l nodes=1:ppn=%.0f", MAX(1, DIV_INT_ROUND_UP(resources->cores, 1)));
 		if(!ignore_mem && resources->memory > 0) {
-			buffer_printf(&cluster_resources, ",mem=%.0f mb", DIV_INT_ROUND_UP(resources->memory, 1));
+			buffer_printf(&cluster_resources, ",mem=%.0fmb", DIV_INT_ROUND_UP(resources->memory, 1));
 		}
 		if(!ignore_disk && resources->disk > 0) {
-			buffer_printf(&cluster_resources, ",file=%.0f mb", DIV_INT_ROUND_UP(resources->disk, 1));
+			buffer_printf(&cluster_resources, ",file=%.0fmb", DIV_INT_ROUND_UP(resources->disk, 1));
 		}
 	} else if(q->type == BATCH_QUEUE_TYPE_SLURM){
 		if(!ignore_mem && resources->memory > 0) {
-			buffer_printf(&cluster_resources, " --mem=%.0f M", DIV_INT_ROUND_UP(resources->memory, 1));
+			buffer_printf(&cluster_resources, " --mem=%.0fM", DIV_INT_ROUND_UP(resources->memory, 1));
 		}
 		if(!ignore_time && resources->wall_time > 0) {
 			// expected in minutes, not seconds


### PR DESCRIPTION
Fix for #2796 