### PR TITLE
wq resources revamp

### DIFF
--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -428,7 +428,7 @@ int64_t category_first_allocation_max_seen(struct histogram *h, int64_t top_reso
     double rounded = max_seen;
     double bucket_size = histogram_bucket_size(h);
 
-    rounded = histogram_round_up(h, rounded + floor(bucket_size/2));
+    rounded = histogram_round_up(h, rounded + floor(bucket_size/3));
 
     double to_cmp = -1;
     if(max_explicit > -1 && max_worker > -1) {
@@ -552,7 +552,6 @@ int category_accumulate_summary(struct category *c, const struct rmsummary *rs, 
     }
 
 	const struct rmsummary *max  = c->max_allocation;
-	const struct rmsummary *seen = c->max_resources_seen;
 
     int new_maximum = 0;
     if(!c->steady_state) {
@@ -567,7 +566,9 @@ int category_accumulate_summary(struct category *c, const struct rmsummary *rs, 
                 continue;
             }
 
-            if(rmsummary_get_by_offset(rs, o) > rmsummary_get_by_offset(seen, o)) {
+            struct histogram *h = itable_lookup(c->histograms, o);
+            double max_seen = histogram_round_up(h, histogram_max_value(h));
+            if(rmsummary_get_by_offset(rs, o) > max_seen) {
                 // the measured is larger than what we have seen, thus we need
                 // to reset the first allocation.
                 new_maximum = 1;
@@ -721,6 +722,9 @@ const struct rmsummary *category_dynamic_task_max_resources(struct category *c, 
          * In max mode, max seen is the first allocation, and next allocation
          * is to use whole workers. */
         rmsummary_merge_override(internal, c->max_resources_seen);
+
+        /* Never go below what first_allocation computer */
+        rmsummary_merge_max(internal, c->first_allocation);
     }
 
     /* load explicit category max values */
@@ -750,7 +754,6 @@ const struct rmsummary *category_dynamic_task_min_resources(struct category *c, 
 
 	/* load seen values */
 	struct rmsummary *seen = c->max_resources_seen;
-
 	if(c->allocation_mode != CATEGORY_ALLOCATION_MODE_FIXED) {
         size_t i;
         for(i = 0; labeled_resources[i]; i++) {

--- a/work_queue/src/bindings/python3/Makefile
+++ b/work_queue/src/bindings/python3/Makefile
@@ -17,10 +17,11 @@ all: $(TARGETS)
 
 # The odd symlink in the following rule is necessary to overcome a problem
 # in the framework search path emitted by the Python configuration on macOS.
-work_queue_wrap.c work_queue.py: work_queue.i work_queue.binding.py
+work_queue_wrap.c work_queue.py: work_queue.i work_queue.binding.py StatusDisplay.py
 	@echo "SWIG work_queue.i (python)"
 	@$(CCTOOLS_SWIG) -o work_queue_wrap.c -python -py3 -I$(CCTOOLS_HOME)/dttools/src -I$(CCTOOLS_HOME)/work_queue/src work_queue.i
 	@cat work_queue.binding.py >> work_queue.py
+	@cat StatusDisplay.py >> work_queue.py
 	ln -sf /System/Library/Frameworks/Python.framework .
 
 $(WQPYTHONSO): work_queue_wrap.o $(EXTERNAL_DEPENDENCIES)

--- a/work_queue/src/bindings/python3/StatusDisplay.py
+++ b/work_queue/src/bindings/python3/StatusDisplay.py
@@ -89,7 +89,7 @@ class StatusDisplay():
             allocs = [
                     ("max_seen", "largest seen", "na"),
                     ("first_allocation", "current allocation", "whole worker"),
-                    ("max_allocation", "maximum allocation worker", "whole worker"),
+                    ("max_allocation", "maximum allocation", "whole worker"),
                     ]
 
             for (k, l, na) in allocs:

--- a/work_queue/src/bindings/python3/StatusDisplay.py
+++ b/work_queue/src/bindings/python3/StatusDisplay.py
@@ -1,0 +1,320 @@
+import numbers
+import time
+import sys
+import math
+from datetime import timedelta
+from string import Template
+
+
+class StatusDisplay():
+    resources = ["cores", "gpus", "memory", "disk"]
+
+    def __init__(self, interval=10):
+        self.interval = interval
+        self._last_update_report = 0
+
+    def active(self):
+        raise NotImplementedError
+
+    def update(self, queue=None, force=False):
+        now = time.time()
+        if not force:
+            if self._last_update_report + self.interval > now:
+                return
+        self._last_update_report = now
+
+        (q_info, rw_info, rc_info, app_info) = self.generate_table_data(queue)
+        self.update_display(q_info, rw_info, rc_info, app_info)
+
+    def update_display(self, queue_info, resources_worker_info, resources_category_info, app_info):
+        raise NotImplementedError
+
+    def generate_table_data(self, queue=None):
+        queue_s = None
+        app_s = None
+        if queue:
+            try:
+                queue_s = queue.status("queue")[0]
+            except Exception as e:
+                print("Error reading work queue status: {}".format(e), file=sys.stderr)
+            try:
+                app_s = queue.application_info()
+            except Exception as e:
+                print("Error reading application information status: {}".format(e), file=sys.stderr)
+
+        rc_info = self.generate_resource_category_tables(queue_s)
+        rw_info = self.generate_resource_worker_tables(queue_s)
+        q_info = self.generate_queue_table(queue_s)
+        app_info = self.generate_app_table(app_s)
+
+        return (q_info, rw_info, rc_info, app_info)
+
+    def generate_resource_worker_tables(self, queue_s):
+        if not queue_s:
+            return None
+
+        suffixes = [("largest", "largest worker"), ("inuse", "allocated"), ("total", "total")]
+
+        rs = []
+        header = ["application resources"] + StatusDisplay.resources
+        rs.append(header)
+
+        for (s, l) in suffixes:
+            d = self._dict_from_q(queue_s, s)
+            rs.append(self.resources_to_row(d, l, "na"))
+
+        return [rs]
+
+    def generate_resource_category_tables(self, queue_s):
+        if not queue_s:
+            return None
+
+        categories = queue_s["categories"]
+        largest_worker = None
+        if queue_s['workers_connected'] > 0:
+            largest_worker = self._dict_from_q(queue_s, "largest")
+
+        categories.sort(key=lambda c: c["category"])
+        cs = []
+        for c in categories:
+            ct = []
+            header = [c["category"]] + StatusDisplay.resources
+
+            ct.append(header)
+
+            larger_worker = self.resources_check_limits(c["max_allocation"], largest_worker)
+            if larger_worker:
+                ct.append(["current workers too small!"] + larger_worker)
+
+            allocs = [
+                    ("max_seen", "largest seen", "na"),
+                    ("first_allocation", "current allocation", "whole worker"),
+                    ("max_allocation", "maximum allocation worker", "whole worker"),
+                    ]
+
+            for (k, l, na) in allocs:
+                try:
+                    alloc = self.resources_to_row(c[k], l, na)
+                    if alloc:
+                        ct.append(alloc)
+                except KeyError:
+                    pass
+
+            cs.append(ct)
+
+        return cs
+
+    def generate_queue_table(self, queue_s):
+        if not queue_s:
+            return None
+
+        stats = ["port",
+                "tasks_done", "tasks_waiting", "tasks_running",
+                "tasks_exhausted_attempts",
+                "workers_connected", "workers_busy", ]
+
+        pairs = list((key.replace("_", " "), str(queue_s[key])) for key in stats)
+
+        pairs.append(("sent", self.with_units("disk", queue_s["bytes_sent"]/1e6, "na")))
+        pairs.append(("received", self.with_units("disk", queue_s["bytes_received"]/1e6, "na")))
+
+        pairs.append(("total send time", str(timedelta(seconds=math.ceil(queue_s["time_send"]/1e6)))))
+        pairs.append(("total receive time", str(timedelta(seconds=math.ceil(queue_s["time_send"]/1e6)))))
+        pairs.append(("total good task time", str(timedelta(seconds=math.ceil(queue_s["time_workers_execute_good"]/1e6)))))
+        pairs.append(("total task time", str(timedelta(seconds=math.ceil(queue_s["time_workers_execute"]/1e6)))))
+        pairs.append(("runtime", str(timedelta(seconds=math.ceil(time.time() - queue_s["time_when_started"]/1e6)))))
+
+        return pairs
+
+    def generate_app_table(self, app_s):
+        if not app_s:
+            return None
+
+        try:
+            app_info = app_s['application_info']
+            values = app_info['values']
+            units = app_info.get('units', {})
+        except KeyError:
+            return None
+
+        pairs = []
+        try:
+            for key in values:
+                name = key.replace("_", " ")
+                unit = units.get(key, None)
+                value = values[key]
+                if unit == "MB":
+                    value = self.with_units("disk", value, "na")
+                elif unit:
+                    value = f"{value} {unit}"
+                else:
+                    value = str(value)
+                pairs.append((name, value))
+        except Exception as e:
+            pairs = [("internal error reading status", str(e))]
+
+        return pairs
+
+    def resources_to_row(self, values, alloc, na="na"):
+        rs = [alloc]
+        for r in StatusDisplay.resources:
+            try:
+                value = values[r]
+                value_with_units = self.with_units(r, value, na)
+            except KeyError:
+                value_with_units = na
+            rs.append(value_with_units)
+        return rs
+
+    def resources_check_limits(self, values, limit):
+        if not limit:
+            return None
+        limits_broken = False
+        rs = []
+        for r in StatusDisplay.resources:
+            try:
+                largest = limit[r]
+                value = values[r]
+                check = "ok"
+                if isinstance(value, numbers.Number) and isinstance(largest, numbers.Number) and value > largest:
+                    limits_broken = True
+                    check = f"{self.with_units(r, largest, '')} is too small"
+            except KeyError:
+                pass
+            rs.append(check)
+        if limits_broken:
+            return rs
+        return None
+
+    def with_units(self, resource, value, na):
+        if value is None:
+            return na
+
+        if not isinstance(value, numbers.Number):
+            return str(value)
+
+        if value < 0:
+            return na
+
+        if resource not in ["memory", "disk"]:
+            return f"{value:.1f}"
+
+        multipliers = ["MB", "GB", "TB"]
+        for m in multipliers:
+            if value < 1000:
+                break
+            value /= 1000.0
+        return f"{value:.2f} {m}"
+
+    def _dict_from_q(self, queue_s, suffix):
+        return {r: queue_s[f"{r}_{suffix}"] for r in StatusDisplay.resources}
+
+
+class JupyterDisplay(StatusDisplay):
+    style = '''
+        <style>
+          table {
+            border: 1px solid white;
+            border-collapse: collapse;
+            width: 100%;
+          }
+          th {
+            background-color: #96D4D4;
+            text-align: right;
+          }
+          td {
+            background-color: #f6f8ff;
+            padding-right: 15px;
+            text-align: right;
+          }
+          td.over {
+            text-align: right;
+            background-color: #ffcccc;
+          }
+        </style>
+    '''
+
+    tbl_fmt = Template(f'''
+        <head>
+        {style}
+        </head>
+        <body>
+        <table>
+        $header
+        $rows
+        </table>
+        </body>
+    ''')
+
+    hdr_fmt = Template('<th colspan="$span"> $value </th>')
+    cell_fmt = Template('<td> $value </td>')
+    cell_over_fmt = Template('<td class="over"> $value </td>')
+    row_fmt = Template('<tr> $cells </tr>')
+
+    def __init__(self, interval=10):
+        super().__init__(interval)
+
+        self._output = None
+        try:
+            import IPython
+            import ipywidgets as ws
+            if 'IPKernelApp' in IPython.get_ipython().config:
+                self._queue_display = ws.HTML(value="")
+                self._app_display = ws.HTML(value="")
+                self._worker_display = ws.HTML(value="")
+                self._category_display = ws.HTML(value="")
+
+                self._output = ws.GridspecLayout(1, 8, grid_gap="20px")
+                self._output[0, :3] = ws.VBox([self._app_display, self._queue_display])
+                self._output[0, 3:] = ws.VBox([self._worker_display, self._category_display])
+                IPython.display.display(self._output)
+
+        except (ImportError, AttributeError):
+            raise
+            pass
+
+    def active(self):
+        return bool(self._output)
+
+    def update_display(self, queue_info, resources_worker_info, resources_category_info, app_info):
+        if app_info:
+            self._app_display.value = self.table_of_pairs(app_info, "application info")
+
+        if queue_info:
+            self._queue_display.value = self.table_of_pairs(queue_info, "queue stats")
+
+        if resources_worker_info:
+            self._worker_display.value = self.table_of_resources(resources_worker_info)
+
+        if resources_category_info:
+            self._category_display.value = self.table_of_resources(resources_category_info)
+
+    def table_of_pairs(self, pairs, label):
+        header = JupyterDisplay.row_fmt.substitute(cells=JupyterDisplay.hdr_fmt.substitute(value=label, span=2))
+        rows = []
+        if pairs:
+            for pair in pairs:
+                row = self.make_row(pair)
+                rows.append(row)
+        return self.make_table(header, rows)
+
+    def table_of_resources(self, groups):
+        rows = []
+        for rs in groups:
+            rows.append(self.make_row(rs[0], fmt=lambda v: JupyterDisplay.hdr_fmt.substitute(value=v, span=0)))
+            rows.extend(map(lambda r: self.make_row(r), rs[1:]))
+        return self.make_table('', rows)
+
+    def make_table(self, header, rows):
+        return JupyterDisplay.tbl_fmt.substitute(header=header, rows="\n".join(rows))
+
+    def make_row(self, cells_info, fmt=None):
+        if not fmt:
+            fmt = lambda v: JupyterDisplay.cell_fmt.substitute(value=v)
+            try:
+                if cells_info[0][-1] == "!":
+                    fmt = lambda v: JupyterDisplay.cell_over_fmt.substitute(value=v)
+            except IndexError:
+                pass
+        cells = map(lambda v: fmt(v), cells_info)
+        return JupyterDisplay.row_fmt.substitute(cells=" ".join(cells))

--- a/work_queue/src/bindings/python3/StatusDisplay.py
+++ b/work_queue/src/bindings/python3/StatusDisplay.py
@@ -84,7 +84,7 @@ class StatusDisplay():
 
             larger_worker = self.resources_check_limits(c["max_allocation"], largest_worker)
             if larger_worker:
-                ct.append(["current workers too small!"] + larger_worker)
+                ct.append(["current workers are too small!"] + larger_worker)
 
             allocs = [
                     ("max_seen", "largest seen", "na"),

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -1213,6 +1213,21 @@ class WorkQueue(object):
         return stats
 
     ##
+    # Get queue information as list of dictionaries
+    # @param self Reference to the current work queue object
+    # @param request One of: "queue", "tasks", "workers", or "categories"
+    # For example:
+    # @code
+    # import json
+    # tasks_info = q.status("tasks")
+    # @endcode
+    def status(self, request):
+        info_raw = work_queue_status(self._work_queue, request)
+        info_json = json.loads(info_raw)
+        del info_raw
+        return info_json
+
+    ##
     # Get resource statistics of workers connected.
     #
     # @param self 	Reference to the current work queue object.

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -375,6 +375,7 @@ char *work_queue_monitor_wrap(struct work_queue *q, struct work_queue_worker *w,
 
 const struct rmsummary *task_max_resources(struct work_queue *q, struct work_queue_task *t);
 const struct rmsummary *task_min_resources(struct work_queue *q, struct work_queue_task *t);
+static struct rmsummary *task_worker_box_size(struct work_queue *q, struct work_queue_worker *w, struct work_queue_task *t);
 
 void work_queue_accumulate_task(struct work_queue *q, struct work_queue_task *t);
 struct category *work_queue_category_lookup_or_create(struct work_queue *q, const char *name);
@@ -1776,6 +1777,13 @@ void read_measured_resources(struct work_queue *q, struct work_queue_task *t) {
 	if(t->resources_measured) {
 		t->resources_measured->category = xxstrdup(t->category);
 		t->return_status = t->resources_measured->exit_status;
+
+		/* cleanup noise in cores value, otherwise small fluctuations trigger new
+		* maximums */
+		if(t->resources_measured->cores > 0) {
+			t->resources_measured->cores = MIN(t->resources_measured->cores, ceil(t->resources_measured->cores - 0.1));
+		}
+
 	} else {
 		/* if no resources were measured, then we don't overwrite the return
 		 * status, and mark the task as with error from monitoring. */
@@ -2521,33 +2529,59 @@ void category_jx_insert_max(struct jx *j, struct category *c, const char *field,
 		char *max_str = string_format("~%s", rmsummary_resource_to_str(field, m, 0));
 		jx_insert_string(j, field_str, max_str);
 		free(max_str);
+	} else {
+		jx_insert_string(j, field_str, "na");
 	}
 
 	free(field_str);
 }
 
+/* create dummy task to obtain first allocation that category would get if using largest worker */
+static struct rmsummary *category_alloc_info(struct work_queue *q, struct category *c, category_allocation_t request) {
+	struct work_queue_task *t = work_queue_task_create("nop");
+	work_queue_task_specify_category(t, c->name);
+	t->resource_request = request;
+
+	struct work_queue_worker *w = malloc(sizeof(*w));
+	w->resources = work_queue_resources_create();
+	w->resources->cores.largest = q->current_max_worker->cores;
+	w->resources->memory.largest = q->current_max_worker->memory;
+	w->resources->disk.largest = q->current_max_worker->disk;
+	w->resources->gpus.largest = q->current_max_worker->gpus;
+
+	struct rmsummary *allocation = task_worker_box_size(q, w, t);
+
+	work_queue_task_delete(t);
+	work_queue_resources_delete(w->resources);
+	free(w);
+
+	return allocation;
+}
+
+static struct jx * alloc_to_jx(struct work_queue *q, struct category *c, struct rmsummary *resources) {
+	struct jx *j = jx_object(0);
+
+	jx_insert_double(j, "cores", resources->cores);
+	jx_insert_integer(j, "memory", resources->memory);
+	jx_insert_integer(j, "disk", resources->disk);
+	jx_insert_integer(j, "gpus", resources->gpus);
+
+	return j;
+}
 
 static struct jx * category_to_jx(struct work_queue *q, const char *category) {
 	struct work_queue_stats s;
 	struct category *c = NULL;
 	const struct rmsummary *largest = largest_seen_resources(q, category);
 
-	if(category) {
-		c = work_queue_category_lookup_or_create(q, category);
-		work_queue_get_stats_category(q, category, &s);
-	} else {
-		work_queue_get_stats(q, &s);
-		category = "whole queue";
-	}
+	c = work_queue_category_lookup_or_create(q, category);
+	work_queue_get_stats_category(q, category, &s);
 
 	if(s.tasks_waiting + s.tasks_on_workers + s.tasks_done < 1) {
-		return 0;
+		return NULL;
 	}
 
 	struct jx *j = jx_object(0);
-	if(!j) {
-		return 0;
-	}
 
 	jx_insert_string(j,  "category",         category);
 	jx_insert_integer(j, "tasks_waiting",    s.tasks_waiting);
@@ -2562,22 +2596,25 @@ static struct jx * category_to_jx(struct work_queue *q, const char *category) {
 	category_jx_insert_max(j, c, "cores",  largest);
 	category_jx_insert_max(j, c, "memory", largest);
 	category_jx_insert_max(j, c, "disk",   largest);
+	category_jx_insert_max(j, c, "gpus",   largest);
 
-	if(c && c->first_allocation) {
-		if(c->first_allocation->cores > -1)
-			jx_insert_integer(j, "first_cores", c->first_allocation->cores);
-		if(c->first_allocation->memory > -1)
-			jx_insert_integer(j, "first_memory", c->first_allocation->memory);
-		if(c->first_allocation->disk > -1)
-			jx_insert_integer(j, "first_disk", c->first_allocation->disk);
+	struct rmsummary *first_allocation = category_alloc_info(q, c, CATEGORY_ALLOCATION_FIRST);
+	struct jx *jr = alloc_to_jx(q, c, first_allocation);
+	rmsummary_delete(first_allocation);
+	jx_insert(j, jx_string("first_allocation"), jr);
 
-		jx_insert_integer(j, "first_allocation_count", task_request_count(q, c->name, CATEGORY_ALLOCATION_FIRST));
-		jx_insert_integer(j, "max_allocation_count",   task_request_count(q, c->name, CATEGORY_ALLOCATION_MAX));
-	} else {
-		jx_insert_integer(j, "first_allocation_count", 0);
-		jx_insert_integer(j, "max_allocation_count", s.tasks_waiting + s.tasks_running + s.tasks_on_workers);
+	struct rmsummary *max_allocation = category_alloc_info(q, c, CATEGORY_ALLOCATION_MAX);
+	jr = alloc_to_jx(q, c, max_allocation);
+	rmsummary_delete(max_allocation);
+	jx_insert(j, jx_string("max_allocation"), jr);
+
+	if(q->monitor_mode) {
+		jr = alloc_to_jx(q, c, c->max_resources_seen);
+		jx_insert(j, jx_string("max_seen"), jr);
 	}
 
+	jx_insert_integer(j, "first_allocation_count", task_request_count(q, c->name, CATEGORY_ALLOCATION_FIRST));
+	jx_insert_integer(j, "max_allocation_count",   task_request_count(q, c->name, CATEGORY_ALLOCATION_MAX));
 
 	return j;
 }
@@ -2593,12 +2630,6 @@ static struct jx *categories_to_jx(struct work_queue *q) {
 		if(j) {
 			jx_array_insert(a, j);
 		}
-	}
-
-	//overall queue
-	struct jx *j = category_to_jx(q, NULL);
-	if(j) {
-		jx_array_insert(a, j);
 	}
 
 	return a;

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -3010,28 +3010,15 @@ static work_queue_msg_code_t process_http_request( struct work_queue *q, struct 
 	return MSG_PROCESSED_DISCONNECT;
 }
 
-/*
-Process a queue status request which returns raw JSON.
-This could come via the HTTP interface, or via a plain request.
-*/
-
-static work_queue_msg_code_t process_queue_status( struct work_queue *q, struct work_queue_worker *target, const char *line, time_t stoptime )
-{
-	struct link *l = target->link;
-
+static struct jx *construct_status_message( struct work_queue *q, const char *request ) {
 	struct jx *a = jx_array(NULL);
 
-	target->type = WORKER_TYPE_STATUS;
-
-	free(target->hostname);
-	target->hostname = xxstrdup("QUEUE_STATUS");
-
-	if(!strcmp(line, "queue_status")) {
+	if(!strcmp(request, "queue_status") || !strcmp(request, "queue") || !strcmp(request, "resources_status")) {
 		struct jx *j = queue_to_jx( q, 0 );
 		if(j) {
 			jx_array_insert(a, j);
 		}
-	} else if(!strcmp(line, "task_status")) {
+	} else if(!strcmp(request, "task_status") || !strcmp(request, "tasks")) {
 		struct work_queue_task *t;
 		struct work_queue_worker *w;
 		struct jx *j;
@@ -3063,7 +3050,7 @@ static work_queue_msg_code_t process_queue_status( struct work_queue *q, struct 
 				}
 			}
 		}
-	} else if(!strcmp(line, "worker_status")) {
+	} else if(!strcmp(request, "worker_status") || !strcmp(request, "workers")) {
 		struct work_queue_worker *w;
 		struct jx *j;
 		char *key;
@@ -3077,17 +3064,31 @@ static work_queue_msg_code_t process_queue_status( struct work_queue *q, struct 
 				jx_array_insert(a, j);
 			}
 		}
-	} else if(!strcmp(line, "wable_status")) {
+	} else if(!strcmp(request, "wable_status") || !strcmp(request, "categories")) {
 		jx_delete(a);
 		a = categories_to_jx(q);
-	} else if(!strcmp(line, "resources_status")) {
-		struct jx *j = queue_to_jx( q, 0 );
-		if(j) {
-			jx_array_insert(a, j);
-		}
 	} else {
-		debug(D_WQ, "Unknown status request: '%s'", line);
+		debug(D_WQ, "Unknown status request: '%s'", request);
 		jx_delete(a);
+		a = NULL;
+	}
+
+	return a;
+}
+
+
+static work_queue_msg_code_t process_queue_status( struct work_queue *q, struct work_queue_worker *target, const char *line, time_t stoptime )
+{
+	struct link *l = target->link;
+
+	struct jx *a = construct_status_message(q, line);
+	target->type = WORKER_TYPE_STATUS;
+
+	free(target->hostname);
+	target->hostname = xxstrdup("QUEUE_STATUS");
+
+	if(!a) {
+		debug(D_WQ, "Unknown status request: '%s'", line);
 		return MSG_FAILURE;
 	}
 
@@ -6695,13 +6696,13 @@ static void print_password_warning( struct work_queue *q )
 	}
 
 	if(!q->password && q->name) {
-		fprintf(stderr,"warning: this work queue manager is visible to the public.\n");
-		fprintf(stderr,"warning: you should set a password with the --password option.\n");
+		fprintf(stdout,"warning: this work queue manager is visible to the public.\n");
+		fprintf(stdout,"warning: you should set a password with the --password option.\n");
 	}
 
 	if(!q->ssl_enabled) {
-		fprintf(stderr,"warning: using plain-text when communicating with workers.\n");
-		fprintf(stderr,"warning: use encryption with a key and cert when creating the manager.\n");
+		fprintf(stdout,"warning: using plain-text when communicating with workers.\n");
+		fprintf(stdout,"warning: use encryption with a key and cert when creating the manager.\n");
 	}
 
 	did_password_warning = 1;
@@ -7560,6 +7561,20 @@ void work_queue_get_stats_category(struct work_queue *q, const char *category, s
 	s->tasks_submitted    = c->total_tasks + s->tasks_waiting + s->tasks_on_workers;
 
 	s->workers_able  = count_workers_for_waiting_tasks(q, largest_seen_resources(q, c->name));
+}
+
+char *work_queue_status(struct work_queue *q, const char *request) {
+	struct jx *a = construct_status_message(q, request);
+
+	if(!a) {
+		return "[]";
+	}
+
+	char *result = jx_print_string(a);
+
+	jx_delete(a);
+
+	return result;
 }
 
 void aggregate_workers_resources( struct work_queue *q, struct work_queue_resources *total, struct hash_table *features)

--- a/work_queue/src/work_queue.h
+++ b/work_queue/src/work_queue.h
@@ -866,6 +866,12 @@ void work_queue_get_stats_hierarchy(struct work_queue *q, struct work_queue_stat
 */
 void work_queue_get_stats_category(struct work_queue *q, const char *c, struct work_queue_stats *s);
 
+/** Get queue information as json
+@param q A work queue object.
+@param request One of: queue, tasks, workers, or categories
+*/
+char *work_queue_status(struct work_queue *q, const char *request);
+
 
 /** Summary data for all workers in buffer.
 @param q A work queue object.

--- a/work_queue/src/work_queue.i
+++ b/work_queue/src/work_queue.i
@@ -27,6 +27,9 @@ long long int is guaranteed to be at least 64bit. */
 %ignore vdebug;
 %ignore debug;
 
+/* returns a char*, enable automatic free */
+%newobject work_queue_status;
+
 /* These return pointers to lists defined in list.h. We aren't
  * wrapping methods in list.h and so ignore these. */
 %ignore work_queue_cancel_all_tasks;


### PR DESCRIPTION
- adds the `work_queue_status` API call, which works like the `work_queue_status` command, but can be called inside the code. (In fact, the status messages to the command are now constructed using this call.)
- adds the `application_info` method to python where applications can include statistics they want displayed.
- adds the StatusDisplay, which shows statistics as the manager runs. Currently only supports jupyter, but I plan to add text tables too. Activate by setting `WorkQueue` parameter like `status_display_interval=10` (update at least 10s apart).

Some examples: dynamic chunksize computation. coffea sends the stats shown in the application info box. 
![image](https://user-images.githubusercontent.com/3081826/183985063-b0641c71-83d7-4e72-965a-2fcaa093cadc.png)

mark when resources available are not enough for the tasks:
![image](https://user-images.githubusercontent.com/3081826/183985379-0b4cefb8-531c-4aad-8c8c-361b38565565.png)


Example of display info implementation:

```python
class MyWQ(wq.WorkQueue):
    def application_info(self):
        app_stats = {"current_time": time.time()}
        return {"application_info": {"value": app_stats, "units": "s"}}
```

For  #2533

