### PR TITLE
Vine: Serverless running on condor

### DIFF
--- a/poncho/src/poncho/package_serverize.py
+++ b/poncho/src/poncho/package_serverize.py
@@ -55,42 +55,24 @@ def send_configuration(config):
     sys.stdout.flush()
 
 def main():
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        # modify the port argument to be 0 to listen on an arbitrary port
-        s.bind(('localhost', 0))
-    except Exception as e:
-        s.close()
-        print(e)
-        exit(1)
-
-    # information to print to stdout for worker
     config = {
-            "name": name(),
-            "port": s.getsockname()[1],
-            }
-
+        "name": name(),
+    }
     send_configuration(config)
-
     while True:
-        s.listen()
-        conn, addr = s.accept()
-        print('Network function: connection from {}'.format(addr), file=sys.stderr)
         while True:
-            # peek at message to find newline to get the size
-            event_size = None
-            line = conn.recv(100, socket.MSG_PEEK)
-            eol = line.find(b'\\n')
-            if eol >= 0:
-                size = eol+1
-                # actually read the size of the event
-                input_spec = conn.recv(size).decode('utf-8').split()
-                function_name = input_spec[0]
-                event_size = int(input_spec[1])
-            try:
+            # wait for message from worker about what function to execute
+            line = input()
+            print(f"Network function received task: {line}", file=sys.stderr, flush=True)
+            if len(line) >= 0:
+                function_name, event_size = line.split(" ")
                 if event_size:
                     # receive the bytes containing the event and turn it into a string
-                    event_str = conn.recv(event_size).decode("utf-8")
+                    event_str = input()
+                    if len(event_str) != int(event_size):
+                        print(event_str, len(event_str), event_size, file=sys.stderr)
+                        print("Size of event does not match what was sent: exiting", file=sys.stderr)
+                        exit(0)
                     # turn the event into a python dictionary
                     event = json.loads(event_str)
                     # see if the user specified an execution method
@@ -102,9 +84,9 @@ def main():
                         p = threading.Thread(target=globals()[function_name], args=(event_str, q))
                         p.start()
                         p.join()
-                        response = json.dumps(q.get()).encode("utf-8")
+                        response = json.dumps(q.get())
                     elif exec_method == "direct":
-                        response = json.dumps(globals()[function_name](event)).encode("utf-8")
+                        response = json.dumps(globals()[function_name](event))
                     else:
                         p = os.fork()
                         if p == 0:
@@ -123,22 +105,20 @@ def main():
                             while (len(chunk) >= 65536):
                                 chunk = os.read(read, 65536).decode("utf-8")
                                 all_chunks.append(chunk)
-                            response = "".join(all_chunks).encode("utf-8")
+                            response = "".join(all_chunks)
                             os.waitid(os.P_PID, p, os.WEXITED)
 
-                    response_size = len(response)
-
-                    size_msg = "{}\\n".format(response_size)
-
-                    # send the size of response
-                    conn.sendall(size_msg.encode('utf-8'))
-
+                    #response_length_msg = f"{len(response)}\n".encode("utf-8")
+                    #sys.stderr.buffer.write(f"{response}\n".encode("utf-8"))
+                    print(response, flush=True)
+                    #sys.stdout.buffer.write(f"{response}\n".encode("utf-8"))
+                    #sys.stdout.buffer.flush()
                     # send response
-                    conn.sendall(response)
+                    #conn.sendall(response)
 
                     break
