### PR TITLE
Network function communication with json and envelope

### DIFF
--- a/work_queue/src/network_function.py
+++ b/work_queue/src/network_function.py
@@ -2,6 +2,7 @@
 
 import socket
 import json
+import time
 
 '''
 The function signature should always be the same, but what is actually
@@ -11,6 +12,10 @@ this is just a dummy prototype
 '''
 def function_handler(event):
 	return int(event["a"]) + int(event["b"])
+
+def send_configuration(config):
+	config_string = json.dumps(config)
+	print(len(config_string) + 1, "\n", config_string, flush=True)
 
 def main():
 	s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -23,11 +28,14 @@ def main():
 		exit(1)
 
 	# information to print to stdout for worker
-	name = "my_func"
-	port = s.getsockname()[1]
-	_type = "python"	
+	config = {
+		"name": "my_func",
+		"port": s.getsockname()[1],
+		"type": "python",
+		"version": "1.1.2"
+	}
 
-	print(json.dumps({"name": name, "port": port, "type": _type}), flush=True)
+	send_configuration(config)
 
 	while True:
 		s.listen()

--- a/work_queue/src/network_function.py
+++ b/work_queue/src/network_function.py
@@ -2,6 +2,7 @@
 
 import socket
 import json
+import os
 
 '''
 The function signature should always be the same, but what is actually
@@ -13,6 +14,7 @@ def function_handler(event):
 	return int(event["a"]) + int(event["b"])
 
 def main():
+	initialppid = os.getppid()
 	s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 	try:
 		# modify the port argument to be 0 to listen on an arbitrary port
@@ -27,7 +29,7 @@ def main():
 	port = s.getsockname()[1]
 	_type = "python"	
 
-	print('name: {}\nport: {}\ntype: {}'.format(name,port,_type),flush=True)
+	print(json.dumps({"name": name, "port": port, "type": _type}), flush=True)
 
 	while True:
 		s.listen()

--- a/work_queue/src/network_function.py
+++ b/work_queue/src/network_function.py
@@ -2,7 +2,6 @@
 
 import socket
 import json
-import os
 
 '''
 The function signature should always be the same, but what is actually
@@ -14,7 +13,6 @@ def function_handler(event):
 	return int(event["a"]) + int(event["b"])
 
 def main():
-	initialppid = os.getppid()
 	s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 	try:
 		# modify the port argument to be 0 to listen on an arbitrary port

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -231,6 +231,7 @@ static pid_t coprocess_pid = 0;
 static int coprocess_num_deaths = 0;
 static int coprocess_in[2];
 static int coprocess_out[2];
+static int coprocess_max_timeout = 1000 * 60 * 5; // set max timeout to 5 minutes
 
 // Global variables for network function
 static char *function_name = NULL;
