### PR TITLE
Fix doc namespaces

### DIFF
--- a/chirp/src/bindings/python2/Makefile
+++ b/chirp/src/bindings/python2/Makefile
@@ -8,30 +8,27 @@ LOCAL_CCFLAGS = -fPIC -w $(CCTOOLS_PYTHON2_CCFLAGS)
 LOCAL_LINKAGE = $(CCTOOLS_PYTHON2_LDFLAGS) $(CCTOOLS_GLOBUS_LDFLAGS) $(CCTOOLS_EXTERNAL_LINKAGE)
 
 EXTERNAL_DEPENDENCIES = $(CCTOOLS_HOME)/chirp/src/libchirp.a $(CCTOOLS_HOME)/dttools/src/libdttools.a
-CHIRPPYTHONSO = _CChirp.$(CCTOOLS_DYNAMIC_SUFFIX)
+CHIRPPYTHONSO = _chirp.$(CCTOOLS_DYNAMIC_SUFFIX)
 LIBRARIES = $(CHIRPPYTHONSO)
 OBJECTS = chirp_wrap.o $(CCTOOLS_HOME)/chirp/src/chirp_swig_wrap.o
-TARGETS = Chirp.py $(LIBRARIES)
+TARGETS = chirp.py $(LIBRARIES)
 
 all: $(TARGETS)
 
-Chirp.py: chirp_wrap.c CChirp.py
-
-chirp_wrap.c CChirp.py: chirp.i chirp.binding.py
+chirp_wrap.c chirp.py: chirp.i chirp.binding.py
 	@echo "SWIG chirp.i (python)"
 	@$(CCTOOLS_SWIG) -o chirp_wrap.c -python -I$(CCTOOLS_HOME)/dttools/src/ -I$(CCTOOLS_HOME)/chirp/src chirp.i
-	@cat CChirp.py > Chirp.py
-	@cat chirp.binding.py >> Chirp.py
+	@cat chirp.binding.py >> chirp.py
 
 $(CHIRPPYTHONSO): $(OBJECTS) $(EXTERNAL_DEPENDENCIES)
 
 clean:
-	rm -f $(OBJECTS) $(TARGETS) Chirp.py CChirp.py chirp_wrap.c *.pyc
+	rm -rf $(OBJECTS) $(TARGETS) chirp.py chirp_wrap.c *.pyc __pycache__
 
 test:
 
 install: all
 	mkdir -p $(CCTOOLS_PYTHON2_PATH)
-	cp Chirp.py $(CHIRPPYTHONSO) $(CCTOOLS_PYTHON2_PATH)/
+	cp chirp.py $(CHIRPPYTHONSO) $(CCTOOLS_PYTHON2_PATH)/
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc
 	cp chirp_python_example.py chirp_jobs_python_example.py $(CCTOOLS_INSTALL_DIR)/doc/

--- a/chirp/src/bindings/python3/Makefile
+++ b/chirp/src/bindings/python3/Makefile
@@ -8,32 +8,29 @@ LOCAL_CCFLAGS = -fPIC -w -DNDEBUG $(CCTOOLS_PYTHON3_CCFLAGS)
 LOCAL_LINKAGE = $(CCTOOLS_PYTHON3_LDFLAGS) $(CCTOOLS_GLOBUS_LDFLAGS) $(CCTOOLS_EXTERNAL_LINKAGE)
 
 EXTERNAL_DEPENDENCIES = $(CCTOOLS_HOME)/chirp/src/libchirp.a $(CCTOOLS_HOME)/dttools/src/libdttools.a
-CHIRPPYTHONSO = _CChirp.$(CCTOOLS_DYNAMIC_SUFFIX)
+CHIRPPYTHONSO = _chirp.$(CCTOOLS_DYNAMIC_SUFFIX)
 LIBRARIES = $(CHIRPPYTHONSO)
 OBJECTS = chirp_wrap.o $(CCTOOLS_HOME)/chirp/src/chirp_swig_wrap.o
-TARGETS = $(LIBRARIES) Chirp.py
+TARGETS = $(LIBRARIES) chirp.py
 
 all: $(TARGETS)
 
-Chirp.py: chirp_wrap.c CChirp.py
-
 # The odd symlink in the following rule is necessary to overcome a problem
 # in the framework search path emitted by the Python configuration on macOS.
-chirp_wrap.c CChirp.py: chirp.i chirp.binding.py
+chirp_wrap.c chirp.py: chirp.i chirp.binding.py
 	@echo "SWIG chirp.i (python)"
