### PR TITLE
Fix __del__ behavior in taskvine

### DIFF
--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -984,7 +984,8 @@ class PythonTask(Task):
                 shutil.rmtree(self._tmpdir)
 
         except Exception as e:
-            sys.stderr.write('could not delete {}: {}\n'.format(self._tmpdir, e))
+            if sys:
+                sys.stderr.write('could not delete {}: {}\n'.format(self._tmpdir, e))
 
 
     def _serialize_python_function(self, func, args, kwargs):


### PR DESCRIPTION
Taskvine had the same del issues that workqueue had so I applied the same fix in the vine bindings. As far as I can tell the python task temp dirs are created in the same way as work queue so everything should be cleaned up regardless at exit!