### PR TITLE
DS Output Buffers

### DIFF
--- a/dataswarm/src/bindings/python3/dataswarm.binding.py
+++ b/dataswarm/src/bindings/python3/dataswarm.binding.py
@@ -376,11 +376,11 @@ class Task(object):
     # @param remote_name    The name of the remote file to create.
     # @param flags          May take the same values as @ref specify_file.
     # @param cache          Whether the file should be cached at workers (True/False)
-    def specify_buffer(self, buffer, remote_name, flags=None, cache=None):
+    def specify_input_buffer(self, buffer, remote_name, flags=None, cache=None):
         if remote_name:
             remote_name = str(remote_name)
         flags = Task._determine_file_flags(flags, cache, None)
-        return ds_task_specify_buffer(self._task, buffer, len(buffer), remote_name, flags)
+        return ds_task_specify_input_buffer(self._task, buffer, len(buffer), remote_name, flags)
 
     ##
     # Add an output buffer to the task.

--- a/dataswarm/src/bindings/python3/dataswarm.binding.py
+++ b/dataswarm/src/bindings/python3/dataswarm.binding.py
@@ -369,7 +369,7 @@ class Task(object):
         return ds_task_specify_directory(self._task, local_name, remote_name, type, flags, recursive)
 
     ##
-    # Add an input bufer to the task.
+    # Add an input buffer to the task.
     #
     # @param self           Reference to the current task object.
     # @param buffer         The contents of the buffer to pass as input.
@@ -382,6 +382,48 @@ class Task(object):
         flags = Task._determine_file_flags(flags, cache, None)
         return ds_task_specify_buffer(self._task, buffer, len(buffer), remote_name, flags)
 
+    ##
+    # Add an output buffer to the task.
+    #
+    # @param self           Reference to the current task object.
+    # @param buffer_name    The logical name of the output buffer.
+    # @param remote_name    The name of the remote file to fetch.
+    # @param flags          May take the same values as @ref specify_file.
+    # @param cache          Whether the file should be cached at workers (True/False)
+    def specify_output_buffer(self, buffer_name, remote_name, flags=None, cache=None):
+        if buffer_name:
+            buffer_name = str(buffer_name)
+        if remote_name:
+            remote_name = str(remote_name)
+        flags = Task._determine_file_flags(flags, cache, None)
+        return ds_task_specify_output_buffer(self._task, buffer_name, remote_name, flags)
+
+
+    ##
+    # Get an output buffer of the task.
+    #
+    # @param self           Reference to the current task object.
+    # @param buffer_name    The logical name of the output buffer.
+    # @return               The bytes of the returned file.
+
+    def get_output_buffer(self, buffer_name ):
+        if buffer_name:
+            buffer_name = str(buffer_name)
+
+        return ds_task_get_output_buffer(self._task, buffer_name )
+
+    ##
+    # Get the length of an output buffer.
+    #
+    # @param self           Reference to the current task object.
+    # @param buffer_name    The logical name of the output buffer.
+    # @return               The length of the output buffer.
+
+    def get_output_buffer_length(self, buffer_name ):
+        if buffer_name:
+            buffer_name = str(buffer_name)
+
+        return ds_task_get_output_buffer_length(self._task, buffer_name )
 
     ##
     # When monitoring, indicates a json-encoded file that instructs the monitor

--- a/dataswarm/src/bindings/python3/dataswarm.i
+++ b/dataswarm/src/bindings/python3/dataswarm.i
@@ -36,6 +36,11 @@ long long int is guaranteed to be at least 64bit. */
 %ignore input_files;
 %ignore output_files;
 
+/* When we enounter buffer_length in the prototype of ds_task_get_output_buffer,
+treat it as an output parameter to be filled in. */
+
+%apply int *OUTPUT { int *buffer_length };
+
 %include "stdint.i"
 %include "debug.h"
 %include "int_sizes.h"
@@ -43,5 +48,7 @@ long long int is guaranteed to be at least 64bit. */
 %include "dataswarm.h"
 %include "rmsummary.h"
 %include "category.h"
+
+
 
 

