### PR TITLE
Fix Install Script on Work Queue manual for Github Install

### DIFF
--- a/doc/manuals/install/index.md
+++ b/doc/manuals/install/index.md
@@ -101,7 +101,7 @@ the software repository and build it:
 ```sh
 git clone git://github.com/cooperative-computing-lab/cctools.git cctools-src
 cd cctools-src
-./configure --with-base-dir $CONDA_PREFIX --prefix $HOME/cctools
+./configure --with-base-dir $CONDA_PREFIX --prefix $CONDA_PREFIX
 make
 make install
 ```


### PR DESCRIPTION
Current install instructions have the prefix as $HOME/cctools and the base directory as $CONDA_PREFIX. This caused python to not recognize work_queue as a package. As far as I can tell both of these need to be the same for the same and $CONDA_PREFIX seems to be the best solution so I have made the change.