### PR TITLE
Vine: Enable coprocess to start with poncho_package_run

### DIFF
--- a/taskvine/src/worker/vine_coprocess.c
+++ b/taskvine/src/worker/vine_coprocess.c
@@ -170,7 +170,7 @@ int vine_coprocess_start(struct vine_coprocess *coprocess, char *sandbox) {
             fatal("coprocess could not attach pipe to stdout: %s\n", strerror(errno));
         }
 		setpgid(0, 0);
-        execlp(coprocess->command, coprocess->command, (char *) 0);
+        execl("/bin/sh", "sh", "-c", coprocess->command, (char *) 0);
         fatal("failed to execute %s: %s\n", coprocess->command, strerror(errno));
 	}
     else {


### PR DESCRIPTION
Change from directly executing the coprocess command to having sh run the command as an argument. This allows the extra flexibly in the duty task to have poncho_package_run added to it.