--- a/dataswarm/src/examples/ds_example_blast.c
+++ b/dataswarm/src/examples/ds_example_blast.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
 	for(i=0;i<10;i++) {
 		struct ds_task *t = ds_task_create("blastdir/ncbi-blast-2.13.0+/bin/blastp -db landmark -query query.file");
 	  
-		ds_task_specify_buffer(t,query_string,strlen(query_string),"query.file", DS_NOCACHE);
+		ds_task_specify_input_buffer(t,query_string,strlen(query_string),"query.file", DS_NOCACHE);
 		ds_task_specify_url(t,BLAST_URL,"blastdir", DS_INPUT, DS_CACHE|DS_UNPACK );
 		ds_task_specify_url(t,LANDMARK_URL,"landmark", DS_INPUT, DS_CACHE|DS_UNPACK );
 		ds_task_specify_env(t,"BLASTDB","landmark");

--- a/dataswarm/src/manager/dataswarm.h
+++ b/dataswarm/src/manager/dataswarm.h
@@ -236,7 +236,7 @@ struct ds_stats {
 
 /** Create a new task object.
 Once created and elaborated with functions such as @ref ds_task_specify_file
-and @ref ds_task_specify_buffer, the task should be passed to @ref ds_submit.
+and @ref ds_task_specify_input_buffer, the task should be passed to @ref ds_submit.
 @param full_command The shell command line or coprocess functions to be
 executed by the task.  If null, the command will be given later by @ref
 ds_task_specify_command
@@ -328,7 +328,7 @@ int ds_task_specify_file_piece(struct ds_task *t, const char *local_name, const 
 @return 1 if the arguments were valid and the file was added to the task; 0 if any of the arguments were invalid.
 */
 
-int ds_task_specify_buffer(struct ds_task *t, const char *data, int length, const char *remote_name, ds_file_flags_t flags);
+int ds_task_specify_input_buffer(struct ds_task *t, const char *data, int length, const char *remote_name, ds_file_flags_t flags);
 
 /** Add an output buffer to a task.
 @param t A task object.

--- a/dataswarm/src/manager/dataswarm.h
+++ b/dataswarm/src/manager/dataswarm.h
@@ -327,7 +327,17 @@ int ds_task_specify_file_piece(struct ds_task *t, const char *local_name, const 
 @param flags May be zero or more @ref ds_file_flags_t or'd together. See @ref ds_task_specify_file.
 @return 1 if the arguments were valid and the file was added to the task; 0 if any of the arguments were invalid.
 */
+
 int ds_task_specify_buffer(struct ds_task *t, const char *data, int length, const char *remote_name, ds_file_flags_t flags);
+
+/** Add an output buffer to a task.
+@param t A task object.
+@param data The logical name of the buffer, to be used with @ref ds_task_get_output_buffer.
+@param remote_name The name that the file will be given in the task sandbox.  Must be a relative path name: it may not begin with a slash.
+@param flags May be zero or more @ref ds_file_flags_t or'd together. See @ref ds_task_specify_file.
+@return 1 if the arguments were valid and the file was added to the task; 0 if any of the arguments were invalid.
+*/
+int ds_task_specify_output_buffer(struct ds_task *t, const char *buffer_name, const char *remote_name, ds_file_flags_t flags);
 
 /** Add an empty directory to a task.
 This is very occasionally needed for applications that expect
@@ -528,6 +538,17 @@ then this function returns null.
 */
 
 const char * ds_task_get_output( struct ds_task *t );
+
+/** Get an output buffer of the task.
+@param t A task object.
+@param buffer_name The name of the output buffer, given by @ref ds_task_specify_output_buffer
+@param data A pointer to a pointer to be filled in with the file data.  Do not free this buffer;
+it will be removed automatically by @ref ds_task_delete.
+@param length A pointer to an integer to be filled with the file length. 
+@return True if the output buffer is available, false otherwise.
+*/
+
+int ds_task_get_output_buffer( struct ds_task *t, const char *buffer_name, char **data, int *length );
 
 /** Get the address and port of the worker on which the task ran.
 @param t A task object.

--- a/dataswarm/src/manager/dataswarm.h
+++ b/dataswarm/src/manager/dataswarm.h
@@ -542,13 +542,22 @@ const char * ds_task_get_output( struct ds_task *t );
 /** Get an output buffer of the task.
 @param t A task object.
 @param buffer_name The name of the output buffer, given by @ref ds_task_specify_output_buffer
-@param data A pointer to a pointer to be filled in with the file data.  Do not free this buffer;
-it will be removed automatically by @ref ds_task_delete.
-@param length A pointer to an integer to be filled with the file length. 
-@return True if the output buffer is available, false otherwise.
+@return A pointer to the contents of the buffer.  The buffer is null-terminated, and so can
+be used directly as a string, if it is expected to contain text.  If the buffer is expected
+to contain binary data, use @ref ds_task_get_output_buffer_length to determine the length.
+Do not attempt to free this pointer, it will be freed when the task is deleted.
+Returns null if the task is not complete or the buffer is not available for some reason.
 */
 
-int ds_task_get_output_buffer( struct ds_task *t, const char *buffer_name, char **data, int *length );
+const char * ds_task_get_output_buffer( struct ds_task *t, const char *buffer_name );
+
+/** Get the length of an output buffer.
+@param t A task object.
+@param buffer_name The name of the output buffer, given by @ref ds_task_specify_output_buffer
+@return The length of the buffer in bytes, or zero if the buffer is not available.
+*/
+
+int ds_task_get_output_buffer_length( struct ds_task *t, const char *buffer_name );
 
 /** Get the address and port of the worker on which the task ran.
 @param t A task object.

--- a/dataswarm/src/manager/ds_file.c
+++ b/dataswarm/src/manager/ds_file.c
@@ -114,26 +114,34 @@ struct ds_file *ds_file_create(const char *source, const char *remote_name, ds_f
 	} else {
 		f->cached_name = make_cached_name(f);
 	}
+
+	f->data = 0;
 	
 	return f;
 }
 
 /* Make a deep copy of a file object to be used independently. */
 
-struct ds_file *ds_file_clone(const struct ds_file *file)
+struct ds_file *ds_file_clone(const struct ds_file *f )
 {
-	return ds_file_create(file->source,file->remote_name,file->type,file->flags);
+	struct ds_file *nf = ds_file_create(f->source,f->remote_name,f->type,f->flags);
+
+	if(f->data) {
+		nf->data = malloc(f->length);
+		nf->length = f->length;
+		memcpy(nf->data,f->data,f->length);
+	}
+
+	return nf;
 }
 
 /* Delete a file object */
 
-void ds_file_delete(struct ds_file *tf)
+void ds_file_delete(struct ds_file *f)
 {
-	if(tf->source)
-		free(tf->source);
-	if(tf->remote_name)
-		free(tf->remote_name);
-	if(tf->cached_name)
-		free(tf->cached_name);
-	free(tf);
+	free(f->source);
+	free(f->remote_name);
+	free(f->cached_name);
+	free(f->data);
+	free(f);
 }

--- a/dataswarm/src/manager/ds_file.h
+++ b/dataswarm/src/manager/ds_file.h
@@ -30,9 +30,10 @@ struct ds_file {
 	int length;		// Length of source data, if known.
 	off_t offset;		// File offset for DS_FILE_PIECE
 	off_t piece_length;	// File piece length for DS_FILE_PIECE
-	char *source;		// Name of source file, url, or literal data if a DS_BUFFER.
+	char *source;		// Name of source file, url, buffer, or literal data if an input buffer.
 	char *remote_name;	// Name of file as it appears to the task.
 	char *cached_name;	// Name of file in the worker's cache directory.
+	char *data;		// Raw data if an output buffer.
 };
 
 struct ds_file * ds_file_create( const char *source, const char *remote_name, ds_file_t type, ds_file_flags_t flags );

--- a/dataswarm/src/manager/ds_manager_get.c
+++ b/dataswarm/src/manager/ds_manager_get.c
@@ -67,7 +67,7 @@ static ds_result_code_t ds_manager_get_buffer( struct ds_manager *q, struct ds_w
 		} else {
 			r = DS_APP_FAILURE;
 		}
-	} else if(sscanf(line,"missing %s %d",name_encoded,&errornum)==2) {
+	} else if(sscanf(line,"error %s %d",name_encoded,&errornum)==2) {
 		debug(D_DS, "%s (%s): could not access requested file %s (%s)",w->hostname,w->addrport,f->remote_name,strerror(errornum));
 
 		/* Mark the task as missing an output, but return success to keep going. */
@@ -248,7 +248,7 @@ static ds_result_code_t ds_manager_get_any( struct ds_manager *q, struct ds_work
 		r = ds_manager_get_dir_contents(q,w,t,subname,totalsize);
 		free(subname);
 
-	} else if(sscanf(line,"missing %s %d",name_encoded,&errornum)==2) {
+	} else if(sscanf(line,"error %s %d",name_encoded,&errornum)==2) {
 
 		// If the output file is missing, we make a note of that in the task result,
 		// but we continue and consider the transfer a 'success' so that other

--- a/dataswarm/src/manager/ds_task.c
+++ b/dataswarm/src/manager/ds_task.c
@@ -810,22 +810,38 @@ void ds_task_delete(struct ds_task *t)
 	free(t);
 }
 
-int ds_task_get_output_buffer( struct ds_task *t, const char *name, char **data, int *length )
+static struct ds_file * find_output_buffer( struct ds_task *t, const char *name )
 {
 	struct ds_file *f;
 
 	list_first_item(t->output_files);
 	while((f = (struct ds_file*)list_next_item(t->output_files))) {
 		if(f->type==DS_BUFFER && !strcmp(f->source,name)) {
-			*data = f->data;
-			*length = f->length;
-			return 1;
+			return f;
 		}
 	}
 
-	*data = 0;
-	*length = 0;
 	return 0;
+}
+
+const char * ds_task_get_output_buffer( struct ds_task *t, const char *buffer_name )
+{
+	struct ds_file *f = find_output_buffer(t,buffer_name);
+	if(f) {
+		return f->data;
+	} else {
+		return 0;
+	}
+}
+
+int ds_task_get_output_buffer_length( struct ds_task *t, const char *buffer_name )
+{
+	struct ds_file *f = find_output_buffer(t,buffer_name);
+	if(f) {
+		return f->length;
+	} else {
+		return 0;
+	}
 }
 
 const char * ds_task_get_command( struct ds_task *t )

--- a/dataswarm/src/manager/ds_task.c
+++ b/dataswarm/src/manager/ds_task.c
@@ -591,7 +591,7 @@ int ds_task_specify_file_piece(struct ds_task *t, const char *local_name, const 
 	return 1;
 }
 
-int ds_task_specify_buffer(struct ds_task *t, const char *data, int length, const char *remote_name, ds_file_flags_t flags)
+int ds_task_specify_input_buffer(struct ds_task *t, const char *data, int length, const char *remote_name, ds_file_flags_t flags)
 {
 	struct ds_file *tf;
 	if(!t || !remote_name) {

--- a/dataswarm/src/manager/ds_task.h
+++ b/dataswarm/src/manager/ds_task.h
@@ -94,5 +94,4 @@ const char *ds_task_state_string( ds_task_state_t task_state );
 
 struct jx * ds_task_to_jx( struct ds_manager *q, struct ds_task *t );
 
-
 #endif

--- a/dataswarm/src/worker/ds_transfer.c
+++ b/dataswarm/src/worker/ds_transfer.c
@@ -90,7 +90,7 @@ static int ds_transfer_put_internal( struct link *lnk, const char *full_name, co
 	} else if(xfer_mode==DS_TRANSFER_MODE_FILE_ONLY) {
 		/*
 		The caller only wants a file, but full_name is something else.
-		Choose a suitable error number to return in the missing message.
+		Choose a suitable error number to return in the error message.
 		*/
 		if(S_ISDIR(info.st_mode)) {
 			errno = EISDIR;
@@ -135,8 +135,8 @@ static int ds_transfer_put_internal( struct link *lnk, const char *full_name, co
 	return 1;
 
 access_failure:
-	// A missing message is not a failure from our perspective, keep going.
-	send_message(lnk, "missing %s %d\n", relative_name, errno);
+	// An error here is not a failure from our perspective, keep going.
+	send_message(lnk, "error %s %d\n", relative_name, errno);
 	return 1;
 
 send_failure:
@@ -269,7 +269,7 @@ static int ds_transfer_get_any_internal( struct link *lnk, const char *dirname, 
 		r = ds_transfer_get_dir_internal(lnk,subname,totalsize,stoptime);
 		free(subname);
 
-	} else if(sscanf(line,"missing %s %d",name_encoded,&errornum)==2) {
+	} else if(sscanf(line,"error %s %d",name_encoded,&errornum)==2) {
 
 		debug(D_DS,"unable to transfer %s: %s",name_encoded,strerror(errornum));
 		r = 0;

--- a/dataswarm/src/worker/ds_transfer.h
+++ b/dataswarm/src/worker/ds_transfer.h
@@ -4,19 +4,23 @@
 #include "ds_cache.h"
 #include "link.h"
 
-/*
-Put any named filesystem item (file, directory, symlink) using the recursive transfer protocol.
+typedef enum {
+	DS_TRANSFER_MODE_ANY,
+	DS_TRANSFER_MODE_FILE_ONLY
+} ds_transfer_mode_t;
+
+/** Put any named filesystem item (file, directory, symlink) using the recursive transfer protocol.
 @param lnk The network link to use.
 @param cache The cache object where the file is located.
 @param filename The name of the file, relative to the cache object.
+@param mode Controls whether any item will be sent, or just a file.
 @param stoptime The absolute Unix time at which to stop and accept failure.
 @return Non-zero on success, zero on failure.
 */
 
-int ds_transfer_put_any( struct link *lnk, struct ds_cache *cache, const char *filename, time_t stoptime );
+int ds_transfer_put_any( struct link *lnk, struct ds_cache *cache, const char *filename, ds_transfer_mode_t mode, time_t stoptime );
 
-/*
-Get any named filesystem item (file, directory, symlink) using the recursive transfer protocol.
+/** Get any named filesystem item (file, directory, symlink) using the recursive transfer protocol.
 @param lnk The network link to use.
 @param cache The cache object where the file is located.
 @param filename The name of the file, relative to the cache object.
@@ -26,8 +30,7 @@ Get any named filesystem item (file, directory, symlink) using the recursive tra
 
 int ds_transfer_get_any( struct link *lnk, struct ds_cache *cache, const char *filename, time_t stoptime );
 
-/*
-Get a directory using the recursive transfer protocol.
+/** Get a directory using the recursive transfer protocol.
 This presumes that the directory header message has already
 been read off the wire by the caller.
 @param lnk The network link to use.
@@ -39,8 +42,7 @@ been read off the wire by the caller.
 
 int ds_transfer_get_dir( struct link *lnk, struct ds_cache *cache, const char *dirname, time_t stoptime );
 
-/*
-Get a single file using the recursive transfer protocol.
+/** Get a single file using the recursive transfer protocol.
 This presumes that the file header message has already
 been read off the wire by the caller.
 @param lnk The network link to use.

--- a/dataswarm/src/worker/ds_transfer_server.c
+++ b/dataswarm/src/worker/ds_transfer_server.c
@@ -42,7 +42,7 @@ static void ds_transfer_handler( struct link *lnk, struct ds_cache *cache )
 	if(link_readline(lnk,line,sizeof(line),time(0)+command_timeout)) {
 		if(sscanf(line,"get %s",filename_encoded)==1) {
 			url_decode(filename_encoded,filename,sizeof(filename));
-			ds_transfer_put_any(lnk,cache,filename,time(0)+transfer_timeout);
+			ds_transfer_put_any(lnk,cache,filename,DS_TRANSFER_MODE_ANY,time(0)+transfer_timeout);
 		} else {
 			debug(D_DS,"invalid peer transfer message: %s\n",line);
 		}

--- a/dataswarm/src/worker/ds_worker.c
+++ b/dataswarm/src/worker/ds_worker.c
@@ -259,7 +259,11 @@ static int64_t measure_worker_disk()
 {
 	static struct path_disk_size_info *state = NULL;
 
-	path_disk_size_info_get_r("./cache", max_time_on_measurement, &state);
+	if(!global_cache) return 0;
+
+	char *cache_dir = ds_cache_full_path(global_cache,".");
+	path_disk_size_info_get_r(cache_dir, max_time_on_measurement, &state);
+	free(cache_dir);
 
 	int64_t disk_measured = 0;
 	if(state->last_byte_size_complete >= 0) {

--- a/dataswarm/src/worker/ds_worker.c
+++ b/dataswarm/src/worker/ds_worker.c
@@ -989,9 +989,12 @@ static int handle_manager(struct link *manager)
 		} else if(sscanf(line, "unlink %s", filename_encoded) == 1) {
 			url_decode(filename_encoded,filename,sizeof(filename));
 			r = do_unlink(filename);
+		} else if(sscanf(line, "getfile %s", filename_encoded) == 1) {
+			url_decode(filename_encoded,filename,sizeof(filename));
+			r = ds_transfer_put_any(manager,global_cache,filename,DS_TRANSFER_MODE_FILE_ONLY,time(0)+active_timeout);
 		} else if(sscanf(line, "get %s", filename_encoded) == 1) {
 			url_decode(filename_encoded,filename,sizeof(filename));
-			r = ds_transfer_put_any(manager,global_cache,filename,time(0)+active_timeout);
+			r = ds_transfer_put_any(manager,global_cache,filename,DS_TRANSFER_MODE_ANY,time(0)+active_timeout);
 		} else if(sscanf(line, "kill %" SCNd64, &taskid) == 1) {
 			if(taskid >= 0) {
 				r = do_kill(taskid);


### PR DESCRIPTION
Add support for named output buffers, to permit retrieving multiple outputs without touching disk at the manager.