### PR TITLE
Vine: Remove always-true condition causing misleading debug messages

### DIFF
--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -354,7 +354,7 @@ static vine_result_code_t vine_manager_put_input_file_if_not_cached(struct vine_
 
 	/* If so, check that it hasn't changed, and return success. */
 	if(remote_info) {
-		if(f->type==VINE_FILE && (info.st_size!=remote_info->size || info.st_mtime!=remote_info->mtime)) {
+		if(f->type==VINE_FILE && info.st_size!=remote_info->size) {
 			debug(D_NOTICE|D_VINE,"File %s has changed since it was first cached!",f->source);
 			debug(D_NOTICE|D_VINE,"You may be getting inconsistent results.");
 		}


### PR DESCRIPTION
In code, `info.st_mtime` refers to the last modified timestamp of the local file and `remote_info->mtime` refers to the last modified timestamp of the remote copy of the local file. The latter is always newer than the former as it is written to the local filesystem of the remote machine, thus the two debug messages are always printed. Removing the comparison condition removes the issue.