### PR TITLE
do not load max_seen resources if not on first allocation

### DIFF
--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -716,16 +716,6 @@ const struct rmsummary *category_dynamic_task_max_resources(struct category *c, 
 
 	struct rmsummary *max   = c->max_allocation;
 	struct rmsummary *first = c->first_allocation;
-	struct rmsummary *seen  = c->max_resources_seen;
-
-	if(c->steady_state && c->allocation_mode != CATEGORY_ALLOCATION_MODE_FIXED) {
-        size_t i;
-        for(i = 0; labeled_resources[i]; i++) {
-            const size_t o = labeled_resources[i];
-            /* set internal to seen value */
-            rmsummary_set_by_offset(internal, o, rmsummary_get_by_offset(seen, o));
-        }
-	}
 
 	/* load max values */
 	rmsummary_merge_override(internal, max);


### PR DESCRIPTION
This fixes a bug found in topEFT where max seen mode would not use the
whole worker. In max seen mode the max_seen values are loaded only for
the first allocation. In all the other modes, they are loaded in the
respective computations.