### PR TITLE
Add start, and end time to transactions log

### DIFF
--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -72,6 +72,9 @@ struct vine_task {
 
 	timestamp_t time_when_retrieval;    /**< The time when output files start to be transfered back to the manager. time_done - time_when_retrieval is the time taken to transfer output files. */
 
+    timestamp_t time_workers_execute_last_start;           /**< The time when the last complete execution for this task started at a worker. */
+    timestamp_t time_workers_execute_last_end;             /**< The time when the last complete execution for this task ended at a worker. */
+
 	timestamp_t time_workers_execute_last;                 /**< Duration of the last complete execution for this task. */
 	timestamp_t time_workers_execute_all;                  /**< Accumulated time for executing the command on any worker, regardless of whether the task completed (i.e., this includes time running on workers that disconnected). */
 	timestamp_t time_workers_execute_exhaustion;           /**< Accumulated time spent in attempts that exhausted resources. */

--- a/taskvine/src/manager/vine_txn_log.c
+++ b/taskvine/src/manager/vine_txn_log.c
@@ -19,6 +19,7 @@ See the file COPYING for details.
 
 #include <stdio.h>
 #include <unistd.h>
+#include <assert.h>
 
 void vine_txn_log_write(struct vine_manager *q, const char *str)
 {
@@ -75,31 +76,27 @@ void vine_txn_log_write_task(struct vine_manager *q, struct vine_task *t)
 		buffer_printf(&B, " %s ", vine_result_string(t->result));
 		buffer_printf(&B, " %d ", t->exit_code);
 
-		if(t->resources_measured) {
-			if(t->result == VINE_RESULT_RESOURCE_EXHAUSTION) {
-				rmsummary_print_buffer(&B, t->resources_measured->limits_exceeded, 1);
-				buffer_printf(&B, " ");
-			}
-			else {
-				// no limits broken, thus printing an empty dictionary
-				buffer_printf(&B, " {} ");
-			}
+        assert(t->resources_measured);
+        if(t->result == VINE_RESULT_RESOURCE_EXHAUSTION) {
+            rmsummary_print_buffer(&B, t->resources_measured->limits_exceeded, 1);
+            buffer_printf(&B, " ");
+        }
+        else {
+            // no limits broken, thus printing an empty dictionary
+            buffer_printf(&B, " {} ");
+        }
 
-			struct jx *m = rmsummary_to_json(t->resources_measured, /* only resources */ 1);
-			jx_insert(m, jx_string("size_input_mgr"), jx_arrayv(jx_double(t->bytes_sent/((double) MEGABYTE)), jx_string("MB"), NULL));
-			jx_insert(m, jx_string("size_output_mgr"), jx_arrayv(jx_double(t->bytes_received/((double) MEGABYTE)), jx_string("MB"), NULL));
+        struct jx *m = rmsummary_to_json(t->resources_measured, /* only resources */ 1);
+        jx_insert(m, jx_string("size_input_mgr"), jx_arrayv(jx_double(t->bytes_sent/((double) MEGABYTE)), jx_string("MB"), NULL));
+        jx_insert(m, jx_string("size_output_mgr"), jx_arrayv(jx_double(t->bytes_received/((double) MEGABYTE)), jx_string("MB"), NULL));
 
-			jx_insert(m, jx_string("time_input_mgr"), jx_arrayv(jx_double((t->time_when_commit_end - t->time_when_commit_start)/((double) ONE_SECOND)), jx_string("s"), NULL));
-			jx_insert(m, jx_string("time_output_mgr"), jx_arrayv(jx_double((t->time_when_done - t->time_when_retrieval)/((double) ONE_SECOND)), jx_string("s"), NULL));
+        jx_insert(m, jx_string("time_input_mgr"), jx_arrayv(jx_double((t->time_when_commit_end - t->time_when_commit_start)/((double) ONE_SECOND)), jx_string("s"), NULL));
+        jx_insert(m, jx_string("time_output_mgr"), jx_arrayv(jx_double((t->time_when_done - t->time_when_retrieval)/((double) ONE_SECOND)), jx_string("s"), NULL));
 
-			jx_insert(m, jx_string("time_worker_start"), jx_arrayv(jx_double(t->time_workers_execute_last_start/((double) ONE_SECOND)), jx_string("s"), NULL));
-			jx_insert(m, jx_string("time_worker_end"), jx_arrayv(jx_double(t->time_workers_execute_last_end/((double) ONE_SECOND)), jx_string("s"), NULL));
-			jx_print_buffer(m, &B);
-			jx_delete(m);
-		} else {
-			// no resources measured, one empty dictionary for limits broken, other for resources.
-			buffer_printf(&B, " {} {}");
-		}
+        jx_insert(m, jx_string("time_worker_start"), jx_arrayv(jx_double(t->time_workers_execute_last_start/((double) ONE_SECOND)), jx_string("s"), NULL));
+        jx_insert(m, jx_string("time_worker_end"), jx_arrayv(jx_double(t->time_workers_execute_last_end/((double) ONE_SECOND)), jx_string("s"), NULL));
+        jx_print_buffer(m, &B);
+        jx_delete(m);
 	} else {
 		struct vine_worker_info *w = t->worker;
 		if(w) {

--- a/taskvine/src/manager/vine_txn_log.c
+++ b/taskvine/src/manager/vine_txn_log.c
@@ -86,10 +86,14 @@ void vine_txn_log_write_task(struct vine_manager *q, struct vine_task *t)
 			}
 
 			struct jx *m = rmsummary_to_json(t->resources_measured, /* only resources */ 1);
-			jx_insert(m, jx_string("vine_input_size"), jx_arrayv(jx_double(t->bytes_sent/((double) MEGABYTE)), jx_string("MB"), NULL));
-			jx_insert(m, jx_string("vine_output_size"), jx_arrayv(jx_double(t->bytes_received/((double) MEGABYTE)), jx_string("MB"), NULL));
-			jx_insert(m, jx_string("vine_input_time"), jx_arrayv(jx_double((t->time_when_commit_end - t->time_when_commit_start)/((double) ONE_SECOND)), jx_string("s"), NULL));
-			jx_insert(m, jx_string("vine_output_time"), jx_arrayv(jx_double((t->time_when_done - t->time_when_retrieval)/((double) ONE_SECOND)), jx_string("s"), NULL));
+			jx_insert(m, jx_string("size_input_mgr"), jx_arrayv(jx_double(t->bytes_sent/((double) MEGABYTE)), jx_string("MB"), NULL));
+			jx_insert(m, jx_string("size_output_mgr"), jx_arrayv(jx_double(t->bytes_received/((double) MEGABYTE)), jx_string("MB"), NULL));
+
+			jx_insert(m, jx_string("time_input_mgr"), jx_arrayv(jx_double((t->time_when_commit_end - t->time_when_commit_start)/((double) ONE_SECOND)), jx_string("s"), NULL));
+			jx_insert(m, jx_string("time_output_mgr"), jx_arrayv(jx_double((t->time_when_done - t->time_when_retrieval)/((double) ONE_SECOND)), jx_string("s"), NULL));
+
+			jx_insert(m, jx_string("time_worker_start"), jx_arrayv(jx_double(t->time_workers_execute_last_start/((double) ONE_SECOND)), jx_string("s"), NULL));
+			jx_insert(m, jx_string("time_worker_end"), jx_arrayv(jx_double(t->time_workers_execute_last_end/((double) ONE_SECOND)), jx_string("s"), NULL));
 			jx_print_buffer(m, &B);
 			jx_delete(m);
 		} else {

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -572,7 +572,7 @@ static void report_task_complete( struct link *manager, struct vine_process *p )
 	fstat(p->output_fd, &st);
 	output_length = st.st_size;
 	lseek(p->output_fd, 0, SEEK_SET);
-	send_message(manager, "result %d %d %lld %llu %d\n", p->result, p->exit_code, (long long) output_length, (unsigned long long) p->execution_end-p->execution_start, p->task->task_id);
+	send_message(manager, "result %d %d %lld %llu %llu %d\n", p->result, p->exit_code, (long long) output_length, (unsigned long long) p->execution_start, (unsigned long long) p->execution_end, p->task->task_id);
 	link_stream_from_fd(manager, p->output_fd, output_length, time(0)+active_timeout);
 
 	total_task_execution_time += (p->execution_end - p->execution_start);


### PR DESCRIPTION
For #3102.

The "result ..." message was modified to include start and end times.

@BarrySlyDelgado `time_worker_start` and `time_worker_end` will appear in the dictionary `measured` of the plotting tool.