### PR TITLE
Use pipes with coprocess

### DIFF
--- a/work_queue/src/network_function.py
+++ b/work_queue/src/network_function.py
@@ -13,18 +13,22 @@ def function_handler(event):
 	return int(event["a"]) + int(event["b"])
 
 def main():
-	HOST = "localhost"
-	PORT = 45107
-
 	s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 	try:
-		s.bind((HOST, PORT))
+		s.bind(('localhost', 45107))
 	except Exception as e:
 		s.close()
 		print(e)
 		exit(1)
-	
-	print('listening on port: {}'.format(s.getsockname()[1]))
+
+	# information to print to stdout for worker
+	name = "my_func"
+	port = s.getsockname()[1]
+	_type = "python"	
+
+	print('name: {}'.format(name))
+	print('port: {}'.format(port))
+	print('type: {}'.format(_type))
 
 	while True:
 		s.listen()

--- a/work_queue/src/network_function.py
+++ b/work_queue/src/network_function.py
@@ -16,7 +16,7 @@ def main():
 	s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 	try:
 		# modify the port argument to be 0 to listen on an arbitrary port
-		s.bind(('localhost', 45107))
+		s.bind(('localhost', 0))
 	except Exception as e:
 		s.close()
 		print(e)
@@ -27,9 +27,9 @@ def main():
 	port = s.getsockname()[1]
 	_type = "python"	
 
-	print('name: {}'.format(name))
-	print('port: {}'.format(port))
-	print('type: {}'.format(_type))
+	print('name: {}'.format(name),flush=True)
+	print('port: {}'.format(port),flush=True)
+	print('type: {}'.format(_type),flush=True)
 
 	while True:
 		s.listen()

--- a/work_queue/src/network_function.py
+++ b/work_queue/src/network_function.py
@@ -15,6 +15,7 @@ def function_handler(event):
 def main():
 	s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 	try:
+		# modify the port argument to be 0 to listen on an arbitrary port
 		s.bind(('localhost', 45107))
 	except Exception as e:
 		s.close()

--- a/work_queue/src/work_queue_process.c
+++ b/work_queue/src/work_queue_process.c
@@ -220,11 +220,10 @@ static char * load_input_file(struct work_queue_task *t) {
 	return buf;	
 }
 
