### PR TITLE
batch_job_cluster: abs name for logfile

### DIFF
--- a/batch_job/src/batch_job_cluster.c
+++ b/batch_job/src/batch_job_cluster.c
@@ -91,7 +91,7 @@ static int setup_batch_wrapper(struct batch_queue *q, const char *sysname )
 	}
 
 	// Each job writes out to its own log file.
-	fprintf(file, "logfile=%s.status.${JOB_ID}\n", sysname);
+	fprintf(file, "logfile=\"${PWD}/%s.status.${JOB_ID}\"\n", sysname);
 	fprintf(file, "starttime=`date +%%s`\n");
 	fprintf(file, "echo start $starttime > $logfile\n");
 


### PR DESCRIPTION
The user command inside the wrapper may change the current directory,
which may cause the "stop" transaction of the job status to be written
to a different file when using relative path names.