### PR TITLE
Vine: Reorganized Use of MD5

### DIFF
--- a/chirp/src/chirp_reli.h
+++ b/chirp/src/chirp_reli.h
@@ -628,14 +628,14 @@ INT64_T chirp_reli_hash(const char *host, const char *path, const char *algorith
 /** Checksum a remote file. (DEPRECATED: use @ref chirp_reli_hash)
 This MD5 checksum is performed remotely by the file server, so it is much more
 efficient than computing one by invoking a local command.  Note that the data
-is returned in <b>binary</b> digest form.  Use @ref md5_string to convert the
+is returned in <b>binary</b> digest form.  Use @ref md5_to_string to convert the
 digest into a human readable form.
 @param host The name and port of the Chirp server to access.
 @param path The pathname of the file to access.
 @param digest The buffer to place the binary checksum digest.
 @param stoptime The absolute time at which to abort.
 @return On success, returns length of digest.  On failure, returns less than zero and sets errno.
-@see md5_string
+@see md5_to_string
 */
 
 INT64_T chirp_reli_md5(const char *host, const char *path, unsigned char digest[CHIRP_DIGEST_MAX], time_t stoptime);

--- a/chirp/src/chirp_ticket.c
+++ b/chirp/src/chirp_ticket.c
@@ -177,8 +177,8 @@ void chirp_ticket_name(const char *pk, char *ticket_subject, char *ticket_filena
 	md5_init(&context);
 	md5_update(&context, (const unsigned char *) pk, strlen(pk));
 	md5_final(digest, &context);
-	sprintf(ticket_subject, TICKET_SUBJECT_FORMAT, md5_string(digest));
-	sprintf(ticket_filename, "/" TICKET_FILENAME_FORMAT, md5_string(digest));
+	sprintf(ticket_subject, TICKET_SUBJECT_FORMAT, md5_to_string(digest));
+	sprintf(ticket_filename, "/" TICKET_FILENAME_FORMAT, md5_to_string(digest));
 }
 
 void chirp_ticket_filename(char *ticket_filename, const char *ticket_subject, const char *digest)
@@ -232,7 +232,7 @@ const char *chirp_ticket_digest(const char *pk)
 	md5_init(&context);
 	md5_update(&context, (const unsigned char *) pk, strlen(pk));
 	md5_final(digest, &context);
-	return md5_string(digest);	/* static memory */
+	return md5_to_string(digest);	/* static memory */
 }
 
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/file_cache.c
+++ b/dttools/src/file_cache.c
@@ -41,7 +41,7 @@ static void cached_name(struct file_cache *c, const char *path, char *lpath)
 {
 	unsigned char digest[MD5_DIGEST_LENGTH];
 	md5_buffer(path, strlen(path), digest);
-	sprintf(lpath, "%s/%02x/%s", c->root, digest[0], md5_string(digest));
+	sprintf(lpath, "%s/%02x/%s", c->root, digest[0], md5_to_string(digest));
 }
 
 static void txn_name(struct file_cache *c, const char *path, char *txn)
@@ -50,7 +50,7 @@ static void txn_name(struct file_cache *c, const char *path, char *txn)
 	char shortname[DOMAIN_NAME_MAX];
 	domain_name_cache_guess_short(shortname);
 	md5_buffer(path, strlen(path), digest);
-	sprintf(txn, "%s/txn/%s.%s.%d.XXXXXX", c->root, md5_string(digest), shortname, (int) getpid());
+	sprintf(txn, "%s/txn/%s.%s.%d.XXXXXX", c->root, md5_to_string(digest), shortname, (int) getpid());
 }
 
 static int wait_for_running_txn(struct file_cache *c, const char *path)
@@ -63,7 +63,7 @@ static int wait_for_running_txn(struct file_cache *c, const char *path)
 	const char *checksum;
 
 	md5_buffer(path, strlen(path), digest);