-static char * invoke_coprocess_function(char *input) {
+static char * invoke_coprocess_function(int function_port, char *input) {
 	char addr[DOMAIN_NAME_MAX];
 	char buf[BUFSIZ];
 	int len;
-	int port = 45107;
 	int timeout = 60000000; // one minute, can be changed
 
 	if(!domain_name_lookup("localhost", addr)) {
@@ -239,7 +238,7 @@ static char * invoke_coprocess_function(char *input) {
 	int tries = 0;
 	// retry connection for ~30 seconds
 	while(!connected && tries < 30) {
-		link = link_connect(addr, port, stoptime);
+		link = link_connect(addr, function_port, stoptime);
 		if(link) {
 			connected = 1;
 		} else {
@@ -355,7 +354,7 @@ pid_t work_queue_process_execute(struct work_queue_process *p )
 			char *input = load_input_file(p->task);
 	
 			// call invoke_coprocess_function
-		 	char *output = invoke_coprocess_function(input);
+		 	char *output = invoke_coprocess_function(p->function_port, input);
 
 			// write data to output file
 			full_write(p->output_fd, output, strlen(output));

--- a/work_queue/src/work_queue_process.c
+++ b/work_queue/src/work_queue_process.c
@@ -350,7 +350,7 @@ pid_t work_queue_process_execute(struct work_queue_process *p )
 		if(result == -1)
 			fatal("could not dup pipe to stderr: %s", strerror(errno));
 
-		if(p->python_function != NULL && strcmp(p->task->command_line, p->python_function) == 0) {	
+		if(p->function_name != NULL && strcmp(p->task->command_line, p->function_name) == 0) {	
 			// load data from input file
 			char *input = load_input_file(p->task);
 	

--- a/work_queue/src/work_queue_process.h
+++ b/work_queue/src/work_queue_process.h
@@ -44,8 +44,10 @@ struct work_queue_process {
 	/* state between complete disk measurements. */
 	struct path_disk_size_info *disk_measurement_state;
 
-	/* optional python function */
-	char *python_function;
+	/* variables for remote function */
+	char *function_name;
+	int function_port;
+	char *function_type;
 };
 
 struct work_queue_process * work_queue_process_create( struct work_queue_task *task, int disk_allocation );

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -233,10 +233,10 @@ static int coprocess_in[2];
 static int coprocess_out[2];
 
 // Global variables for network function
-static char *python_function = NULL;
 static char *function_name = NULL;
 static int function_port = -1;
 static char *function_type = NULL;
+
 
 __attribute__ (( format(printf,2,3) ))
 static void send_manager_message( struct link *manager, const char *fmt, ... )
@@ -1930,7 +1930,7 @@ static void work_for_manager(struct link *manager) {
 				if(!p) {
 					break;
 				} else if(task_resources_fit_now(p->task)) {
-					// attach the function name, port, and type to process
+					// attach the function name, port, and type to process, if applicable
 					if(function_name != NULL && function_port != -1 && function_type != NULL) {
 						p->function_name = xxstrdup(function_name);
 						p->function_port = function_port;
@@ -2506,74 +2506,107 @@ struct list *parse_manager_addresses(const char *specs, int default_port) {
 	return(managers);
 }
 
-int write_to_coprocess(char *buffer, int len) {
-	return write(coprocess_in[1], buffer, len);
-}
-
-int read_from_coprocess(char *buffer, int len) {
-	int bytes_read = read(coprocess_out[0], buffer, len - 1);
-	if(bytes_read < 0) {
-		debug(D_WQ, "Read from coprocess failed\n");
-		return -1;
-	}
-	buffer[bytes_read] = '\0';
-	printf("%d %s\n", bytes_read, buffer);
-	return bytes_read;
-}
-
 void start_coprocess() {
-
 	if (pipe(coprocess_in) || pipe(coprocess_out)) { // create pipes to communicate with the coprocess
 		fatal("couldn't create coprocess pipes: %s\n", strerror(errno));
 		return;
 	}
 	coprocess_pid = fork();
 	if (coprocess_pid < 0) { // unable to fork
-		debug(D_WQ, "couldn't create new process: %s\n", strerror(errno));
+		fatal("couldn't create new process: %s\n", strerror(errno));
 		return;
 	}		
 	else if (coprocess_pid == 0) { // child executes this
-		/*
-		if (close(coprocess_in[1]) || close(0)) {
-			debug(D_WQ, "coprocess could not close stdin: %s\n", strerror(errno));
-			_exit(127);
-		}
-		if (dup(coprocess_in[0])) {
-			debug(D_WQ, "coprocess could not attach pipe to stdin: %s\n", strerror(errno));
+		if ( (close(coprocess_in[1]) < 0) || (close(coprocess_out[0]) < 0) ) {
+			debug(D_WQ, "coprocess could not close pipes: %s\n", strerror(errno));
 			_exit(127);
 		}
 		
-		if (close(coprocess_out[0]) || close(1)) {
-			debug(D_WQ, "coprocess could not close stdout: %s\n", strerror(errno));
+		if (dup2(coprocess_in[0], 0) < 0) {
+			debug(D_WQ, "coprocess could not attach pipe to stdin: %s\n", strerror(errno));
 			_exit(127);
 		}
-		if (dup(coprocess_out[1])) {
+
+		if (dup2(coprocess_out[1], 1) < 0) {
+			printf("%s\n", strerror(errno));
 			debug(D_WQ, "coprocess could not attach pipe to stdout: %s\n", strerror(errno));
 			_exit(127);
 		}
-		*/
+		
 		execlp(coprocess_command, coprocess_command, (char *) 0);
 		debug(D_WQ, "failed to execute %s: %s\n", coprocess_command, strerror(errno));
 		_exit(127); // if we get here, the exec failed so we just quit
 	}
 	else { // parent goes here
-		if (fcntl(coprocess_out[0], F_SETFL, O_NONBLOCK))
-		{
-			debug(D_WQ, "parent could not set pipe to nonblocking: %s\n", strerror(errno));
+		/*
+		if (fcntl(coprocess_out[0], F_SETFL, O_NONBLOCK) < 0) {
+			debug(D_WQ, "parent could not make pipe nonblocking: %s\n", strerror(errno));
 			return;
 		}
-		
-		// read from coprocess - values just hardcoded for now but can get rid of this later
-		function_name = "my_func";
-		function_port = 45107;
-		function_type = "python";
-
+		*/
 		if (close(coprocess_in[0]) || close(coprocess_out[1])) {
-			debug(D_WQ, "parent could not close unneeded pipes: %s\n", strerror(errno));
+			debug(D_WQ, "parent could not close pipes: %s\n", strerror(errno));
 			return;
 		}
 		debug(D_WQ, "Forked child process to run %s\n", coprocess_command);
 	}
+}
+
+int write_to_coprocess_timeout(char *buffer, int len, int timeout)
+{
+	struct pollfd read_poll = {coprocess_in[1], POLLOUT, 0};
+	int poll_result = poll(&read_poll, 1, timeout);
+	if (poll_result < 0)
+	{
+		debug(D_WQ, "Write to coprocess failed: %s\n", strerror(errno));
+		return -1;
+	}
+	if (poll_result == 0) // check for timeout
+	{
+		debug(D_WQ, "writing to coprocess timed out\n");
+		return -1;
+	}
+	if ( !(read_poll.revents & POLLOUT)) // check we have data
+	{
+		debug(D_WQ, "Data able to be written to pipe: %s\n", strerror(errno));
+		return -1;
+	}
+	int bytes_written = write(coprocess_in[1], buffer, len);
+	if (bytes_written < 0)
+	{
+		debug(D_WQ, "Read from coprocess failed: %s\n", strerror(errno));
+		return -2;
+	}
+	return bytes_written;
+}
+
+int read_from_coprocess_timeout(char *buffer, int len, int timeout){
+	struct pollfd read_poll = {coprocess_out[0], POLLIN, 0};
+	int poll_result = poll(&read_poll, 1, timeout);
+	if (poll_result < 0)
+	{
+		debug(D_WQ, "Read from coprocess failed: %s\n", strerror(errno));
+		return -1;
+	}
+	if (poll_result == 0) // check for timeout
+	{
+		debug(D_WQ, "reading from coprocess timed out\n");
+		return -1;
+	}
+	if ( !(read_poll.revents & POLLIN)) // check we have data
+	{
+		debug(D_WQ, "Data not returned from pipe: %s\n", strerror(errno));
+		return -1;
+	}
+	
+	int bytes_read = read(coprocess_out[0], buffer, len - 1);
+	if (bytes_read < 0)
+	{
+		debug(D_WQ, "Read from coprocess failed: %s\n", strerror(errno));
+		return -2;
+	}
+	buffer[bytes_read] = '\0';
+	return bytes_read;
 }
 
 int check_if_coprocess_exited()
@@ -2654,7 +2687,6 @@ static void show_help(const char *cmd)
 	printf( " %-30s Set the percent chance per minute that the worker will shut down (simulates worker failures, for testing only).\n", "--volatility=<chance>");
 	printf( " %-30s Set the port used to lookup the worker's TLQ URL (-d and -o options also required).\n", "--tlq=<port>");
 	printf( " %-30s Start an arbitrary process when the worker starts up and kill the process when the worker shuts down.\n", "--coprocess <executable>");
-	printf( " %-30s Specify a python function to execute remotely.\n", "--python-function=<func>");
 }
 
 enum {LONG_OPT_DEBUG_FILESIZE = 256, LONG_OPT_VOLATILITY, LONG_OPT_BANDWIDTH,
@@ -2711,7 +2743,6 @@ static const struct option long_options[] = {
 	{"connection-mode",     required_argument,  0,  LONG_OPT_CONN_MODE},
 	{"ssl",                 no_argument,        0,  LONG_OPT_USE_SSL},
 	{"coprocess",           required_argument,  0,  LONG_OPT_COPROCESS},
-	{"python-function",		required_argument,	0, 	LONG_OPT_PYTHON_FUNCTION},
 	{0,0,0,0}
 };
 
@@ -2964,9 +2995,6 @@ int main(int argc, char *argv[])
 			free(coprocess_command);
 			coprocess_command = xxstrdup(absolute); 
 			break;
-		case LONG_OPT_PYTHON_FUNCTION:
-			python_function = xxstrdup(optarg);
-			break;
 		default:
 			show_help(argv[0]);
 			return 1;
@@ -3119,6 +3147,21 @@ int main(int argc, char *argv[])
 	if (coprocess_command != NULL)
 	{
 		start_coprocess();
+		char buffer[4096];
+		int bytes_read = read_from_coprocess_timeout(buffer, 4096, 5000);
+		if (bytes_read < 0)
+		{
+			debug(D_WQ, "Unable to get information from network function");
+		}
+		else
+		{
+			char *token = strtok(buffer, "\n");
+			function_name = xxstrdup(token + 6);
+			token = strtok(NULL, "\n");
+			function_port = atoi(token + 6);
+			token = strtok(NULL, "\n");
+			function_type = xxstrdup(token + 6);
+		}
 	}
 
 	while(1) {
@@ -3179,12 +3222,7 @@ int main(int argc, char *argv[])
 				start_coprocess();
 			}
 		}
-		/*
-		char buffer[4096];
-		write_to_coprocess("haha", strlen(buffer));
-		read_from_coprocess(buffer, 4096);
-		printf("%s\n", buffer);
-		*/
+		printf("coprocess listening on: %d\n", function_port);
 		sleep(backoff_interval);
 	}
 	workspace_delete();
@@ -3192,6 +3230,8 @@ int main(int argc, char *argv[])
 	{
 		int max_wait = 5; // maximum seconds we wish to wait for a given process
 		process_kill_waitpid(coprocess_pid, max_wait);
+		free(function_name);
+		free(function_type);
 	}
 	return 0;
 }

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -2557,28 +2557,17 @@ void start_coprocess() {
 		_exit(127); // if we get here, the exec failed so we just quit
 	}
 	else { // parent goes here
-		function_name = "my_func";
-		function_port = 45107;
-		function_type = "python";
-
-
 		if (fcntl(coprocess_out[0], F_SETFL, O_NONBLOCK))
 		{
 			debug(D_WQ, "parent could not set pipe to nonblocking: %s\n", strerror(errno));
 			return;
 		}
 		
-		char buffer[BUFSIZ];
-		int reading = 1;
-		int count = 0;
+		// read from coprocess - values just hardcoded for now but can get rid of this later
+		function_name = "my_func";
+		function_port = 45107;
+		function_type = "python";
 
-		while(reading && count < 15) {
-			int bytes_read = read_from_coprocess(buffer, 30);
-			printf("%d %s\n", bytes_read, buffer);
-			sleep(1);
-			count++;
-		}
-		
 		if (close(coprocess_in[0]) || close(coprocess_out[1])) {
 			debug(D_WQ, "parent could not close unneeded pipes: %s\n", strerror(errno));
 			return;

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -2576,6 +2576,7 @@ void start_coprocess() {
 			int bytes_read = read_from_coprocess(buffer, 30);
 			printf("%d %s\n", bytes_read, buffer);
 			sleep(1);
+			count++;
 		}
 		
 		if (close(coprocess_in[0]) || close(coprocess_out[1])) {


### PR DESCRIPTION
Here is what @David-Simonetti-ND and I got working this week. The coprocess and worker now communicate via pipes on startup so that the port is no longer hardcoded and you don't have to pass the name of the function via the command line. We can now run multiple workers with the network function!