### PR TITLE
category: fix update to max seen values

### DIFF
--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -590,7 +590,13 @@ int category_accumulate_summary(struct category *c, const struct rmsummary *rs, 
 
 	c->steady_state = c->completions_since_last_reset >= first_allocation_every_n_tasks;
 
-	rmsummary_merge_max(c->max_resources_seen, rs);
+    /* load new max values */
+    int i;
+    for(i = 0; labeled_resources[i]; i++) {
+        const size_t o = labeled_resources[i];
+        double max = MAX(rmsummary_get_by_offset(rs, o), rmsummary_get_by_offset(c->max_resources_seen, o));
+        rmsummary_set_by_offset(c->max_resources_seen, o, max);
+    }
 	if(rs && (!rs->exit_type || !strcmp(rs->exit_type, "normal"))) {
         size_t i;
         for(i = 0; labeled_resources[i]; i++) {


### PR DESCRIPTION
A recent change was loading all the max observed resources, rather than just cores, memory, disk, and gpus. This was incorrectly setting limits in other measurements, such as start and end times.

As observed by tphung3