### PR TITLE
Vine logs per run

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1556,56 +1556,66 @@ Pair: [2, 4, 6, 8, 4, 8, 12, 16, 6, 12, 18, 24, 8, 18, 24, 32]
 Tree: 8
 ```
 
+
 ## Logging facilities
 
-We can observe the lifetime of the queue through three different logs:
+A taskvine manager produces three logs: `debug`, `performance`, and
+`transactions`. These logs are always enabled, and appear in the current
+working directory in the sudirectories:
+
+```sh
+vine-run-info/YYYY-mm-ddTHH:MM:SS/logs
+
+# for example: vine-run-info/2023-02-10T09\:08\:47/logs
+```
+
+If you need to change the prefix `vine-run-info` to some other directory, use
+
+=== "Python"
+    ```python
+    # logs appear at /new/desired/path/%Y-%m-%dT%H:%M:%S/logs
+    m = vine.Manager(run_info_path="/new/desired/path")
+    ```
+
+=== "C"
+    // logs appear at /new/desired/path/%Y-%m-%dT%H:%M:%S/logs
+    vine_set_runtime_info_path("/new/desired/path")
+    struct taskvine *m = vine_create(0);
+    ```
+
+If the new path is not absolute, it is taken relative to the current working
+directory.
+
+If set, the environment variable `VINE_RUNTIME_INFO_DIR` determines the logging
+directory. If `VINE_RUNTIME_INFO_DIR` is not an absolute path, then it is taken
+relative to the current logging prefix (i.e. `vine-run-info/` by default).
 
 
 ### Debug Log
 
 The debug log prints unstructured messages as the queue transfers files and
 tasks, workers connect and report resources, etc. This is specially useful to
-find failures, bugs, and other errors. To activate debug output:
+find failures, bugs, and other errors. It is located by default at:
 
-=== "Python"
-    ```python
-    m = vine.Manager(debug_log = "my.debug.log")
-    ```
-
-=== "C"
-    ```C
-    #include "debug.h"
-    cctools_debug_flags_set("all");
-    cctools_debug_config_file("my.debug.log");
-    ```
-
-The `all` flag causes debug messages from every subsystem called by taskvine
-to be printed. More information about the debug flags are
-[here](api/html/debug_8h.html).
-
+```sh
+vine-run-info/%Y-%m-%dT%H:%M:%S/logs/debug
+```
 
 To enable debugging at the worker, set the `-d` option:
-
 
 ```sh
 $ vine_worker -d all -o worker.debug -M myproject
 ```
 
-### Statistics Log
+### Performance Log
 
-The statistics logs contains a time series of the statistics collected by the manager,
+The performance log contains a time series of the statistics collected by the manager,
 such as number of tasks waiting and completed, number of workers busy,
-total number of cores available, etc. The log is activated as follows:
+total number of cores available, etc. The log is located by default at:
 
-=== "Python"
-    ```python
-    m = vine.Manager(stats_log = "my.statslog")
-    ```
-
-=== "C"
-    ```C
-    vine_enable_perf_log(m, "my.stats.log");
-    ```
+```sh
+vine-run-info/%Y-%m-%dT%H:%M:%S/logs/performance
+```
 
 The time series are presented in columns, with the leftmost column as a
 timestamp in microseconds. The first row always contains the name of the
@@ -1636,17 +1646,11 @@ taskvine applications.
 
 Finally, the transactions log records the lifetime of tasks and workers. It is
 specially useful for tracking the resources requested, allocated, and used by
-tasks. It is activated as follows:
+tasks. It is located by default at:
 
-=== "Python"
-    ```python
-    m = vine.Manager(transactions_log = "my.tr.log")
-    ```
-
-=== "C"
-    ```C
-    vine_enable_transactions_log(m, "my.tr.log");
-    ```
+```sh
+vine-run-info/%Y-%m-%dT%H:%M:%S/logs/transactions
+```
 
 The first few lines of the log document the possible log records:
 

--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1564,21 +1564,21 @@ A taskvine manager produces three logs: `debug`, `performance`, and
 working directory in the sudirectories:
 
 ```sh
-vine-run-info/YYYY-mm-ddTHH:MM:SS/logs
+vine-run-info/YYYY-mm-ddTHH:MM:SS/vine-logs
 
-# for example: vine-run-info/2023-02-10T09\:08\:47/logs
+# for example: vine-run-info/2023-02-10T09\:08\:47/vine-logs
 ```
 
 If you need to change the prefix `vine-run-info` to some other directory, use
 
 === "Python"
     ```python
-    # logs appear at /new/desired/path/%Y-%m-%dT%H:%M:%S/logs
+    # logs appear at /new/desired/path/%Y-%m-%dT%H:%M:%S/vine-logs
     m = vine.Manager(run_info_path="/new/desired/path")
     ```
 
 === "C"
-    // logs appear at /new/desired/path/%Y-%m-%dT%H:%M:%S/logs
+    // logs appear at /new/desired/path/%Y-%m-%dT%H:%M:%S/vine-logs
     vine_set_runtime_info_path("/new/desired/path")
     struct taskvine *m = vine_create(0);
     ```
@@ -1598,7 +1598,7 @@ tasks, workers connect and report resources, etc. This is specially useful to
 find failures, bugs, and other errors. It is located by default at:
 
 ```sh
-vine-run-info/%Y-%m-%dT%H:%M:%S/logs/debug
+vine-run-info/%Y-%m-%dT%H:%M:%S/vine-logs/debug
 ```
 
 To enable debugging at the worker, set the `-d` option:
@@ -1614,7 +1614,7 @@ such as number of tasks waiting and completed, number of workers busy,
 total number of cores available, etc. The log is located by default at:
 
 ```sh
-vine-run-info/%Y-%m-%dT%H:%M:%S/logs/performance
+vine-run-info/%Y-%m-%dT%H:%M:%S/vine-logs/performance
 ```
 
 The time series are presented in columns, with the leftmost column as a
@@ -1649,7 +1649,7 @@ specially useful for tracking the resources requested, allocated, and used by
 tasks. It is located by default at:
 
 ```sh
