### PR TITLE
Fixed buffer overflow in load_input_file

### DIFF
--- a/work_queue/src/work_queue_process.c
+++ b/work_queue/src/work_queue_process.c
@@ -211,7 +211,7 @@ static char * load_input_file(struct work_queue_task *t) {
 	size_t fsize = ftell(fp);
 	fseek(fp, 0L, SEEK_SET);
 	// using calloc solves problem of garbage appended to buffer
-	char *buf = calloc(fsize, sizeof(*buf));
+	char *buf = calloc(fsize + 1, sizeof(*buf));
 
 	int bytes_read = full_fread(fp, buf, fsize);
 	if(bytes_read < 0) {


### PR DESCRIPTION
I noticed I was sometimes getting extra characters at the end of the string returned by load_input_file, and the issue appears to be that the buf returned by load_input_file is sometimes (or never) properly terminated with a null character (in my case, fsize and bytes_read were always the exact same size, meaning that buf is entirely filled with no room for a null terminator).