### PR TITLE
remote_execute decorator and switch to explicit fork()

### DIFF
--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -2060,8 +2060,9 @@ class WorkQueue(object):
 
 class RemoteTask(Task):
 
-    def __init__(self, fn, event, coprocess):
+    def __init__(self, fn, coprocess, **kwargs):
         Task.__init__(self, fn)
+        event = json.dumps(kwargs)
         Task.specify_buffer(self, event, "infile")
         Task.specify_coprocess(self, coprocess)
 

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -2058,8 +2058,22 @@ class WorkQueue(object):
 
         return seq[0]
 
+##
+# \class RemoteTask
+#
+# Python RemoteTask object
+#
+# This class is used to create a task that will execute on a worker running a coprocess
 class RemoteTask(Task):
-
+    ##
+    # Create a new remote task specification.
+    #
+    # @param self       Reference to the current remote task object.
+    # @param fn         The name of the function to be executed on the coprocess
+    # @param coprocess  The name of the coprocess which has the function you wish to execute. The coprocess should have a name() method that returns this
+    # @param
+    # @param command    The shell command line to be exected by the task.
+    # @param kwargs	    keyword arguments used in function to be executed by task. An optional kwarg exec_method can be specified to one of fork, thread, and direct to choose between those three methods of execution
     def __init__(self, fn, coprocess, **kwargs):
         Task.__init__(self, fn)
         event = json.dumps(kwargs)

--- a/work_queue/src/coprocess_example.py
+++ b/work_queue/src/coprocess_example.py
@@ -5,7 +5,11 @@ def name():
     return "my_coprocess_example"
 
 def remote_execute(func):
-    def remote_wrapper(event):
+    def remote_wrapper(event, q=None):
+        import sys, json
+        if q:
+            event = json.loads(event)
+            del event["method"]
         try:
             response = {
                 "Result": func(**event),
@@ -16,7 +20,9 @@ def remote_execute(func):
                 "Result": str(e),
                 "StatusCode": 500 
             }
-        return response
+        if not q:
+            return response
+        q.put(response)
     return remote_wrapper
 
 
@@ -32,6 +38,12 @@ def my_sum(a, b):
 @remote_execute
 def my_multiplication(a, b):
 	return a * b
+
+@remote_execute
+def my_sleep(t):
+    import time
+    time.sleep(t)
+    return "x" * 655
 
 @remote_execute
 def my_prime(number):

--- a/work_queue/src/coprocess_example.py
+++ b/work_queue/src/coprocess_example.py
@@ -1,7 +1,13 @@
 '''
 A work queue worker coprocess should at a minimum define a get_name() function.
 '''
-import time, json
+import json, tensorflow, sys
+from copy import copy
+
+mnist = tensorflow.keras.datasets.mnist
+(x_train, y_train), (x_test, y_test) = mnist.load_data()
+x_train, x_test = x_train / 255.0, x_test / 255.0
+
 def name():
     return "my_coprocess_example"
 
@@ -9,7 +15,7 @@ def remote_execute(func):
     def remote_wrapper(event, q=None):
         if q:
             event = json.loads(event)
