### PR TITLE
deltadb: avoid strcpy line overlap

### DIFF
--- a/deltadb/src/deltadb.c
+++ b/deltadb/src/deltadb.c
@@ -409,7 +409,7 @@ static int log_replay( struct deltadb *db, const char *filename, time_t snapshot
 
 					/* Now process the remainder of the line as a new command. */
 					int position = strlen(key) + strlen(name) + 2;
-					strcpy(line,&line[position]);
+					line = &line[position];
 					goto reconsider;
 				} else {
 					/* Invalid type: the line is totally corrupted. */


### PR DESCRIPTION
Compiler used in conda-forge complained that strcpy src and dest may overlap. As far as I can tell, the strcpy is unnecessary as we can simply move the pointer of the start of the string (line is a pointer to whole_line).