@@ -2570,7 +2571,7 @@ void update_coprocess_info()
 	char *envelope_size;
 	while (1)
 	{
-		int curr_bytes_read = read_from_coprocess_timeout(buffer + buffer_offset, 4096 - buffer_offset, 5000);
+		int curr_bytes_read = read_from_coprocess_timeout(buffer + buffer_offset, 4096 - buffer_offset, coprocess_max_timeout);
 		if (curr_bytes_read < 0) {
 			debug(D_WQ, "Unable to get information from network function\n");
 			return;

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -2506,52 +2506,6 @@ struct list *parse_manager_addresses(const char *specs, int default_port) {
 	return(managers);
 }
 
-void start_coprocess() {
-	if (pipe(coprocess_in) || pipe(coprocess_out)) { // create pipes to communicate with the coprocess
-		fatal("couldn't create coprocess pipes: %s\n", strerror(errno));
-		return;
-	}
-	coprocess_pid = fork();
-	if (coprocess_pid < 0) { // unable to fork
-		fatal("couldn't create new process: %s\n", strerror(errno));
-		return;
-	}		
-	else if (coprocess_pid == 0) { // child executes this
-		if ( (close(coprocess_in[1]) < 0) || (close(coprocess_out[0]) < 0) ) {
-			debug(D_WQ, "coprocess could not close pipes: %s\n", strerror(errno));
-			_exit(127);
-		}
-		
-		if (dup2(coprocess_in[0], 0) < 0) {
-			debug(D_WQ, "coprocess could not attach pipe to stdin: %s\n", strerror(errno));
-			_exit(127);
-		}
-
-		if (dup2(coprocess_out[1], 1) < 0) {
-			printf("%s\n", strerror(errno));
-			debug(D_WQ, "coprocess could not attach pipe to stdout: %s\n", strerror(errno));
-			_exit(127);
-		}
-		
-		execlp(coprocess_command, coprocess_command, (char *) 0);
-		debug(D_WQ, "failed to execute %s: %s\n", coprocess_command, strerror(errno));
-		_exit(127); // if we get here, the exec failed so we just quit
-	}
-	else { // parent goes here
-		/*
-		if (fcntl(coprocess_out[0], F_SETFL, O_NONBLOCK) < 0) {
-			debug(D_WQ, "parent could not make pipe nonblocking: %s\n", strerror(errno));
-			return;
-		}
-		*/
-		if (close(coprocess_in[0]) || close(coprocess_out[1])) {
-			debug(D_WQ, "parent could not close pipes: %s\n", strerror(errno));
-			return;
-		}
-		debug(D_WQ, "Forked child process to run %s\n", coprocess_command);
-	}
-}
-
 int write_to_coprocess_timeout(char *buffer, int len, int timeout)
 {
 	struct pollfd read_poll = {coprocess_in[1], POLLOUT, 0};
@@ -2607,6 +2561,84 @@ int read_from_coprocess_timeout(char *buffer, int len, int timeout){
 	}
 	buffer[bytes_read] = '\0';
 	return bytes_read;
+}
+
+void update_coprocess_info()
+{
+	char buffer[4096];
+	int bytes_read = read_from_coprocess_timeout(buffer, 4096, 5000);
+	
+	if (bytes_read < 0) {
+		debug(D_WQ, "Unable to get information from network function\n");
+		return;
+	}
+	else {
+		struct jx *item, *coprocess_json = jx_parse_string(buffer);
+		void *i = NULL;
+		const char *key;
+		while ((item = jx_iterate_values(coprocess_json, &i))) {
+			key = jx_get_key(&i);
+			if (key == NULL) {
+				continue;
+			}
+			if (!strcmp(key, "name")) {
+				function_name = jx_print_string(item);
+			}
+			else if (!strcmp(key, "port")) {
+				char *temp_port = jx_print_string(item);
+				function_port = atoi(temp_port);
+				free(temp_port);
+			}
+			else if (!strcmp(key, "type")) {
+				function_type = jx_print_string(item);
+			}
+			else {
+				debug(D_WQ, "Unable to recognize key %s\n", key);
+			}
+		}
+		jx_delete(coprocess_json);
+	}
+}
+
+void start_coprocess() {
+	if (pipe(coprocess_in) || pipe(coprocess_out)) { // create pipes to communicate with the coprocess
+		fatal("couldn't create coprocess pipes: %s\n", strerror(errno));
+		return;
+	}
+	coprocess_pid = fork();
+	if (coprocess_pid < 0) { // unable to fork
+		fatal("couldn't create new process: %s\n", strerror(errno));
+		return;
+	}		
+	else if (coprocess_pid == 0) { // child executes this
+		if ( (close(coprocess_in[1]) < 0) || (close(coprocess_out[0]) < 0) ) {
+			debug(D_WQ, "coprocess could not close pipes: %s\n", strerror(errno));
+			_exit(127);
+		}
+		
+		if (dup2(coprocess_in[0], 0) < 0) {
+			debug(D_WQ, "coprocess could not attach pipe to stdin: %s\n", strerror(errno));
+			_exit(127);
+		}
+
+		if (dup2(coprocess_out[1], 1) < 0) {
+			printf("%s\n", strerror(errno));
+			debug(D_WQ, "coprocess could not attach pipe to stdout: %s\n", strerror(errno));
+			_exit(127);
+		}
+		
+		execlp(coprocess_command, coprocess_command, (char *) 0);
+		debug(D_WQ, "failed to execute %s: %s\n", coprocess_command, strerror(errno));
+		_exit(127); // if we get here, the exec failed so we just quit
+	}
+	else { // parent goes here
+		update_coprocess_info();
+		if (close(coprocess_in[0]) || close(coprocess_out[1])) {
+			debug(D_WQ, "parent could not close pipes: %s\n", strerror(errno));
+			return;
+		}
+		debug(D_WQ, "Forked child process to run %s\n", coprocess_command);
+	}
 }
 
 int check_if_coprocess_exited()
@@ -3147,21 +3179,6 @@ int main(int argc, char *argv[])
 	if (coprocess_command != NULL)
 	{
 		start_coprocess();
-		char buffer[4096];
-		int bytes_read = read_from_coprocess_timeout(buffer, 4096, 5000);
-		if (bytes_read < 0)
-		{
-			debug(D_WQ, "Unable to get information from network function");
-		}
-		else
-		{
-			char *token = strtok(buffer, "\n");
-			function_name = xxstrdup(token + 6);
-			token = strtok(NULL, "\n");
-			function_port = atoi(token + 6);
-			token = strtok(NULL, "\n");
-			function_type = xxstrdup(token + 6);
-		}
 	}
 
 	while(1) {


### PR DESCRIPTION
I changed the network function to send the size of the json followed by a newline followed by the actual json itself. There are also sanity checks to ensure that the received json matches the sent size.