### PR TITLE
Adds statx to parrot

### DIFF
--- a/configure
+++ b/configure
@@ -1333,6 +1333,7 @@ optional_function pread       unistd.h   HAS_PREAD USE_PREAD
 optional_function pread64     unistd.h   USE_PREAD64
 optional_function pwrite      unistd.h   HAS_PWRITE USE_PWRITE
 optional_function pwrite64    unistd.h   USE_PWRITE64
+optional_function statx       sys/stat.h HAS_STATX
 optional_function strchrnul   string.h   HAVE_STRCHRNUL
 optional_function strsignal   string.h   HAS_STRSIGNAL
 optional_function usleep      unistd.h   HAS_USLEEP HAVE_USLEEP

--- a/parrot/src/pfs_dispatch64.cc
+++ b/parrot/src/pfs_dispatch64.cc
@@ -634,6 +634,50 @@ static void decode_statfs( struct pfs_process *p, int entering, INT64_T syscall,
 	}
 }
 
+
+#ifdef HAS_STATX
+static void decode_statx( struct pfs_process *p, int entering, const INT64_T *args )
+{
+	if(entering) {
+		char path[PFS_PATH_MAX];
+		struct pfs_statx buf;
+
+		tracer_copy_in_string(p->tracer,path,POINTER(args[1]),sizeof(path),0);
+
+		//args:
+		//int dirfd, const char *pathname, int flags, unsigned int mask, struct statx *statxbuf
+		p->syscall_result = pfs_statx(args[0],path,args[2],args[3],&buf);
+
+		if(p->syscall_result>=0) {
+			struct pfs_kernel_statx kbuf;
+			COPY_STATX(buf,kbuf);
+			ssize_t count = tracer_copy_out(p->tracer, &kbuf, POINTER(args[4]), sizeof(kbuf), TRACER_O_ATOMIC|TRACER_O_FAST);
+			if (count == (ssize_t)sizeof(kbuf)) {
+				divert_to_dummy(p, 0);
+			} else if (count == -1 && errno != ENOSYS) {
+				debug(D_DEBUG, "tracer memory write failed: %s", strerror(errno));\
+				divert_to_dummy(p, -errno);
+			} else if(pfs_channel_alloc(0,sizeof(struct pfs_kernel_statx),&p->io_channel_offset)) {
+				char *local_addr = pfs_channel_base() + p->io_channel_offset;
+				memcpy(local_addr,&kbuf,sizeof(kbuf));
+				divert_to_channel(p,SYSCALL64_pread64,POINTER(args[4]),sizeof(kbuf),p->io_channel_offset);
+			} else {
+				divert_to_dummy(p,-ENOMEM);
+			}
+		} else {
+			divert_to_dummy(p,-errno);
+		}
+	} else if (!p->syscall_dummy) {
+		INT64_T actual;
+		tracer_result_get(p->tracer,&actual);
+		debug(D_DEBUG, "channel read %" PRId64, actual);
+		pfs_channel_free(p->io_channel_offset);
+		tracer_result_set(p->tracer, 0);
+	}
+}
+#endif
+
+
 static int fix_execve ( struct pfs_process *p, uintptr_t old_user_argv, const char *exe, const char *replace_arg0, const char *arg1, const char *arg2 )
 {
 	uintptr_t scratch = pfs_process_scratch_address(p);
@@ -2188,7 +2232,11 @@ static void decode_syscall( struct pfs_process *p, int entering )
 		case SYSCALL64_statfs:
 			decode_statfs(p,entering,SYSCALL64_statfs,args);
 			break;
-
+#ifdef HAS_STATX
+		case SYSCALL64_statx:
+			decode_statx(p,entering,args);
+			break;
+#endif
 		case SYSCALL64_access:
 			if(entering) {
 				TRACER_MEM_OP(tracer_copy_in_string(p->tracer,path,POINTER(args[0]),sizeof(path),0));

--- a/parrot/src/pfs_service.h
+++ b/parrot/src/pfs_service.h
@@ -30,6 +30,7 @@ public:
 	virtual pfs_dir * getdir( pfs_name *name );
 
 	virtual int stat( pfs_name *name, struct pfs_stat *buf );
+	virtual int statx( pfs_name *name, int flags, unsigned int mask, struct pfs_statx *buf );
 	virtual int statfs( pfs_name *name, struct pfs_statfs *buf );
 	virtual int lstat( pfs_name *name, struct pfs_stat *buf );
 	virtual int unlink( pfs_name *name );
@@ -83,6 +84,7 @@ void pfs_service_print();
 
 void pfs_service_emulate_statfs( struct pfs_statfs *buf );
 void pfs_service_emulate_stat( pfs_name *name, struct pfs_stat *buf );
+void pfs_service_emulate_statx( pfs_name *name, struct pfs_statx *buf );
 
 void pfs_service_set_block_size( int bs );
 int  pfs_service_get_block_size();

--- a/parrot/src/pfs_service_cvmfs.cc
+++ b/parrot/src/pfs_service_cvmfs.cc
@@ -1505,25 +1505,6 @@ class pfs_service_cvmfs:public pfs_service {
 		return rc;
 	}
 
-	virtual int statx(pfs_name *name, int flags, unsigned int mask, struct pfs_statx *info) {
-		struct pfs_stat info_stat;
-		struct pfs_statx info_statx;
-
-		debug(D_NOTICE, "%s", name->path);
-
-		int follow_leaf_symlinks = !(AT_SYMLINK_NOFOLLOW & flags);
-
-		int rc = anystat(name,&info_stat,follow_leaf_symlinks,1);
-		if( rc == -1 && errno == EAGAIN ) {
-			class pfs_service *local = pfs_service_lookup_default();
-			return local->statx(name,flags,mask,info);
-		} else {
-			COPY_STAT_TO_STATX(info_stat, info_statx);
-			memcpy(info, &info_statx, sizeof(*info));
-		}
-		return rc;
-	}
-
 	virtual int access(pfs_name * name, mode_t mode) {
 		struct pfs_stat info;
 		if(this->stat(name, &info) == 0) {

--- a/parrot/src/pfs_service_cvmfs.cc
+++ b/parrot/src/pfs_service_cvmfs.cc
@@ -1505,6 +1505,25 @@ class pfs_service_cvmfs:public pfs_service {
 		return rc;
 	}
 
+	virtual int statx(pfs_name *name, int flags, unsigned int mask, struct pfs_statx *info) {
+		struct pfs_stat info_stat;
+		struct pfs_statx info_statx;
+
+		debug(D_NOTICE, "%s", name->path);
+
+		int follow_leaf_symlinks = !(AT_SYMLINK_NOFOLLOW & flags);
+
+		int rc = anystat(name,&info_stat,follow_leaf_symlinks,1);
+		if( rc == -1 && errno == EAGAIN ) {
+			class pfs_service *local = pfs_service_lookup_default();
+			return local->statx(name,flags,mask,info);
+		} else {
+			COPY_STAT_TO_STATX(info_stat, info_statx);
+			memcpy(info, &info_statx, sizeof(*info));
+		}
+		return rc;
+	}
+
 	virtual int access(pfs_name * name, mode_t mode) {
 		struct pfs_stat info;
 		if(this->stat(name, &info) == 0) {

--- a/parrot/src/pfs_service_local.cc
+++ b/parrot/src/pfs_service_local.cc
@@ -417,6 +417,19 @@ RETRY:
 		}
 		END
 	}
+	virtual int statx( pfs_name *name, int flags, unsigned int mask, struct pfs_statx *buf ) {
+		stats_inc("parrot.local.statx", 1);
+		int result;
+		struct statx lbuf;
+		memset(&lbuf,0,sizeof(lbuf));
+		if(!pfs_acl_check(name,IBOX_ACL_LIST)) return -1;
+		debug(D_LOCAL,"statx %s %p",name->rest,buf);
+		result = ::statx(AT_FDCWD,name->rest,flags,mask,&lbuf);
+		if(result>=0){
+				COPY_STATX(lbuf,*buf);
+		}
+		END
+	}
 	virtual int access( pfs_name *name, mode_t mode ) {
 		stats_inc("parrot.local.access", 1);
 		int result;

--- a/parrot/src/pfs_service_local.cc
+++ b/parrot/src/pfs_service_local.cc
@@ -417,6 +417,7 @@ RETRY:
 		}
 		END
 	}
+#ifdef HAS_STATX
 	virtual int statx( pfs_name *name, int flags, unsigned int mask, struct pfs_statx *buf ) {
 		stats_inc("parrot.local.statx", 1);
 		int result;
@@ -430,6 +431,7 @@ RETRY:
 		}
 		END
 	}
+#endif
 	virtual int access( pfs_name *name, mode_t mode ) {
 		stats_inc("parrot.local.access", 1);
 		int result;

--- a/parrot/src/pfs_sys.cc
+++ b/parrot/src/pfs_sys.cc
@@ -299,6 +299,17 @@ int pfs_statx( int dirfd, const char *pathname, int flags, unsigned int mask, st
 	BEGIN
 	char newpath[PFS_PATH_MAX];
 
+	//statx:
+	//If pathname starts with a /, it is absolute and it is the path used.
+	//Otherwise, if pathname is not NULL or an empty string, it is taken as a
+	//relative path from dirfd. dirfd must be a file descriptor to an opened
+	//directory, or AT_FDCWD. If AT_FDCWD, paths are relative to the current
+	//workind directory.
+	//Otherwise, if pathnames is NULL or the empty string, and flags has
+	//AT_EMPTY_PATH, then the path is taken from the dirfd.
+	//Further, if flags contains AT_SYMLINK_NOFOLLOW, then statx does not
+	//dereference the path if it points to a symlink.
+
 	const char *path_ptr = pathname;
 	//when pathname is the empty string, or NULL, then statx behaves like stat*at functions.
 	if(!pathname || strnlen(pathname, 1) == 0) {

--- a/parrot/src/pfs_sys.cc
+++ b/parrot/src/pfs_sys.cc
@@ -295,6 +295,24 @@ int pfs_lstat( const char *path, struct pfs_stat *buf )
 	END
 }
 
+int pfs_statx( int dirfd, const char *pathname, int flags, unsigned int mask, struct pfs_statx *buf ) {
+	BEGIN
+	char newpath[PFS_PATH_MAX];
+
+	const char *path_ptr = pathname;
+	//when pathname is the empty string, or NULL, then statx behaves like stat*at functions.
+	if(!pathname || strnlen(pathname, 1) == 0) {
+		path_ptr = NULL;
+	}
+
+	if (pfs_current->table->complete_at_path(dirfd,path_ptr,newpath) == -1) return -1;
+	debug(D_LIBCALL,"statx %s %p",newpath,buf);
+
+	//newpath is an absolute path after complete_at_path, thus we can drop the dirfd argument to statx
+	result = pfs_current->table->statx(newpath,flags,mask,buf);
+	END
+}
+
 int pfs_access( const char *path, mode_t mode )
 {
 	BEGIN

--- a/parrot/src/pfs_sys.h
+++ b/parrot/src/pfs_sys.h
@@ -50,6 +50,8 @@ char *		pfs_getcwd( char *path, pfs_size_t size );
 int		pfs_stat( const char *name, struct pfs_stat *buf );
 int		pfs_statfs( const char *path, struct pfs_statfs *buf );
 int		pfs_lstat( const char *name, struct pfs_stat *buf );
+int		pfs_statx( int dirfd, const char *pathname, int flags, unsigned int mask, struct pfs_statx *buf );
+
 int		pfs_access( const char *name, mode_t mode );
 int		pfs_chmod( const char *name, mode_t mode );
 int		pfs_chown( const char *name, struct pfs_process *p, uid_t uid, gid_t gid );

--- a/parrot/src/pfs_sysdeps64.h
+++ b/parrot/src/pfs_sysdeps64.h
@@ -94,6 +94,36 @@ struct pfs_kernel_statfs {
 		INT64_T f_spare[6];
 };
 
+struct pfs_kernel_statx_timestamp {
+	INT64_T tv_sec;
+	UINT32_T tv_nsec;
+};
+
+struct pfs_kernel_statx {
+	UINT32_T stx_mask;
+	UINT32_T stx_blksize;
+	UINT64_T stx_attributes;
+	UINT32_T stx_nlink;
+	UINT32_T stx_uid;
+	UINT32_T stx_gid;
+	UINT16_T stx_mode;
+	UINT64_T stx_ino;
+	UINT64_T stx_size;
+	UINT64_T stx_blocks;
+	UINT64_T stx_attributes_mask;
+
+	struct pfs_kernel_statx_timestamp stx_atime;
+	struct pfs_kernel_statx_timestamp stx_btime;
+	struct pfs_kernel_statx_timestamp stx_ctime;
+	struct pfs_kernel_statx_timestamp stx_mtime;
+
+	UINT32_T stx_rdev_major;
+	UINT32_T stx_rdev_minor;
+
+	UINT32_T stx_dev_major;
+	UINT32_T stx_dev_minor;
+};
+
 struct pfs_kernel_iovec {
 	void     *iov_base;
 	UINT64_T  iov_len;

--- a/parrot/src/pfs_table.cc
+++ b/parrot/src/pfs_table.cc
@@ -1553,8 +1553,10 @@ int pfs_table::statx( const char *name, int flags, unsigned int mask, struct pfs
 	pfs_name pname;
 	int result = -1;
 
+	int follow_symlink = !(flags & AT_SYMLINK_NOFOLLOW);
+
 	/* You don't need to have read permission on a file to stat it. */
-	if(resolve_name(0,name,&pname,F_OK)) {
+	if(resolve_name(0,name,&pname,F_OK,follow_symlink)) {
 		result = pname.service->statx(&pname,flags,mask,b);
 		if(result>=0 && b->stx_blksize < 1) {
 			b->stx_blksize = pname.service->get_block_size();

--- a/parrot/src/pfs_table.h
+++ b/parrot/src/pfs_table.h
@@ -77,6 +77,7 @@ public:
 
 	/* operations on services */
 	int	stat( const char *name, struct pfs_stat *buf );
+	int	statx( const char *pathname, int flags, unsigned int mask, struct pfs_statx *buf );
 	int	statfs( const char *path, struct pfs_statfs *buf );
 	int	lstat( const char *name, struct pfs_stat *buf );
 	int	access( const char *name, mode_t mode );

--- a/parrot/src/pfs_types.h
+++ b/parrot/src/pfs_types.h
@@ -59,6 +59,36 @@ struct pfs_statfs {
 	INT64_T f_ffree;
 };
 
+struct pfs_statx_timestamp {
+	INT64_T tv_sec;
+	UINT32_T tv_nsec;
+};
+
+struct pfs_statx {
+	UINT32_T stx_mask;
+	UINT32_T stx_blksize;
+	UINT64_T stx_attributes;
+	UINT32_T stx_nlink;
+	UINT32_T stx_uid;
+	UINT32_T stx_gid;
+	UINT16_T stx_mode;
+	UINT64_T stx_ino;
+	UINT64_T stx_size;
+	UINT64_T stx_blocks;
+	UINT64_T stx_attributes_mask;
+
+	struct pfs_statx_timestamp stx_atime;
+	struct pfs_statx_timestamp stx_btime;
+	struct pfs_statx_timestamp stx_ctime;
+	struct pfs_statx_timestamp stx_mtime;
+
+	UINT32_T stx_rdev_major;
+	UINT32_T stx_rdev_minor;
+
+	UINT32_T stx_dev_major;
+	UINT32_T stx_dev_minor;
+};
+
 extern uid_t pfs_uid;
 extern gid_t pfs_gid;
 
@@ -108,6 +138,36 @@ extern gid_t pfs_gid;
 	(b).f_bfree = (a).f_bfree;\
 	(b).f_files = (a).f_files;\
 	(b).f_ffree = (a).f_ffree;
+#endif
+
+#ifndef COPY_STATX_TIMESTAMP
+#define COPY_STATX_TIMESTAMP( a, b )\
+	(b).tv_sec = (a).tv_sec;\
+	(b).tv_nsec = (a).tv_nsec;
+#endif
+
+#ifndef COPY_STATX
+#define COPY_STATX( a, b )\
+	memset(&(b),0,sizeof(b));\
+	(b).stx_mask = (a).stx_mask;\
+	(b).stx_blksize = (a).stx_blksize;\
+	(b).stx_attributes = (a).stx_attributes;\
+	(b).stx_nlink = (a).stx_nlink;\
+	(b).stx_uid = (a).stx_uid;\
+	(b).stx_gid = (a).stx_gid;\
+	(b).stx_mode = (a).stx_mode;\
+	(b).stx_ino = (a).stx_ino;\
+	(b).stx_size = (a).stx_size;\
+	(b).stx_blocks = (a).stx_blocks;\
+	(b).stx_attributes_mask = (a).stx_attributes_mask;\
+	COPY_STATX_TIMESTAMP((a).stx_atime, (b).stx_atime);\
+	COPY_STATX_TIMESTAMP((a).stx_btime, (b).stx_btime);\
+	COPY_STATX_TIMESTAMP((a).stx_ctime, (b).stx_ctime);\
+	COPY_STATX_TIMESTAMP((a).stx_mtime, (b).stx_mtime);\
+	(b).stx_dev_major = (a).stx_dev_major;\
+	(b).stx_rdev_major = (a).stx_rdev_major;\
+	(b).stx_dev_minor = (a).stx_dev_minor;\
+	(b).stx_rdev_minor = (a).stx_rdev_minor;
 #endif
 
 #endif

--- a/parrot/src/pfs_types.h
+++ b/parrot/src/pfs_types.h
@@ -170,4 +170,28 @@ extern gid_t pfs_gid;
 	(b).stx_rdev_minor = (a).stx_rdev_minor;
 #endif
 
+
+#ifndef COPY_STAT_TO_STATX
+#define COPY_STAT_TO_STATX( a, b )\
+	memset(&(b),0,sizeof(b));\
+	(b).stx_blksize = (a).st_blksize;\
+	(b).stx_nlink = (a).st_nlink;\
+	(b).stx_uid = (a).st_uid;\
+	(b).stx_gid = (a).st_gid;\
+	(b).stx_mode = (a).st_mode;\
+	(b).stx_ino = (a).st_ino;\
+	(b).stx_size = (a).st_size;\
+	(b).stx_blocks = (a).st_blocks;\
+	(b).stx_atime.tv_sec = (a).st_atime;\
+	(b).stx_atime.tv_nsec = 0;\
+	(b).stx_mtime.tv_sec = (a).st_mtime;\
+	(b).stx_mtime.tv_nsec = 0;\
+	(b).stx_ctime.tv_sec = (a).st_ctime;\
+	(b).stx_ctime.tv_nsec = 0;\
+	(b).stx_dev_major = (a).st_dev;\
+	(b).stx_rdev_major = (a).st_rdev;\
+	(b).stx_dev_minor = 1;\
+	(b).stx_rdev_minor = 1;
+#endif
+
 #endif

--- a/parrot/src/syscall_64.tbl
+++ b/parrot/src/syscall_64.tbl
@@ -331,6 +331,8 @@
 322	64	execveat		stub_execveat
 323	common	userfaultfd		sys_userfaultfd
 324	common	membarrier		sys_membarrier
+332 64      statx           sys_statx
+
 
 #
 # x32-specific system call numbers start at 512 to avoid cache impact

--- a/parrot/test/TR_parrot_stat.sh
+++ b/parrot/test/TR_parrot_stat.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+. ../../dttools/test/test_runner_common.sh
+. ./parrot-test.sh
+
+file=hello.txt
+link=link.txt
+expected=expected.out
+from_parrot=parrot.out
+
+prepare()
+{
+	set -e 
+
+	echo hello > $file
+	ln -sf $file $link
+
+	return 0
+}
+
+run()
+{
+	set -e
+
+	stat -L --terse $file $link 2>/dev/null > $expected
+	parrot -dall -- stat -L --terse $file $link > $from_parrot
+
+	if ! diff $expected $from_parrot
+	then
+		return 1
+	else
+		return 0
+	fi
+}
+
+clean()
+{
+	rm -rf $file $link $expected $from_parrot
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:


### PR DESCRIPTION
As observed in NDCMS+parrot in rh8,  utilities like ls and stat now use the call statx.

Local service redirects to statx.
cvmfs uses stat, and then copies relevant info to statx structures.

The rest of the services use a dummy entry, as with stat.