-            except Exception as e:
-                print("Network function encountered exception ", str(e), file=sys.stderr)
+            else:
+                print("Network function could not read from worker\n", file=sys.stderr)
     return 0
 
 '''

--- a/poncho/src/poncho/package_serverize.py
+++ b/poncho/src/poncho/package_serverize.py
@@ -108,13 +108,7 @@ def main():
                             response = "".join(all_chunks)
                             os.waitid(os.P_PID, p, os.WEXITED)
 
-                    #response_length_msg = f"{len(response)}\n".encode("utf-8")
-                    #sys.stderr.buffer.write(f"{response}\n".encode("utf-8"))
                     print(response, flush=True)
-                    #sys.stdout.buffer.write(f"{response}\n".encode("utf-8"))
-                    #sys.stdout.buffer.flush()
-                    # send response
-                    #conn.sendall(response)
 
                     break
             else:

--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -1088,6 +1088,7 @@ class Manager(object):
         self._stats = None
         self._stats_hierarchy = None
         self._task_table = {}
+        self._duty_table = {}
 
         # if we were given a range ports, rather than a single port to try.
         lower, upper = None, None
@@ -1828,6 +1829,7 @@ class Manager(object):
     # @param task   A task description created from @ref taskvine::Task.
     # @param name   Name of the duty to be installed.
     def install_duty(self, task, name):
+        self._duty_table[name] = task
         vine_manager_install_duty(self._taskvine, task._task, "duty_coprocess:" + name)
 
     ##
@@ -1837,6 +1839,7 @@ class Manager(object):
     # @param self   Reference to the current manager object.
     # @param name   Name of the duty to be removed.
     def remove_duty(self, name):
+        del self._duty_table[name]
         vine_manager_remove_duty(self._taskvine, "duty_coprocess:" + name)
 
     ##

--- a/taskvine/src/worker/vine_coprocess.c
+++ b/taskvine/src/worker/vine_coprocess.c
@@ -221,14 +221,6 @@ char *vine_coprocess_run(const char *function_name, const char *function_input, 
 	char *buffer = calloc(VINE_LINE_MAX, sizeof(char));
 	memset(buffer, 0, VINE_LINE_MAX * sizeof(char));
 	link_readline(coprocess->read_link, buffer, VINE_LINE_MAX, stoptime);
-	//link_readline(coprocess->read_link, buffer, VINE_LINE_MAX, stoptime);
-	//fprintf(stderr, "HEYA %s HYEA\n", buffer);
-	/*
-	if (vine_coprocess_read_from_link(buffer, VINE_LINE_MAX, timeout, coprocess->read_link) < 0) {
-		free(buffer);
-		return NULL;
-	}
-	*/
 
 	return buffer;
 }
@@ -253,7 +245,6 @@ struct vine_coprocess *vine_coprocess_initialize_coprocess(char *coprocess_comma
 }
 
 void vine_coprocess_specify_resources(struct vine_coprocess *coprocess, struct rmsummary *allocated_resources) {
-	printf("%lf %lf %lf %lf\n", allocated_resources->cores, allocated_resources->memory, allocated_resources->disk, allocated_resources->gpus);
 	int coprocess_cores_normalized  = ( (allocated_resources->cores > 0)  ? allocated_resources->cores  : COPROCESS_CORES_DEFAULT);
 	int coprocess_memory_normalized = ( (allocated_resources->memory > 0) ? allocated_resources->memory : COPROCESS_MEMORY_DEFAULT);
 	int coprocess_disk_normalized   = ( (allocated_resources->disk > 0)   ? allocated_resources->disk   : COPROCESS_DISK_DEFAULT);

--- a/taskvine/src/worker/vine_coprocess.c
+++ b/taskvine/src/worker/vine_coprocess.c
@@ -169,6 +169,7 @@ int vine_coprocess_start(struct vine_coprocess *coprocess, char *sandbox) {
         if (dup2(coprocess->pipe_out[1], 1) < 0) {
             fatal("coprocess could not attach pipe to stdout: %s\n", strerror(errno));
         }
+		setpgid(0, 0);
         execlp(coprocess->command, coprocess->command, (char *) 0);
         fatal("failed to execute %s: %s\n", coprocess->command, strerror(errno));
 	}

--- a/taskvine/src/worker/vine_coprocess.c
+++ b/taskvine/src/worker/vine_coprocess.c
@@ -252,11 +252,12 @@ struct vine_coprocess *vine_coprocess_initialize_coprocess(char *coprocess_comma
 	return coprocess;
 }
 
-void vine_coprocess_specify_resources(struct vine_coprocess *coprocess, int coprocess_cores, int coprocess_memory, int coprocess_disk, int coprocess_gpus) {
-	int coprocess_cores_normalized  = ( (coprocess_cores > 0)  ? coprocess_cores  : COPROCESS_CORES_DEFAULT);
-	int coprocess_memory_normalized = ( (coprocess_memory > 0) ? coprocess_memory : COPROCESS_MEMORY_DEFAULT);
-	int coprocess_disk_normalized   = ( (coprocess_disk > 0)   ? coprocess_disk   : COPROCESS_DISK_DEFAULT);
-	int coprocess_gpus_normalized   = ( (coprocess_gpus > 0)   ? coprocess_gpus   : COPROCESS_GPUS_DEFAULT);
+void vine_coprocess_specify_resources(struct vine_coprocess *coprocess, struct rmsummary *allocated_resources) {
+	printf("%lf %lf %lf %lf\n", allocated_resources->cores, allocated_resources->memory, allocated_resources->disk, allocated_resources->gpus);
+	int coprocess_cores_normalized  = ( (allocated_resources->cores > 0)  ? allocated_resources->cores  : COPROCESS_CORES_DEFAULT);
+	int coprocess_memory_normalized = ( (allocated_resources->memory > 0) ? allocated_resources->memory : COPROCESS_MEMORY_DEFAULT);
+	int coprocess_disk_normalized   = ( (allocated_resources->disk > 0)   ? allocated_resources->disk   : COPROCESS_DISK_DEFAULT);
+	int coprocess_gpus_normalized   = ( (allocated_resources->gpus > 0)   ? allocated_resources->gpus   : COPROCESS_GPUS_DEFAULT);
 	
 	coprocess->coprocess_resources = vine_resources_create();
 	coprocess->coprocess_resources->cores.total  = coprocess_cores_normalized;
@@ -264,31 +265,6 @@ void vine_coprocess_specify_resources(struct vine_coprocess *coprocess, int copr
 	coprocess->coprocess_resources->disk.total   = coprocess_disk_normalized;
 	coprocess->coprocess_resources->gpus.total   = coprocess_gpus_normalized;
 }
-
-/*
-struct vine_coprocess *vine_coprocess_initalize_all_coprocesses(int coprocess_cores, int coprocess_memory, int coprocess_disk, int coprocess_gpus, struct vine_resources *total_resources, char *coprocess_command, int number_of_coprocess_instances) {
-	if (number_of_coprocess_instances <= 0) return NULL;
-	int coprocess_cores_normalized  = ( (coprocess_cores > 0)  ? coprocess_cores  : total_resources->cores.total);
-	int coprocess_memory_normalized = ( (coprocess_memory > 0) ? coprocess_memory : total_resources->memory.total);
-	int coprocess_disk_normalized   = ( (coprocess_disk > 0)   ? coprocess_disk   : total_resources->disk.total);
-	int coprocess_gpus_normalized   = ( (coprocess_gpus > 0)   ? coprocess_gpus   : total_resources->gpus.total);
-
-	struct vine_coprocess * coprocess_info = malloc(sizeof(struct vine_coprocess) * number_of_coprocess_instances);
-	memset(coprocess_info, 0, sizeof(struct vine_coprocess) * number_of_coprocess_instances);
-	for (int coprocess_num = 0; coprocess_num < number_of_coprocess_instances; coprocess_num++){
-		struct vine_coprocess *curr_coprocess = &coprocess_info[coprocess_num];
-		coprocess_info[coprocess_num] = (struct vine_coprocess) {NULL, NULL, -1, -1, VINE_COPROCESS_UNINITIALIZED, {-1, -1}, {-1, -1}, NULL, NULL, NULL, 0, NULL};
-		curr_coprocess->command = xxstrdup(coprocess_command);
-		curr_coprocess->coprocess_resources = vine_resources_create();
-		curr_coprocess->coprocess_resources->cores.total  = coprocess_cores_normalized;
-		curr_coprocess->coprocess_resources->memory.total = coprocess_memory_normalized;
-		curr_coprocess->coprocess_resources->disk.total   = coprocess_disk_normalized;
-		curr_coprocess->coprocess_resources->gpus.total   = coprocess_gpus_normalized;
-		vine_coprocess_start(curr_coprocess);
-	}
-	return coprocess_info;
-}
-*/
 
 void vine_coprocess_shutdown_all_coprocesses(struct list *coprocess_list) {
 	struct vine_coprocess *coprocess;

--- a/taskvine/src/worker/vine_coprocess.h
+++ b/taskvine/src/worker/vine_coprocess.h
@@ -4,6 +4,7 @@ This software is distributed under the GNU General Public License.
 See the file COPYING for details.
 */
 #include "list.h"
+#include "taskvine.h"
 typedef enum {
 	VINE_COPROCESS_UNINITIALIZED, /**< worker has not yet created coprocess instance **/
 	VINE_COPROCESS_READY,         /**< coprocess is ready to receive and run a RemoteTask **/
@@ -32,7 +33,7 @@ int vine_coprocess_check(struct vine_coprocess *coprocess);
 char *vine_coprocess_run(const char *function_name, const char *function_input, struct vine_coprocess *coprocess);
 struct vine_coprocess *vine_coprocess_find_state(struct list *coprocess_list, vine_coprocess_state_t state, char *coprocess_name);
 struct vine_coprocess *vine_coprocess_initialize_coprocess(char *coprocess_command);
-void vine_coprocess_specify_resources(struct vine_coprocess *coprocess, int coprocess_cores, int coprocess_memory, int coprocess_disk, int coprocess_gpus);
+void vine_coprocess_specify_resources(struct vine_coprocess *coprocess, struct rmsummary *allocated_resources);
 void vine_coprocess_shutdown_all_coprocesses(struct list *coprocess_list);
 void vine_coprocess_measure_resources(struct list *coprocess_list);
 int vine_coprocess_enforce_limit(struct vine_coprocess *coprocess);

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -274,7 +274,7 @@ pid_t vine_process_execute(struct vine_process *p )
 		p->pid = fork();
 	} else {
 		p->coprocess = vine_coprocess_initialize_coprocess(p->task->command_line);
-		vine_coprocess_specify_resources(p->coprocess, 0, 0, 0, 0);
+		vine_coprocess_specify_resources(p->coprocess, p->task->resources_requested);
 		p->pid = vine_coprocess_start(p->coprocess, p->sandbox);
 	}
 


### PR DESCRIPTION
Getting serverless to work on condor required changing the method of communication between coprocess and worker from using TCP to using pipes, as for whatever reason the task responsible for invoking the function call on the coprocess would not connect.