### PR TITLE
move coprocess to its own .h.c

### DIFF
--- a/work_queue/src/Makefile
+++ b/work_queue/src/Makefile
@@ -13,6 +13,7 @@ SOURCES_LIBRARY = \
 
 SOURCES_WORKER = \
 	work_queue_process.o \
+	work_queue_coprocess.o \
 	work_queue_watcher.o \
 	work_queue_gpus.o
 

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -126,6 +126,16 @@ class Task(object):
     def specify_command(self, command):
         return work_queue_task_specify_command(self._task, command)
 
+
+    ##
+    # Set the coprocess at the worker that should execute the task's command.
+    # This is not needed for regular tasks.
+    #
+    # @param self       Reference to the current task object.
+    # @param coprocess  The name of the coprocess.
+    def specify_coprocess(self, coprocess):
+        return work_queue_task_specify_coprocess(self._task, coprocess)
+
     ##
     # Set the worker selection algorithm for task.
     #

--- a/work_queue/src/coprocess_example.py
+++ b/work_queue/src/coprocess_example.py
@@ -1,0 +1,58 @@
+'''
+A work queue worker coprocess should at a minimum define a get_name() function.
+'''
+def name():
+    return "my_coprocess_example"
+
+'''
+The function signatures should always be the same, but what is actually
+contained in the event will be different. You decide what is in the event, and
+the function body (that you define) will work accordingly.
+'''
+def my_sum(event, response):
+	result = int(event["a"]) + int(event["b"])
+	response["Result"] = result
+	response["StatusCode"] = 200
+
+def my_multiplication(event, response):
+	result = int(event["a"]) * int(event["b"])
+	response["Result"] = result
+	response["StatusCode"] = 200
+
+
+if __name__ == "__main__":
+    # Run workers as:
+    # work_queue_worker --coprocess ./network_function.py localhost 9123
+    # For tests:
+    # python coprocess_example.py
+
+    import json
+
+    # Ensure we are testing the most recent source code
+    from importlib.machinery import SourceFileLoader
+    import site
+
+    site.addsitedir("bindings/python3")
+    wq = SourceFileLoader("wq", "bindings/python3/work_queue.py").load_module()
+    wq.set_debug_flag("all")
+
+    event = json.dumps({"a": 2, "b": 3})
+
+    q = wq.WorkQueue(9123)
+
+    t = wq.Task("my_sum");
+    t.specify_coprocess("my_coprocess_example")
+    t.specify_buffer(event, "infile")
+    q.submit(t)
+
+    t = wq.Task("my_multiplication");
+    t.specify_coprocess("my_coprocess_example")
+    t.specify_buffer(event, "infile")
+    q.submit(t)
+
+    while not q.empty():
+        t = q.wait(5)
+        if t:
+            print(f"task {t.id} done. status: {t.result} exit code: {t.return_status}.\noutput:\n{t.output}")
+
+

--- a/work_queue/src/function_handler.py
+++ b/work_queue/src/function_handler.py
@@ -1,7 +1,0 @@
-def handler(event, response):
-	result = int(event["a"]) + int(event["b"])
-	response["Result"] = result
-	response["StatusCode"] = 200
-
-def get_name():
-	return "my_func"

--- a/work_queue/src/network_function.py
+++ b/work_queue/src/network_function.py
@@ -5,83 +5,79 @@ import json
 import multiprocessing
 import os
 
-from function_handler import handler, get_name
+# Note: To change. the actual name of the module (i.e. instead of
+# "coprocess_example") should come from some worker's argument.
+import coprocess_example as wq_worker_coprocess
 
-'''
-The function signature should always be the same, but what is actually
-contained in the event will be different. You decide what is in the event,
-and the function body (that you define) will work accordingly. For now,
-this is just a dummy prototype
-'''
-def function_handler(event, response):
-	result = int(event["a"]) + int(event["b"])
-	response["Result"] = result
-	response["StatusCode"] = 200
 
 def send_configuration(config):
-	config_string = json.dumps(config)
-	print(len(config_string) + 1, "\n", config_string, flush=True)
+    config_string = json.dumps(config)
+    print(len(config_string) + 1, "\n", config_string, flush=True)
 
 def main():
-	s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-	try:
-		# modify the port argument to be 0 to listen on an arbitrary port
-		s.bind(('localhost', 0))
-	except Exception as e:
-		s.close()
-		print(e)
-		exit(1)
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        # modify the port argument to be 0 to listen on an arbitrary port
+        s.bind(('localhost', 0))
+    except Exception as e:
+        s.close()
+        print(e)
+        exit(1)
 
-	# information to print to stdout for worker
-	config = {
-		"name": get_name(),
-		"port": s.getsockname()[1],
-	}
+    # information to print to stdout for worker
+    config = {
+            "name": wq_worker_coprocess.name(),
+            "port": s.getsockname()[1],
+            }
 
-	send_configuration(config)
+    send_configuration(config)
 