-	@$(CCTOOLS_SWIG) -o chirp_wrap.c -python -I$(CCTOOLS_HOME)/dttools/src/ -I$(CCTOOLS_HOME)/chirp/src chirp.i
-	@cat -u CChirp.py chirp.binding.py > Chirp.py
-	ln -sf /System/Library/Frameworks/Python.framework .
+	@$(CCTOOLS_SWIG) -o chirp_wrap.c -python -py3 -I$(CCTOOLS_HOME)/dttools/src/ -I$(CCTOOLS_HOME)/chirp/src chirp.i
+	@cat -u chirp.binding.py >> chirp.py
 
 $(CHIRPPYTHONSO): $(OBJECTS) $(EXTERNAL_DEPENDENCIES)
 
 clean:
-	rm -rf $(OBJECTS) $(TARGETS) Python.framework Chirp.py CChirp.py chirp_wrap.c *.pyc __pycache__
+	rm -rf $(OBJECTS) $(TARGETS) Python.framework chirp.py chirp_wrap.c *.pyc __pycache__
 
 test:
 
 install: all
 	mkdir -p $(CCTOOLS_PYTHON3_PATH)
-	cp Chirp.py $(CHIRPPYTHONSO) $(CCTOOLS_PYTHON3_PATH)/
+	cp chirp.py $(CHIRPPYTHONSO) $(CCTOOLS_PYTHON3_PATH)/
 	mkdir -p $(CCTOOLS_INSTALL_DIR)/doc
 	cp chirp_python_example.py chirp_jobs_python_example.py $(CCTOOLS_INSTALL_DIR)/doc/

--- a/chirp/src/bindings/python3/Makefile
+++ b/chirp/src/bindings/python3/Makefile
@@ -11,7 +11,7 @@ EXTERNAL_DEPENDENCIES = $(CCTOOLS_HOME)/chirp/src/libchirp.a $(CCTOOLS_HOME)/dtt
 CHIRPPYTHONSO = _chirp.$(CCTOOLS_DYNAMIC_SUFFIX)
 LIBRARIES = $(CHIRPPYTHONSO)
 OBJECTS = chirp_wrap.o $(CCTOOLS_HOME)/chirp/src/chirp_swig_wrap.o
-TARGETS = $(LIBRARIES) chirp.py
+TARGETS = chirp.py $(LIBRARIES)
 
 all: $(TARGETS)
 
@@ -25,7 +25,7 @@ chirp_wrap.c chirp.py: chirp.i chirp.binding.py
 $(CHIRPPYTHONSO): $(OBJECTS) $(EXTERNAL_DEPENDENCIES)
 
 clean:
-	rm -rf $(OBJECTS) $(TARGETS) Python.framework chirp.py chirp_wrap.c *.pyc __pycache__
+	rm -rf $(OBJECTS) $(TARGETS) chirp.py chirp_wrap.c *.pyc __pycache__
 
 test:
 

--- a/chirp/src/bindings/python3/chirp.binding.py
+++ b/chirp/src/bindings/python3/chirp.binding.py
@@ -1,4 +1,4 @@
-## @package Chirp
+## @package chirp
 #
 # Python Chirp bindings.
 #
@@ -8,14 +8,14 @@
 # The SWIG-based Python bindings provide a higher-level interface that
 # revolves around:
 #
-# - @ref Chirp.Client
-# - @ref Chirp.Stat
+# - @ref chirp.Client
+# - @ref chirp.Stat
 import os
 import time
 import json
 
 ##
-# \class Chirp.Client
+# \class chirp.Client
 # Python Client object
 #
 # This class is used to create a chirp client
@@ -184,7 +184,7 @@ class Client(object):
 
 
     ##
-    # Returns a Chirp.Stat object with information on path.
+    # Returns a chirp.Stat object with information on path.
     # Throws an IOError on error (e.g., no such path or insufficient permissions).
     #
     # @param self                Reference to the current task object.
@@ -225,7 +225,7 @@ class Client(object):
     ##
     # Copies local file/directory source to the chirp server as file/directory destination.
     # If destination is not given, source name is used.
-    # Raises Chirp.TransferFailure on error.
+    # Raises chirp.TransferFailure on error.
     #
     # @param self                Reference to the current task object.
     # @param source              A local file or directory.
@@ -250,7 +250,7 @@ class Client(object):
     ##
     # Copies server file/directory source to the local file/directory destination.
     # If destination is not given, source name is used.
-    # Raises Chirp.TransferFailure on error.
+    # Raises chirp.TransferFailure on error.
     #
     # @param self                Reference to the current task object.
     # @param source              A server file or directory.

--- a/chirp/src/bindings/python3/chirp.binding.py
+++ b/chirp/src/bindings/python3/chirp.binding.py
@@ -1,4 +1,4 @@
-## @package ChirpPython
+## @package Chirp
 #
 # Python Chirp bindings.
 #

