### PR TITLE
Vine: Cleanup Debug Output

### DIFF
--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -53,8 +53,6 @@ struct vine_file *vine_file_create(const char *source, const char *cached_name, 
 		f->cached_name = vine_cached_name(f);
 	}
 
-	debug(D_VINE,"cached name: %s\n",f->cached_name);
-
 	f->refcount = 1;
 
 	return f;

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -314,7 +314,7 @@ static int handle_cache_update( struct vine_manager *q, struct vine_worker_info 
 			- The worker is telling us about an item from a previous run.
 			- The file was created as an output of a task.
 			*/
-			remote_info = vine_remote_file_info_create(size,time(0));
+			remote_info = vine_remote_file_info_create(size,0);
 			hash_table_insert(w->current_files,cachename,remote_info);
 		}
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -310,8 +310,9 @@ static int handle_cache_update( struct vine_manager *q, struct vine_worker_info 
 
 		if(!remote_info) {
 			/*
-			If an unsolicited cache-update arrives, then the worker
-			is telling us about something from a previous run.
+			If an unsolicited cache-update arrives, there are several possibilities:
+			- The worker is telling us about an item from a previous run.
+			- The file was created as an output of a task.
 			*/
 			remote_info = vine_remote_file_info_create(size,time(0));
 			hash_table_insert(w->current_files,cachename,remote_info);

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -342,8 +342,7 @@ static vine_result_code_t vine_manager_put_input_file_if_not_cached(struct vine_
 		vine_task_set_result(t, VINE_RESULT_INPUT_MISSING);
 		if(f->type==VINE_URL) t->exit_code = 1;
 		return VINE_APP_FAILURE;
-
-	} else{
+	} else {
 		/* Any other type, just record dummy values for size and time, until we know better. */
 		info.st_size = f->length;
 		info.st_mtime = time(0);
@@ -360,11 +359,12 @@ static vine_result_code_t vine_manager_put_input_file_if_not_cached(struct vine_
 	cache-update messages.
 	*/
 	
-	if(remote_info && f->type==VINE_FILE) {
-		if(info.st_size!=remote_info->size || ((info.st_mtime!=remote_info->mtime) && (remote_info->mtime!=0))) {
+	if(remote_info) {
+		if(f->type==VINE_FILE && (info.st_size!=remote_info->size || ((info.st_mtime!=remote_info->mtime) && (remote_info->mtime!=0)))) {
 			debug(D_NOTICE|D_VINE,"File %s has changed since it was first cached!",f->source);
 			debug(D_NOTICE|D_VINE,"You may be getting inconsistent results.");
 		}
+		/* If the file is already cached, don't send it. */
 		return VINE_SUCCESS;
 	}
 

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -352,9 +352,16 @@ static vine_result_code_t vine_manager_put_input_file_if_not_cached(struct vine_
 	/* Has this file already been sent and cached? */
 	struct vine_remote_file_info *remote_info = hash_table_lookup(w->current_files,f->cached_name);
 
-	/* If so, check that it hasn't changed, and return success. */
-	if(remote_info) {
-		if(f->type==VINE_FILE && (info.st_size!=remote_info->size || info.st_mtime!=remote_info->mtime)) {
+	/*
+	If so, check that it hasn't changed, and return success.
+	XXX The mtime might not be set (0) if the file was cached
+	from a previous session.  This would work better if the
+	mtime was sent in file transfers, and then returned by
+	cache-update messages.
+	*/
+	
+	if(remote_info && f->type==VINE_FILE) {
+		if(info.st_size!=remote_info->size || ((info.st_mtime!=remote_info->mtime) && (remote_info->mtime!=0))) {
 			debug(D_NOTICE|D_VINE,"File %s has changed since it was first cached!",f->source);
 			debug(D_NOTICE|D_VINE,"You may be getting inconsistent results.");
 		}

--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -379,7 +379,7 @@ int vine_cache_ensure( struct vine_cache *c, const char *cachename, struct link 
 	}
 
 	if(f->complete) {
-		debug(D_VINE,"cache: %s is already present.",cachename);
+		/* File is already present in the cache. */
 		return 1;
 	}
 

--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -111,13 +111,14 @@ void vine_cache_load(struct vine_cache *c)
 /*
 send cache updates to manager from existing cache_directory 
 */
-void vine_init_update(struct vine_cache *c, struct link *manager)
+
+void vine_cache_scan(struct vine_cache *c, struct link *manager)
 {
 	struct cache_file *f;
 	char * cachename;
 	HASH_TABLE_ITERATE(c->table, cachename, f){
-		timestamp_t transfer_time = timestamp_get();
-		vine_worker_send_cache_update(manager,cachename,f->actual_size,transfer_time);
+		/* XXX the worker doesn't know how long it took to transfer. */
+		vine_worker_send_cache_update(manager,cachename,f->actual_size,0);
 	}
 }
 

--- a/taskvine/src/worker/vine_cache.h
+++ b/taskvine/src/worker/vine_cache.h
@@ -32,7 +32,7 @@ typedef enum {
 struct vine_cache * vine_cache_create( const char *cachedir );
 void vine_cache_delete( struct vine_cache *c );
 void vine_cache_load( struct vine_cache *c );
-void vine_init_update(struct vine_cache *c, struct link *manager);
+void vine_cache_scan( struct vine_cache *c, struct link *manager );
 
 char *vine_cache_full_path( struct vine_cache *c, const char *cachename );
 

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -471,7 +471,7 @@ static void report_worker_ready( struct link *manager )
 	domain_name_cache_guess(hostname);
 	send_message(manager,"taskvine %d %s %s %s %d.%d.%d\n",VINE_PROTOCOL_VERSION,hostname,os_name,arch_name,CCTOOLS_VERSION_MAJOR,CCTOOLS_VERSION_MINOR,CCTOOLS_VERSION_MICRO);
 	send_message(manager, "info worker-id %s\n", worker_id);
-	vine_init_update(global_cache, manager);
+	vine_cache_scan(global_cache, manager);
 
 	send_features(manager);
 	send_transfer_address(manager);


### PR DESCRIPTION
- Fixed incorrect warning about local files changing while in use.
- Fixed several cases of cache-update and remote-info fields set incorrectly. (Use zero for don't-know instead of assuming current time.)
- Fixed up some duplicate debug output.
