### PR TITLE
Option to specify RemoteTask arguments by keyword, position, dictionary, or position

### DIFF
--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -2080,9 +2080,8 @@ class RemoteTask(Task):
     def __init__(self, fn, coprocess, *args, **kwargs):
         Task.__init__(self, fn)
         self._event = ""
-        if ( len(args) + len(kwargs.keys()) ) >= 1:
-            kwargs["work_queue_positional_args"] = args
-            self._event = kwargs
+        kwargs["work_queue_positional_args"] = args
+        self._event = kwargs
         Task.specify_coprocess(self, coprocess)
     ##
     # Specify function arguments as a dictionary argument

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -2079,18 +2079,18 @@ class RemoteTask(Task):
     # @param kwargs	    keyword arguments used in function to be executed by task. 
     def __init__(self, fn, coprocess, *args, **kwargs):
         Task.__init__(self, fn)
-        self._event = ""
-        kwargs["work_queue_positional_args"] = args
-        self._event = kwargs
+        self._event = {}
+        self._event["work_queue_kwargs"] = kwargs
+        self._event["work_queue_positional_args"] = args
         Task.specify_coprocess(self, coprocess)
     ##
-    # Specify function arguments as a dictionary argument
+    # Specify function arguments as a dictionary argument. This function overrides and kwargs and args passed to the task previously
     # @param self             Reference to the current remote task object
     # @param *args            Positonal args to passed to the function 
     # @param argument_dict    A dictionary that contains arguments by keyword. The key is the name of the argument and the value is the value that should be passed to the argument
     def specify_argument_dictionary(self, *args, argument_dict=None):
-        argument_dict["work_queue_positional_args"] = args
-        self._event = argument_dict
+        self._event["work_queue_kwargs"] = argument_dict
+        self._event["work_queue_positional_args"] = args
     ##
     # Specify how the remote task should execute
     # @param self                    Reference to the current remote task object

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -1931,7 +1931,7 @@ class WorkQueue(object):
     # @param coprocess  The name of the coprocess that contains the function fn.
     # @param name       This defines the key in the event json that wraps the data sent to the coprocess. 
     # @param chunk_size The number of elements to process at once
-    def remote_map(self, fn,  coprocess, array, chunk_size=1):
+    def remote_map(self, fn, array, coprocess, name, chunk_size=1):
         size = math.ceil(len(array)/chunk_size)
         results = [None] * size
         tasks = {}
@@ -1940,8 +1940,8 @@ class WorkQueue(object):
             start = i*chunk_size
             end = min(len(array), start+chunk_size)
 
-            p_task = RemoteTask(fn, coprocess)
-            p_task.specify_chunk_arguments(array[start:end])
+            event = json.dumps({name : array[start:end]})
+            p_task = RemoteTask(fn, event, coprocess)
             
             p_task.specify_tag(str(i))
             self.submit(p_task)
@@ -2084,10 +2084,10 @@ class RemoteTask(Task):
         self._event["fn_args"] = args
         Task.specify_coprocess(self, coprocess)
     ##
-    # Specify function arguments as a dictionary argument. This function overrides and kwargs and args passed to the task previously
+    # Specify function arguments. Accepts arrays and dictionarys. This overrides any arguments passed during task creation
     # @param self             Reference to the current remote task object
-    # @param *args            Positonal args to passed to the function 
-    # @param argument_dict    A dictionary that contains arguments by keyword. The key is the name of the argument and the value is the value that should be passed to the argument
+    # @param args             An array of positional args to be passed to the function
+    # @param kwargs           A dictionary of keyword arguments to be passed to the function
     def specify_fn_args(self, args=[], kwargs={}):
         self._event["fn_kwargs"] = kwargs
         self._event["fn_args"] = args

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -2073,10 +2073,16 @@ class RemoteTask(Task):
     # @param coprocess  The name of the coprocess which has the function you wish to execute. The coprocess should have a name() method that returns this
     # @param
     # @param command    The shell command line to be exected by the task.
