### PR TITLE
Remove use of special symbolic link to Python.framework.

### DIFF
--- a/chirp/src/bindings/python2/.gitignore
+++ b/chirp/src/bindings/python2/.gitignore
@@ -2,6 +2,5 @@
 *.so
 CChirp.py
 Chirp.py
-Python.framework
 cctools.test.log
 chirp_wrap.*

--- a/chirp/src/bindings/python2/Makefile
+++ b/chirp/src/bindings/python2/Makefile
@@ -17,19 +17,16 @@ all: $(TARGETS)
 
 Chirp.py: chirp_wrap.c CChirp.py
 
-# The odd symlink in the following rule is necessary to overcome a problem
-# in the framework search path emitted by the Python configuration on macOS.
 chirp_wrap.c CChirp.py: chirp.i chirp.binding.py
 	@echo "SWIG chirp.i (python)"
 	@$(CCTOOLS_SWIG) -o chirp_wrap.c -python -I$(CCTOOLS_HOME)/dttools/src/ -I$(CCTOOLS_HOME)/chirp/src chirp.i
 	@cat CChirp.py > Chirp.py
 	@cat chirp.binding.py >> Chirp.py
-	ln -sf /System/Library/Frameworks/Python.framework .
 
 $(CHIRPPYTHONSO): $(OBJECTS) $(EXTERNAL_DEPENDENCIES)
 
 clean:
-	rm -f $(OBJECTS) $(TARGETS) Python.framework Chirp.py CChirp.py chirp_wrap.c *.pyc
+	rm -f $(OBJECTS) $(TARGETS) Chirp.py CChirp.py chirp_wrap.c *.pyc
 
 test:
 

--- a/chirp/src/bindings/python3/.gitignore
+++ b/chirp/src/bindings/python3/.gitignore
@@ -2,6 +2,5 @@
 *.so
 CChirp.py
 Chirp.py
-Python.framework
 cctools.test.log
 chirp_wrap.*

--- a/resource_monitor/src/bindings/python2/.gitignore
+++ b/resource_monitor/src/bindings/python2/.gitignore
@@ -1,4 +1,3 @@
-Python.framework
 _resource_monitor.so
 resource_monitor.py
 rmonitor_wrap.c

--- a/resource_monitor/src/bindings/python2/Makefile
+++ b/resource_monitor/src/bindings/python2/Makefile
@@ -15,8 +15,6 @@ TARGETS = $(LIBRARIES)
 
 all: $(TARGETS)
 
-# The odd symlink in the following rule is necessary to overcome a problem
-# in the framework search path emitted by the Python configuration on macOS.
 rmonitor_wrap.c resource_monitor.py: rmonitor.i
 	@echo "SWIG rmonitor.i (python)"
 	@$(CCTOOLS_SWIG) -o rmonitor_wrap.c -python -I$(CCTOOLS_HOME)/dttools/src/ rmonitor.i
@@ -25,7 +23,7 @@ rmonitor_wrap.c resource_monitor.py: rmonitor.i
 $(RMPYTHONSO): rmonitor_wrap.o $(EXTERNAL_DEPENDENCIES)
 
 clean:
-	rm -f $(OBJECTS) $(TARGETS) Python.framework rmonitor_wrap.c *.so *.pyc
+	rm -f $(OBJECTS) $(TARGETS) rmonitor_wrap.c *.so *.pyc
 
 test:
 

--- a/resource_monitor/src/bindings/python3/.gitignore
+++ b/resource_monitor/src/bindings/python3/.gitignore
@@ -1,4 +1,3 @@
-Python.framework
 _resource_monitor.so
 resource_monitor.py
 rmonitor_wrap.c

--- a/taskvine/src/bindings/python3/.gitignore
+++ b/taskvine/src/bindings/python3/.gitignore
@@ -1,5 +1,4 @@
 cctools.test.log
 vine_wrap.*
 taskvine.py
-Python.framework
 *.so

--- a/taskvine/src/bindings/python3/Makefile
+++ b/taskvine/src/bindings/python3/Makefile
@@ -14,20 +14,17 @@ TARGETS = $(LIBRARIES)
 
 all: $(TARGETS)
 
