### PR TITLE
readthedocs + doxygen

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ mkdocs:
 build:
     os: ubuntu-20.04
     tools:
-      python: "3.10"
+      python: 3.7
     jobs:
       pre_build:
         - cd docs && doxygen cctools.doxygen.config

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,5 @@ build:
 
 # Additional pip modules needed from doc/requirements.txt
 python:
-    version: 3.9
     install:
     - requirements: doc/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,6 @@ build:
 
 # Additional pip modules needed from doc/requirements.txt
 python:
-    version: "3.10"
+    version: 3.7
     install:
     - requirements: doc/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,13 +11,13 @@ mkdocs:
 build:
     os: "ubuntu-20.04"
     tools:
-      python: "3.7"
+      python: "3.9"
     jobs:
       pre_build:
         - cd docs && doxygen cctools.doxygen.config
 
 # Additional pip modules needed from doc/requirements.txt
 python:
-    version: 3.7
+    version: 3.9
     install:
     - requirements: doc/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,9 +9,9 @@ mkdocs:
     configuration: mkdocs.yml
 
 build:
-    os: ubuntu-20.04
+    os: "ubuntu-20.04"
     tools:
-      python: 3.7
+      python: "3.7"
     jobs:
       pre_build:
         - cd docs && doxygen cctools.doxygen.config

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,8 +8,16 @@ formats: all
 mkdocs:
     configuration: mkdocs.yml
 
+build:
+    os: ubuntu-20.04
+    tools:
+      python: "3.10"
+    jobs:
+      pre_build:
+        - cd docs && doxygen cctools.doxygen.config
+
 # Additional pip modules needed from doc/requirements.txt
 python:
-    version: 3.7
+    version: "3.10"
     install:
     - requirements: doc/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,10 @@ build:
       python: "3.9"
     jobs:
       pre_build:
-        - cd doc && doxygen cctools.doxygen.config
+        - cd doc && git clone https://github.com/jothepro/doxygen-awesome-css.git --branch v2.1.0
+        - cp doc/cctools.doxygen.config doc/cctools.doxygen-mod.config
+        - echo "HTML_EXTRA_STYLESHEET = doxygen-awesome-css/doxygen-awesome.css" >> doc/cctools.doxygen-mod.config
+        - cd doc && doxygen cctools.doxygen-mod.config
 
 # Additional pip modules needed from doc/requirements.txt
 python:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
       python: "3.9"
     jobs:
       pre_build:
-        - cd docs && doxygen cctools.doxygen.config
+        - cd doc && doxygen cctools.doxygen.config
 
 # Additional pip modules needed from doc/requirements.txt
 python:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -5,31 +5,31 @@ all: ${CCTOOLS_DOCTARGETS}
 htmlpages manpages mdpages:
 	$(MAKE) -C man $@
 
-apiperl: api/html/work_queue_perl.html api/html/work_queue_task_perl.html api/html/chirp_client_perl.html api/html/chirp_stat_perl.html
+apiperl: manuals/api/html/work_queue_perl.html manuals/api/html/work_queue_task_perl.html manuals/api/html/chirp_client_perl.html manuals/api/html/chirp_stat_perl.html
 
-apipages: api/html/index.html apiperl
+apipages: manuals/api/html/index.html apiperl
 
-api/html/index.html:
-	mkdir -p api/html
+manuals/api/html/index.html:
+	mkdir -p manuals/api/html
 	doxygen cctools.doxygen.config
 
-api/html/work_queue_perl.html:
-	mkdir -p api/html
+manuals/api/html/work_queue_perl.html:
+	mkdir -p manuals/api/html
 	pod2html ../work_queue/src/bindings/perl/Work_Queue.pm > $@
 	@rm -f pod2htm*.tmp
 
-api/html/work_queue_task_perl.html:
-	mkdir -p api/html
+manuals/api/html/work_queue_task_perl.html:
+	mkdir -p manuals/api/html
 	pod2html ../work_queue/src/bindings/perl/Work_Queue/Task.pm > $@
 	@rm -f pod2htm*.tmp
 
-api/html/chirp_client_perl.html:
-	mkdir -p api/html
+manuals/api/html/chirp_client_perl.html:
+	mkdir -p manuals/api/html
 	pod2html ../chirp/src/bindings/perl/Chirp/Client.pm > $@
 	@rm -f pod2htm*.tmp
 
-api/html/chirp_stat_perl.html:
-	mkdir -p api/html
+manuals/api/html/chirp_stat_perl.html:
+	mkdir -p manuals/api/html
 	pod2html ../chirp/src/bindings/perl/Chirp/Stat.pm > $@
 	@rm -f pod2htm*.tmp
 
@@ -37,13 +37,12 @@ api/html/chirp_stat_perl.html:
 install: all
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc
 	cp -r manuals $(CCTOOLS_INSTALL_DIR)/doc/
-	if [ -d api ]; then cp -rp api $(CCTOOLS_INSTALL_DIR)/doc; fi
 	$(MAKE) -C man install
 
 test:
 
 clean:
-	rm -rf api *~
+	rm -rf manuals/api *~
 	$(MAKE) -C man clean
 
 .PHONY: all clean install test

--- a/doc/cctools.doxygen.config
+++ b/doc/cctools.doxygen.config
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = api
+OUTPUT_DIRECTORY       = manuals/api
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/doc/cctools.doxygen.config
+++ b/doc/cctools.doxygen.config
@@ -1359,7 +1359,7 @@ DISABLE_INDEX          = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-GENERATE_TREEVIEW      = NO
+GENERATE_TREEVIEW      = YES
 
 # The ENUM_VALUES_PER_LINE tag can be used to set the number of enum values that
 # doxygen will group on one line in the generated HTML documentation.

