### PR TITLE
bindigns: disable cat buffering

### DIFF
--- a/chirp/src/bindings/python3/Makefile
+++ b/chirp/src/bindings/python3/Makefile
@@ -22,8 +22,7 @@ Chirp.py: chirp_wrap.c CChirp.py
 chirp_wrap.c CChirp.py: chirp.i chirp.binding.py
 	@echo "SWIG chirp.i (python)"
 	@$(CCTOOLS_SWIG) -o chirp_wrap.c -python -I$(CCTOOLS_HOME)/dttools/src/ -I$(CCTOOLS_HOME)/chirp/src chirp.i
-	@cat CChirp.py > Chirp.py
-	@cat chirp.binding.py >> Chirp.py
+	@cat -u CChirp.py chirp.binding.py > Chirp.py
 	ln -sf /System/Library/Frameworks/Python.framework .
 
 $(CHIRPPYTHONSO): $(OBJECTS) $(EXTERNAL_DEPENDENCIES)

--- a/dataswarm/src/bindings/python3/Makefile
+++ b/dataswarm/src/bindings/python3/Makefile
@@ -19,7 +19,7 @@ all: $(TARGETS)
 ds_wrap.c dataswarm.py: dataswarm.i dataswarm.binding.py
 	@echo "SWIG dataswarm.i (python)"
 	@$(CCTOOLS_SWIG) -o ds_wrap.c -python -py3 -I$(CCTOOLS_HOME)/dttools/src -I$(CCTOOLS_HOME)/dataswarm/src/manager dataswarm.i
-	@cat dataswarm.binding.py >> dataswarm.py
+	@cat -u dataswarm.binding.py >> dataswarm.py
 	ln -sf /System/Library/Frameworks/Python.framework .
 
 $(DSPYTHONSO): ds_wrap.o $(EXTERNAL_DEPENDENCIES)

--- a/work_queue/src/bindings/python3/Makefile
+++ b/work_queue/src/bindings/python3/Makefile
@@ -20,8 +20,8 @@ all: $(TARGETS)
 work_queue_wrap.c work_queue.py: work_queue.i work_queue.binding.py StatusDisplay.py
 	@echo "SWIG work_queue.i (python)"
 	@$(CCTOOLS_SWIG) -o work_queue_wrap.c -python -py3 -I$(CCTOOLS_HOME)/dttools/src -I$(CCTOOLS_HOME)/work_queue/src work_queue.i
-	@cat work_queue.binding.py >> work_queue.py
-	@cat StatusDisplay.py >> work_queue.py
+	@cat -u work_queue.binding.py >> work_queue.py
+	@cat -u StatusDisplay.py >> work_queue.py
 	ln -sf /System/Library/Frameworks/Python.framework .
 
 $(WQPYTHONSO): work_queue_wrap.o $(EXTERNAL_DEPENDENCIES)


### PR DESCRIPTION
Possible fix to conda azure builds sometimes messing up the final
modules

Traceback (most recent call last):
  File "$SRC_DIR/chirp/test/../src/bindings/python3//chirp_python_example.py", line 6, in <module>
    import Chirp
  File "$SRC_DIR/chirp/src/bindings/python3/Chirp.py", line 1655
    f the chirp jobs to be reaped.
                                  ^
IndentationError: unindent does not match any outer indentation level

Most likely than not, this won't fix it as the chances of the cat command doing something wrong are slim to none. However, this is the only step I can see where these errors are introduced. This errors occur only sometimes when running the conda-forge builds in azure for OSX.  The error goes away usually after a couple of retries.  I have tried building this commit in conda-forge, and has not failed yet.