-    # @param kwargs	    keyword arguments used in function to be executed by task. An optional kwarg exec_method can be specified to one of fork, thread, and direct to choose between those three methods of execution
-    def __init__(self, fn, coprocess, **kwargs):
+    # @param args       positional arguments used in function to be executed by task. Can be mixed with kwargs
+    # @param kwargs	    keyword arguments used in function to be executed by task. An optional kwarg exec_method can be specified to one of fork, thread, and direct to choose between those three methods of execution. Another optional kwarg is work_queue_argument_dict, which contains a dictionary of keyword arguments for the remote function
+    def __init__(self, fn, coprocess, *args, **kwargs):
         Task.__init__(self, fn)
-        event = json.dumps(kwargs)
+        if kwargs.get("work_queue_argument_dict", None) is None:
+            kwargs["work_queue_positional_args"] = args
+            event = json.dumps(kwargs)
+        else:
+            kwargs["work_queue_argument_dict"]["work_queue_positional_args"] = args
+            event = json.dumps(kwargs["work_queue_argument_dict"])
         Task.specify_buffer(self, event, "infile")
         Task.specify_coprocess(self, coprocess)
 

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -2076,7 +2076,7 @@ class RemoteTask(Task):
     # @param
     # @param command    The shell command line to be exected by the task.
     # @param args       positional arguments used in function to be executed by task. Can be mixed with kwargs
-    # @param kwargs	    keyword arguments used in function to be executed by task. An optional kwarg exec_method can be specified to one of fork, thread, and direct to choose between those three methods of execution. Another optional kwarg is work_queue_argument_dict, which contains a dictionary of keyword arguments for the remote function
+    # @param kwargs	    keyword arguments used in function to be executed by task. 
     def __init__(self, fn, coprocess, *args, **kwargs):
         Task.__init__(self, fn)
         self._event = ""
@@ -2084,9 +2084,18 @@ class RemoteTask(Task):
             kwargs["work_queue_positional_args"] = args
             self._event = kwargs
         Task.specify_coprocess(self, coprocess)
+    ##
+    # Specify function arguments as a dictionary argument
+    # @param self             Reference to the current remote task object
+    # @param *args            Positonal args to passed to the function 
+    # @param argument_dict    A dictionary that contains arguments by keyword. The key is the name of the argument and the value is the value that should be passed to the argument
     def specify_argument_dictionary(self, *args, argument_dict=None):
         argument_dict["work_queue_positional_args"] = args
         self._event = argument_dict
+    ##
+    # Specify how the remote task should execute
+    # @param self                    Reference to the current remote task object
+    # @param work_queue_exec_method  Can be one of "fork", "direct", or "thread". Fork creates a child process to execute the function, direct has the worker directly call the function, and thread spawns a thread to execute the function
     def specify_exec_method(self, work_queue_exec_method):
         if work_queue_exec_method not in ["fork", "direct", "thread"]:
             print("Error, work_queue_exec_method must be one of fork, direct, or thread")

--- a/work_queue/src/coprocess_example.py
+++ b/work_queue/src/coprocess_example.py
@@ -10,8 +10,8 @@ def work_queue_remote_execute(func):
     def remote_wrapper(event, q=None):
         if q:
             event = json.loads(event)
