### PR TITLE
taskvine: build library before anything else

### DIFF
--- a/taskvine/src/Makefile
+++ b/taskvine/src/Makefile
@@ -5,6 +5,9 @@ TARGETS=manager worker tools bindings examples
 
 all: $(TARGETS)
 
+worker: manager
+bindings: manager
+tools: manager
 examples: manager worker tools bindings
 
 $(TARGETS): %:


### PR DESCRIPTION
@colinthomas-z80, I think this should fix the issues you saw yesterday with `make -j3`.