### PR TITLE
guard against incorrect values in cpu_time

### DIFF
--- a/dttools/src/macros.h
+++ b/dttools/src/macros.h
@@ -25,7 +25,7 @@ See the file COPYING for details.
 #define ABS(x) ( ((x)>=0) ? (x) : (-(x)) )
 #endif
 
-#define DIV_INT_ROUND_UP(a, b) ((__typeof__(a)) ((int64_t) ((((a) + (b) - 1) / (b)))))
+#define DIV_INT_ROUND_UP(a, b) ((__typeof__(a)) ((int64_t) (((((double) (a)) + ((double) (b)) - 1) / (b)))))
 
 #define KILO 1024
 #define MEGA (KILO*KILO)

--- a/dttools/src/rmonitor_poll.c
+++ b/dttools/src/rmonitor_poll.c
@@ -354,7 +354,10 @@ int rmonitor_get_cpu_time_usage(pid_t pid, struct rmonitor_cpu_time_info *cpu)
 
 	uint64_t accum = clicks_to_usecs(kernel) + clicks_to_usecs(user);
 
-	cpu->delta       = accum  - cpu->accumulated;
+	cpu->delta = 0;
+	if(cpu->accumulated < accum) {
+		cpu->delta = accum - cpu->accumulated;
+	}
 	cpu->accumulated = accum;
 
 	return 0;
@@ -838,7 +841,7 @@ void rmonitor_info_to_rmsummary(struct rmsummary *tr, struct rmonitor_process_in
 	tr->cores_avg = 0;
 
 	/* set both cores and cores_avg to avg, as info does not come from time windows. */
-	if(tr->wall_time > 0) {
+	if(tr->wall_time > 0 && tr->cpu_time >= 0) {
 		// set cores = cpu_time/wall_time;
 		tr->cores = DIV_INT_ROUND_UP(tr->cpu_time, tr->wall_time);
 		tr->cores_avg = tr->cores;

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -889,14 +889,14 @@ void rmonitor_summary_header()
 }
 
 struct peak_cores_sample {
-	int64_t wall_time;
-	int64_t cpu_time;
+	double wall_time;
+	double cpu_time;
 };
 
 double peak_cores(double wall_time, double cpu_time) {
 	static struct list *samples = NULL;
 
-	double max_separation = 180 + 2*interval; /* at least one minute and a complete interval */
+	double max_separation = 180 + 2*interval; /* at least three minutes and a complete interval */
 
 	if(!samples) {
 		samples = list_create();
@@ -929,8 +929,8 @@ double peak_cores(double wall_time, double cpu_time) {
 
 	head = list_peek_head(samples);
 
-	double diff_wall = tail->wall_time - head->wall_time;
-	double diff_cpu  = tail->cpu_time  - head->cpu_time;
+	double diff_wall = MAX(0, tail->wall_time - head->wall_time);
+	double diff_cpu  = MAX(0, tail->cpu_time  - head->cpu_time);
 
 	if(tail->wall_time - summary->start < max_separation) {
 		/* hack to elimiate noise. if we have not collected enough samples,


### PR DESCRIPTION
As reported by @kmohrman, in some rare cases the cpu_time had a negative
value, which meant it was not included in the resource summary, but
cores where computed anyway as cpu_time/wall_time with an undefined
cpu_time value.