### PR TITLE
fix C api for transactions log in manual

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1651,8 +1651,8 @@ tasks. It is activated as follows:
 
 === "C"
     ```C
-   vine_enable_transactions_log(q, "my.tr.log");
-   ```
+    vine_enable_transactions_log(q, "my.tr.log");
+    ```
 
 The first few lines of the log document the possible log records:
 

--- a/doc/manuals/work_queue/index.md
+++ b/doc/manuals/work_queue/index.md
@@ -2045,8 +2045,8 @@ tasks. It is activated as follows:
 
 === "C"
     ```C
-   work_queue_specify_transactions_log(q, "my.tr.log");
-   ```
+    work_queue_specify_transactions_log(q, "my.tr.log");
+    ```
 
 The first few lines of the log document the possible log records:
 


### PR DESCRIPTION
Fixes #3078. Line of code was incorrectly indented. 