-            del event["method"]
+            del event["exec_method"]
         try:
             response = {
                 "Result": func(**event),
@@ -40,27 +46,32 @@ def my_multiplication(a, b):
 	return a * b
 
 @remote_execute
-def my_sleep(t):
-    time.sleep(t)
-    return "x" * 655
+def tensorflow_import(t):
+    return tensorflow.reduce_sum(tensorflow.random.normal([t, t])).numpy().tolist()
 
 @remote_execute
-def my_prime(number):
-    import math
-    for factor in range(2, int(math.sqrt(number))):
-        if number % factor == 0:
-            return f"{number} is not prime"
-    return f"{number} is prime"
-
-
+def tensorflow_train(epochs):
+    sys.stdout = sys.stderr
+    model = tensorflow.keras.models.Sequential([
+    tensorflow.keras.layers.Flatten(input_shape=(28, 28)),
+    tensorflow.keras.layers.Dense(128, activation='relu'),
+    tensorflow.keras.layers.Dropout(0.2),
+    tensorflow.keras.layers.Dense(10)
+    ])
+    loss_fn = tensorflow.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
+    model.compile(optimizer='adam',
+            loss=loss_fn,
+            metrics=['accuracy'])
+    model.fit(x_train, y_train, epochs=epochs)
+    result = model.evaluate(x_test,  y_test)
+    del model
+    return result
 
 if __name__ == "__main__":
     # Run workers as:
     # work_queue_worker --coprocess ./network_function.py localhost 9123
     # For tests:
     # python coprocess_example.py
-
-    import json
 
     # Ensure we are testing the most recent source code
     from importlib.machinery import SourceFileLoader
@@ -72,10 +83,10 @@ if __name__ == "__main__":
 
     q = wq.WorkQueue(9123)
 
-    t = wq.RemoteTask("my_sum", "my_coprocess_example", a=2, b=3)
+    t = wq.RemoteTask("my_sum", "my_coprocess_example", a=2, b=3, exec_method="fork")
     q.submit(t)
 
-    t = wq.RemoteTask("my_multiplication", "my_coprocess_example", a=2, b=3)
+    t = wq.RemoteTask("my_multiplication", "my_coprocess_example", a=2, b=3, exec_method="thread")
     q.submit(t)
 
     while not q.empty():

--- a/work_queue/src/coprocess_example.py
+++ b/work_queue/src/coprocess_example.py
@@ -4,6 +4,12 @@ A work queue worker coprocess should at a minimum define a get_name() function.
 def name():
     return "my_coprocess_example"
 
+def remote_execute(func):
+    def remote_wrapper(event):
+        return func(**event)
+    return remote_wrapper
+
+
 '''
 The function signatures should always be the same, but what is actually
 contained in the event will be different. You decide what is in the event, and
@@ -19,11 +25,12 @@ def my_multiplication(event, response):
 	response["Result"] = result
 	response["StatusCode"] = 200
 
-def my_fact(event, response):
-    import math
-    result = math.factorial(int(event["a"][0]))
-    response["Result"] = result
+@remote_execute
+def my_fact(a):
+    response = dict()
+    response["Result"] = [5]
     response["StatusCode"] = 200
+    return response
 
 def my_pair(event, response):
     result = int(event["a"][0][0]) + int(event["a"][0][1])

--- a/work_queue/src/coprocess_example.py
+++ b/work_queue/src/coprocess_example.py
@@ -2,7 +2,6 @@
 A work queue worker coprocess should at a minimum define a get_name() function.
 '''
 import json, tensorflow, sys
-from copy import copy
 
 mnist = tensorflow.keras.datasets.mnist
 (x_train, y_train), (x_test, y_test) = mnist.load_data()

--- a/work_queue/src/coprocess_example.py
+++ b/work_queue/src/coprocess_example.py
@@ -3,7 +3,7 @@ A work queue worker coprocess should at a minimum define a get_name() function.
 '''
 def name():
     return "my_coprocess_example"
-
+import math
 def remote_execute(func):
     def remote_wrapper(event):
         return func(**event)
@@ -28,7 +28,7 @@ def my_multiplication(event, response):
 @remote_execute
 def my_fact(a):
     response = dict()
-    response["Result"] = [5]
+    response["Result"] = [math.factorial(x) for x in a]
     response["StatusCode"] = 200
     return response
 

--- a/work_queue/src/coprocess_example.py
+++ b/work_queue/src/coprocess_example.py
@@ -34,6 +34,12 @@ def my_multiplication(a, b):
 	return a * b
 
 @remote_execute
+def my_sleep(t):
+    import time
+    time.sleep(t)
+    return "x" * 655390
+
+@remote_execute
 def my_prime(number):
     import math
     for factor in range(2, int(math.sqrt(number))):

--- a/work_queue/src/coprocess_example.py
+++ b/work_queue/src/coprocess_example.py
@@ -34,12 +34,6 @@ def my_multiplication(a, b):
 	return a * b
 
 @remote_execute
-def my_sleep(t):
-    import time
-    time.sleep(t)
-    return "x" * 655390
-
-@remote_execute
 def my_prime(number):
     import math
     for factor in range(2, int(math.sqrt(number))):

--- a/work_queue/src/coprocess_example.py
+++ b/work_queue/src/coprocess_example.py
@@ -1,11 +1,7 @@
 '''
 A work queue worker coprocess should at a minimum define a get_name() function.
 '''
-import json, tensorflow, sys
-
-mnist = tensorflow.keras.datasets.mnist
-(x_train, y_train), (x_test, y_test) = mnist.load_data()
-x_train, x_test = x_train / 255.0, x_test / 255.0
+import json
 
 def name():
     return "my_coprocess_example"
@@ -43,28 +39,6 @@ def my_sum(a, b):
 @remote_execute
 def my_multiplication(a, b):
 	return a * b
-
-@remote_execute
-def tensorflow_import(t):
-    return tensorflow.reduce_sum(tensorflow.random.normal([t, t])).numpy().tolist()
-
-@remote_execute
-def tensorflow_train(epochs):
-    sys.stdout = sys.stderr
-    model = tensorflow.keras.models.Sequential([
-    tensorflow.keras.layers.Flatten(input_shape=(28, 28)),
-    tensorflow.keras.layers.Dense(128, activation='relu'),
-    tensorflow.keras.layers.Dropout(0.2),
-    tensorflow.keras.layers.Dense(10)
-    ])
-    loss_fn = tensorflow.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
-    model.compile(optimizer='adam',
-            loss=loss_fn,
-            metrics=['accuracy'])
-    model.fit(x_train, y_train, epochs=epochs)
-    result = model.evaluate(x_test,  y_test)
-    del model
-    return result
 
 if __name__ == "__main__":
     # Run workers as:

--- a/work_queue/src/coprocess_example.py
+++ b/work_queue/src/coprocess_example.py
@@ -1,12 +1,12 @@
 '''
 A work queue worker coprocess should at a minimum define a get_name() function.
 '''
+import time, json
 def name():
     return "my_coprocess_example"
 
 def remote_execute(func):
     def remote_wrapper(event, q=None):
-        import sys, json
         if q:
             event = json.loads(event)
             del event["method"]
@@ -41,7 +41,6 @@ def my_multiplication(a, b):
 
 @remote_execute
 def my_sleep(t):
-    import time
     time.sleep(t)
     return "x" * 655
 

--- a/work_queue/src/network_function.py
+++ b/work_queue/src/network_function.py
@@ -57,20 +57,20 @@ def main():
                     # turn the event into a python dictionary
                     event = json.loads(event_str)
                     # see if the user specified an execution method
-                    method = event.get("method", None)
+                    exec_method = event.get("exec_method", None)
                     print('Network function: recieved event: {}'.format(event), file=sys.stderr)
-                    if method == "thread":
+                    if exec_method == "thread":
                         # create a forked process for function handler
                         q = queue.Queue()
                         p = threading.Thread(target=getattr(wq_worker_coprocess, function_name), args=(event_str, q))
                         p.start()
                         p.join()
                         response = json.dumps(q.get()).encode("utf-8")
-                    elif method == "direct":
-                        del event["method"]
+                    elif exec_method == "direct":
+                        del event["exec_method"]
                         response = json.dumps(getattr(wq_worker_coprocess, function_name)(event)).encode("utf-8")
                     else:
-                        event.pop("method", None)
+                        event.pop("exec_method", None)
                         p = os.fork()
                         if p == 0:
                             response = getattr(wq_worker_coprocess, function_name)(event)

--- a/work_queue/src/work_queue_coprocess.c
+++ b/work_queue/src/work_queue_coprocess.c
@@ -225,7 +225,6 @@ int work_queue_coprocess_check()
 
 char *work_queue_coprocess_run(const char *function_name, const char *function_input, int coprocess_port) {
 	char addr[DOMAIN_NAME_MAX];
-	char buf[BUFSIZ];
 	int len;
 	int timeout = 60000000; // one minute, can be changed
 
@@ -269,8 +268,6 @@ char *work_queue_coprocess_run(const char *function_name, const char *function_i
 		fatal("could not send input data: %s", strerror(errno));
 	}
 
-	memset(buf, 0, sizeof(buf));
-
 	curr_time = timestamp_get();
 	stoptime = curr_time + timeout;
 	// read in the length of the response
@@ -279,11 +276,10 @@ char *work_queue_coprocess_run(const char *function_name, const char *function_i
 	link_readline(link, line, sizeof(line), stoptime);
 	sscanf(line, "output %d", &length);
 
+	char *output = calloc(length + 1, sizeof(char));
+	
 	// read the response
-	link_read(link, buf, length, stoptime);
-
-	char *output = calloc(strlen(buf) + 1, sizeof(char));
-	memcpy(output, buf, strlen(buf));
+	link_read(link, output, length, stoptime);
 
 	return output;
 }


### PR DESCRIPTION
Reworks the decorator to also wrap up the output of the user function into the response dict, and allows the user to specify the remote function arguments when creating the RemoteTask. Also switched from the multiprocess library to explicitly forking a process to run the function.