### PR TITLE
fix makeflow wall_time

### DIFF
--- a/batch_job/src/batch_job_cluster.c
+++ b/batch_job/src/batch_job_cluster.c
@@ -165,7 +165,7 @@ static char *cluster_set_resource_string(struct batch_queue *q, const struct rms
 	} else if(q->type == BATCH_QUEUE_TYPE_SGE){
 		if(!ignore_mem && resources->memory > 0) {
 			const char *mem_type = batch_queue_get_option(q, "mem-type");
-			buffer_printf(&cluster_resources, " -l %s=%.0f M", mem_type ? mem_type : "h_vmem", resources->memory);
+			buffer_printf(&cluster_resources, " -l %s=%.0fM", mem_type ? mem_type : "h_vmem", resources->memory);
 		}
 		if(!ignore_time && resources->wall_time > 0) {
 			buffer_printf(&cluster_resources, " -l h_rt=00:%.0f:00", DIV_INT_ROUND_UP(resources->wall_time, 60));

--- a/batch_job/src/batch_job_cluster.c
+++ b/batch_job/src/batch_job_cluster.c
@@ -171,7 +171,7 @@ static char *cluster_set_resource_string(struct batch_queue *q, const struct rms
 			buffer_printf(&cluster_resources, " -l h_rt=00:%.0f:00", DIV_INT_ROUND_UP(resources->wall_time, 60));
 		}
 
-		buffer_printf(&cluster_resources, " -pe smp %0.f", resources->cores > 0 ? DIV_INT_ROUND_UP(resources->cores, 1) : 1);
+		buffer_printf(&cluster_resources, " -pe smp %.0f", resources->cores > 0 ? DIV_INT_ROUND_UP(resources->cores, 1) : 1);
 	} else if(q->type==BATCH_QUEUE_TYPE_LSF) {
 		if(!ignore_mem && resources->memory>0) {
 			// resources->memory is in units of MB

--- a/dttools/src/macros.h
+++ b/dttools/src/macros.h
@@ -25,7 +25,7 @@ See the file COPYING for details.
 #define ABS(x) ( ((x)>=0) ? (x) : (-(x)) )
 #endif
 
-#define DIV_INT_ROUND_UP(a, b) (((a) + (b) - 1) / (b))
+#define DIV_INT_ROUND_UP(a, b) ((__typeof__(a)) ((int64_t) ((((a) + (b) - 1) / (b)))))
 
 #define KILO 1024
 #define MEGA (KILO*KILO)

--- a/makeflow/src/parser.c
+++ b/makeflow/src/parser.c
@@ -217,9 +217,6 @@ void set_resources_from_env(struct rmsummary *rs, struct dag_variable_lookup_set
             debug(D_NOTICE, "%s defined multiple times for category %s. Using last defined value: %s",
                     RESOURCES_WALL_TIME, c->name, rmsummary_resource_to_str("wall_time", rs->wall_time, 0));
         }
-
-        /* value in RESOURCES_WALL_TIME is in seconds. struct rmsummary expects it in useconds. */
-		rs->wall_time *= 1000000;
 	}
 }
 


### PR DESCRIPTION
Time was parsed as usecs, rather than secs. Also fixed round up to integer resources from double specifications.