-# The odd symlink in the following rule is necessary to overcome a problem
-# in the framework search path emitted by the Python configuration on macOS.
 vine_wrap.c taskvine.py: taskvine.i taskvine.binding.py
 	@echo "SWIG taskvine.i (python)"
 	@$(CCTOOLS_SWIG) -o vine_wrap.c -python -py3 -I$(CCTOOLS_HOME)/dttools/src -I$(CCTOOLS_HOME)/taskvine/src/manager taskvine.i
 	@cat -u taskvine.binding.py >> taskvine.py
-	ln -sf /System/Library/Frameworks/Python.framework .
 
 $(DSPYTHONSO): vine_wrap.o $(EXTERNAL_DEPENDENCIES)
 
 test:
 
 clean:
-	rm -rf $(OBJECTS) $(TARGETS) Python.framework taskvine.py vine_wrap.c vine_wrap.o *.pyc __pycache__
+	rm -rf $(OBJECTS) $(TARGETS) taskvine.py vine_wrap.c vine_wrap.o *.pyc __pycache__
 
 install: all
 	mkdir -p $(CCTOOLS_PYTHON3_PATH)

--- a/work_queue/src/bindings/python2/.gitignore
+++ b/work_queue/src/bindings/python2/.gitignore
@@ -1,5 +1,4 @@
 cctools.test.log
 work_queue_wrap.*
 work_queue.py
-Python.framework
 *.so

--- a/work_queue/src/bindings/python2/Makefile
+++ b/work_queue/src/bindings/python2/Makefile
@@ -15,18 +15,15 @@ TARGETS = $(LIBRARIES)
 
 all: $(TARGETS)
 
-# The odd symlink in the following rule is necessary to overcome a problem
-# in the framework search path emitted by the Python configuration on macOS.
 work_queue_wrap.c work_queue.py: work_queue.i work_queue.binding.py
 	@echo "SWIG work_queue.i (python)"
 	@$(CCTOOLS_SWIG) -o work_queue_wrap.c -python -I$(CCTOOLS_HOME)/dttools/src/ -I$(CCTOOLS_HOME)/work_queue/src work_queue.i
 	@cat work_queue.binding.py >> work_queue.py
-	ln -sf /System/Library/Frameworks/Python.framework .
 
 $(WQPYTHONSO): work_queue_wrap.o $(EXTERNAL_DEPENDENCIES)
 
 clean:
-	rm -f $(OBJECTS) $(TARGETS) Python.framework work_queue.py work_queue_wrap.c *.pyc
+	rm -f $(OBJECTS) $(TARGETS) work_queue.py work_queue_wrap.c *.pyc
 
 test:
 

--- a/work_queue/src/bindings/python3/.gitignore
+++ b/work_queue/src/bindings/python3/.gitignore
@@ -1,6 +1,5 @@
 __pycache__
 _work_queue.so
-Python.framework
 work_queue.py
 work_queue.binding.py*
 work_queue_example.py*

--- a/work_queue/src/bindings/python3/Makefile
+++ b/work_queue/src/bindings/python3/Makefile
@@ -15,21 +15,18 @@ TARGETS = $(LIBRARIES)
 
 all: $(TARGETS)
 
-# The odd symlink in the following rule is necessary to overcome a problem
-# in the framework search path emitted by the Python configuration on macOS.
 work_queue_wrap.c work_queue.py: work_queue.i work_queue.binding.py StatusDisplay.py
 	@echo "SWIG work_queue.i (python)"
 	@$(CCTOOLS_SWIG) -o work_queue_wrap.c -python -py3 -I$(CCTOOLS_HOME)/dttools/src -I$(CCTOOLS_HOME)/work_queue/src work_queue.i
 	@cat -u work_queue.binding.py >> work_queue.py
 	@cat -u StatusDisplay.py >> work_queue.py
-	ln -sf /System/Library/Frameworks/Python.framework .
 
 $(WQPYTHONSO): work_queue_wrap.o $(EXTERNAL_DEPENDENCIES)
 
 test:
 
 clean:
-	rm -rf $(OBJECTS) $(TARGETS) Python.framework work_queue.py work_queue_wrap.c *.pyc __pycache__
+	rm -rf $(OBJECTS) $(TARGETS) work_queue.py work_queue_wrap.c *.pyc __pycache__
 
 install: all
 	mkdir -p $(CCTOOLS_PYTHON3_PATH)


### PR DESCRIPTION
This was used on OSX when we depended on the local python installation. Now we make use of Python coming from Conda to get consistency.