-	while True:
-		s.listen()
-		conn, addr = s.accept()
-		print('Connection from {}'.format(addr))
-		while True:
-			# peek at message to find newline to get the size
-			event_size = None
-			line = conn.recv(100, socket.MSG_PEEK)
-			eol = line.find(b'\n')
-			if eol >= 0:
-				size = eol+1
-				# actually read the size of the event
-				event_size = int(conn.recv(size).decode('utf-8').split()[1])
+    while True:
+        s.listen()
+        conn, addr = s.accept()
+        print('Connection from {}'.format(addr))
+        while True:
+            # peek at message to find newline to get the size
+            event_size = None
+            line = conn.recv(100, socket.MSG_PEEK)
+            eol = line.find(b'\n')
+            if eol >= 0:
+                size = eol+1
+                # actually read the size of the event
+                input_spec = conn.recv(size).decode('utf-8').split()
+                function_name = input_spec[0]
+                event_size = int(input_spec[1])
 
-			if event_size:
-				# receive the event itself
-				event = conn.recv(event_size)
+            if event_size:
+                # receive the event itself
+                event = conn.recv(event_size)
 
-				event = json.loads(event)
-				print('event: {}'.format(event))
+                event = json.loads(event)
+                print('event: {}'.format(event))
 
-				# create a forked process for function handler
-				manager = multiprocessing.Manager()
-				response = manager.dict()
-				p = multiprocessing.Process(target=handler, args=(event, response))
-				p.start()
-				p.join()
+                # create a forked process for function handler
+                manager = multiprocessing.Manager()
+                response = manager.dict()
+                p = multiprocessing.Process(target=getattr(wq_worker_coprocess, function_name), args=(event, response))
+                p.start()
+                p.join()
 
-				response = json.dumps(response.copy())
-				response_size = len(response)
+                response = json.dumps(dict(response))
+                response_size = len(response)
 
-				size_msg = "data {}\n".format(response_size)
+                size_msg = "output {}\n".format(response_size)
 
-				# send the size of response
-				conn.sendall(size_msg.encode('utf-8'))
+                # send the size of response
+                conn.sendall(size_msg.encode('utf-8'))
 
-				# send response
-				conn.sendall(response.encode('utf-8'))
+                # send response
+                conn.sendall(response.encode('utf-8'))
 
-				break
+                break
 
-	return 0
+    return 0
 
 if __name__ == "__main__":
-	main()
+    main()
+
+

