### PR TITLE
Update cross reference in Makeflow manual

### DIFF
--- a/doc/manuals/makeflow/index.md
+++ b/doc/manuals/makeflow/index.md
@@ -118,8 +118,8 @@ $ makeflow -T torque example.makeflow
 $ makeflow -T amazon example.makeflow
 ```
 
-To learn more about the various batch system options, see the Batch System
-Support section.
+To learn more about the various batch system options, see the [Batch System
+Support section](#batch-system-support).
 
 
 !!! warning


### PR DESCRIPTION
"see the Batch System Support section" now is a hyperlink to the section.