-vine-run-info/%Y-%m-%dT%H:%M:%S/logs/transactions
+vine-run-info/%Y-%m-%dT%H:%M:%S/vine-logs/transactions
 ```
 
 The first few lines of the log document the possible log records:

--- a/dttools/test/test_runner_common.sh
+++ b/dttools/test/test_runner_common.sh
@@ -166,6 +166,12 @@ check_needed()
 	return 0
 }
 
+latest_vine_debug_log()
+{
+	echo "vine-runtime/$(/bin/ls -1 -r vine-runtime | /bin/head -n1)/debug"
+}
+
+
 # For OS X
 if ! echo $PATH | grep /sbin > /dev/null 2>&1; then
 	export PATH=$PATH:/usr/sbin:/sbin

--- a/dttools/test/test_runner_common.sh
+++ b/dttools/test/test_runner_common.sh
@@ -168,7 +168,8 @@ check_needed()
 
 latest_vine_debug_log()
 {
-	echo "vine-runtime/$(/bin/ls -1 -r vine-runtime | /bin/head -n1)/debug"
+	base=${1:-vine-run-info}
+	echo "$(/bin/ls -1 -r -d ${base}/* 2>/dev/null | /bin/head -n1)/vine-logs/debug"
 }
 
 

--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -1084,12 +1084,12 @@ class Manager(object):
     # @param port       The port number to listen on. If zero, then a random port is chosen. A range of possible ports (low, hight) can be also specified instead of a single integer.
     # @param name       The project name to use.
     # @param shutdown   Automatically shutdown workers when queue is finished. Disabled by default.
-    # @param run_info_dir Directory to write log and staging files per run. If None, defaults to "vine-runtime"
+    # @param run_info_dir Directory to write log and staging files per run. If None, defaults to "vine-run-info"
     # @param ssl        A tuple of filenames (ssl_key, ssl_cert) in pem format, or True.
     #                   If not given, then TSL is not activated. If True, a self-signed temporary key and cert are generated.
     #
     # @see vine_create    - For more information about environmental variables that affect the behavior this method.
-    def __init__(self, port=VINE_DEFAULT_PORT, name=None, shutdown=False, run_info_dir="vine-runtime", ssl=None):
+    def __init__(self, port=VINE_DEFAULT_PORT, name=None, shutdown=False, run_info_dir="vine-run-info", ssl=None):
         self._shutdown = shutdown
         self._taskvine = None
         self._stats = None
@@ -1511,8 +1511,8 @@ class Manager(object):
     #
     # @param self     Reference to the current manager object.
     # @param dirname  A directory name
-    def set_runtime_info_path(self, dir):
-        vine_set_runtime_info_path(self._taskvine, dirname)
+    def set_runtime_info_path(self, dirname):
+        vine_set_runtime_info_path(dirname)
 
     ##
     # Add a mandatory password that each worker must present.

--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -1084,12 +1084,12 @@ class Manager(object):
     # @param port       The port number to listen on. If zero, then a random port is chosen. A range of possible ports (low, hight) can be also specified instead of a single integer.
     # @param name       The project name to use.
     # @param shutdown   Automatically shutdown workers when queue is finished. Disabled by default.
-    # @param run_info_dir Directory to write log and staging files per run. If None, defaults to "vine-run-info"
+    # @param run_info_path Directory to write log and staging files per run. If None, defaults to "vine-run-info"
     # @param ssl        A tuple of filenames (ssl_key, ssl_cert) in pem format, or True.
     #                   If not given, then TSL is not activated. If True, a self-signed temporary key and cert are generated.
     #
     # @see vine_create    - For more information about environmental variables that affect the behavior this method.
-    def __init__(self, port=VINE_DEFAULT_PORT, name=None, shutdown=False, run_info_dir="vine-run-info", ssl=None):
+    def __init__(self, port=VINE_DEFAULT_PORT, name=None, shutdown=False, run_info_path="vine-run-info", ssl=None):
         self._shutdown = shutdown
         self._taskvine = None
         self._stats = None
@@ -1109,8 +1109,8 @@ class Manager(object):
             raise ValueError('port should be a single integer, or a sequence of two integers')
 
         try:
-            if run_info_dir:
-                self.set_runtime_info_path(run_info_dir)
+            if run_info_path:
+                self.set_runtime_info_path(run_info_path)
 
             self._stats = vine_stats()
             self._stats_hierarchy = vine_stats()

--- a/taskvine/src/bindings/python3/taskvine.i
+++ b/taskvine/src/bindings/python3/taskvine.i
@@ -17,6 +17,7 @@
 	#include "taskvine.h"
 	#include "rmsummary.h"
     #include "vine_task.h"
+    #include "vine_runtime_dir.h"
 %}
 
 /* We compile with -D__LARGE64_FILES, thus off_t is at least 64bit.
@@ -27,8 +28,9 @@ long long int is guaranteed to be at least 64bit. */
 %ignore vdebug;
 %ignore debug;
 
-/* returns a char*, enable automatic free */
-%newobject work_queue_status;
+/* return a char*, enable automatic free */
+%newobject vine_status;
+%newobject vine_get_runtime_path_staging;
 
 /* These return pointers to lists defined in list.h. We aren't
  * wrapping methods in list.h and so ignore these. */
@@ -48,6 +50,7 @@ treat it as an output parameter to be filled in. */
 %include "rmsummary.h"
 %include "category.h"
 %include "vine_task.h"
+%include "vine_runtime_dir.h"
 
 
 

--- a/taskvine/src/examples/vine_example_blast.c
+++ b/taskvine/src/examples/vine_example_blast.c
@@ -41,6 +41,8 @@ int main(int argc, char *argv[])
 	struct vine_task *t;
 	int i;
 
+    vine_set_runtime_info_path("vine-runtime/vine-example-blast");
+
 	m = vine_create(VINE_DEFAULT_PORT);
 	if(!m) {
 		printf("couldn't create manager: %s\n", strerror(errno));
@@ -48,12 +50,11 @@ int main(int argc, char *argv[])
 	}
 	printf("listening on port %d...\n", vine_port(m));
 
-	vine_enable_debug_log(m,"manager.log");
 	vine_set_scheduler(m,VINE_SCHEDULE_FILES);
 
 	for(i=0;i<10;i++) {
 		struct vine_task *t = vine_task_create("blastdir/ncbi-blast-2.13.0+/bin/blastp -db landmark -query query.file");
-	  
+
 		vine_task_add_input_buffer(t,query_string,strlen(query_string),"query.file", VINE_NOCACHE);
 		vine_task_add_input(t,vine_file_untar(vine_file_url(BLAST_URL)),"blastdir", VINE_CACHE );
 		vine_task_add_input(t,vine_file_untar(vine_file_url(LANDMARK_URL)),"landmark", VINE_CACHE );

--- a/taskvine/src/examples/vine_example_blast.c
+++ b/taskvine/src/examples/vine_example_blast.c
@@ -41,7 +41,8 @@ int main(int argc, char *argv[])
 	struct vine_task *t;
 	int i;
 
-    vine_set_runtime_info_path("vine-runtime/vine-example-blast");
+    //runtime logs will be written to vine_example_blast_info/%Y-%m-%dT%H:%M:%S
+    vine_set_runtime_info_path("vine_example_blast_info");
 
 	m = vine_create(VINE_DEFAULT_PORT);
 	if(!m) {

--- a/taskvine/src/examples/vine_example_blast.py
+++ b/taskvine/src/examples/vine_example_blast.py
@@ -34,7 +34,6 @@ if __name__ == "__main__":
         sys.exit(1)
     print("listening on port", m.port)
 
-    m.enable_debug_log("manager.log")
     m.set_scheduler(vine.VINE_SCHEDULE_FILES)
 
     for i in range(10):

--- a/taskvine/src/examples/vine_example_gutenberg.c
+++ b/taskvine/src/examples/vine_example_gutenberg.c
@@ -59,6 +59,8 @@ int main(int argc, char *argv[])
 	struct vine_task *t;
 	int i,j ;
 
+	vine_set_runtime_info_path("vine-runtime/vine_example_gutenberg");
+
 	m = vine_create(VINE_DEFAULT_PORT);
 	if(!m) {
 		printf("couldn't create manager: %s\n", strerror(errno));
@@ -66,7 +68,6 @@ int main(int argc, char *argv[])
 	}
 	printf("listening on port %d...\n", vine_port(m));
 
-	vine_enable_debug_log(m,"manager.log");
 	vine_set_scheduler(m,VINE_SCHEDULE_FILES);
 
 	for(i=0;i<url_count;i++) {

--- a/taskvine/src/examples/vine_example_gutenberg.c
+++ b/taskvine/src/examples/vine_example_gutenberg.c
@@ -59,7 +59,8 @@ int main(int argc, char *argv[])
 	struct vine_task *t;
 	int i,j ;
 
-	vine_set_runtime_info_path("vine-runtime/vine_example_gutenberg");
+    //runtime logs will be written to vine_example_gutenberg_info/%Y-%m-%dT%H:%M:%S
+	vine_set_runtime_info_path("vine_example_gutenberg_info");
 
 	m = vine_create(VINE_DEFAULT_PORT);
 	if(!m) {

--- a/taskvine/src/examples/vine_example_gutenberg.py
+++ b/taskvine/src/examples/vine_example_gutenberg.py
@@ -53,7 +53,6 @@ if __name__ == "__main__":
         sys.exit(1)
     print("listening on port", m.port)
 
-    m.enable_debug_log("manager.log")
     m.set_scheduler(vine.VINE_SCHEDULE_FILES)
 
     for i in range(url_count):

--- a/taskvine/src/examples/vine_example_map.py
+++ b/taskvine/src/examples/vine_example_map.py
@@ -21,7 +21,6 @@ if __name__ == "__main__":
         sys.exit(1)
     print("listening on port", m.port)
 
-    m.enable_debug_log("manager.log")
     m.set_scheduler(vine.VINE_SCHEDULE_FILES)
 
     print("mapping ages...")

--- a/taskvine/src/examples/vine_example_minitask.c
+++ b/taskvine/src/examples/vine_example_minitask.c
@@ -24,7 +24,8 @@ int main(int argc, char *argv[])
 	struct vine_task *t;
 	int i;
 
-	vine_set_runtime_info_path("vine-runtime/vine_example_minitask");
+    //runtime logs will be written to vine_example_minitask_info/%Y-%m-%dT%H:%M:%S
+	vine_set_runtime_info_path("vine_example_minitask_info");
 
 	m = vine_create(VINE_DEFAULT_PORT);
 	if(!m) {

--- a/taskvine/src/examples/vine_example_minitask.c
+++ b/taskvine/src/examples/vine_example_minitask.c
@@ -24,6 +24,8 @@ int main(int argc, char *argv[])
 	struct vine_task *t;
 	int i;
 
+	vine_set_runtime_info_path("vine-runtime/vine_example_minitask");
+
 	m = vine_create(VINE_DEFAULT_PORT);
 	if(!m) {
 		printf("couldn't create manager: %s\n", strerror(errno));
@@ -31,7 +33,6 @@ int main(int argc, char *argv[])
 	}
 	printf("listening on port %d...\n", vine_port(m));
 
-	vine_enable_debug_log(m,"manager.log");
 	vine_set_scheduler(m,VINE_SCHEDULE_FILES);
 
 	for(i=0;i<10;i++) {

--- a/taskvine/src/examples/vine_example_mosaic.c
+++ b/taskvine/src/examples/vine_example_mosaic.c
@@ -36,7 +36,8 @@ int main(int argc, char *argv[])
 	struct vine_manager *m;
 	struct vine_task *t;
 
-	vine_set_runtime_info_path("vine-runtime/vine_example_mosaic");
+    //runtime logs will be written to vine_example_mosaic_info/%Y-%m-%dT%H:%M:%S
+	vine_set_runtime_info_path("vine_example_mosaic_info");
 
 	printf("Checking that /usr/bin/convert is installed...\n");
 	int r = access("/usr/bin/convert",X_OK);

--- a/taskvine/src/examples/vine_example_mosaic.c
+++ b/taskvine/src/examples/vine_example_mosaic.c
@@ -36,6 +36,8 @@ int main(int argc, char *argv[])
 	struct vine_manager *m;
 	struct vine_task *t;
 
+	vine_set_runtime_info_path("vine-runtime/vine_example_mosaic");
+
 	printf("Checking that /usr/bin/convert is installed...\n");
 	int r = access("/usr/bin/convert",X_OK);
 	if(r!=0) {
@@ -64,7 +66,6 @@ int main(int argc, char *argv[])
 	}
 	printf("Listening on port %d...\n", vine_port(m));
 
-	vine_enable_debug_log(m,"manager.log");
 	vine_enable_peer_transfers(m);
 
 	struct vine_file *temp_file[36];

--- a/taskvine/src/examples/vine_example_mosaic.py
+++ b/taskvine/src/examples/vine_example_mosaic.py
@@ -46,8 +46,6 @@ if __name__ == "__main__":
         sys.exit(1)
     print("listening on port", m.port)
 
-    m.enable_debug_log("manager.log")
-
     for i in range(0, 360, 10):
         outfile = str(i) + ".cat.jpg"
         command = "./convert.sfx -swirl " + str(i) + " cat.jpg " + str(i) + ".cat.jpg"

--- a/taskvine/src/examples/vine_example_pair.py
+++ b/taskvine/src/examples/vine_example_pair.py
@@ -16,7 +16,6 @@ if __name__ == "__main__":
         sys.exit(1)
     print("listening on port", m.port)
 
-    m.enable_debug_log("manager.log")
     m.set_scheduler(vine.VINE_SCHEDULE_FILES)
 
     print("pairing first and last names...")

--- a/taskvine/src/examples/vine_example_peer_transfer.c
+++ b/taskvine/src/examples/vine_example_peer_transfer.c
@@ -41,15 +41,16 @@ int main(int argc, char *argv[])
 	struct vine_task *t;
 	int i;
 
-	vine_set_runtime_info_path("vine-runtime/vine_example_peer_transfer");
+    //runtime logs will be written to vine_example_peer_info/%Y-%m-%dT%H:%M:%S
+	vine_set_runtime_info_path("vine_example_peer_transfer_info");
 
 	m = vine_create(VINE_DEFAULT_PORT);
 	if(!m) {
 		printf("couldn't create manager: %s\n", strerror(errno));
 		return 1;
-	}	
+	}
 	printf("listening on port %d...\n", vine_port(m));
-	
+
 	if(argv[1] &&(strcmp(argv[1], "-peer") == 0)){
 		printf("Peer transfers enabled\n");
 		vine_enable_peer_transfers(m);

--- a/taskvine/src/examples/vine_example_peer_transfer.c
+++ b/taskvine/src/examples/vine_example_peer_transfer.c
@@ -41,6 +41,8 @@ int main(int argc, char *argv[])
 	struct vine_task *t;
 	int i;
 
+	vine_set_runtime_info_path("vine-runtime/vine_example_peer_transfer");
+
 	m = vine_create(VINE_DEFAULT_PORT);
 	if(!m) {
 		printf("couldn't create manager: %s\n", strerror(errno));
@@ -52,10 +54,8 @@ int main(int argc, char *argv[])
 		printf("Peer transfers enabled\n");
 		vine_enable_peer_transfers(m);
 		vine_tune(m, "file-source-max-transfers", 2);
-		vine_enable_transactions_log(m, "my.transactions.log");
 	}
 
-	vine_enable_debug_log(m,"manager.log");
 	vine_set_scheduler(m,VINE_SCHEDULE_FILES);
 
 	for(i=0;i<1000;i++) {

--- a/taskvine/src/examples/vine_example_tree_reduce.py
+++ b/taskvine/src/examples/vine_example_tree_reduce.py
@@ -22,7 +22,6 @@ if __name__ == "__main__":
         sys.exit(1)
     print("listening on port", m.port)
 
-    m.enable_debug_log("manager.log")
     m.set_scheduler(vine.VINE_SCHEDULE_FILES)
 
     print("reducing arrays...")

--- a/taskvine/src/examples/vine_example_unponcho_task.c
+++ b/taskvine/src/examples/vine_example_unponcho_task.c
@@ -22,6 +22,8 @@ int main(int argc, char *argv[])
 	struct vine_task *t;
 	int i;
 
+	vine_set_runtime_info_path("vine-runtime/vine_example_unponcho_task");
+
 	m = vine_create(VINE_DEFAULT_PORT);
 	if(!m) {
 		printf("couldn't create manager: %s\n", strerror(errno));
@@ -29,7 +31,6 @@ int main(int argc, char *argv[])
 	}
 	printf("listening on port %d...\n", vine_port(m));
 
-	vine_enable_debug_log(m,"manager.log");
 	vine_set_scheduler(m,VINE_SCHEDULE_FILES);
 	vine_set_name(m, "bslydelg_test");
 

--- a/taskvine/src/examples/vine_example_unponcho_task.c
+++ b/taskvine/src/examples/vine_example_unponcho_task.c
@@ -22,7 +22,8 @@ int main(int argc, char *argv[])
 	struct vine_task *t;
 	int i;
 
-	vine_set_runtime_info_path("vine-runtime/vine_example_unponcho_task");
+    //runtime logs will be written to vine_example_unponcho_task_info/%Y-%m-%dT%H:%M:%S
+	vine_set_runtime_info_path("vine_example_unponcho_task_info");
 
 	m = vine_create(VINE_DEFAULT_PORT);
 	if(!m) {

--- a/taskvine/src/examples/vine_example_unponcho_worker.c
+++ b/taskvine/src/examples/vine_example_unponcho_worker.c
@@ -22,6 +22,8 @@ int main(int argc, char *argv[])
 	struct vine_task *t;
 	int i;
 
+	vine_set_runtime_info_path("vine-runtime/vine_example_unponcho_worker");
+
 	m = vine_create(VINE_DEFAULT_PORT);
 	if(!m) {
 		printf("couldn't create manager: %s\n", strerror(errno));
@@ -29,7 +31,6 @@ int main(int argc, char *argv[])
 	}
 	printf("listening on port %d...\n", vine_port(m));
 
-	vine_enable_debug_log(m,"manager.log");
 	vine_set_scheduler(m,VINE_SCHEDULE_FILES);
 	vine_set_name(m, "bslydelg_test");
 

--- a/taskvine/src/examples/vine_example_unponcho_worker.c
+++ b/taskvine/src/examples/vine_example_unponcho_worker.c
@@ -22,7 +22,8 @@ int main(int argc, char *argv[])
 	struct vine_task *t;
 	int i;
 
-	vine_set_runtime_info_path("vine-runtime/vine_example_unponcho_worker");
+    //runtime logs will be written to vine_example_unponcho_worker_info/%Y-%m-%dT%H:%M:%S
+	vine_set_runtime_info_path("vine_example_unponcho_worker_info");
 
 	m = vine_create(VINE_DEFAULT_PORT);
 	if(!m) {

--- a/taskvine/src/examples/vine_example_watch.c
+++ b/taskvine/src/examples/vine_example_watch.c
@@ -34,14 +34,14 @@ int main(int argc, char *argv[])
 	struct vine_manager *m;
 	struct vine_task *t;
 
+	vine_set_runtime_info_path("vine-runtime/vine_example_watch");
+
 	m = vine_create(VINE_DEFAULT_PORT);
 	if(!m) {
 		printf("Couldn't create manager: %s\n", strerror(errno));
 		return 1;
 	}
 	printf("Listening on port %d...\n", vine_port(m));
-
-	vine_enable_debug_log(m,"manager.log");
 
 	int i;
 	for(i=0;i<10;i++) {

--- a/taskvine/src/examples/vine_example_watch.c
+++ b/taskvine/src/examples/vine_example_watch.c
@@ -34,7 +34,8 @@ int main(int argc, char *argv[])
 	struct vine_manager *m;
 	struct vine_task *t;
 
-	vine_set_runtime_info_path("vine-runtime/vine_example_watch");
+    //runtime logs will be written to vine_example_watch_info/%Y-%m-%dT%H:%M:%S
+	vine_set_runtime_info_path("vine_example_watch_info");
 
 	m = vine_create(VINE_DEFAULT_PORT);
 	if(!m) {

--- a/taskvine/src/examples/vine_example_watch.py
+++ b/taskvine/src/examples/vine_example_watch.py
@@ -30,9 +30,7 @@ if __name__ == "__main__":
         sys.exit(1)
     print("listening on port", m.port)
 
-    m.enable_debug_log("manager.log")
     n = 3
-
     for i in range(n):
         output = "output." + str(i)
         t = vine.Task("./vine_example_watch_trickle.sh > output")

--- a/taskvine/src/manager/Makefile
+++ b/taskvine/src/manager/Makefile
@@ -19,7 +19,8 @@ SOURCES = \
 	vine_factory_info.c \
 	vine_task_info.c \
 	vine_blocklist.c \
-	vine_current_transfers.c
+	vine_current_transfers.c \
+	vine_runtime_dir.c
 
 PUBLIC_HEADERS = taskvine.h taskvine_json.h
 

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -1073,26 +1073,6 @@ struct list * vine_tasks_cancel(struct vine_manager *m);
 */
 int vine_workers_shutdown(struct vine_manager *m, int n);
 
-/** Turn on the debugging log output and send to the named file.
-@param m A manager object
-@param logfile The filename.
-@return 1 if logfile was opened, 0 otherwise.
-*/
-int vine_enable_debug_log( struct vine_manager *m, const char *logfile );
-
-/** Add a performance log file that records cummulative statistics of the connected workers and submitted tasks.
-@param m A manager object
-@param logfile The filename.
-@return 1 if logfile was opened, 0 otherwise.
-*/
-int vine_enable_perf_log(struct vine_manager *m, const char *logfile);
-
-/** Add a log file that records the states of the connected workers and tasks.
-@param m A manager object
-@param logfile The filename.
-@return 1 if logfile was opened, 0 otherwise.
-*/
-int vine_enable_transactions_log(struct vine_manager *m, const char *logfile);
 
 /** Add a mandatory password that each worker must present.
 @param m A manager object

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -1190,6 +1190,11 @@ void vine_set_category_first_allocation_guess(struct vine_manager *m,  const cha
 */
 void vine_initialize_categories(struct vine_manager *m, struct rmsummary *max, const char *summaries_file);
 
+/** Sets the path where runtime info directories (logs and staging) are created.
+@param path A directory
+*/
+void vine_set_runtime_info_path(const char *path);
+
 
 //@}
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4745,8 +4745,7 @@ static void aggregate_workers_resources( struct vine_manager *q, struct vine_res
 }
 
 /* This simple wrapper function allows us to hide the debug.h interface from the end user. */
-
-int vine_enable_debug_log( struct vine_manager *m, const char *logfile )
+int vine_enable_debug_log( const char *logfile )
 {
 	debug_config("vine_manager");
 	debug_config_file(logfile);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -939,6 +939,7 @@ static char *monitor_file_name(struct vine_manager *q, struct vine_task *t, cons
 		dir = q->monitor_output_directory;
 	} else {
 		dir = vine_get_runtime_path_staging(q, NULL);
+		free_dir = 1;
 	}
 
 	char *name = string_format("%s/" RESOURCE_MONITOR_TASK_LOCAL_NAME "%s",

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -315,7 +315,7 @@ static int handle_cache_update( struct vine_manager *q, struct vine_worker_info 
 		remote_info->size = size;
 		remote_info->transfer_time = transfer_time;
 		remote_info->in_cache = 1;
-		
+
 		vine_current_transfers_remove(q, id);
 
 		vine_txn_log_write_cache_update(q,w,size,transfer_time,cachename);
@@ -3117,6 +3117,13 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 		return 0;
 	}
 
+	// set debug logfile as soon as possible need to manually use runtime_dir
+	// as the manager has not been created yet, but we would like to have debug
+	// information of its creation.
+	char *debug_tmp = string_format("%s/logs/debug", runtime_dir);
+	vine_enable_debug_log(debug_tmp);
+	free(debug_tmp);
+
 	q->manager_link = link_serve(port);
 	if(!q->manager_link) {
 		debug(D_NOTICE, "Could not create work_queue on port %i.", port);
@@ -3219,7 +3226,7 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 		}
 	}
 
-	vine_enable_perf_log(q, vine_get_runtime_path_log(q, "perfomance"));
+	vine_enable_perf_log(q, vine_get_runtime_path_log(q, "performance"));
 	vine_enable_transactions_log(q, vine_get_runtime_path_log(q, "transactions"));
 
 	vine_perf_log_write_update(q, 1);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3235,8 +3235,8 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 		}
 	}
 
-	vine_enable_perf_log(q, vine_get_runtime_path_log(q, "performance"));
-	vine_enable_transactions_log(q, vine_get_runtime_path_log(q, "transactions"));
+	vine_enable_perf_log(q, "performance");
+	vine_enable_transactions_log(q, "transactions");
 
 	vine_perf_log_write_update(q, 1);
 
@@ -3488,6 +3488,7 @@ void vine_delete(struct vine_manager *q)
 			debug(D_VINE, "unable to write transactions log: %s\n", strerror(errno));
 		}
 	}
+	free(q->runtime_directory);
 
 	rmsummary_delete(q->measured_local_resources);
 	rmsummary_delete(q->current_max_worker);
@@ -4777,7 +4778,10 @@ int vine_enable_debug_log( const char *logfile )
 
 int vine_enable_perf_log(struct vine_manager *q, const char *filename)
 {
-	q->perf_logfile = fopen(filename, "w");
+	char *logpath = vine_get_runtime_path_log(q, filename);
+	q->perf_logfile = fopen(logpath, "w");
+	free(logpath);
+
 	if(q->perf_logfile) {
 		vine_perf_log_write_header(q);
 		vine_perf_log_write_update(q,1);
@@ -4791,7 +4795,10 @@ int vine_enable_perf_log(struct vine_manager *q, const char *filename)
 
 int vine_enable_transactions_log(struct vine_manager *q, const char *filename)
 {
-	q->txn_logfile = fopen(filename, "w");
+	char *logpath = vine_get_runtime_path_log(q, filename);
+	q->txn_logfile = fopen(logpath, "w");
+	free(logpath);
+
 	if(q->txn_logfile) {
 		debug(D_VINE, "transactions log enabled and is being written to %s\n", filename);
 		vine_txn_log_write_header(q);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3506,7 +3506,7 @@ void vine_disable_monitoring(struct vine_manager *q) {
 	if(q->monitor_mode && q->monitor_summary_filename) {
 		fclose(q->monitor_file);
 
-		char template[] = "rmonitor-summaries-XXXXXX";
+		char *template = vine_get_runtime_path_log(q, "rmonitor-summaries.json");
 		int final_fd = mkstemp(template);
 		int summs_fd = open(q->monitor_summary_filename, O_RDONLY);
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -930,16 +930,24 @@ static void delete_uncacheable_files( struct vine_manager *q, struct vine_worker
 static char *monitor_file_name(struct vine_manager *q, struct vine_task *t, const char *ext) {
 	char *dir;
 
+	int free_dir = 0;
+
 	if(t->monitor_output_directory) {
 		dir = t->monitor_output_directory;
 	} else if(q->monitor_output_directory) {
 		dir = q->monitor_output_directory;
 	} else {
-		dir = "./";
+		dir = vine_get_runtime_path_staging(q, NULL);
 	}
 
-	return string_format("%s/" RESOURCE_MONITOR_TASK_LOCAL_NAME "%s",
+	char *name = string_format("%s/" RESOURCE_MONITOR_TASK_LOCAL_NAME "%s",
 			dir, getpid(), t->task_id, ext ? ext : "");
+
+	if(free_dir) {
+		free(dir);
+	}
+
+	return name;
 }
 
 /* Extract the resources consumed by a task by reading the appropriate resource monitor file. */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3130,7 +3130,7 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 	// set debug logfile as soon as possible need to manually use runtime_dir
 	// as the manager has not been created yet, but we would like to have debug
 	// information of its creation.
-	char *debug_tmp = string_format("%s/logs/debug", runtime_dir);
+	char *debug_tmp = string_format("%s/vine-logs/debug", runtime_dir);
 	vine_enable_debug_log(debug_tmp);
 	free(debug_tmp);
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3480,6 +3480,8 @@ void vine_delete(struct vine_manager *q)
 	rmsummary_delete(q->current_max_worker);
 	rmsummary_delete(q->max_task_resources_requested);
 
+	debug(D_VINE, "manager log end\n");
+
 	free(q);
 }
 

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -197,6 +197,29 @@ struct rmsummary *vine_manager_choose_resources_for_task( struct vine_manager *q
 
 int64_t overcommitted_resource_total(struct vine_manager *q, int64_t total);
 
+/** Turn on the debugging log output and send to the named file.
+ * (Note it does not need the vine_manager structure, as it is enabled before
+ * the manager is created.)
+@param logfile The filename.
+@return 1 if logfile was opened, 0 otherwise.
+*/
+int vine_enable_debug_log( const char *logfile );
+
+/** Add a performance log file that records cummulative statistics of the connected workers and submitted tasks.
+@param m A manager object
+@param logfile The filename.
+@return 1 if logfile was opened, 0 otherwise.
+*/
+int vine_enable_perf_log(struct vine_manager *m, const char *logfile);
+
+/** Add a log file that records the states of the connected workers and tasks.
+@param m A manager object
+@param logfile The filename.
+@return 1 if logfile was opened, 0 otherwise.
+*/
+int vine_enable_transactions_log(struct vine_manager *m, const char *logfile);
+
+
 /* The expected format of files created by the resource monitor.*/
 #define RESOURCE_MONITOR_TASK_LOCAL_NAME "vine-%d-task-%d"
 #define RESOURCE_MONITOR_REMOTE_NAME "cctools-monitor"

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -131,6 +131,7 @@ struct vine_manager {
 
 	/* Logging configuration. */
 
+    char *runtime_directory;
 	FILE *perf_logfile; /* Performance logfile for tracking metrics by time. */
 	FILE *txn_logfile;  /* Transaction logfile for recording every event of interest. */
 

--- a/taskvine/src/manager/vine_runtime_dir.c
+++ b/taskvine/src/manager/vine_runtime_dir.c
@@ -1,0 +1,89 @@
+/*
+Copyright (C) 2023- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include <stdlib.h>
+
+#include "taskvine.h"
+#include "vine_manager.h"
+#include "assert.h"
+#include "create_dir.h"
+#include "path.h"
+#include "stringtools.h"
+#include "xxmalloc.h"
+
+static char *vine_runtime_info_path = "vine-runtime";
+
+
+char *vine_runtime_directory_create() {
+    /* runtime directories are created at vine_runtime_info_path, which defaults
+     * to "vine-runtime" of the current working directory.
+     * Each workflow run has its own directory of the form: %Y-%m-%dT%H:%M:%S,
+     * but this can be changed with VINE_RUNTIME_INFO_DIR.
+     *
+     * If VINE_RUNTIME_INFO_DIR is not an absolute path, then it is
+     * interpreted as a suffix to vine_runtime_info_path.
+     *
+     * VINE_RUNTIME_INFO_DIR has the subdirectories: logs and staging
+     */
+
+	char *runtime_dir = NULL;
+	if(getenv("VINE_RUNTIME_INFO_DIR")) {
+		runtime_dir = xxstrdup(getenv("VINE_RUNTIME_INFO_DIR"));
+	} else {
+		char buf[20];
+		time_t now = time(NULL);
+		struct tm *tm_info = localtime(&now);
+		strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S", tm_info);
+		runtime_dir = xxstrdup(buf);
+	}
+
+	if(strncmp(runtime_dir, "/", 1)) {
+        char *tmp = path_concat(vine_runtime_info_path, runtime_dir);
+		free(runtime_dir);
+		runtime_dir = tmp;
+	}
+
+	setenv("VINE_RUNTIME_INFO_DIR", runtime_dir, 1);
+	if(!create_dir(runtime_dir, 755)) {
+        return NULL;
+    }
+
+	char pabs[PATH_MAX];
+	path_absolute(runtime_dir, pabs, 0);
+	free(runtime_dir);
+	runtime_dir = xxstrdup(pabs);
+
+	char *tmp = string_format("%s/logs", runtime_dir);
+	if(!create_dir(tmp, 755)) {
+        return NULL;
+    }
+	free(tmp);
+
+	tmp = string_format("%s/staging", runtime_dir);
+	if(!create_dir(tmp, 755)) {
+        return NULL;
+    }
+	free(tmp);
+
+    return runtime_dir;
+}
+
+char *vine_get_runtime_path_log(struct vine_manager *m, const char *path) {
+    return string_format("%s/logs/%s", m->runtime_directory, path ? path : "");
+}
+
+char *vine_get_path_runtime_staging(struct vine_manager *m, const char *path) {
+    return string_format("%s/staging/%s", m->runtime_directory, path ? path : "");
+}
+
+char *vine_runtime_path_staging(struct vine_manager *m, const char *path) {
+    return string_format("%s/staging/%s", m->runtime_directory, path ? path : "");
+}
+
+void vine_set_runtime_info_path(const char *path) {
+    assert(path);
+    vine_runtime_info_path = xxstrdup(path);
+}

--- a/taskvine/src/manager/vine_runtime_dir.c
+++ b/taskvine/src/manager/vine_runtime_dir.c
@@ -75,7 +75,7 @@ char *vine_get_runtime_path_log(struct vine_manager *m, const char *path) {
     return string_format("%s/logs/%s", m->runtime_directory, path ? path : "");
 }
 
-char *vine_get_path_runtime_staging(struct vine_manager *m, const char *path) {
+char *vine_get_runtime_path_staging(struct vine_manager *m, const char *path) {
     return string_format("%s/staging/%s", m->runtime_directory, path ? path : "");
 }
 

--- a/taskvine/src/manager/vine_runtime_dir.c
+++ b/taskvine/src/manager/vine_runtime_dir.c
@@ -91,7 +91,7 @@ char *vine_runtime_directory_create() {
 	free(runtime_dir);
 	runtime_dir = xxstrdup(pabs);
 
-	char *tmp = string_format("%s/logs", runtime_dir);
+	char *tmp = string_format("%s/vine-logs", runtime_dir);
 	if(!create_dir(tmp, 755)) {
         return NULL;
     }
@@ -108,7 +108,7 @@ char *vine_runtime_directory_create() {
 }
 
 char *vine_get_runtime_path_log(struct vine_manager *m, const char *path) {
-    return string_format("%s/logs/%s", m->runtime_directory, path ? path : "");
+    return string_format("%s/vine-logs/%s", m->runtime_directory, path ? path : "");
 }
 
 char *vine_get_runtime_path_staging(struct vine_manager *m, const char *path) {

--- a/taskvine/src/manager/vine_runtime_dir.c
+++ b/taskvine/src/manager/vine_runtime_dir.c
@@ -79,10 +79,6 @@ char *vine_get_path_runtime_staging(struct vine_manager *m, const char *path) {
     return string_format("%s/staging/%s", m->runtime_directory, path ? path : "");
 }
 
-char *vine_runtime_path_staging(struct vine_manager *m, const char *path) {
-    return string_format("%s/staging/%s", m->runtime_directory, path ? path : "");
-}
-
 void vine_set_runtime_info_path(const char *path) {
     assert(path);
     vine_runtime_info_path = xxstrdup(path);

--- a/taskvine/src/manager/vine_runtime_dir.c
+++ b/taskvine/src/manager/vine_runtime_dir.c
@@ -19,7 +19,7 @@ See the file COPYING for details.
 #include "unlink_recursive.h"
 #include "xxmalloc.h"
 
-static char *vine_runtime_info_path = "vine-runtime";
+static char *vine_runtime_info_path = "vine-run-info";
 
 static struct list *known_staging_dirs = NULL;
 
@@ -54,7 +54,7 @@ void register_staging_dir(const char *path) {
 
 char *vine_runtime_directory_create() {
     /* runtime directories are created at vine_runtime_info_path, which defaults
-     * to "vine-runtime" of the current working directory.
+     * to "vine-run-info" of the current working directory.
      * Each workflow run has its own directory of the form: %Y-%m-%dT%H:%M:%S,
      * but this can be changed with VINE_RUNTIME_INFO_DIR.
      *

--- a/taskvine/src/manager/vine_runtime_dir.h
+++ b/taskvine/src/manager/vine_runtime_dir.h
@@ -1,0 +1,28 @@
+/*
+Copyright (C) 2023- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include "vine_manager.h"
+
+/*
+This module creates the directory hierarchy for logs and staging files.
+This module is private to the manager and should not be invoked by the end user.
+*/
+
+#ifndef VINE_RUNTIME_DIR_H
+#define VINE_RUNTIME_DIR_H
+
+/* Create the runtime directory hierarchy.
+ * Return NULL on failure.
+ */
+char *vine_runtime_directory_create();
+
+/* Returns path relative to the logs runtime directory */
+char *vine_get_runtime_path_log(struct vine_manager *m, const char *path);
+
+/* Returns path relative to the staging runtime directory */
+char *vine_get_runtime_path_staging(struct vine_manager *m, const char *path);
+
+#endif

--- a/taskvine/src/tools/vine_benchmark.c
+++ b/taskvine/src/tools/vine_benchmark.c
@@ -6,7 +6,6 @@ See the file COPYING for details.
 
 #include "taskvine.h"
 
-#include "cctools.h"
 #include "debug.h"
 #include "cctools.h"
 #include "path.h"
@@ -132,8 +131,6 @@ void show_help( const char *cmd )
 	printf("-Z <file>  Write listening port to this file.\n");
 	printf("-p <port>  Listen on this port.\n");
 	printf("-N <name>  Advertise this project name.\n");
-	printf("-d <flag>  Enable debugging for this subsystem.\n");
-	printf("-o <file>  Send debugging output to this file.\n");
 	printf("-v         Show version information.\n");
 	printf("-h         Show this help screen.\n");
 }
@@ -146,14 +143,8 @@ int main(int argc, char *argv[])
 	int monitor_flag = 0;
 	int c;
 
-	while((c = getopt(argc, argv, "d:o:mN:p:Z:vh"))!=-1) {
+	while((c = getopt(argc, argv, "d:mN:p:Z:vh"))!=-1) {
 		switch (c) {
-		case 'd':
-			debug_flags_set(optarg);
-			break;
-		case 'o':
-			debug_config_file(optarg);
-			break;
 		case 'p':
 			port = atoi(optarg);
 			break;
@@ -180,7 +171,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-    vine_set_runtime_info_path("vine-runtime/vine_benchmark");
+    vine_set_runtime_info_path("vine_benchmark_info");
 
 	struct vine_manager *q = vine_create(port);
 	if(!q) fatal("couldn't listen on any port!");

--- a/taskvine/src/tools/vine_benchmark.c
+++ b/taskvine/src/tools/vine_benchmark.c
@@ -180,6 +180,8 @@ int main(int argc, char *argv[])
 		}
 	}
 
+    vine_set_runtime_info_path("vine-runtime/vine_benchmark");
+
 	struct vine_manager *q = vine_create(port);
 	if(!q) fatal("couldn't listen on any port!");
 
@@ -200,7 +202,6 @@ int main(int argc, char *argv[])
 		unlink_recursive("vine_benchmark_monitor");
 		vine_enable_monitoring(q, "vine_benchmark_monitorr", 1);
 		vine_set_category_mode(q, NULL, VINE_ALLOCATION_MODE_MAX_THROUGHPUT);
-		vine_enable_transactions_log(q, "vine_benchmark_monitor/transactions.log");
 	}
 
 

--- a/taskvine/test/TR_vine_allocations.sh
+++ b/taskvine/test/TR_vine_allocations.sh
@@ -56,7 +56,7 @@ clean()
 	rm -rf executable.file
 	rm -rf testdir
 
-	rm -rf vine-runtime
+	rm -rf vine-run-info
 
 	exit 0
 }

--- a/taskvine/test/TR_vine_allocations.sh
+++ b/taskvine/test/TR_vine_allocations.sh
@@ -56,6 +56,8 @@ clean()
 	rm -rf executable.file
 	rm -rf testdir
 
+	rm -rf vine-runtime
+
 	exit 0
 }
 

--- a/taskvine/test/TR_vine_python.sh
+++ b/taskvine/test/TR_vine_python.sh
@@ -55,10 +55,11 @@ run()
 	if [ $status -ne 0 ]
 	then
 		# display log files in case of failure.
-		if [ -f master.log  ]
+        logfile=$(latest_vine_debug_log)
+		if [ -f ${logfile}  ]
 		then
 			echo "master log:"
-			cat master.log
+            cat ${logfile}
 		fi
 
 		if [ -f worker.log  ]
@@ -83,6 +84,8 @@ clean()
 	rm -rf executable.file
 	rm -rf testdir
 	rm -rf dummy.tar.gz
+
+	rm -rf vine-runtime
 
 	exit 0
 }

--- a/taskvine/test/TR_vine_python.sh
+++ b/taskvine/test/TR_vine_python.sh
@@ -85,7 +85,7 @@ clean()
 	rm -rf testdir
 	rm -rf dummy.tar.gz
 
-	rm -rf vine-runtime
+	rm -rf vine-run-info
 
 	exit 0
 }

--- a/taskvine/test/TR_vine_python_task.sh
+++ b/taskvine/test/TR_vine_python_task.sh
@@ -55,7 +55,7 @@ clean()
 	rm -f $STATUS_FILE
 	rm -f $PORT_FILE
 
-	rm -rf vine-runtime
+	rm -rf vine-run-info
 
 	exit 0
 }

--- a/taskvine/test/TR_vine_python_task.sh
+++ b/taskvine/test/TR_vine_python_task.sh
@@ -55,6 +55,8 @@ clean()
 	rm -f $STATUS_FILE
 	rm -f $PORT_FILE
 
+	rm -rf vine-runtime
+
 	exit 0
 }
 

--- a/taskvine/test/TR_vine_ssl.sh
+++ b/taskvine/test/TR_vine_ssl.sh
@@ -83,6 +83,8 @@ clean()
 	rm -rf testdir
 	rm -rf dummy.tar.gz
 
+	rm -rf vine-runtime
+
 	exit 0
 }
 

--- a/taskvine/test/TR_vine_ssl.sh
+++ b/taskvine/test/TR_vine_ssl.sh
@@ -83,7 +83,7 @@ clean()
 	rm -rf testdir
 	rm -rf dummy.tar.gz
 
-	rm -rf vine-runtime
+	rm -rf vine-run-info
 
 	exit 0
 }

--- a/taskvine/test/TR_vine_tag.sh
+++ b/taskvine/test/TR_vine_tag.sh
@@ -53,7 +53,7 @@ clean()
 	rm -f $STATUS_FILE
 	rm -f $PORT_FILE
 
-	rm -rf vine-runtime
+	rm -rf vine-run-info
 
 	exit 0
 }

--- a/taskvine/test/TR_vine_tag.sh
+++ b/taskvine/test/TR_vine_tag.sh
@@ -52,7 +52,8 @@ clean()
 {
 	rm -f $STATUS_FILE
 	rm -f $PORT_FILE
-	rm -f debug.log
+
+	rm -rf vine-runtime
 
 	exit 0
 }

--- a/taskvine/test/TR_vine_valgrind.sh
+++ b/taskvine/test/TR_vine_valgrind.sh
@@ -67,7 +67,7 @@ EOF
 
 clean()
 {
-	rm -f manager.script vine-run-info manager.port manager.exitcode manager.valgrind worker.log worker.exitcode worker.valgrind output.* input.*
+	rm -f manager.script vine_benchmark_info manager.port manager.exitcode manager.valgrind worker.log worker.exitcode worker.valgrind output.* input.*
 }
 
 dispatch "$@"

--- a/taskvine/test/TR_vine_valgrind.sh
+++ b/taskvine/test/TR_vine_valgrind.sh
@@ -31,7 +31,7 @@ quit
 EOF
 
 	echo "starting manager"
-	(${VALGRIND} --log-file=manager.valgrind -- vine_benchmark -d all -o manager.log -Z manager.port < manager.script; echo $? > manager.exitcode ) &
+	(${VALGRIND} --log-file=manager.valgrind -- vine_benchmark -Z manager.port < manager.script; echo $? > manager.exitcode ) &
 
 	echo "waiting for manager to get ready"
 	wait_for_file_creation manager.port 15
@@ -67,7 +67,7 @@ EOF
 
 clean()
 {
-	rm -f manager.script manager.log manager.port manager.exitcode manager.valgrind worker.log worker.exitcode worker.valgrind output.* input.*
+	rm -f manager.script vine-runtime manager.port manager.exitcode manager.valgrind worker.log worker.exitcode worker.valgrind output.* input.*
 }
 
 dispatch "$@"

--- a/taskvine/test/TR_vine_valgrind.sh
+++ b/taskvine/test/TR_vine_valgrind.sh
@@ -67,7 +67,7 @@ EOF
 
 clean()
 {
-	rm -f manager.script vine-runtime manager.port manager.exitcode manager.valgrind worker.log worker.exitcode worker.valgrind output.* input.*
+	rm -f manager.script vine-run-info manager.port manager.exitcode manager.valgrind worker.log worker.exitcode worker.valgrind output.* input.*
 }
 
 dispatch "$@"

--- a/taskvine/test/TR_vine_valgrind.sh
+++ b/taskvine/test/TR_vine_valgrind.sh
@@ -6,7 +6,7 @@ export PATH=../src/tools:../src/worker:$PATH
 
 export CORES=4
 export TASKS=20
-export VALGRIND="valgrind --error-exitcode=1 --leak-check=full"
+export VALGRIND="valgrind --error-exitcode=1 --leak-check=full --show-leak-kinds=all"
 
 check_needed()
 {

--- a/taskvine/test/vine_alloc_test.py
+++ b/taskvine/test/vine_alloc_test.py
@@ -59,7 +59,6 @@ worker.gpus=worker_gpus
 worker.debug="all"
 worker.debug_file="factory.log"
 
-
 with worker:
     r = {'cores': 1, 'memory': 2, 'disk': 3, 'gpus': 4}
     check_task('all_specified', vine.VINE_ALLOCATION_MODE_FIXED, max = r, min = {}, expected = r)

--- a/taskvine/test/vine_common.sh
+++ b/taskvine/test/vine_common.sh
@@ -18,7 +18,7 @@ quit
 EOF
 
 	echo "starting master"
-	vine_benchmark -d all -o master.log -Z master.port < master.script &
+	vine_benchmark -Z master.port < master.script &
 
 	echo "waiting for master to get ready"
 	wait_for_file_creation master.port 5
@@ -26,7 +26,7 @@ EOF
 	port=`cat master.port`
 
 	echo "starting worker"
-	vine_worker -d all -o worker.log localhost $port -b 1 --timeout 20 --cores $CORES --memory-threshold 10 --memory 50 --single-shot
+	vine_worker -o worker.log localhost $port -b 1 --timeout 20 --cores $CORES --memory-threshold 10 --memory 50 --single-shot
 
 	echo "checking for output"
 	i=0
@@ -37,10 +37,11 @@ EOF
 		then
 			echo "$file is missing!"
 
-			if [ -f master.log  ]
+			logfile=$(latest_vine_debug_log)
+			if [ -f ${logfile}  ]
 			then
 				echo "master log:"
-				cat master.log
+				cat ${logfile}
 			fi
 
 			if [ -f worker.log  ]
@@ -60,7 +61,7 @@ EOF
 
 clean()
 {
-	rm -f master.script master.log master.port worker.log output.* input.*
+	rm -f master.script vine-runtime master.port worker.log output.* input.*
 }
 
 dispatch "$@"

--- a/taskvine/test/vine_common.sh
+++ b/taskvine/test/vine_common.sh
@@ -61,7 +61,7 @@ EOF
 
 clean()
 {
-	rm -f master.script vine-run-info master.port worker.log output.* input.*
+	rm -rf master.script vine-run-info vine_benchmark_info master.port worker.log output.* input.*
 }
 
 dispatch "$@"

--- a/taskvine/test/vine_common.sh
+++ b/taskvine/test/vine_common.sh
@@ -61,7 +61,7 @@ EOF
 
 clean()
 {
-	rm -f master.script vine-runtime master.port worker.log output.* input.*
+	rm -f master.script vine-run-info master.port worker.log output.* input.*
 }
 
 dispatch "$@"

--- a/taskvine/test/vine_test.py
+++ b/taskvine/test/vine_test.py
@@ -77,7 +77,7 @@ if __name__ == '__main__':
     os.chmod(path.join(test_dir, exec_file), stat.S_IRWXU)
 
 
-    q = vine.Manager(port=0, ssl=(args.ssl_key, args.ssl_cert), debug_log="manager.log")
+    q = vine.Manager(port=0, ssl=(args.ssl_key, args.ssl_cert))
 
     with open(args.port_file, 'w') as f:
         print('Writing port {port} to file {file}'.format(port=q.port, file=args.port_file))

--- a/taskvine/test/vine_test_tag.py
+++ b/taskvine/test/vine_test_tag.py
@@ -17,7 +17,7 @@ desired_tag_order = "7 5 9 6 3 8 2 1".split()
 alpha_order = sorted(desired_tag_order)
 done_order = []
 
-q = vine.Manager(port=0, debug_log='debug.log')
+q = vine.Manager(port=0)
 with open(port_file, 'w') as f:
     print('Writing port {port} to file {file}'.format(port=q.port, file=port_file))
     f.write(str(q.port))


### PR DESCRIPTION
By default, logs and staging files are written to:

```C
"vine-run-info/%Y-%m-%dT%H:%M:%S/logs/{debug,performance,transactions}"
"vine-run-info/%Y-%m-%dT%H:%M:%S/staging"
```

The prefix can be changed with:

```C
vine_set_runtime_info_path(path);   // where path is "vine-run-info" by default 
```

If the env variable `VINE_RUNTIME_INFO_DIR` is set, then logs and staging are written to that directory.

Logs are enabled by default and can't be disabled or renamed. The only aspect that can change is where they are written to (as above).


I added `Task.submit_finalize` to python, which is called by the manager in `submit` before the task is really submitted. This allows the task to know the staging directory of the manager and do the serialization of its files correctly.

The global staging directory in python was removed. Tasks use the one from their manager, and factories use one per factory.