### PR TITLE
Vine: Disable old taskvine JSON API proxy.

### DIFF
--- a/taskvine/src/manager/Makefile
+++ b/taskvine/src/manager/Makefile
@@ -2,7 +2,6 @@ include ../../../config.mk
 include ../../../rules.mk
 
 SOURCES = \
-	taskvine_json.c \
 	vine_manager.c \
 	vine_manager_get.c \
 	vine_manager_put.c \
@@ -25,10 +24,10 @@ SOURCES = \
 	vine_current_transfers.c \
 	vine_runtime_dir.c
 
-PUBLIC_HEADERS = taskvine.h taskvine_json.h
+PUBLIC_HEADERS = taskvine.h
 
 OBJECTS = $(SOURCES:%.c=%.o)
-PUBLIC_HEADERS = taskvine.h taskvine_json.h
+PUBLIC_HEADERS = taskvine.h
 LIBRARIES = libtaskvine.a
 TARGETS = $(LIBRARIES)
 

--- a/taskvine/src/tools/Makefile
+++ b/taskvine/src/tools/Makefile
@@ -4,7 +4,7 @@ include ../../../rules.mk
 LOCAL_LINKAGE+=${CCTOOLS_HOME}/taskvine/src/manager/libtaskvine.a ${CCTOOLS_HOME}/dttools/src/libdttools.a
 LOCAL_CCFLAGS+=-I ${CCTOOLS_HOME}/taskvine/src/manager
 
-PROGRAMS = vine_status vine_api_proxy vine_benchmark
+PROGRAMS = vine_status vine_benchmark
 SCRIPTS = vine_graph_log vine_graph_workers vine_plot_txn_log
 TEST_PROGRAMS = vine_test
 TARGETS = $(PROGRAMS) $(TEST_PROGRAMS)


### PR DESCRIPTION
Don't build and install this feature, it was never completed.
(But may be of interest in the future.)