--- a/doc/manuals/index.md
+++ b/doc/manuals/index.md
@@ -19,9 +19,9 @@
 - [**Work Queue**](work_queue) is a system and library for creating and
   managing scalable manager-worker style programs that scale up to thousands of
   machines on clusters, clouds, and grids. Work Queue programs are easy to
-Python ([example](work_queue/examples/work_queue_example.py)|[api](http://ccl.cse.nd.edu/software/manuals/api/html/namespaceWorkQueuePython.html))
+Python ([example](work_queue/examples/work_queue_example.py)|[api](api/html/namespaceWorkQueuePython.html))
 Perl   ([example](work_queue/examples/work_queue_example.pl)|[api](http://ccl.cse.nd.edu/software/manuals/api/html/work__queue_8h.html)),
-or C   ([example](work_queue/examples/work_queue_example.c)|[api](http://ccl.cse.nd.edu/software/manuals/api/html/work__queue_8h.html))
+or C   ([example](work_queue/examples/work_queue_example.c)|[api](api/html/work__queue_8h.html))
 .
 
 - [**Resource Monitor**](resource_monitor) is a tool to monitors the cpu,
@@ -29,7 +29,7 @@ or C   ([example](work_queue/examples/work_queue_example.c)|[api](http://ccl.cse
   and can optionally enforce limits on each resource. The monitor can be
   compiled to a single executable that is easily deployed to track executable
   file, or it can be used as a library to track the execution of [Python
-  functions](http://ccl.cse.nd.edu/software/manuals/api/html/namespaceresource__monitor.html).
+  functions](api/html/namespaceresource__monitor.html).
 
 - [**Parrot**](parrot) is a transparent user-level virtual filesystem that
   allows any ordinary program to be attached to many different remote storage
@@ -79,4 +79,4 @@ or C   ([example](work_queue/examples/work_queue_example.c)|[api](http://ccl.cse
 
 - [**Networking Configuration**](network)
 
-- [**API**](http://ccl.cse.nd.edu/software/manuals/api/html/index.html)
+- [**API**](api/html/index.html)

--- a/doc/manuals/work_queue/index.md
+++ b/doc/manuals/work_queue/index.md
@@ -115,9 +115,9 @@ A manager program can be written in Python, Perl, or C.
 In each language, the underlying principles are the same, but there are some syntactic differences shown below.
 The full API documentation for each language is here:
 
-- [Work Queue Python API](http://ccl.cse.nd.edu/software/manuals/api/html/namespaceWorkQueuePython.html)
+- [Work Queue Python API](api/html/namespaceWorkQueuePython.html)
 - [Work Queue Perl API](http://ccl.cse.nd.edu/software/manuals/api/html/namespaceWorkQueuePerl.html)
-- [Work Queue C API](http://ccl.cse.nd.edu/software/manuals/api/html/work__queue_8h.html)
+- [Work Queue C API](api/html/work__queue_8h.html)
 
 The basic outline of a Work Queue manager is:
 
@@ -408,7 +408,7 @@ is done, delete the queue (only needed for C):
     work_queue_delete(q);
     ```
 
-Full details of all of the Work Queue functions can be found in the [Work Queue API](http://ccl.cse.nd.edu/software/manuals/api/html/work__queue_8h.html).
+Full details of all of the Work Queue functions can be found in the [Work Queue API](api/html/work__queue_8h.html).
 
 ### Managing Python Tasks
 
@@ -1220,7 +1220,7 @@ cores, memory and disk have modifiers `~` and `>` as follows:
 A variety of advanced features are available for programs with unusual needs
 or very large scales. Each feature is described briefly here, and more details
 may be found in the [Work Queue
-API](http://ccl.cse.nd.edu/software/manuals/api/html/work__queue_8h.html).
+API](api/html/work__queue_8h.html).
 
 ### Security
 
@@ -1770,7 +1770,7 @@ find failures, bugs, and other errors. To activate debug output:
     
 The `all` flag causes debug messages from every subsystem called by Work Queue
 to be printed. More information about the debug flags are
-[here](http://ccl.cse.nd.edu/software/manuals/api/html/debug_8h.html).
+[here](api/html/debug_8h.html).
 
 
 To enable debugging at the worker, set the `-d` option:

--- a/doc/manuals/work_queue/index.md
+++ b/doc/manuals/work_queue/index.md
@@ -115,9 +115,9 @@ A manager program can be written in Python, Perl, or C.
 In each language, the underlying principles are the same, but there are some syntactic differences shown below.
 The full API documentation for each language is here:
 
-- [Work Queue Python API](api/html/namespaceWorkQueuePython.html)
+- [Work Queue Python API](../api/html/namespaceWorkQueuePython.html)
 - [Work Queue Perl API](http://ccl.cse.nd.edu/software/manuals/api/html/namespaceWorkQueuePerl.html)
-- [Work Queue C API](api/html/work__queue_8h.html)
+- [Work Queue C API](../api/html/work__queue_8h.html)
 
 The basic outline of a Work Queue manager is:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,7 @@ nav:
         - Network Configuration: 'network/index.md'
         - JX Expression Language: 'jx/index.md'
         - Chirp Reference: 'chirp/chirp_protocol.md'
-        - API Reference: 'http://ccl.cse.nd.edu/software/manuals/api/html/index.html'
+        - API Reference: 'api/html/index.html'
 
 extra_css:
     - css/tabs.css


### PR DESCRIPTION
readthedocs now runs the doxygen config file. The generated docs are hosted in readthedocs.
As part of the doc generation, a theme is cloned from github (default theme is ugly.)