-        kwargs = event["work_queue_kwargs"]
-        args = event["work_queue_positional_args"]
+        kwargs = event["fn_kwargs"]
+        args = event["fn_args"]
         try:
             response = {
                 "Result": func(*args, **kwargs),

--- a/work_queue/src/coprocess_example.py
+++ b/work_queue/src/coprocess_example.py
@@ -10,12 +10,11 @@ def work_queue_remote_execute(func):
     def remote_wrapper(event, q=None):
         if q:
             event = json.loads(event)
-            del event["work_queue_exec_method"]
+        kwargs = event["work_queue_kwargs"]
         args = event["work_queue_positional_args"]
-        del event["work_queue_positional_args"]
         try:
             response = {
-                "Result": func(*args, **event),
+                "Result": func(*args, **kwargs),
                 "StatusCode": 200
             }
         except Exception as e:

--- a/work_queue/src/coprocess_example.py
+++ b/work_queue/src/coprocess_example.py
@@ -6,14 +6,16 @@ import json
 def name():
     return "my_coprocess_example"
 
-def remote_execute(func):
+def work_queue_remote_execute(func):
     def remote_wrapper(event, q=None):
         if q:
             event = json.loads(event)
-            del event["exec_method"]
+            del event["work_queue_exec_method"]
+        args = event["work_queue_positional_args"]
+        del event["work_queue_positional_args"]
         try:
             response = {
-                "Result": func(**event),
+                "Result": func(*args, **event),
                 "StatusCode": 200
             }
         except Exception as e:
@@ -27,16 +29,17 @@ def remote_execute(func):
     return remote_wrapper
 
 
+
 '''
 The function signatures should always be the same, but what is actually
 contained in the event will be different. You decide what is in the event, and
 the function body (that you define) will work accordingly.
 '''
-@remote_execute
+@work_queue_remote_execute
 def my_sum(a, b):
 	return a + b
 
-@remote_execute
+@work_queue_remote_execute
 def my_multiplication(a, b):
 	return a * b
 
@@ -56,10 +59,16 @@ if __name__ == "__main__":
 
     q = wq.WorkQueue(9123)
 
-    t = wq.RemoteTask("my_sum", "my_coprocess_example", a=2, b=3, exec_method="fork")
+    t = wq.RemoteTask("my_sum", "my_coprocess_example", a=2, b=3, work_queue_exec_method="fork")
     q.submit(t)
 
-    t = wq.RemoteTask("my_multiplication", "my_coprocess_example", a=2, b=3, exec_method="thread")
+    t = wq.RemoteTask("my_sum", "my_coprocess_example", work_queue_argument_dict={"a":20, "b":30}, work_queue_exec_method="direct")
+    q.submit(t)
+
+    t = wq.RemoteTask("my_multiplication", "my_coprocess_example", 5, 15, work_queue_exec_method="thread")
+    q.submit(t)
+
+    t = wq.RemoteTask("my_multiplication", "my_coprocess_example", 5, b=125, work_queue_exec_method="thread")
     q.submit(t)
 
     while not q.empty():

--- a/work_queue/src/network_function.py
+++ b/work_queue/src/network_function.py
@@ -57,7 +57,7 @@ def main():
                     # turn the event into a python dictionary
                     event = json.loads(event_str)
                     # see if the user specified an execution method
-                    exec_method = event.get("work_queue_exec_method", None)
+                    exec_method = event.get("remote_task_exec_method", None)
                     print('Network function: recieved event: {}'.format(event), file=sys.stderr)
                     if exec_method == "thread":
                         # create a forked process for function handler

--- a/work_queue/src/network_function.py
+++ b/work_queue/src/network_function.py
@@ -67,10 +67,8 @@ def main():
                         p.join()
                         response = json.dumps(q.get()).encode("utf-8")
                     elif exec_method == "direct":
-                        del event["work_queue_exec_method"]
                         response = json.dumps(getattr(wq_worker_coprocess, function_name)(event)).encode("utf-8")
                     else:
-                        event.pop("work_queue_exec_method", None)
                         p = os.fork()
                         if p == 0:
                             response = getattr(wq_worker_coprocess, function_name)(event)

--- a/work_queue/src/network_function.py
+++ b/work_queue/src/network_function.py
@@ -57,7 +57,7 @@ def main():
                     # turn the event into a python dictionary
                     event = json.loads(event_str)
                     # see if the user specified an execution method
-                    exec_method = event.get("exec_method", None)
+                    exec_method = event.get("work_queue_exec_method", None)
                     print('Network function: recieved event: {}'.format(event), file=sys.stderr)
                     if exec_method == "thread":
                         # create a forked process for function handler
@@ -67,10 +67,10 @@ def main():
                         p.join()
                         response = json.dumps(q.get()).encode("utf-8")
                     elif exec_method == "direct":
-                        del event["exec_method"]
+                        del event["work_queue_exec_method"]
                         response = json.dumps(getattr(wq_worker_coprocess, function_name)(event)).encode("utf-8")
                     else:
-                        event.pop("exec_method", None)
+                        event.pop("work_queue_exec_method", None)
                         p = os.fork()
                         if p == 0:
                             response = getattr(wq_worker_coprocess, function_name)(event)


### PR DESCRIPTION
When creating a RemoteTask, one can specify arguments by keyword as before, but now there is support for positional arguments and passing in a dictionary containing keyword arguments (pass in the dictionary as work_queue_argument_dict). The user can also mix and match these arguments, passing some arguments by keyword and some by position.