### PR TITLE
activate env before conda-unpack

### DIFF
--- a/poncho/src/poncho_package_run
+++ b/poncho/src/poncho_package_run
@@ -207,6 +207,8 @@ then
         exit 1
     fi
 
+    source ${UNPACK_TO}/bin/activate
+
     if ! ${UNPACK_TO}/bin/conda-unpack
     then
         errmsg could not relocate environment: ${ENV_NAME}


### PR DESCRIPTION
Needed because conda-unpack looks for a 'python' in PATH, but rh8 has
none.