### PR TITLE
wq: use cache path to remove file at worker

### DIFF
--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -1299,7 +1299,7 @@ static int do_unlink(const char *path)
 		return 0;
 	}
 
-	trash_file(path);
+	trash_file(cached_path);
 
 	return 1;
 }


### PR DESCRIPTION
unlink file messages from the manager were silently ignored as the path to unlink was relative to the task, and not the cache path.