### PR TITLE
poncho_package_create: fallback to $CONDA_EXE

### DIFF
--- a/doc/man/m4/poncho_package_create.m4
+++ b/doc/man/m4/poncho_package_create.m4
@@ -7,7 +7,6 @@ BOLD(poncho_package_create) - command-line utility for creating a Conda virtual 
 SECTION(SYNOPSIS)
 
 CODE(poncho_package_create [options] PARAM(dependency-file) PARAM(PARAM(output-path)))
-CODE(poncho_package_create [options] PARAM(dependency-file) PARAM(PARAM(output-path)))
 
 SECTION(DESCRIPTION)
 
@@ -19,7 +18,9 @@ The CODE(dependency-file) argument is the path (relative or absolute) to the a J
 
 SECTION(OPTIONS)
 OPTIONS_BEGIN
-OPTION_FLAG_SHORT(h)        Show this help message
+OPTION_ARG_LONG(conda-executable, path) Location of conda executable to use. If not given, mamba, $CONDA_EXE, conda, and microconda are tried, in that order.
+OPTION_FLAG_LONG(no-microconda) Do not try to download microconda if a conda executable is not found.
+OPTION_FLAG(h, help)               Show the help message.
 OPTIONS_END
 SECTION(EXIT STATUS)
 
@@ -27,7 +28,7 @@ On success, returns zero. On failure, returns non-zero.
 
 SECTION(EXAMPLE)
 
-CODE($ poncho_package_create dependencies.json example_venv.tar.gz)
+CODE(poncho_package_create dependencies.json example_venv.tar.gz)
 
 This will create an example_venv.tar.gz environment tarball within the current working directory, which can then be exported to different machines for execution.
 

--- a/doc/man/md/poncho_package_create.md
+++ b/doc/man/md/poncho_package_create.md
@@ -29,7 +29,6 @@
 ## SYNOPSIS
 
 **poncho_package_create [options] _&lt;dependency-file&gt;_ _&lt;_&lt;output-path&gt;_&gt;_**
-**poncho_package_create [options] _&lt;dependency-file&gt;_ _&lt;_&lt;output-path&gt;_&gt;_**
 
 ## DESCRIPTION
 
@@ -41,7 +40,9 @@ The **dependency-file** argument is the path (relative or absolute) to the a JSO
 
 ## OPTIONS
 
-- **-h**<br />        Show this help message
+- **--conda-executable=_&lt;path&gt;_**<br /> Location of conda executable to use. If not given, mamba, $CONDA_EXE, conda, and microconda are tried, in that order.
+- **--no-microconda**<br /> Do not try to download microconda if a conda executable is not found.
+- **-h**,**--help**<br />               Show the help message.
 
 ## EXIT STATUS
 
@@ -49,7 +50,7 @@ On success, returns zero. On failure, returns non-zero.
 
 ## EXAMPLE
 
-**$ poncho_package_create dependencies.json example_venv.tar.gz**
+**poncho_package_create dependencies.json example_venv.tar.gz**
 
 This will create an example_venv.tar.gz environment tarball within the current working directory, which can then be exported to different machines for execution.
 

--- a/poncho/src/poncho_package_create
+++ b/poncho/src/poncho_package_create
@@ -5,7 +5,9 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Create a packed environment from a spec.')
     parser.add_argument('spec', help='Read in a spec file, or - for stdin.')
     parser.add_argument('output', help='Write output from conda-pack to the given file.')
-    parser.add_argument('-m', action='store_true', help='Uses mamba instead of conda')
+    parser.add_argument('--conda-executable', action='store_true', help='Path to conda executable to use. Default are, in this order: mamba, $CONDA_EXE, conda')
+
+    parser.add_argument('--no-micromamba', action='store_true', help='Do not try no download micromamba if a conda executable is not found.')
 
     args = parser.parse_args()
-    create.pack_env(args.spec, output=args.output, mamba=args.m)
+    create.pack_env(args.spec, args.output, args.conda_executable, not args.no_micromamba)


### PR DESCRIPTION
conda installation uses shell functions to wrap its commands. These functions are not available when using subprocesses inside python.

This commit makes it so that mamba, micromamba, $CONDA_EXE, and conda are prefered, in that order.

It also automatically installs micromamba without the need to use the --mamba switch. This can be prevented with --no-micromamba