### PR TITLE
wq: always provide t.resources_measured

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1563,8 +1563,9 @@ void read_measured_resources(struct work_queue *q, struct work_queue_task *t) {
 
 	char *summary = monitor_file_name(q, t, ".summary");
 
-	if(t->resources_measured)
+	if(t->resources_measured) {
 		rmsummary_delete(t->resources_measured);
+	}
 
 	t->resources_measured = rmsummary_parse_file_single(summary);
 
@@ -1574,7 +1575,8 @@ void read_measured_resources(struct work_queue *q, struct work_queue_task *t) {
 	} else {
 		/* if no resources were measured, then we don't overwrite the return
 		 * status, and mark the task as with error from monitoring. */
-			update_task_result(t, WORK_QUEUE_RESULT_RMONITOR_ERROR);
+		t->resources_measured = rmsummary_create(-1);
+		update_task_result(t, WORK_QUEUE_RESULT_RMONITOR_ERROR);
 	}
 
 	free(summary);


### PR DESCRIPTION
t.resources_measured was meant to always have a valid value, even when
no resource summary was available.