### PR TITLE
Chirp: Modified chirp_client_getdir to consider >=0 a success.

### DIFF
--- a/chirp/src/chirp_client.c
+++ b/chirp/src/chirp_client.c
@@ -459,7 +459,7 @@ INT64_T chirp_client_getdir(struct chirp_client * c, const char *path, chirp_dir
 	const char *name;
 
 	result = chirp_client_opendir(c, path, stoptime);
-	if(result == 0) {
+	if(result >= 0) {
 		while((name = chirp_client_readdir(c, stoptime))) {
 			callback(name, arg);
 		}


### PR DESCRIPTION
The CCL-Chirp implementation getdir returns 0 on success, however the HTCondor-Chirp implementation of getdir returns the number of bytes in the directory listing.  This change accomodates both.