### PR TITLE
Workqueue __del__ issue fixed on last instance of a python task

### DIFF
--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -52,6 +52,7 @@ if cctools_tmpdir:
 else:
     staging_directory = tempfile.mkdtemp(prefix='wq-py-staging-')
 
+
 def cleanup_staging_directory():
     try:
         shutil.rmtree(staging_directory)
@@ -1007,13 +1008,14 @@ class PythonTask(Task):
 
     specify_package = specify_environment
 
-    def __del__(self, os=os, sys=sys):
+    def __del__(self):
         try:
             if self._tmpdir and os.path.exists(self._tmpdir):
                 shutil.rmtree(self._tmpdir)
 
         except Exception as e:
-            sys.stderr.write('could not delete {}: {}\n'.format(self._tmpdir, e))
+            if sys:
+                sys.stderr.write('could not delete {}: {}\n'.format(self._tmpdir, e))
 
 
     def _serialize_python_function(self, func, args, kwargs):

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -1007,7 +1007,7 @@ class PythonTask(Task):
 
     specify_package = specify_environment
 
-    def __del__(self):
+    def __del__(self, os=os, sys=sys):
         try:
             if self._tmpdir and os.path.exists(self._tmpdir):
                 shutil.rmtree(self._tmpdir)


### PR DESCRIPTION
Previously there was an issue of __del__ being called on a python task after os and sys had gone out of scope, causing the test case in the manual to error out at the end. By giving del two arguements (os and sys) with default arguments being the required libraries, Python will preserve references to the libraries, allowing __del__ to be called successfully.