### PR TITLE
Fixed typo causing error in package_create

### DIFF
--- a/poncho/src/poncho/package_create.py
+++ b/poncho/src/poncho/package_create.py
@@ -200,7 +200,7 @@ def create_conda_spec(spec_file, out_dir, local_pip_pkgs):
 
         conda_spec['channels'] = poncho_spec['conda'].get('channels', ['conda-forge', 'defaults'])
 
-        if 'depdnedencies' in poncho_spec['conda']:
+        if 'dependencies' in poncho_spec['conda']:
 
             conda_spec['dependencies'] = poncho_spec['conda'].get('dependencies', [])
 


### PR DESCRIPTION
A typo in the an the IF branch when converting the PONCHO spec file caused an error in which empty environments would be created.