### PR TITLE
wq: equal resource proportions mode

### DIFF
--- a/doc/manuals/work_queue/index.md
+++ b/doc/manuals/work_queue/index.md
@@ -1915,6 +1915,38 @@ of file transfer time on overall performance. See
 [work_queue_graph_workers(1)](../man_pages/work_queue_graph_workers.md) for
 detailed information.
 
+## Specialized and Experimental Settings
+
+The behaviour of Work Queue can be tuned by the following parameters. We advise
+caution when using these parameters, as the standard behaviour may drastically
+change.
+
+| Parameter | Description | Default Value |
+|-----------|-------------|---------------|
+| category-steady-n-tasks | Minimum number of successful tasks to use a sample for automatic resource allocation modes<br>after encountering a new resource maximum. | 25 |
+| force-proportional-resources | When task with requirement r of resources is allocated in a worker,<br>divide the resources of the worker evenly so that only a whole number<br> of tasks with requirement r fit in the worker. <br> Use in conjunction with [task resources](#task-resources) | 0 |
+| hungry-minimum          | Smallest number of waiting tasks in the queue before declaring it hungry | 10 |
+| resource-submit-multiplier | Assume that workers have `resource x resources-submit-multiplier` available.<br> This overcommits resources at the worker, causing tasks to be sent to workers that cannot be immediately executed.<br>The extra tasks wait at the worker until resources become available. | 1 |
+| wait-for-workers        | Do not schedule any tasks until `wait-for-workers` are connected. | 0 |
+| wait-retrieve-many      | Rather than immediately returning when a task is done, `q.wait(timeout)` retrieves and dispatches as many tasks<br> as `timeout` allows. Warning: This may exceed the capacity of the manager to receive results. | 0 |
+
+=== "Python"
+    ```python
+    q.tune("hungry-minumum", 20)
+    ```
+
+=== "Perl"
+    ```perl
+    $q->tune("hungry-minumum", 20)
+    ```
+
+=== "C"
+    ```
+    work_queue_tune(q, "hungry-minumum", 20)
+    ```
+
+
+
 ## Further Information
 
 For more information, please see [Getting Help](../help) or visit the [Cooperative Computing Lab](http://ccl.cse.nd.edu) website.

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -7209,7 +7209,7 @@ int work_queue_tune(struct work_queue *q, const char *name, double value)
 	} else if(!strcmp(name, "wait-for-workers")) {
 		q->wait_for_workers = MAX(0, (int)value);
 
-	} else if(!strcmp(name, "wait_retrieve_many")){
+	} else if(!strcmp(name, "wait-retrieve-many")){
 		q->wait_retrieve_many = MAX(0, (int)value);
 
 	} else if(!strcmp(name, "force-proportional-resources")){

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -235,6 +235,7 @@ struct work_queue {
 	char *tlq_url;
 
 	int wait_retrieve_many;
+	int force_proportional_resources;
 };
 
 struct work_queue_worker {
@@ -3592,7 +3593,7 @@ static struct rmsummary *task_worker_box_size(struct work_queue *q, struct work_
 	int use_whole_worker = 1;
 
 	struct category *c = work_queue_category_lookup_or_create(q, t->category);
-	if(c->allocation_mode == CATEGORY_ALLOCATION_MODE_FIXED) {
+	if(q->force_proportional_resources || c->allocation_mode == CATEGORY_ALLOCATION_MODE_FIXED) {
 		double max_proportion = -1;
 		if(w->resources->cores.largest > 0) {
 			max_proportion = MAX(max_proportion, limits->cores / w->resources->cores.largest);
@@ -3619,10 +3620,17 @@ static struct rmsummary *task_worker_box_size(struct work_queue *q, struct work_
 		}
 		else if(max_proportion > 0) {
 			use_whole_worker = 0;
+
+			// adjust max_proportion so that an integer number of tasks fit the
+			// worker.
+			if(q->force_proportional_resources) {
+				max_proportion = 1.0/(floor(1.0/max_proportion));
+			}
+
 			/* when cores are unspecified, they are set to 0 if gpus are specified.
 			 * Otherwise they get a proportion according to specified
 			 * resources. Tasks will get at least one core. */
-			if(limits->cores < 0) {
+			if(q->force_proportional_resources || limits->cores < 0) {
 				if(limits->gpus > 0) {
 					limits->cores = 0;
 				} else {
@@ -3635,11 +3643,11 @@ static struct rmsummary *task_worker_box_size(struct work_queue *q, struct work_
 				limits->gpus = 0;
 			}
 
-			if(limits->memory < 0) {
+			if(q->force_proportional_resources || limits->memory < 0) {
 				limits->memory = MAX(1, floor(w->resources->memory.largest * max_proportion));
 			}
 
-			if(limits->disk < 0) {
+			if(q->force_proportional_resources || limits->disk < 0) {
 				limits->disk = MAX(1, floor(w->resources->disk.largest * max_proportion));
 			}
 		}
@@ -7203,6 +7211,9 @@ int work_queue_tune(struct work_queue *q, const char *name, double value)
 
 	} else if(!strcmp(name, "wait_retrieve_many")){
 		q->wait_retrieve_many = MAX(0, (int)value);
+
+	} else if(!strcmp(name, "force-proportional-resources")){
+		q->force_proportional_resources = MAX(0, (int)value);
 
 	} else {
 		debug(D_NOTICE|D_WQ, "Warning: tuning parameter \"%s\" not recognized\n", name);


### PR DESCRIPTION
Adds q.tune("force_proportional_resources", 1), which makes adjust
max_proportion so that an integer number of the given task category fit
the worker. In other words, it exchanges external for internal
fragmentation of resources. For automatic allocation modes such as
CATEGORY_ALLOCATION_MODE_MAX, this is beneficial, as tasks are much less
likely to fail for resource exhaustion.
    
For example, if a worker has 12GB, and the task asks for 3.5GB, then
force_proportional_resources will assign 4GB per task (three tasks
completely cover the worker, other than only 3*3.5GB=10.5GB, with 1.5GB
of external fragmentation). If the task asks
for 7GB, then it assigns 12GB to the task.

Advantages:
    
Eliminates avoidable resource exhaustion when using
ALLOCATION_MODE_MAX. For example, if the maximum task seen has 1 core,
4GB of memory, and a worker has 2 cores, 4GB of memory, without
force_proportional_resources, a future task may fail by exhausting the 1
core. But this avoidable, as the task will be assigned %100 of the
memory, so no other task will be running by that worker anyway.
    
This aggressive ALLOCATION_MODE_MAX has been very successful in reducing
the retries of accumulation tasks in topEFT, where tasks get larger and
larger.
    
Disadvantages:
    
If there are many different sizes of small and large tasks, throughput
may be reduced, as small tasks won't be able to run in the 'leftovers'
that large tasks previously left.