--- a/chirp/src/bindings/python3/chirp_jobs_python_example.py
+++ b/chirp/src/bindings/python3/chirp_jobs_python_example.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys
-import Chirp
+import chirp
 
 def make_job(job_number):
     job = { 'executable' : './my_script',
@@ -26,11 +26,11 @@ if __name__ == '__main__':
     executable = sys.argv[2]
 
     try:
-        client = Chirp.Client(hostport,
+        client = chirp.Client(hostport,
                               authentication = ['unix'],
                               timeout = 15,
                               debug   = True)
-    except Chirp.AuthenticationFailure as e:
+    except chirp.AuthenticationFailure as e:
          print("Could not authenticate using: %s" % ', '.join(e.value))
          sys.exit(1)
 
@@ -57,7 +57,7 @@ if __name__ == '__main__':
                     client.job_reap( state['id'] )
                 elif state['status'] == 'ERRORED':
                     client.job_kill( state['id'] )
-            except Chirp.ChirpJobError:
+            except chirp.ChirpJobError:
                 print('error trying to clean job ' + str(state['id']))
 
             jobs_running -= 1

--- a/chirp/src/bindings/python3/chirp_python_example.py
+++ b/chirp/src/bindings/python3/chirp_python_example.py
@@ -3,7 +3,7 @@
 import sys
 import os
 
-import Chirp
+import chirp
 
 def write_some_file(filename='bar.txt'):
     message  = '''
@@ -34,12 +34,12 @@ if __name__ == '__main__':
     write_some_file()
 
     try:
-        client = Chirp.Client(hostport,
+        client = chirp.Client(hostport,
                               authentication = ['ticket'],
                               tickets = [ticket],
                               timeout = 15,
                               debug = True)
-    except Chirp.AuthenticationFailure as e:
+    except chirp.AuthenticationFailure as e:
         print("Could not authenticate using: %s" % ', '.join(e.value))
         sys.exit(1)
 
@@ -55,7 +55,7 @@ if __name__ == '__main__':
     try:
         client.put('bar.txt', '/bar.txt')
         client.get('/bar.txt', 'foo.txt')
-    except Chirp.TransferFailure as e:
+    except chirp.TransferFailure as e:
         print("Could not transfer file: %s" % e)
         sys.exit(1)
 

--- a/chirp/src/chirp.i
+++ b/chirp/src/chirp.i
@@ -1,5 +1,5 @@
 /* chirp.i */
-%module CChirp
+%module chirp
 
 /* next is a perl keyword. rename it to next_entry */
 %rename(next_entry) chirp_dirent::next;

--- a/chirp/test/TR_chirp_job_python.sh
+++ b/chirp/test/TR_chirp_job_python.sh
@@ -8,12 +8,12 @@ set -e
 c="./hostport.$PPID"
 cr="./root.$PPID"
 
-python=${CCTOOLS_PYTHON_TEST_EXEC}
-python_dir=${CCTOOLS_PYTHON_TEST_DIR}
+import_config_val CCTOOLS_PYTHON_TEST_EXEC
+import_config_val CCTOOLS_PYTHON_TEST_DIR
 
 check_needed()
 {
-	[ -n "${python}" ] || return 1
+	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
 }
 
 prepare()
@@ -31,9 +31,9 @@ run()
 	fi
 	hostport=$(cat "$c")
 
-	base=$(pwd)/../src/bindings/${python_dir}
+	base=$(pwd)/../src/bindings/${CCTOOLS_PYTHON_TEST_DIR}
 
-	PYTHONPATH=${base} ${python} ${base}/chirp_jobs_python_example.py $hostport ${base}/my_script.sh
+	PYTHONPATH=${base} ${CCTOOLS_PYTHON_TEST_EXEC} ${base}/chirp_jobs_python_example.py $hostport ${base}/my_script.sh
 
 	return 0
 }

--- a/doc/cctools.doxygen
+++ b/doc/cctools.doxygen
@@ -6,12 +6,12 @@ which includes TaskVine, Work Queue, Makeflow, Parrot, Chirp and other software.
 If you are writing a TaskVine application, start here:
 
 - @ref taskvine.h (C Language Interface)
-- @ref TaskVinePython (Python Language Interface)
+- @ref taskvine (Python Language Interface)
 
 If you are writing a Work Queue application, start here:
 
 - @ref work_queue.h (C Language Interface)
-- @ref WorkQueuePython (Python Language Interface)
+- @ref work_queue (Python Language Interface)
 
 
 If you are writing a program to submit jobs to arbitrary batch systems,

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -1,4 +1,4 @@
-## @package WorkQueuePython
+## @package work_queue
 #
 # Python Work Queue bindings.
 #


### PR DESCRIPTION
@fixes #3040 

Also, it moves `import Chirp`  to `import chirp`,  as `Chirp` implies a class.  This is only used with lobster, and they won't be using a newer cctools for a while.