### PR TITLE
Vine: Temporary Files

### DIFF
--- a/taskvine/src/examples/vine_example_mosaic.c
+++ b/taskvine/src/examples/vine_example_mosaic.c
@@ -55,19 +55,24 @@ int main(int argc, char *argv[])
 	printf("Listening on port %d...\n", vine_port(m));
 
 	vine_enable_debug_log(m,"manager.log");
+	vine_enable_peer_transfers(m);
+
+	struct vine_file *temp_file[36];
 
 	int i;
-	for(i = 0; i < 360; i+=10) {
+	for(i=0; i<36; i++) {
 		char outfile[256];
 		char command[1024];
 
 		sprintf(outfile, "%d.cat.jpg",i);
-		sprintf(command, "./convert.sfx -swirl %d cat.jpg %d.cat.jpg", i, i);
+		sprintf(command, "./convert.sfx -swirl %d cat.jpg %d.cat.jpg", i*10, i);
 
+		temp_file[i] = vine_file_temp();
+		
 		t = vine_task_create(command);
 		vine_task_add_input_file(t, "convert.sfx", "convert.sfx", VINE_CACHE);
 		vine_task_add_input_url(t,"https://upload.wikimedia.org/wikipedia/commons/7/74/A-Cat.jpg", "cat.jpg", VINE_CACHE );
-		vine_task_add_output_file(t,outfile,outfile,VINE_NOCACHE);
+		vine_task_add_output(t,vine_file_clone(temp_file[i]),outfile,VINE_CACHE);
 
 		vine_task_set_cores(t,1);
 
@@ -81,31 +86,37 @@ int main(int argc, char *argv[])
 	while(!vine_empty(m)) {
 		t = vine_wait(m, 5);
 		if(t) {
-      vine_result_t r = vine_task_get_result(t);
-      int id = vine_task_get_id(t);
+			vine_result_t r = vine_task_get_result(t);
+			int id = vine_task_get_id(t);
 
 			if(r==VINE_RESULT_SUCCESS) {
-		    printf("Task %d complete: %s\n",id,vine_task_get_command(t));
-      } else {
-        printf("Task %d failed: %s\n",id,vine_result_string(r));
-      }
-      vine_task_delete(t);
+				printf("Task %d complete: %s\n",id,vine_task_get_command(t));
+			} else {
+				printf("Task %d failed: %s\n",id,vine_result_string(r));
+			}
+			vine_task_delete(t);
 		}
 	}
 
+	printf("Combining images into mosaic.jpg...\n");
+
+	t = vine_task_create("montage `ls *.cat.jpg | sort -n` -tile 6x6 -geometry 128x128+0+0 mosaic.jpg");
+	for(i=0;i<36;i++) {
+		char filename[256];
+		sprintf(filename,"%d.cat.jpg",i);
+		vine_task_add_input(t,temp_file[i],filename,VINE_CACHE);
+	}
+	vine_task_add_output_file(t,"mosaic.jpg","mosaic.jpg",VINE_NOCACHE);
+
+	int task_id = vine_submit(m,t);
+	printf("Submitted task (id# %d): %s\n", task_id, vine_task_get_command(t) );
+
+	printf("Waiting for tasks to complete...\n");
+	t = vine_wait(m,VINE_WAITFORTASK);
+	
 	printf("All tasks complete!\n");
 
 	vine_delete(m);
-
-	printf("Combining images into mosaic.jpg...\n");
-	system("montage `ls *.cat.jpg | sort -n` -tile 6x6 -geometry 128x128+0+0 mosaic.jpg");
-
-	printf("Deleting intermediate images...\n");
-	for(i=0;i<360;i+=10) {
-		char filename[256];
-		sprintf(filename,"%d.cat.jpg",i);
-		unlink(filename);
-	}
 
 	return 0;
 }

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -97,9 +97,10 @@ typedef enum {
 typedef enum {
 	VINE_FILE = 1,              /**< A file or directory present at the manager. **/
 	VINE_URL,                   /**< A file obtained by downloading from a URL. */
+	VINE_TEMP,		    /**< A temporary file created as an output of a task. */
 	VINE_BUFFER,                /**< A file obtained from data in the manager's memory space. */
 	VINE_MINI_TASK,             /**< A file obtained by executing a Unix command line. */
-	VINE_EMPTY_DIR              /**< An empty directory to create in the task sandbox. */
+	VINE_EMPTY_DIR,              /**< An empty directory to create in the task sandbox. */
 } vine_file_t;
 
 /** Select how to allocate resources for similar tasks with @ref vine_set_category_mode */
@@ -649,6 +650,14 @@ struct vine_file * vine_file_local( const char *source );
 */
 
 struct vine_file * vine_file_url( const char *url );
+
+/** Create a scratch file object.
+A scratch file has no initial content, but is created
+as the output of a task, and may be consumed by other tasks.
+@return A general file object for use by @ref vine_task_add_input.
+*/
+
+struct vine_file * vine_file_temp();
 
 /** Create a file object from a data buffer.
 @param name The abstract name of the buffer.

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -138,7 +138,9 @@ struct vine_file *vine_file_create(const char *source, const char *remote_name, 
 struct vine_file *vine_file_clone(const struct vine_file *f )
 {
 	if(!f) return 0;
-	return vine_file_create(f->source,f->remote_name,f->data,f->length,f->type,f->flags,vine_task_clone(f->mini_task));
+	struct vine_file *nf = vine_file_create(f->source,f->remote_name,f->data,f->length,f->type,f->flags,vine_task_clone(f->mini_task));
+	nf->cached_name = strdup(f->cached_name);
+	return nf;
 }
 
 /* Delete a file object */

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -80,6 +80,15 @@ char *make_cached_name( const struct vine_file *f )
 	       	case VINE_URL:
 			return string_format("url-%d-%s", cache_file_id, md5_string(digest));
 			break;
+		case VINE_TEMP:
+			/* A temporary file has no initial content. */
+			/* Replace with task-derived string once known. */
+			{
+			char cookie[17];
+			string_cookie(cookie,16);
+			return string_format("temp-%d-%s", cache_file_id, cookie);
+			break;
+			}
 		case VINE_BUFFER:
 		default:
 			return string_format("buffer-%d-%s", cache_file_id, md5_string(digest));
@@ -153,6 +162,11 @@ struct vine_file * vine_file_local( const char *source )
 struct vine_file * vine_file_url( const char *source )
 {
 	return vine_file_create(source,0,0,0,VINE_URL,0,0);
+}
+
+struct vind_file * vine_file_temp()
+{
+	return vine_file_create("temp",0,0,0,VINE_TEMP,0,0);
 }
 
 struct vine_file * vine_file_buffer( const char *buffer_name,const char *data, int length )

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -98,7 +98,7 @@ char *make_cached_name( const struct vine_file *f )
 
 /* Create a new file object with the given properties. */
 
-struct vine_file *vine_file_create(const char *source, const char *remote_name, const char *data, int length, vine_file_t type, vine_file_flags_t flags, struct vine_task *mini_task )
+struct vine_file *vine_file_create(const char *source, const char *remote_name, const char *cached_name, const char *data, int length, vine_file_t type, vine_file_flags_t flags, struct vine_task *mini_task )
 {
 	struct vine_file *f;
 
@@ -124,12 +124,16 @@ struct vine_file *vine_file_create(const char *source, const char *remote_name, 
 		f->data = 0;
 	}
 
-	if(vine_hack_do_not_compute_cached_name) {
-  		f->cached_name = xxstrdup(f->source);
+	if(cached_name) {
+		f->cached_name = xxstrdup(cached_name);
 	} else {
-		f->cached_name = make_cached_name(f);
+		if(vine_hack_do_not_compute_cached_name) {
+			f->cached_name = xxstrdup(f->source);
+		} else {
+			f->cached_name = make_cached_name(f);
+		}
 	}
-
+	
 	return f;
 }
 
@@ -138,9 +142,7 @@ struct vine_file *vine_file_create(const char *source, const char *remote_name, 
 struct vine_file *vine_file_clone(const struct vine_file *f )
 {
 	if(!f) return 0;
-	struct vine_file *nf = vine_file_create(f->source,f->remote_name,f->data,f->length,f->type,f->flags,vine_task_clone(f->mini_task));
-	nf->cached_name = strdup(f->cached_name);
-	return nf;
+	return vine_file_create(f->source,f->remote_name,f->cached_name,f->data,f->length,f->type,f->flags,vine_task_clone(f->mini_task));
 }
 
 /* Delete a file object */
@@ -148,6 +150,7 @@ struct vine_file *vine_file_clone(const struct vine_file *f )
 void vine_file_delete(struct vine_file *f)
 {
 	if(!f) return;
+	vine_file_delete(f->substitute);
 	vine_task_delete(f->mini_task);
 	free(f->source);
 	free(f->remote_name);
@@ -158,32 +161,37 @@ void vine_file_delete(struct vine_file *f)
 
 struct vine_file * vine_file_local( const char *source )
 {
-	return vine_file_create(source,0,0,0,VINE_FILE,0,0);
+	return vine_file_create(source,0,0,0,0,VINE_FILE,0,0);
 }
 
 struct vine_file * vine_file_url( const char *source )
 {
-	return vine_file_create(source,0,0,0,VINE_URL,0,0);
+	return vine_file_create(source,0,0,0,0,VINE_URL,0,0);
+}
+
+struct vine_file * vine_file_substitute_url( struct vine_file *f, const char *source )
+{
+	return vine_file_create(source,0,f->cached_name,0,f->length,VINE_URL,0,0);
 }
 
 struct vine_file * vine_file_temp()
 {
-	return vine_file_create("temp",0,0,0,VINE_TEMP,0,0);
+	return vine_file_create("temp",0,0,0,0,VINE_TEMP,0,0);
 }
 
 struct vine_file * vine_file_buffer( const char *buffer_name,const char *data, int length )
 {
-	return vine_file_create(buffer_name,0,data,length,VINE_BUFFER,0,0);
+	return vine_file_create(buffer_name,0,0,data,length,VINE_BUFFER,0,0);
 }
 
 struct vine_file * vine_file_empty_dir()
 {
-	return vine_file_create("unnamed",0,0,0,VINE_EMPTY_DIR,0,0);
+	return vine_file_create("unnamed",0,0,0,0,VINE_EMPTY_DIR,0,0);
 }
 
 struct vine_file * vine_file_mini_task( struct vine_task *t )
 {
-	return vine_file_create(t->command_line,0,0,0,VINE_MINI_TASK,0,t);
+	return vine_file_create(t->command_line,0,0,0,0,VINE_MINI_TASK,0,t);
 }
 
 struct vine_file * vine_file_untar( struct vine_file *f )

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -164,7 +164,7 @@ struct vine_file * vine_file_url( const char *source )
 	return vine_file_create(source,0,0,0,VINE_URL,0,0);
 }
 
-struct vind_file * vine_file_temp()
+struct vine_file * vine_file_temp()
 {
 	return vine_file_create("temp",0,0,0,VINE_TEMP,0,0);
 }

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -33,8 +33,11 @@ struct vine_file {
 	char *cached_name;	// Name of file in the worker's cache directory.
 	char *data;		// Raw data for an input or output buffer.
 	struct vine_task *mini_task; // Mini task used to generate the desired output file.
+	struct vine_file *substitute; // Fetch from this substitute file source instead.
 };
 
-struct vine_file * vine_file_create( const char *source, const char *remote_name, const char *data, int length, vine_file_t type, vine_file_flags_t flags, struct vine_task *mini_task );
+struct vine_file * vine_file_create( const char *source, const char *remote_name, const char *cached_name, const char *data, int length, vine_file_t type, vine_file_flags_t flags, struct vine_task *mini_task );
+
+struct vine_file * vine_file_substitute_url( struct vine_file *f, const char *source );
 
 #endif

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -305,7 +305,16 @@ static int handle_cache_update( struct vine_manager *q, struct vine_worker_info 
 			remote_info->size = size;
 			remote_info->transfer_time = transfer_time;
 			remote_info->in_cache = 1;
+		} else {
+			debug(D_VINE,"warning: unexpected cache-update message: %s %lld %lld %s",cachename,size,transfer_time,id);
+			/* XXX what is the correct file type to use here? */
+			remote_info = vine_remote_file_info_create(VINE_FILE,size,time(0));
+			remote_info->size = size;
+			remote_info->transfer_time = transfer_time;
+			remote_info->in_cache = 1;
+			hash_table_insert(w->current_files,cachename,remote_info);
 		}
+		
 		vine_current_transfers_remove(q, id);
 	}
 

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -402,6 +402,10 @@ static vine_result_code_t vine_manager_put_input_file(struct vine_manager *q, st
 		}
 		break;
 		}
+	case VINE_TEMP:
+		debug(D_VINE, "%s (%s) will use temp file %s", w->hostname, w->addrport, f->source);
+		// Do nothing.  Temporary files are created and used in place.
+		break;
 	}
 
 	if(result == VINE_SUCCESS) {

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -241,7 +241,7 @@ int vine_process_execute_and_wait( struct vine_task *task, struct vine_cache *ca
 		p->exit_code = 1;
 	}
 	
-	vine_sandbox_stageout(p,cache);
+	vine_sandbox_stageout(p,cache,manager);
 
 	/* Remove the task from the process so it is not deleted */
 	p->task = 0;

--- a/taskvine/src/worker/vine_sandbox.h
+++ b/taskvine/src/worker/vine_sandbox.h
@@ -12,6 +12,6 @@ See the file COPYING for details.
 #include "link.h"
 
 int vine_sandbox_stagein( struct vine_process *p, struct vine_cache *c, struct link *manager );
-int vine_sandbox_stageout( struct vine_process *p, struct vine_cache *c );
+int vine_sandbox_stageout( struct vine_process *p, struct vine_cache *c, struct link *manager );
 
 #endif

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -520,7 +520,7 @@ account for the resources as necessary.
 Should maintain parallel structure to start_process() above.
 */
 
-static void reap_process( struct vine_process *p )
+static void reap_process( struct vine_process *p, struct link *manager )
 {
 	p->execution_end = timestamp_get();
 
@@ -531,7 +531,7 @@ static void reap_process( struct vine_process *p )
 
 	vine_gpus_free(p->task->task_id);
 
-	if(!vine_sandbox_stageout(p,global_cache)) {
+	if(!vine_sandbox_stageout(p,global_cache,manager)) {
 		p->result = VINE_RESULT_OUTPUT_MISSING;
 		p->exit_code = 1;
 	}
@@ -630,7 +630,7 @@ static int handle_completed_tasks(struct link *manager)
 			}
 
 			/* collect the resources associated with the process */
-			reap_process(p);
+			reap_process(p,manager);
 			
 			/* must reset the table iterator because an item was removed. */
 			itable_firstkey(procs_running);

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -425,7 +425,7 @@ void send_cache_update( struct link *manager, const char *cachename, int64_t siz
 		send_message(manager,"cache-update %s %lld %lld %s\n",cachename,(long long)size,(long long)transfer_time, transfer_id);
 	}
 	else{
-		send_message(manager,"cache-update %s %lld %lld\n",cachename,(long long)size,(long long)transfer_time);
+		send_message(manager,"cache-update %s %lld %lld X\n",cachename,(long long)size,(long long)transfer_time);
 	}
 	if(transfer_id)
 	{


### PR DESCRIPTION
- Adds first pass at temporary files, which exist only at the workers and are never returned to the manager.
- Reworks peer transfer so that temporary files may be accessed from other workers.  (Needed if a task consumes multiple temp files.)
- Cleans up peer transfers to work by creating a "substitute" file object, rather than by modifying the original file object.
- Reworks `vine_example_mosaic` to make use of temporary files.

Big limitation:
- If a temporary file is lost due to worker disappearance, then the task is stuck forever.  Need to work out how to regenerate the file by running the missing task.