--- a/work_queue/src/network_function.py
+++ b/work_queue/src/network_function.py
@@ -36,7 +36,6 @@ def main():
 	config = {
 		"name": get_name(),
 		"port": s.getsockname()[1],
-		"type": "python",
 	}
 
 	send_configuration(config)

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -139,6 +139,8 @@ struct work_queue_task {
 	char *host;                                       /**< The address and port of the host on which it ran. */
 	char *hostname;                                   /**< The name of the host on which it ran. */
 
+	char *coprocess;                                  /**< The name of the coprocess name in the worker that executes this task. For regular tasks it is NULL. */
+
 	char *category;                         /**< User-provided label for the task. It is expected that all task with the same category will have similar resource usage. See @ref work_queue_task_specify_category. If no explicit category is given, the label "default" is used. **/
 	category_allocation_t resource_request; /**< See @ref category_allocation_t */
 
@@ -359,8 +361,9 @@ struct work_queue;
 /** Create a new task object.
 Once created and elaborated with functions such as @ref work_queue_task_specify_file
 and @ref work_queue_task_specify_buffer, the task should be passed to @ref work_queue_submit.
-@param full_command The shell command line to be executed by the task.  If null,
-the command will be given later by @ref work_queue_task_specify_command
+@param full_command The shell command line or coprocess functions to be
+executed by the task.  If null, the command will be given later by @ref
+work_queue_task_specify_command
 @return A new task object, or null if it could not be created.
 */
 struct work_queue_task *work_queue_task_create(const char *full_command);
@@ -377,6 +380,13 @@ struct work_queue_task *work_queue_task_clone(const struct work_queue_task *task
 @param cmd The command to be executed.  This string will be duplicated by this call, so the argument may be freed or re-used afterward.
 */
 void work_queue_task_specify_command( struct work_queue_task *t, const char *cmd );
+
+/** Indicate the command to be executed.
+@param t A task object.
+@param cmd The coprocess name that will execute the command at the worker. The task
+will only be sent to workers running the coprocess.
+*/
+void work_queue_task_specify_coprocess( struct work_queue_task *t, const char *coprocess_name );
 
 /** Add a file to a task.
 @param t A task object.

--- a/work_queue/src/work_queue_coprocess.c
+++ b/work_queue/src/work_queue_coprocess.c
@@ -1,0 +1,286 @@
+/*
+Copyright (C) 2022- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include <errno.h>
+#include <poll.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "work_queue_coprocess.h"
+#include "work_queue_protocol.h"
+
+#include "debug.h"
+#include "domain_name_cache.h"
+#include "jx.h"
+#include "jx_parse.h"
+#include "jx_print.h"
+#include "link.h"
+#include "timestamp.h"
+#include "process.h"
+
+static pid_t coprocess_pid = 0;
+static int coprocess_in[2];
+static int coprocess_out[2];
+static int coprocess_max_timeout = 1000 * 60 * 5; // set max timeout to 5 minutes
+
+
+int work_queue_coprocess_write(char *buffer, int len, int timeout)
+{
+	struct pollfd read_poll = {coprocess_in[1], POLLOUT, 0};
+	int poll_result = poll(&read_poll, 1, timeout);
+	if (poll_result < 0)
+	{
+		debug(D_WQ, "Write to coprocess failed: %s\n", strerror(errno));
+		return -1;
+	}
+	if (poll_result == 0) // check for timeout
+	{
+		debug(D_WQ, "writing to coprocess timed out\n");
+		return -1;
+	}
+	if ( !(read_poll.revents & POLLOUT)) // check we have data
+	{
+		debug(D_WQ, "Data able to be written to pipe: %s\n", strerror(errno));
+		return -1;
+	}
+	int bytes_written = write(coprocess_in[1], buffer, len);
+	if (bytes_written < 0)
+	{
+		debug(D_WQ, "Read from coprocess failed: %s\n", strerror(errno));
+		return -2;
+	}
+	return bytes_written;
+}
+
+int work_queue_coprocess_read(char *buffer, int len, int timeout){
+	struct pollfd read_poll = {coprocess_out[0], POLLIN, 0};
+	int poll_result = poll(&read_poll, 1, timeout);
+	if (poll_result < 0)
+	{
+		debug(D_WQ, "Read from coprocess failed: %s\n", strerror(errno));
+		return -1;
+	}
+	if (poll_result == 0) // check for timeout
+	{
+		debug(D_WQ, "reading from coprocess timed out\n");
+		return -3;
+	}
+	if ( !(read_poll.revents & POLLIN)) // check we have data
+	{
+		debug(D_WQ, "Data not returned from pipe: %s\n", strerror(errno));
+		return -1;
+	}
+
+	int bytes_read = read(coprocess_out[0], buffer, len - 1);
+	if (bytes_read < 0)
+	{
+		debug(D_WQ, "Read from coprocess failed: %s\n", strerror(errno));
+		return -2;
+	}
+	buffer[bytes_read] = '\0';
+	return bytes_read;
+}
+
+char *work_queue_coprocess_setup(int *coprocess_port)
+{
+	int json_offset, json_length = -1, cumulative_bytes_read = 0, buffer_offset = 0;
+	char buffer[WORK_QUEUE_LINE_MAX];
+	char *envelope_size;
+    char *name = NULL;
+
+	while (1)
+	{
+		int curr_bytes_read = work_queue_coprocess_read(buffer + buffer_offset, 4096 - buffer_offset, coprocess_max_timeout);
+		if (curr_bytes_read < 0) {
+			fatal("Unable to get information from coprocess\n");
+		}
+		else if (curr_bytes_read == -3)
+		{
+			break;
+		}
+		cumulative_bytes_read += curr_bytes_read;
+
+		envelope_size = memchr(buffer, '\n', cumulative_bytes_read);
+		if ( envelope_size != NULL )
+		{
+			if (json_length == -1)
+			{
+				json_length = atoi(buffer);
+				debug(D_WQ, "json_length %d\n", json_length);
+			}
+			if (json_length != -1)
+			{
+				json_offset = (int) (envelope_size - buffer) + 1;
+				while ( json_offset < cumulative_bytes_read )
+				{
+					if (buffer[json_offset] == '\n')
+					{
+						buffer_offset = -1;
+					}
+					json_offset++;
+				}
+			}
+		}
+		if (buffer_offset == -1)
+		{
+			break;
+		}
+		buffer_offset += curr_bytes_read;
+	}
+
+	if ( ( (envelope_size - buffer + 1) + json_length + 1 ) != cumulative_bytes_read)
+	{
+		return NULL;
+	}
+
+	struct jx *item, *coprocess_json = jx_parse_string(envelope_size + 1);
+	void *i = NULL;
+	const char *key;
+	while ((item = jx_iterate_values(coprocess_json, &i))) {
+		key = jx_get_key(&i);
+		if (key == NULL) {
+			continue;
+		}
+		if (!strcmp(key, "name")) {
+			name = jx_print_string(item);
+		}
+		else if (!strcmp(key, "port")) {
+			char *temp_port = jx_print_string(item);
+			*coprocess_port = atoi(temp_port);
+			free(temp_port);
+		}
+		else {
+			debug(D_WQ, "Unable to recognize key %s\n", key);
+		}
+	}
+
+	jx_delete(coprocess_json);
+
+    return name;
+}
+
+char *work_queue_coprocess_start(char *command, int *coprocess_port) {
+	if (pipe(coprocess_in) || pipe(coprocess_out)) { // create pipes to communicate with the coprocess
+		fatal("couldn't create coprocess pipes: %s\n", strerror(errno));
+		return NULL;
+	}
+	coprocess_pid = fork();
+
+	if(coprocess_pid > 0) {
+		char *name = work_queue_coprocess_setup(coprocess_port);
+
+		if (close(coprocess_in[0]) || close(coprocess_out[1])) {
+			fatal("coprocess error parent: %s\n", strerror(errno));
+		}
+		debug(D_WQ, "coprocess running command %s\n", command);
+
+        return name;
+	}
+    else if(coprocess_pid == 0) {
+        if ( (close(coprocess_in[1]) < 0) || (close(coprocess_out[0]) < 0) ) {
+            fatal("coprocess error: %s\n", strerror(errno));
+        }
+
+        if (dup2(coprocess_in[0], 0) < 0) {
+            fatal("coprocess could not attach to stdin: %s\n", strerror(errno));
+        }
+
+        if (dup2(coprocess_out[1], 1) < 0) {
+            fatal("coprocess could not attach pipe to stdout: %s\n", strerror(errno));
+        }
+
+        execlp(command, command, (char *) 0);
+        fatal("failed to execute %s: %s\n", command, strerror(errno));
+	}
+    else {
+        fatal("couldn't create fork coprocess: %s\n", strerror(errno));
+    }
+
+    return NULL;
+}
+
+void work_queue_coprocess_terminate() {
+    process_kill_waitpid(coprocess_pid, 30);
+}
+
+int work_queue_coprocess_check()
+{
+	struct process_info *p = process_waitpid(coprocess_pid, 0);
+	if (!p) {
+        return 0;
+	}
+
+    free(p);
+    return 1;
+}
+
+char *work_queue_coprocess_run(int coprocess_port, char *input) {
+	char addr[DOMAIN_NAME_MAX];
+	char buf[BUFSIZ];
+	int len;
+	int timeout = 60000000; // one minute, can be changed
+
+	if(!domain_name_lookup("localhost", addr)) {
+		fatal("could not lookup address of localhost");
+	}
+
+	timestamp_t curr_time = timestamp_get();
+	time_t stoptime = curr_time + timeout;
+
+	int connected = 0;
+	struct link *link;
+	int tries = 0;
+	// retry connection for ~30 seconds
+	while(!connected && tries < 30) {
+		link = link_connect(addr, coprocess_port, stoptime);
+		if(link) {
+			connected = 1;
+		} else {
+			tries++;
+			sleep(1);
+		}
+	}
+	// if we can't connect at all, abort
+	if(!link) {
+		fatal("connection error: %s", strerror(errno));
+	}
+
+	memcpy(buf, input, strlen(input)+1);
+	len = strlen(buf);
+
+	curr_time = timestamp_get();
+	stoptime = curr_time + timeout;
+	// send the length of the data first
+	int bytes_sent = link_printf(link, stoptime, "data: %d\n", len);
+	if(bytes_sent < 0) {
+		fatal("could not send size: %s", strerror(errno));
+	}
+
+	// send actual data
+	bytes_sent = link_write(link, buf, len, stoptime);
+	if(bytes_sent < 0) {
+		fatal("could not send data: %s", strerror(errno));
+	}
+
+	memset(buf, 0, sizeof(buf));
+
+	curr_time = timestamp_get();
+	stoptime = curr_time + timeout;
+	// read in the length of the response
+	char line[WORK_QUEUE_LINE_MAX];
+	int length;
+	link_readline(link, line, sizeof(line), stoptime);
+	sscanf(line, "data %d", &length);
+
+	// read the response
+	link_read(link, buf, length, stoptime);
+
+	char *output = calloc(strlen(buf), sizeof(char));
+	memcpy(output, buf, strlen(buf));
+
+	return output;
+}
+

--- a/work_queue/src/work_queue_coprocess.c
+++ b/work_queue/src/work_queue_coprocess.c
@@ -254,21 +254,19 @@ char *work_queue_coprocess_run(const char *function_name, const char *function_i
 		fatal("connection error: %s", strerror(errno));
 	}
 
-	memcpy(buf, input, strlen(input)+1);
-	len = strlen(buf);
-
+	len = strlen(function_input);
 	curr_time = timestamp_get();
 	stoptime = curr_time + timeout;
 	// send the length of the data first
-	int bytes_sent = link_printf(link, stoptime, "data: %d\n", len);
+	int bytes_sent = link_printf(link, stoptime, "%s %d\n", function_name, len);
 	if(bytes_sent < 0) {
-		fatal("could not send size: %s", strerror(errno));
+		fatal("could not send input data size: %s", strerror(errno));
 	}
 
 	// send actual data
-	bytes_sent = link_write(link, buf, len, stoptime);
+	bytes_sent = link_write(link, function_input, len, stoptime);
 	if(bytes_sent < 0) {
-		fatal("could not send data: %s", strerror(errno));
+		fatal("could not send input data: %s", strerror(errno));
 	}
 
 	memset(buf, 0, sizeof(buf));
@@ -279,7 +277,7 @@ char *work_queue_coprocess_run(const char *function_name, const char *function_i
 	char line[WORK_QUEUE_LINE_MAX];
 	int length;
 	link_readline(link, line, sizeof(line), stoptime);
-	sscanf(line, "data %d", &length);
+	sscanf(line, "output %d", &length);
 
 	// read the response
 	link_read(link, buf, length, stoptime);

--- a/work_queue/src/work_queue_coprocess.h
+++ b/work_queue/src/work_queue_coprocess.h
@@ -1,0 +1,12 @@
+/*
+Copyright (C) 2022- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+/* return the name of the coprocess */
+char *work_queue_coprocess_start(char *coprocess_command, int *coprocess_port);
+void work_queue_coprocess_terminate();
+int work_queue_coprocess_check();
+char *work_queue_coprocess_run(int coprocess_port, char *input);
+

--- a/work_queue/src/work_queue_coprocess.h
+++ b/work_queue/src/work_queue_coprocess.h
@@ -8,5 +8,5 @@ See the file COPYING for details.
 char *work_queue_coprocess_start(char *coprocess_command, int *coprocess_port);
 void work_queue_coprocess_terminate();
 int work_queue_coprocess_check();
-char *work_queue_coprocess_run(int coprocess_port, char *input);
+char *work_queue_coprocess_run(const char *function_name, const char *function_input, int coprocess_port);
 

--- a/work_queue/src/work_queue_process.c
+++ b/work_queue/src/work_queue_process.c
@@ -4,6 +4,7 @@
 #include "work_queue_internal.h"
 #include "work_queue_gpus.h"
 #include "work_queue_protocol.h"
+#include "work_queue_coprocess.h"
 
 #include "debug.h"
 #include "errno.h"
@@ -217,74 +218,7 @@ static char * load_input_file(struct work_queue_task *t) {
 		fatal("error reading file: %s", strerror(errno));
 	}
 
-	return buf;	
-}
-
-static char * invoke_coprocess_function(int function_port, char *input) {
-	char addr[DOMAIN_NAME_MAX];
-	char buf[BUFSIZ];
-	int len;
-	int timeout = 60000000; // one minute, can be changed
-
-	if(!domain_name_lookup("localhost", addr)) {
-		fatal("could not lookup address of localhost");
-	}
-
-	timestamp_t curr_time = timestamp_get();
-	time_t stoptime = curr_time + timeout;
-
-	int connected = 0;
-	struct link *link;
-	int tries = 0;
-	// retry connection for ~30 seconds
-	while(!connected && tries < 30) {
-		link = link_connect(addr, function_port, stoptime);
-		if(link) {
-			connected = 1;
-		} else {
-			tries++;
-			sleep(1);
-		}
-	}
-	// if we can't connect at all, abort
-	if(!link) {
-		fatal("connection error: %s", strerror(errno));
-	}
-	
-	memcpy(buf, input, strlen(input)+1);
-	len = strlen(buf);
-
-	curr_time = timestamp_get();
-	stoptime = curr_time + timeout;
-	// send the length of the data first
-	int bytes_sent = link_printf(link, stoptime, "data: %d\n", len);
-	if(bytes_sent < 0) {
-		fatal("could not send size: %s", strerror(errno));
-	}
-	
-	// send actual data
-	bytes_sent = link_write(link, buf, len, stoptime);
-	if(bytes_sent < 0) {
-		fatal("could not send data: %s", strerror(errno));
-	}
-
-	memset(buf, 0, sizeof(buf));
-
-	curr_time = timestamp_get();
-	stoptime = curr_time + timeout;
-	// read in the length of the response
-	char line[WORK_QUEUE_LINE_MAX];
-	int length;
-	link_readline(link, line, sizeof(line), stoptime);
-	sscanf(line, "data %d", &length);
-
-	// read the response
-	link_read(link, buf, length, stoptime);
-
-	char *output = calloc(strlen(buf), sizeof(char));
-	memcpy(output, buf, strlen(buf));
-
-	return output;
+	return buf;
 }
 
 pid_t work_queue_process_execute(struct work_queue_process *p )
@@ -349,16 +283,16 @@ pid_t work_queue_process_execute(struct work_queue_process *p )
 		if(result == -1)
 			fatal("could not dup pipe to stderr: %s", strerror(errno));
 
-		if(p->function_name != NULL && strcmp(p->task->command_line, p->function_name) == 0) {	
+		if(p->coprocess_name != NULL && strcmp(p->task->command_line, p->coprocess_name) == 0) {
 			// load data from input file
 			char *input = load_input_file(p->task);
-	
+
 			// call invoke_coprocess_function
-		 	char *output = invoke_coprocess_function(p->function_port, input);
+		 	char *output = work_queue_coprocess_run(p->coprocess_port, input);
 
 			// write data to output file
 			full_write(p->output_fd, output, strlen(output));
-			
+
 			exit(0);
 		}
 

--- a/work_queue/src/work_queue_process.c
+++ b/work_queue/src/work_queue_process.c
@@ -204,7 +204,7 @@ static const char task_output_template[] = "./worker.stdout.XXXXXX";
 static char * load_input_file(struct work_queue_task *t) {
 	FILE *fp = fopen("infile", "r");
 	if(!fp) {
-		fatal("could not open file for reading: %s", strerror(errno));
+		fatal("coprocess could not open file 'infile' for reading: %s", strerror(errno));
 	}
 
 	fseek(fp, 0L, SEEK_END);
@@ -283,12 +283,12 @@ pid_t work_queue_process_execute(struct work_queue_process *p )
 		if(result == -1)
 			fatal("could not dup pipe to stderr: %s", strerror(errno));
 
-		if(p->coprocess_name != NULL && strcmp(p->task->command_line, p->coprocess_name) == 0) {
+		if(p->coprocess_name != NULL) {
 			// load data from input file
 			char *input = load_input_file(p->task);
 
 			// call invoke_coprocess_function
-		 	char *output = work_queue_coprocess_run(p->coprocess_port, input);
+		 	char *output = work_queue_coprocess_run(p->task->command_line, input, p->coprocess_port);
 
 			// write data to output file
 			full_write(p->output_fd, output, strlen(output));

--- a/work_queue/src/work_queue_process.h
+++ b/work_queue/src/work_queue_process.h
@@ -44,10 +44,9 @@ struct work_queue_process {
 	/* state between complete disk measurements. */
 	struct path_disk_size_info *disk_measurement_state;
 
-	/* variables for remote function */
-	char *function_name;
-	int function_port;
-	char *function_type;
+	/* variables for coprocess funciton calls */
+	char *coprocess_name;
+	int coprocess_port;
 };
 
 struct work_queue_process * work_queue_process_create( struct work_queue_task *task, int disk_allocation );

--- a/work_queue/src/work_queue_protocol.h
+++ b/work_queue/src/work_queue_protocol.h
@@ -20,7 +20,8 @@ This file should not be installed and should only be included by .c files.
 /* 7: added category message */
 /* 8: worker send feature message. */
 /* 9: recursive send/recv and filename encoding. */
-#define WORK_QUEUE_PROTOCOL_VERSION 9
+/* 10: added coprocess message. */
+#define WORK_QUEUE_PROTOCOL_VERSION 10
 
 #define WORK_QUEUE_LINE_MAX 4096       /**< Maximum length of a work queue message line. */
 #define WORK_QUEUE_POOL_NAME_MAX 128   /**< Maximum length of a work queue pool name. */

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -989,6 +989,13 @@ static int do_task( struct link *manager, int taskid, time_t stoptime )
 			work_queue_task_specify_command(task,cmd);
 			debug(D_WQ,"rx from manager: %s",cmd);
 			free(cmd);
+		} else if(sscanf(line,"coprocess %d",&length)==1) {
+			char *cmd = malloc(length+1);
+			link_read(manager,cmd,length,stoptime);
+			cmd[length] = 0;
+			work_queue_task_specify_coprocess(task,cmd);
+			debug(D_WQ,"rx from manager: %s",cmd);
+			free(cmd);
 		} else if(sscanf(line,"infile %s %s %d", filename, taskname_encoded, &flags)) {
 			string_nformat(localname, sizeof(localname), "cache/%s", filename);
 			url_decode(taskname_encoded, taskname, WORK_QUEUE_LINE_MAX);

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -12,6 +12,7 @@ See the file COPYING for details.
 #include "work_queue_catalog.h"
 #include "work_queue_watcher.h"
 #include "work_queue_gpus.h"
+#include "work_queue_coprocess.h"
 
 #include "cctools.h"
 #include "macros.h"
@@ -225,19 +226,9 @@ static char *debug_path = NULL;
 static char *catalog_hosts = NULL;
 static int tlq_port = 0;
 
-
 static char *coprocess_command = NULL;
-static pid_t coprocess_pid = 0;
-static int coprocess_num_deaths = 0;
-static int coprocess_in[2];
-static int coprocess_out[2];
-static int coprocess_max_timeout = 1000 * 60 * 5; // set max timeout to 5 minutes
-
-// Global variables for network function
-static char *function_name = NULL;
-static int function_port = -1;
-static char *function_type = NULL;
-
+static char *coprocess_name = NULL;
+static int coprocess_port = -1;
 
 __attribute__ (( format(printf,2,3) ))
 static void send_manager_message( struct link *manager, const char *fmt, ... )
@@ -1932,10 +1923,11 @@ static void work_for_manager(struct link *manager) {
 					break;
 				} else if(task_resources_fit_now(p->task)) {
 					// attach the function name, port, and type to process, if applicable
-					if(function_name != NULL && function_port != -1 && function_type != NULL) {
-						p->function_name = xxstrdup(function_name);
-						p->function_port = function_port;
-						p->function_type = xxstrdup(function_type);
+					if(coprocess_command) {
+						/* for coprocesses, p->task->command_line is the name
+						 * of the function to execute */
+						p->coprocess_name = xxstrdup(coprocess_name);
+						p->coprocess_port = coprocess_port;
 					}
 					start_process(p);
 					task_event++;
@@ -2507,195 +2499,6 @@ struct list *parse_manager_addresses(const char *specs, int default_port) {
 	return(managers);
 }
 
-int write_to_coprocess_timeout(char *buffer, int len, int timeout)
-{
-	struct pollfd read_poll = {coprocess_in[1], POLLOUT, 0};
-	int poll_result = poll(&read_poll, 1, timeout);
-	if (poll_result < 0)
-	{
-		debug(D_WQ, "Write to coprocess failed: %s\n", strerror(errno));
-		return -1;
-	}
-	if (poll_result == 0) // check for timeout
-	{
-		debug(D_WQ, "writing to coprocess timed out\n");
-		return -1;
-	}
-	if ( !(read_poll.revents & POLLOUT)) // check we have data
-	{
-		debug(D_WQ, "Data able to be written to pipe: %s\n", strerror(errno));
-		return -1;
-	}
-	int bytes_written = write(coprocess_in[1], buffer, len);
-	if (bytes_written < 0)
-	{
-		debug(D_WQ, "Read from coprocess failed: %s\n", strerror(errno));
-		return -2;
-	}
-	return bytes_written;
-}
-
-int read_from_coprocess_timeout(char *buffer, int len, int timeout){
-	struct pollfd read_poll = {coprocess_out[0], POLLIN, 0};
-	int poll_result = poll(&read_poll, 1, timeout);
-	if (poll_result < 0)
-	{
-		debug(D_WQ, "Read from coprocess failed: %s\n", strerror(errno));
-		return -1;
-	}
-	if (poll_result == 0) // check for timeout
-	{
-		debug(D_WQ, "reading from coprocess timed out\n");
-		return -3;
-	}
-	if ( !(read_poll.revents & POLLIN)) // check we have data
-	{
-		debug(D_WQ, "Data not returned from pipe: %s\n", strerror(errno));
-		return -1;
-	}
-
-	int bytes_read = read(coprocess_out[0], buffer, len - 1);
-	if (bytes_read < 0)
-	{
-		debug(D_WQ, "Read from coprocess failed: %s\n", strerror(errno));
-		return -2;
-	}
-	buffer[bytes_read] = '\0';
-	return bytes_read;
-}
-
-void update_coprocess_info()
-{
-	int json_offset, json_length = -1, cumulative_bytes_read = 0, buffer_offset = 0;
-	char buffer[4096];
-	char *envelope_size;
-	while (1)
-	{
-		int curr_bytes_read = read_from_coprocess_timeout(buffer + buffer_offset, 4096 - buffer_offset, coprocess_max_timeout);
-		if (curr_bytes_read < 0) {
-			debug(D_WQ, "Unable to get information from network function\n");
-			return;
-		}
-		else if (curr_bytes_read == -3)
-		{
-			break;
-		}
-		cumulative_bytes_read += curr_bytes_read;
-
-		envelope_size = memchr(buffer, '\n', cumulative_bytes_read);
-		if ( envelope_size != NULL )
-		{
-			if (json_length == -1)
-			{
-				json_length = atoi(buffer);
-				debug(D_WQ, "json_length %d\n", json_length);
-			}
-			if (json_length != -1)
-			{
-				json_offset = (int) (envelope_size - buffer) + 1;
-				while ( json_offset < cumulative_bytes_read )
-				{
-					if (buffer[json_offset] == '\n')
-					{
-						buffer_offset = -1;
-					}
-					json_offset++;
-				}
-			}
-		}
-		if (buffer_offset == -1)
-		{
-			break;
-		}
-		buffer_offset += curr_bytes_read;
-	}
-	
-	if ( ( (envelope_size - buffer + 1) + json_length + 1 ) != cumulative_bytes_read)
-	{
-		return;
-	}
-	
-	struct jx *item, *coprocess_json = jx_parse_string(envelope_size + 1);
-	void *i = NULL;
-	const char *key;
-	while ((item = jx_iterate_values(coprocess_json, &i))) {
-		key = jx_get_key(&i);
-		if (key == NULL) {
-			continue;
-		}
-		if (!strcmp(key, "name")) {
-			function_name = jx_print_string(item);
-		}
-		else if (!strcmp(key, "port")) {
-			char *temp_port = jx_print_string(item);
-			function_port = atoi(temp_port);
-			free(temp_port);
-		}
-		else if (!strcmp(key, "type")) {
-			function_type = jx_print_string(item);
-		}
-		else {
-			debug(D_WQ, "Unable to recognize key %s\n", key);
-		}
-	}
-	jx_delete(coprocess_json);
-}
-
-void start_coprocess() {
-	if (pipe(coprocess_in) || pipe(coprocess_out)) { // create pipes to communicate with the coprocess
-		fatal("couldn't create coprocess pipes: %s\n", strerror(errno));
-		return;
-	}
-	coprocess_pid = fork();
-	if (coprocess_pid < 0) { // unable to fork
-		fatal("couldn't create new process: %s\n", strerror(errno));
-		return;
-	}		
-	else if (coprocess_pid == 0) { // child executes this
-		if ( (close(coprocess_in[1]) < 0) || (close(coprocess_out[0]) < 0) ) {
-			debug(D_WQ, "coprocess could not close pipes: %s\n", strerror(errno));
-			_exit(127);
-		}
-		
-		if (dup2(coprocess_in[0], 0) < 0) {
-			debug(D_WQ, "coprocess could not attach pipe to stdin: %s\n", strerror(errno));
-			_exit(127);
-		}
-
-		if (dup2(coprocess_out[1], 1) < 0) {
-			printf("%s\n", strerror(errno));
-			debug(D_WQ, "coprocess could not attach pipe to stdout: %s\n", strerror(errno));
-			_exit(127);
-		}
-		
-		execlp(coprocess_command, coprocess_command, (char *) 0);
-		debug(D_WQ, "failed to execute %s: %s\n", coprocess_command, strerror(errno));
-		_exit(127); // if we get here, the exec failed so we just quit
-	}
-	else { // parent goes here
-		update_coprocess_info();
-		if (close(coprocess_in[0]) || close(coprocess_out[1])) {
-			debug(D_WQ, "parent could not close pipes: %s\n", strerror(errno));
-			return;
-		}
-		debug(D_WQ, "Forked child process to run %s\n", coprocess_command);
-	}
-}
-
-int check_if_coprocess_exited()
-{
-	struct process_info *p = process_waitpid(coprocess_pid, 0); // see if p has exitex
-	if (p) { // if we get a nonnull return, the process exited
-		coprocess_num_deaths++;
-		free(p);
-		return 1;
-	}
-	else // otherwise the process is still running
-	{
-		return 0;
-	}
-}
-
 static void show_help(const char *cmd)
 {
 	printf( "Use: %s [options] <managerhost> <port> \n"
@@ -2830,6 +2633,7 @@ int main(int argc, char *argv[])
 	int enable_capacity = 1; // enabled by default
 	double fast_abort_multiplier = 0;
 	char *foreman_stats_filename = NULL;
+
 	catalog_hosts = CATALOG_HOST;
 
 	features = hash_table_create(4, 0);
@@ -3062,11 +2866,10 @@ int main(int argc, char *argv[])
 			manual_ssl_option=1;
 			break;
 		case LONG_OPT_COPROCESS:
-			coprocess_command = xxstrdup(optarg); // get coprocess name from argument list
-			char absolute[1024];
-			path_absolute(coprocess_command, absolute, 1); // get absolute path of executable
-			free(coprocess_command);
-			coprocess_command = xxstrdup(absolute);
+			coprocess_command = calloc(PATH_MAX, sizeof(char));
+			path_absolute(optarg, coprocess_command, 1);
+			realloc(coprocess_command, strlen(coprocess_command)+1);
+			printf("%s\n", coprocess_command);
 			break;
 		default:
 			show_help(argv[0]);
@@ -3217,9 +3020,10 @@ int main(int argc, char *argv[])
 		total_resources->disk.total,
 		total_resources->gpus.total);
 
-	if (coprocess_command != NULL)
-	{
-		start_coprocess();
+	if(coprocess_command) {
+		/* start coprocess per manager attempt */
+		coprocess_name = work_queue_coprocess_start(coprocess_command, &coprocess_port);
+		hash_table_insert(features, coprocess_name, (void **) 1);
 	}
 
 	while(1) {
@@ -3273,24 +3077,17 @@ int main(int argc, char *argv[])
 			debug(D_NOTICE,"stopping: could not connect after %d seconds.",connect_timeout);
 			break;
 		}
-		if (coprocess_pid > 0 && coprocess_num_deaths < 10)
-		{
-			if (check_if_coprocess_exited())
-			{
-				start_coprocess();
-			}
-			printf("coprocess listening on: %d\n", function_port);
-		}
+
 		sleep(backoff_interval);
 	}
-	workspace_delete();
-	if (coprocess_pid > 0 && coprocess_num_deaths < 10)
-	{
-		int max_wait = 5; // maximum seconds we wish to wait for a given process
-		process_kill_waitpid(coprocess_pid, max_wait);
-		free(function_name);
-		free(function_type);
+
+	if (coprocess_command) {
+		work_queue_coprocess_terminate();
+		free(coprocess_name);
 	}
+
+	workspace_delete();
+
 	return 0;
 }
 


### PR DESCRIPTION
E.g.
```
t = Task("my_sum")
t->specify_coprocess("my_coprocess")
```

will call the function "my_sum" in the coprocess with the "my_coprocess" name. Tasks are only sent to workers with matching coprocesses.

Run `work_queue/src/coprocess_example.py` as an example. (The file works both as the coprocess and the wq manager.)