-	checksum = md5_string(digest);
+	checksum = md5_to_string(digest);
 
 	txn[0] = 0;
 

--- a/dttools/src/hmac.h
+++ b/dttools/src/hmac.h
@@ -30,7 +30,7 @@ Routines for computing Hash-based Message Authentication Codes.
 int hmac(const void *buffer, size_t buffer_length, const void *key, size_t key_length, unsigned char *digest, size_t digest_len, size_t block_size, void (*hash_func) (const void *, size_t, unsigned char *));
 
 /** Generate HMAC using md5 hash function
-Note that this function produces a digest in binary form which must be converted to a human readable form with md5_string.
+Note that this function produces a digest in binary form which must be converted to a human readable form with md5_to_string.
 @param buffer Pointer to a memory buffer.
 @param buffer_length Length of the buffer in bytes.
 @param key Pointer to a buffer containing the key for hashing.

--- a/dttools/src/md5.c
+++ b/dttools/src/md5.c
@@ -371,7 +371,7 @@ const char *md5_string(unsigned char digest[16])
 	return str;
 }
 
-char *md5_cal(const char *s)
+char *md5_of_string(const char *s)
 {
  	unsigned char digest[MD5_DIGEST_LENGTH_HEX];
  	md5_context_t context;

--- a/dttools/src/md5.c
+++ b/dttools/src/md5.c
@@ -360,7 +360,7 @@ int md5_file(const char *filename, unsigned char digest[MD5_DIGEST_LENGTH])
 	return 1;
 }
 
-const char *md5_string(unsigned char digest[16])
+const char *md5_to_string(unsigned char digest[16])
 {
 	static char str[33];
 	int i;
@@ -378,7 +378,7 @@ char *md5_of_string(const char *s)
 	md5_init(&context);
  	md5_update(&context, (const unsigned char *)s, strlen(s));
  	md5_final(digest, &context);
-	return strdup(md5_string(digest));
+	return strdup(md5_to_string(digest));
 }
 	
 /*
@@ -425,7 +425,7 @@ char *md5_dir( const char *path )
 
 	free(dirstring);
 	
-	return strdup(md5_string(digest));
+	return strdup(md5_to_string(digest));
 }
 
 char *md5_symlink( const char *path, int linklength )
@@ -439,7 +439,7 @@ char *md5_symlink( const char *path, int linklength )
 		return 0;
 	} else {
 		md5_buffer(linktext,linklength,digest);
-		return strdup(md5_string(digest));
+		return strdup(md5_to_string(digest));
 	}
 }
 	
@@ -454,7 +454,7 @@ char *md5_file_or_dir( const char *path )
 		return md5_dir(path);
 	} else if(S_ISREG(info.st_mode)) {
 		md5_file(path, digest);
-		return strdup(md5_string(digest));
+		return strdup(md5_to_string(digest));
 	} else if(S_ISLNK(info.st_mode)) {
 		return md5_symlink(path,info.st_size);
 	} else {

--- a/dttools/src/md5.c
+++ b/dttools/src/md5.c
@@ -28,9 +28,6 @@ documentation and/or software.
 
 #include "md5.h"
 #include "xxmalloc.h"
-#include "stringtools.h"
-#include "path.h"
-#include "debug.h"
 
 #include <fcntl.h>
 #include <unistd.h>
@@ -379,88 +376,6 @@ char *md5_of_string(const char *s)
  	md5_update(&context, (const unsigned char *)s, strlen(s));
  	md5_final(digest, &context);
 	return strdup(md5_to_string(digest));
-}
-	
-/*
-Compute the recursive hash of a directory by building up a string like this:
-
-	filea:hash-of-filea
-	fileb:hash-of-fileb
-	dirc:hash-of-dirc
-
-And then compute the hash of that string.
-
-Returns an allocated string that must be freed.
-
-XXX For consistency, this should sort the directory entries before hashing.
-*/
-
-char *md5_dir( const char *path )
-{
-	DIR * dir = opendir(path);
-	if(!dir) return 0;
-
-	char *dirstring=strdup("");
-	
-	struct dirent *d;
-	while((d=readdir(dir))){
-		if(!strcmp(d->d_name,".")) continue;
-		if(!strcmp(d->d_name,"..")) continue;
-
-		char *subpath = string_format("%s/%s",path,d->d_name);
-		char *subhash = md5_file_or_dir(subpath);
-		char *line = string_format("%s:%s\n",d->d_name,subhash);
-
-		dirstring = string_combine(dirstring,line);
-
-		free(subpath);
-		free(subhash);
-		free(line);
-	}
-
-	closedir(dir);
-
-	unsigned char digest[MD5_DIGEST_LENGTH];
-	md5_buffer(dirstring, strlen(dirstring), digest);
-
-	free(dirstring);
-	
-	return strdup(md5_to_string(digest));
-}
-
-char *md5_symlink( const char *path, int linklength )
-{
-	unsigned char digest[MD5_DIGEST_LENGTH];
-	
-	char *linktext = xxmalloc(linklength);
-	ssize_t actual = readlink(path,linktext,linklength);
-	if(actual!=linklength) {
-		free(linktext);
-		return 0;
-	} else {
-		md5_buffer(linktext,linklength,digest);
-		return strdup(md5_to_string(digest));
-	}
-}
-	
-char *md5_file_or_dir( const char *path )
-{
-	struct stat info;
-	unsigned char digest[MD5_DIGEST_LENGTH];
-
-	if(lstat(path, &info)) return 0; 
-
-	if(S_ISDIR(info.st_mode)) {
-		return md5_dir(path);
-	} else if(S_ISREG(info.st_mode)) {
-		md5_file(path, digest);
-		return strdup(md5_to_string(digest));
-	} else if(S_ISLNK(info.st_mode)) {
-		return md5_symlink(path,info.st_size);
-	} else {
-		debug(D_NOTICE,	"unexpected file type: %s is not a file, directory, or symlink.",path);
-		return 0;
-	}
 }
 
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/md5.h
+++ b/dttools/src/md5.h
@@ -16,6 +16,7 @@ See the file COPYING for details.
 #define md5_buffer cctools_md5_buffer
 #define md5_file cctools_md5_file
 #define md5_to_string cctools_md5_to_string
