### PR TITLE
vine symlink to most recent logs

### DIFF
--- a/dttools/test/test_runner_common.sh
+++ b/dttools/test/test_runner_common.sh
@@ -169,7 +169,7 @@ check_needed()
 latest_vine_debug_log()
 {
 	base=${1:-vine-run-info}
-	echo "$(ls -1 -r -d ${base}/* 2>/dev/null | head -n1)/vine-logs/debug"
+	echo "${base}/most-recent/vine-logs/debug"
 }
 
 

--- a/taskvine/src/manager/vine_runtime_dir.c
+++ b/taskvine/src/manager/vine_runtime_dir.c
@@ -65,6 +65,7 @@ char *vine_runtime_directory_create() {
      */
 
 	char *runtime_dir = NULL;
+    int symlink_most_recent = 0;
 	if(getenv("VINE_RUNTIME_INFO_DIR")) {
 		runtime_dir = xxstrdup(getenv("VINE_RUNTIME_INFO_DIR"));
 	} else {
@@ -73,6 +74,8 @@ char *vine_runtime_directory_create() {
 		struct tm *tm_info = localtime(&now);
 		strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S", tm_info);
 		runtime_dir = xxstrdup(buf);
+
+        symlink_most_recent = 1;
 	}
 
 	if(strncmp(runtime_dir, "/", 1)) {
@@ -103,6 +106,13 @@ char *vine_runtime_directory_create() {
     }
     register_staging_dir(tmp);
 	free(tmp);
+
+    if(symlink_most_recent) {
+        char *tmp = path_concat(vine_runtime_info_path, "most-recent");
+        unlink(tmp);
+        symlink(runtime_dir, tmp);
+        free(tmp);
+    }
 
     return runtime_dir;
 }


### PR DESCRIPTION
When creating the logs files by date, the most recent one will be symlinked to "most-recent". E.g.:

```
ls /tmp/vine-run-info
total 11
drwxr-xr-x 4 btovar campus 2048 Feb 22 12:55 .
drwxr-xr-x 3 btovar campus 4096 Feb 22 12:52 ..
drwxr-xr-x 3 btovar campus 2048 Feb 22 12:54 2023-02-22T12:52:17
drwxr-xr-x 3 btovar campus 2048 Feb 22 12:57 2023-02-22T12:55:47
lrwxr-xr-x 1 btovar campus  119 Feb 22 12:55 most-recent -> /tmp/vine-run-info/2023-02-22T12:55:47
```
Thus, most recent debug log is in:

```
vine-run-info/most-recent/vine-logs/debug
```