+#define md5_of_string cctools_md5_of_string
 
 /** @file md5.h
 Routines for computing MD5 checksums.

--- a/dttools/src/md5.h
+++ b/dttools/src/md5.h
@@ -15,7 +15,7 @@ See the file COPYING for details.
 #define md5_final cctools_md5_final
 #define md5_buffer cctools_md5_buffer
 #define md5_file cctools_md5_file
-#define md5_string cctools_md5_string
+#define md5_to_string cctools_md5_to_string
 
 /** @file md5.h
 Routines for computing MD5 checksums.
@@ -36,7 +36,7 @@ void md5_final(unsigned char digest[MD5_DIGEST_LENGTH], md5_context_t * ctx);
 
 /** Checksum a memory buffer.
 Note that this function produces a digest in binary form
-which  must be converted to a human readable form with @ref md5_string.
+which  must be converted to a human readable form with @ref md5_to_string.
 @param buffer Pointer to a memory buffer.
 @param length Length of the buffer in bytes.
 @param digest Pointer to a buffer to store the digest.
@@ -47,7 +47,7 @@ void md5_buffer(const void *buffer, size_t length, unsigned char digest[MD5_DIGE
 @param digest A binary digest returned from @ref md5_file, @ref md5_buffer, or @ref chirp_reli_md5.
 @returns A static pointer to a human readable form of the digest.
 */
-const char *md5_string(unsigned char digest[MD5_DIGEST_LENGTH]);
+const char *md5_to_string(unsigned char digest[MD5_DIGEST_LENGTH]);
 
 /* md5_of_string calculates the md5 checksum of string s.
  * @param s: a string pointer
@@ -58,7 +58,7 @@ char *md5_of_string(const char *s);
 
 /** Checksum a local file.
 Note that this function produces a digest in binary form
-which  must be converted to a human readable form with @ref md5_string.
+which  must be converted to a human readable form with @ref md5_to_string.
 @param filename Path to the file to checksum.
 @param digest Pointer to a buffer to store the digest.
 @return One on success, zero on failure.

--- a/dttools/src/md5.h
+++ b/dttools/src/md5.h
@@ -49,12 +49,12 @@ void md5_buffer(const void *buffer, size_t length, unsigned char digest[MD5_DIGE
 */
 const char *md5_string(unsigned char digest[MD5_DIGEST_LENGTH]);
 
-/* md5_cal calculates the md5 checksum of string s.
+/* md5_of_string calculates the md5 checksum of string s.
  * @param s: a string pointer
  * return the md5 checksum of s on success, return NULL on failure.
  * The caller should free the returned string.
  */
-char *md5_cal(const char *s);
+char *md5_of_string(const char *s);
 
 /** Checksum a local file.
 Note that this function produces a digest in binary form

--- a/dttools/src/md5.h
+++ b/dttools/src/md5.h
@@ -66,16 +66,4 @@ which  must be converted to a human readable form with @ref md5_to_string.
 */
 int md5_file(const char *filename, unsigned char digest[MD5_DIGEST_LENGTH]);
 
-/** Converts a directory to a string of its hashed contents.
-@param src The path to the source directory
-@returns An allocated string that must be freed.
-*/
-char *md5_dir( const char *path );
-
-/** Converts either a file or directory to a string of its hashed contents.
-@param src The path to the source file or a directory
-@returns An allocated string that must be freed.
-*/
-char *md5_file_or_dir( const char *path );
-
 #endif

--- a/dttools/test/TR_hmac_test.sh
+++ b/dttools/test/TR_hmac_test.sh
@@ -37,7 +37,7 @@ int main(int argc, char **argv)
 
 	// Test Str 1
 	hmac_md5("Hi There", 8, "\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b", 16, md5_digest);
-	string = md5_string(md5_digest);
+	string = md5_to_string(md5_digest);
 	if(verbose) {
 		printf("MD5 Test 1 ref: \t0x%s\n", md5_ref1);
 		printf("MD5 Test 1 digest:\t0x%s\n", string);
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 	}
 
 	hmac_md5("what do ya want for nothing?", 28, "Jefe", 4, md5_digest);
-	string = md5_string(md5_digest);
+	string = md5_to_string(md5_digest);
 	if(verbose) {
 		printf("\n");
 		printf("MD5 Test 2 ref: \t0x%s\n", md5_ref2);
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
 	memset(data, '\xDD', 50);
 	data[50] = 0;
 	hmac_md5(data, 50, "\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA", 16, md5_digest);
-	string = md5_string(md5_digest);
+	string = md5_to_string(md5_digest);
 	if(verbose) {
 		printf("\n");
 		printf("MD5 Test 3 ref: \t0x%s\n", md5_ref3);

--- a/makeflow/src/makeflow_mounts.c
+++ b/makeflow/src/makeflow_mounts.c
@@ -180,11 +180,11 @@ int mount_check(const char *source, const char *target, file_type *s_type) {
 	return 0;
 }
 
-/* md5_cal_source calculates the checksum of a file path.
+/* md5_of_string_source calculates the checksum of a file path.
  * @param source: the source location of a dependency, which can be a local file path or http URL.
  * @is_local: whether source is a lcoal path.
  */
-char *md5_cal_source(const char *source, int is_local) {
+char *md5_of_string_source(const char *source, int is_local) {
 	char *cache_name = NULL;
 
 	if(is_local) {
@@ -197,14 +197,14 @@ char *md5_cal_source(const char *source, int is_local) {
 			return NULL;
 		}
 
-		cache_name = md5_cal(s_real);
+		cache_name = md5_of_string(s_real);
 
 		if(!cache_name) {
-			debug(D_DEBUG, "md5_cal(%s) failed: %s!\n", s_real, strerror(errno));
+			debug(D_DEBUG, "md5_of_string(%s) failed: %s!\n", s_real, strerror(errno));
 		}
 		free(s_real);
 	} else {
-		cache_name = md5_cal(source);
+		cache_name = md5_of_string(source);
 	}
 	return cache_name;
 }
@@ -276,9 +276,9 @@ int mount_install(const char *source, const char *target, const char *cache_dir,
 	}
 
 	/* calculate the filename in the cache dir */
-	cache_name = md5_cal_source(source, *type == DAG_FILE_SOURCE_LOCAL);
+	cache_name = md5_of_string_source(source, *type == DAG_FILE_SOURCE_LOCAL);
 	if(!cache_name) {
-		debug(D_DEBUG, "md5_cal_source(%s) failed: %s!\n", source, strerror(errno));
+		debug(D_DEBUG, "md5_of_string_source(%s) failed: %s!\n", source, strerror(errno));
 		return -1;
 	}
 
@@ -647,7 +647,7 @@ int makeflow_mount_check_target(struct dag *d) {
 		if(!df->source)
 			continue;
 
-		cache_name = md5_cal_source(df->source, (strncmp(df->source, "http://", 7) && strncmp(df->source, "https://", 8)));
+		cache_name = md5_of_string_source(df->source, (strncmp(df->source, "http://", 7) && strncmp(df->source, "https://", 8)));
 		if(!cache_name) {
 			return -1;
 		}

--- a/parrot/src/parrot_md5.c
+++ b/parrot/src/parrot_md5.c
@@ -24,7 +24,7 @@ int main( int argc, char *argv[] )
 
 	for(i=1;i<argc;i++) {
 		if(parrot_md5(argv[i],digest)>=0 || md5_file(argv[i],digest)) {
-			printf("%s %s\n",md5_string(digest),argv[i]);
+			printf("%s %s\n",md5_to_string(digest),argv[i]);
 		} else {
 			fprintf(stderr,"parrot_md5: %s: %s\n",argv[i],strerror(errno));
 		}

--- a/taskvine/src/manager/Makefile
+++ b/taskvine/src/manager/Makefile
@@ -16,6 +16,7 @@ SOURCES = \
 	vine_mount.c \
 	vine_txn_log.c \
 	vine_cached_name.c \
+	vine_checksum.c \
 	vine_perf_log.c \
 	vine_remote_file_info.c \
 	vine_factory_info.c \

--- a/taskvine/src/manager/vine_cached_name.c
+++ b/taskvine/src/manager/vine_cached_name.c
@@ -7,6 +7,7 @@ See the file COPYING for details.
 #include "vine_file.h"
 #include "vine_task.h"
 #include "vine_protocol.h"
+#include "vine_checksum.h"
 
 #include "stringtools.h"
 #include "md5.h"
@@ -120,7 +121,7 @@ static vine_url_cache_t get_url_properties( const char *url, char *tag )
 	*/
 
 	if(!strncmp(url,"file://",7)) {
-		char *hash = md5_file_or_dir(&url[7]);
+		char *hash = vine_checksum_any(&url[7]);
 		strcpy(tag,hash);
 		free(hash);
 		return VINE_FOUND_MD5;
@@ -266,7 +267,7 @@ char *vine_cached_name( const struct vine_file *f )
 
 	switch(f->type) {
 		case VINE_FILE:
-			hash = md5_file_or_dir(f->source);
+			hash = vine_checksum_any(f->source);
 			if(hash) {
 				/* An existing file is identified by its content. */
 				name = string_format("file-md5-%s",hash);

--- a/taskvine/src/manager/vine_cached_name.c
+++ b/taskvine/src/manager/vine_cached_name.c
@@ -201,7 +201,7 @@ static char *make_url_cached_name( const struct vine_file *f )
 			method = "md5-url";
 			content = string_format("%s",f->source);
 			md5_buffer(content,strlen(content),digest);
-			hash = md5_string(digest);
+			hash = md5_to_string(digest);
 			free(content);
 			break;
 		case VINE_FOUND_LAST_MODIFIED:
@@ -209,7 +209,7 @@ static char *make_url_cached_name( const struct vine_file *f )
 			method = "md5-lm";
 			content = string_format("%s-%s",f->source,tag);
 			md5_buffer(content,strlen(content),digest);
-			hash = md5_string(digest);
+			hash = md5_to_string(digest);
 			free(content);
 			break;
 		case VINE_FOUND_ETAG:
@@ -217,7 +217,7 @@ static char *make_url_cached_name( const struct vine_file *f )
 			method = "md5-et";
 			content = string_format("%s-%s",f->source,tag);
 			md5_buffer(content,strlen(content),digest);
-			hash = md5_string(digest);
+			hash = md5_to_string(digest);
 			free(content);
 			break;
 		case VINE_FOUND_MD5:	
@@ -250,7 +250,7 @@ char *make_mini_task_cached_name(const struct vine_file *f)
 	free(buffer);
 	free(taskstr);
 	
-	return strdup(md5_string(digest));
+	return strdup(md5_to_string(digest));
 }
 
 /*
@@ -303,7 +303,7 @@ char *vine_cached_name( const struct vine_file *f )
 			if(f->data) {
 				/* If the buffer exists, then checksum the content. */ 
 				md5_buffer(f->data, f->length, digest);
-				const char *hash = md5_string(digest);
+				const char *hash = md5_to_string(digest);
 				name = string_format("buffer-md5-%s",hash);
 			} else {
 				/* If the buffer doesn't exist yet, then give a random name. */

--- a/taskvine/src/manager/vine_cached_name.c
+++ b/taskvine/src/manager/vine_cached_name.c
@@ -121,7 +121,8 @@ static vine_url_cache_t get_url_properties( const char *url, char *tag )
 	*/
 
 	if(!strncmp(url,"file://",7)) {
-		char *hash = vine_checksum_any(&url[7]);
+		ssize_t totalsize;
+		char *hash = vine_checksum_any(&url[7],&totalsize);
 		strcpy(tag,hash);
 		free(hash);
 		return VINE_FOUND_MD5;
@@ -259,7 +260,7 @@ Compute the cached name of a file object, based on its type.
 Returns a string that must be freed with free().
 */
 
-char *vine_cached_name( const struct vine_file *f )
+char *vine_cached_name( const struct vine_file *f, ssize_t *totalsize )
 {
 	unsigned char digest[MD5_DIGEST_LENGTH];
 	char *hash, *name;
@@ -267,7 +268,7 @@ char *vine_cached_name( const struct vine_file *f )
 
 	switch(f->type) {
 		case VINE_FILE:
-			hash = vine_checksum_any(f->source);
+			hash = vine_checksum_any(f->source,totalsize);
 			if(hash) {
 				/* An existing file is identified by its content. */
 				name = string_format("file-md5-%s",hash);

--- a/taskvine/src/manager/vine_cached_name.h
+++ b/taskvine/src/manager/vine_cached_name.h
@@ -8,7 +8,8 @@ See the file COPYING for details.
 #define VINE_CACHED_NAME_H
 
 #include "vine_file.h"
+#include <sys/types.h>
 
-char *vine_cached_name( const struct vine_file *f );
+char *vine_cached_name( const struct vine_file *f, ssize_t *totalsize );
 
 #endif

--- a/taskvine/src/manager/vine_checksum.c
+++ b/taskvine/src/manager/vine_checksum.c
@@ -90,12 +90,11 @@ char *vine_checksum_any( const char *path, ssize_t *totalsize )
 	if(lstat(path, &info)) return 0; 
 
 	if(S_ISDIR(info.st_mode)) {
-		return vine_checksum_dir(path);
+		return vine_checksum_dir(path,totalsize);
 	} else if(S_ISREG(info.st_mode)) {
 		*totalsize += info.st_size;
 		return vine_checksum_file(path);
 	} else if(S_ISLNK(info.st_mode)) {
-		*totalsize += info.st_size;
 		return vine_checksum_symlink(path,info.st_size);
 	} else {
 		debug(D_NOTICE,	"unexpected file type: %s is not a file, directory, or symlink.",path);

--- a/taskvine/src/manager/vine_checksum.c
+++ b/taskvine/src/manager/vine_checksum.c
@@ -1,0 +1,97 @@
+
+#include "vine_checksum.h"
+
+#include "stringtools.h"
+#include "md5.h"
+#include "xxmalloc.h"
+
+#include <debug.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <string.h>
+
+/*
+Compute the recursive hash of a directory by building up a string like this:
+
+	filea:hash-of-filea
+	fileb:hash-of-fileb
+	dirc:hash-of-dirc
+
+And then compute the hash of that string.
+
+Returns an allocated string that must be freed.
+
+XXX For consistency, this should sort the directory entries before hashing.
+*/
+
+char *vine_checksum_dir( const char *path )
+{
+	DIR * dir = opendir(path);
+	if(!dir) return 0;
+
+	char *dirstring=xxstrdup("");
+	
+	struct dirent *d;
+	while((d=readdir(dir))){
+		if(!strcmp(d->d_name,".")) continue;
+		if(!strcmp(d->d_name,"..")) continue;
+
+		char *subpath = string_format("%s/%s",path,d->d_name);
+		char *subhash = vine_checksum_any(subpath);
+		char *line = string_format("%s:%s\n",d->d_name,subhash);
+
+		dirstring = string_combine(dirstring,line);
+
+		free(subpath);
+		free(subhash);
+		free(line);
+	}
+
+	closedir(dir);
+
+	char *result = md5_of_string(dirstring);
+
+	free(dirstring);
+
+	return result;
+}
+
+char *vine_checksum_file( const char *path )
+{
+	unsigned char digest[MD5_DIGEST_LENGTH];
+	md5_file(path, digest);
+	return xxstrdup(md5_to_string(digest));
+}
+
+char *vine_checksum_symlink( const char *path, ssize_t linklength )
+{
+	char *linktext = xxmalloc(linklength+1);
+	ssize_t actual = readlink(path,linktext,linklength);
+	if(actual!=linklength) {
+		free(linktext);
+		return 0;
+	} else {
+		linktext[linklength] = 0;
+		char *result = md5_of_string(linktext);
+		free(linktext);
+		return result;
+	}
+}
+	
+char *vine_checksum_any( const char *path )
+{
+	struct stat info;
+
+	if(lstat(path, &info)) return 0; 
+
+	if(S_ISDIR(info.st_mode)) {
+		return vine_checksum_dir(path);
+	} else if(S_ISREG(info.st_mode)) {
+		return vine_checksum_file(path);
+	} else if(S_ISLNK(info.st_mode)) {
+		return vine_checksum_symlink(path,info.st_size);
+	} else {
+		debug(D_NOTICE,	"unexpected file type: %s is not a file, directory, or symlink.",path);
+		return 0;
+	}
+}

--- a/taskvine/src/manager/vine_checksum.h
+++ b/taskvine/src/manager/vine_checksum.h
@@ -1,13 +1,14 @@
+/*
+Copyright (C) 2023- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
 
 #ifndef VINE_CHECKSUM_H
 #define VINE_CHECKSUM_H
 
 #include <sys/types.h>
 
-char *vine_checksum_dir( const char *path );
-char *vine_checksum_file( const char *path );
-char *vine_checksum_symlink( const char *path, ssize_t length );
-
-char *vine_checksum_any( const char *path );
+char *vine_checksum_any( const char *path, ssize_t *totalsize );
 
 #endif

--- a/taskvine/src/manager/vine_checksum.h
+++ b/taskvine/src/manager/vine_checksum.h
@@ -1,0 +1,13 @@
+
+#ifndef VINE_CHECKSUM_H
+#define VINE_CHECKSUM_H
+
+#include <sys/types.h>
+
+char *vine_checksum_dir( const char *path );
+char *vine_checksum_file( const char *path );
+char *vine_checksum_symlink( const char *path, ssize_t length );
+
+char *vine_checksum_any( const char *path );
+
+#endif

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -50,7 +50,10 @@ struct vine_file *vine_file_create(const char *source, const char *cached_name, 
 		f->cached_name = xxstrdup(cached_name);
 	} else {
 		/* Otherwise we need to figure it out ourselves from the content. */
-		f->cached_name = vine_cached_name(f);
+		/* This may give us the actual size of the object along the way. */
+		ssize_t totalsize = 0;
+		f->cached_name = vine_cached_name(f,&totalsize);
+		if(length==0) f->length = totalsize;
 	}
 
 	debug(D_VINE,"cached name: %s\n",f->cached_name);

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1790,7 +1790,7 @@ void set_worker_id()
 	unsigned char digest[MD5_DIGEST_LENGTH];
 
 	md5_buffer(salt_and_pepper, strlen(salt_and_pepper), digest);
-	worker_id = string_format("worker-%s", md5_string(digest));
+	worker_id = string_format("worker-%s", md5_to_string(digest));
 
 	free(salt_and_pepper);
 }

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1602,20 +1602,20 @@ char *make_cached_name( const struct work_queue_file *f )
 	switch(f->type) {
 		case WORK_QUEUE_FILE:
 		case WORK_QUEUE_DIRECTORY:
-			return string_format("file-%d-%s-%s", cache_file_id, md5_string(digest), payload_enc);
+			return string_format("file-%d-%s-%s", cache_file_id, md5_to_string(digest), payload_enc);
 			break;
 		case WORK_QUEUE_FILE_PIECE:
-			return string_format("piece-%d-%s-%s-%lld-%lld",cache_file_id, md5_string(digest),payload_enc,(long long)f->offset,(long long)f->piece_length);
+			return string_format("piece-%d-%s-%s-%lld-%lld",cache_file_id, md5_to_string(digest),payload_enc,(long long)f->offset,(long long)f->piece_length);
 			break;
 		case WORK_QUEUE_REMOTECMD:
-			return string_format("cmd-%d-%s", cache_file_id, md5_string(digest));
+			return string_format("cmd-%d-%s", cache_file_id, md5_to_string(digest));
 			break;
 		case WORK_QUEUE_URL:
-			return string_format("url-%d-%s", cache_file_id, md5_string(digest));
+			return string_format("url-%d-%s", cache_file_id, md5_to_string(digest));
 			break;
 		case WORK_QUEUE_BUFFER:
 		default:
-			return string_format("buffer-%d-%s", cache_file_id, md5_string(digest));
+			return string_format("buffer-%d-%s", cache_file_id, md5_to_string(digest));
 			break;
 	}
 }

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -2265,7 +2265,7 @@ void set_worker_id()
 	unsigned char digest[MD5_DIGEST_LENGTH];
 
 	md5_buffer(salt_and_pepper, strlen(salt_and_pepper), digest);
-	worker_id = string_format("worker-%s", md5_string(digest));
+	worker_id = string_format("worker-%s", md5_to_string(digest));
 
 	free(salt_and_pepper);
 }


### PR DESCRIPTION
Recursive checksumming functions are now in `vine_checksum.[ch]` since we are going to play around with that to introduce different checksum types.
