### PR TITLE
int file->length to size_t file->size

### DIFF
--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -64,18 +64,16 @@ class File(object):
     # Typically used to return the contents of an output buffer.
     #
     # @param self       A file object.
-    
     def contents(self):
         return vine_file_contents(self._file)
 
     ##
-    # Return the length of a file object.
+    # Return the size of a file object, in bytes.
     #
     # @param self       A file object.
-    
     def __len__(self):
-        return vine_file_length(self._file)
-    
+        return vine_file_size(self._file)
+
 ##
 # \class FileLocal
 #

--- a/taskvine/src/bindings/python3/taskvine.i
+++ b/taskvine/src/bindings/python3/taskvine.i
@@ -23,6 +23,7 @@
 /* We compile with -D__LARGE64_FILES, thus off_t is at least 64bit.
 long long int is guaranteed to be at least 64bit. */
 %typemap(in) off_t = long long int;
+%typemap(in) size_t = unsigned long long;
 
 /* vdebug() takes va_list as arg but SWIG can't wrap such functions. */
 %ignore vdebug;
@@ -44,9 +45,9 @@ treat it as an output parameter to be filled in. */
 
 
 /* Convert a python buffer into a vine buffer */
-/* Note!! This changes any C function with the signature f(const char *data, int length) into
+/* Note!! This changes any C function with the signature f(const char *buffer, size_t size) into
 a swig function f(data) */
-%typemap(in, numinputs=1) (const char *data, int length) {
+%typemap(in, numinputs=1) (const char *buffer, size_t size) {
     if ($input == Py_None) {
         $1 = NULL;
         $2 = 0;

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -643,12 +643,12 @@ as the output of a task, and may be consumed by other tasks.
 struct vine_file * vine_file_temp();
 
 /** Create a file object from a data buffer.
-@param data The contents of the buffer.
-@param length The length of the buffer, in bytes.
+@param buffer The contents of the buffer.
+@param size The length of the buffer, in bytes.
 @return A general file object for use by @ref vine_task_add_input.
 */
 
-struct vine_file * vine_file_buffer( const char *data, int length );
+struct vine_file * vine_file_buffer( const char *buffer, size_t size );
 
 /** Create a file object representing an empty directory.
 @return A general file object for use by @ref vine_task_add_input.
@@ -695,7 +695,7 @@ const char * vine_file_contents( struct vine_file *f );
 @param f A file object.
 @return The length of the file, or zero if unknown.
 */
-int64_t vine_file_length( struct vine_file *f );
+size_t vine_file_size( struct vine_file *f );
 
 /** Clone a file object.
 @param f A file object.

--- a/taskvine/src/manager/vine_cached_name.c
+++ b/taskvine/src/manager/vine_cached_name.c
@@ -303,8 +303,8 @@ char *vine_cached_name( const struct vine_file *f, ssize_t *totalsize )
 			break;
 		case VINE_BUFFER:
 			if(f->data) {
-				/* If the buffer exists, then checksum the content. */ 
-				md5_buffer(f->data, f->length, digest);
+				/* If the buffer exists, then checksum the content. */
+				md5_buffer(f->data, f->size, digest);
 				const char *hash = md5_to_string(digest);
 				name = string_format("buffer-md5-%s",hash);
 			} else {

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -22,7 +22,7 @@ int vine_hack_do_not_compute_cached_name = 0;
 
 /* Create a new file object with the given properties. */
 
-struct vine_file *vine_file_create(const char *source, const char *cached_name, const char *data, int length, vine_file_t type, struct vine_task *mini_task )
+struct vine_file *vine_file_create(const char *source, const char *cached_name, const char *data, size_t size, vine_file_t type, struct vine_task *mini_task )
 {
 	struct vine_file *f;
 
@@ -32,14 +32,14 @@ struct vine_file *vine_file_create(const char *source, const char *cached_name, 
 
 	f->source = xxstrdup(source);
 	f->type = type;
-	f->length = length;
+	f->size = size;
 	f->mini_task = mini_task;
 
 	if(data) {
 		/* Terminate with a null, just in case the user tries to treat this as a C string. */
-		f->data = malloc(length+1);
-		memcpy(f->data,data,length);
-		f->data[length] = 0;
+		f->data = malloc(size+1);
+		memcpy(f->data,data,size);
+		f->data[size] = 0;
 	} else {
 		f->data = 0;
 	}
@@ -55,7 +55,9 @@ struct vine_file *vine_file_create(const char *source, const char *cached_name, 
 		/* This may give us the actual size of the object along the way. */
 		ssize_t totalsize = 0;
 		f->cached_name = vine_cached_name(f,&totalsize);
-		if(length==0) f->length = totalsize;
+		if(size==0) {
+			f->size = totalsize;
+		}
 	}
 
 	f->refcount = 1;
@@ -98,11 +100,11 @@ const char * vine_file_contents( struct vine_file *f )
 	return f->data;
 }
 
-/* Return the length of any kind of file. */
+/* Return the size of any kind of file. */
 
-int64_t vine_file_length( struct vine_file *f )
+size_t vine_file_size( struct vine_file *f )
 {
-	return f->length;
+	return f->size;
 }
 
 struct vine_file * vine_file_local( const char *source )
@@ -117,7 +119,7 @@ struct vine_file * vine_file_url( const char *source )
 
 struct vine_file * vine_file_substitute_url( struct vine_file *f, const char *source )
 {
-	return vine_file_create(source,f->cached_name,0,f->length,VINE_URL,0);
+	return vine_file_create(source,f->cached_name,0,f->size,VINE_URL,0);
 }
 
 struct vine_file * vine_file_temp()
@@ -125,9 +127,9 @@ struct vine_file * vine_file_temp()
 	return vine_file_create("temp",0,0,0,VINE_TEMP,0);
 }
 
-struct vine_file * vine_file_buffer( const char *data, int length )
+struct vine_file * vine_file_buffer( const char *data, size_t size )
 {
-	return vine_file_create("buffer",0,data,length,VINE_BUFFER,0);
+	return vine_file_create("buffer",0,data,size,VINE_BUFFER,0);
 }
 
 struct vine_file * vine_file_empty_dir()

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -36,16 +36,16 @@ typedef enum {
 } vine_file_t;
 
 struct vine_file {
-	vine_file_t type;       // Type of data source: VINE_FILE, VINE_BUFFER, VINE_URL, etc.
-	int length;		// Length of source data, if known.
-	char *source;		// Name of source file, url, buffer.
-	char *cached_name;	// Name of file in the worker's cache directory.
-	char *data;		// Raw data for an input or output buffer.
+	vine_file_t type;   // Type of data source: VINE_FILE, VINE_BUFFER, VINE_URL, etc.
+	char *source;       // Name of source file, url, buffer.
+	char *cached_name;  // Name of file in the worker's cache directory.
+	size_t size;        // Length of source data, if known.
+	char *data;         // Raw data for an input or output buffer.
 	struct vine_task *mini_task; // Mini task used to generate the desired output file.
-	int refcount;		// Number of references from a task object, delete when zero.
+	int refcount;       // Number of references from a task object, delete when zero.
 };
 
-struct vine_file * vine_file_create( const char *source, const char *cached_name, const char *data, int length, vine_file_t type, struct vine_task *mini_task );
+struct vine_file * vine_file_create( const char *source, const char *cached_name, const char *data, size_t size, vine_file_t type, struct vine_task *mini_task );
 
 struct vine_file * vine_file_substitute_url( struct vine_file *f, const char *source );
 

--- a/taskvine/src/manager/vine_manager_get.c
+++ b/taskvine/src/manager/vine_manager_get.c
@@ -51,18 +51,18 @@ static vine_result_code_t vine_manager_get_buffer( struct vine_manager *q, struc
 
 	if(sscanf(line,"file %s %" SCNd64 " 0%o",name_encoded,&size,&mode)==3) {
 
-		f->length = size;
-		debug(D_VINE, "Receiving buffer %s (size: %"PRId64" bytes) from %s (%s) ...", f->source, (int64_t)f->length, w->addrport, w->hostname);
+		f->size = size;
+		debug(D_VINE, "Receiving buffer %s (size: %"PRId64" bytes) from %s (%s) ...", f->source, (int64_t)f->size, w->addrport, w->hostname);
 
 		f->data = malloc(size+1);
 		if(f->data) {
-			time_t stoptime = time(0) + vine_manager_transfer_time(q, w, t, f->length);
+			time_t stoptime = time(0) + vine_manager_transfer_time(q, w, t, f->size);
 
-			ssize_t actual = link_read(w->link,f->data,f->length,stoptime);
-			if(actual==f->length) {
+			ssize_t actual = link_read(w->link,f->data,f->size,stoptime);
+			if(actual >= 0 && (size_t)actual == f->size) {
 				/* While not strictly necessary, add a null terminator to facilitate printing text data. */
-				f->data[f->length] = 0;
-				*total_size += f->length;
+				f->data[f->size] = 0;
+				*total_size += f->size;
 				r = VINE_SUCCESS;
 			} else {
 				/* If insufficient data was read, the connection must be broken. */

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -207,10 +207,10 @@ static vine_result_code_t vine_manager_put_url( struct vine_manager *q, struct v
 
 	url_encode(f->source,source_encoded,sizeof(source_encoded));
 	url_encode(f->cached_name,cached_name_encoded,sizeof(cached_name_encoded));
-									
+
 	char *transfer_id = vine_current_transfers_add(q, w, f->source);
 	vine_current_transfers_print_table(q);
-	vine_manager_send(q,w,"puturl %s %s %d %o %s\n",source_encoded, cached_name_encoded, f->length, 0777, transfer_id);
+	vine_manager_send(q,w,"puturl %s %s %lld %o %s\n",source_encoded, cached_name_encoded, (long long)f->size, 0777, transfer_id);
 
 	return VINE_SUCCESS;
 }
@@ -219,15 +219,15 @@ static vine_result_code_t vine_manager_put_url( struct vine_manager *q, struct v
 
 vine_result_code_t vine_manager_put_buffer( struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct vine_file *f, int64_t *total_bytes )
 {
-	time_t stoptime = time(0) + vine_manager_transfer_time(q, w, t, f->length);
-	vine_manager_send(q,w, "file %s %d %o\n",f->cached_name, f->length, 0777 );
-	int64_t actual = link_putlstring(w->link, f->data, f->length, stoptime);
-	if(actual!=f->length) {
-		return VINE_WORKER_FAILURE;
-		*total_bytes = 0;
-	} else {
+	time_t stoptime = time(0) + vine_manager_transfer_time(q, w, t, f->size);
+	vine_manager_send(q,w, "file %s %lld %o\n",f->cached_name, (long long)f->size, 0777 );
+	int64_t actual = link_putlstring(w->link, f->data, f->size, stoptime);
+	if(actual >= 0 && (size_t)actual ==f->size) {
 		*total_bytes = actual;
 		return VINE_SUCCESS;
+	} else {
+		*total_bytes = 0;
+		return VINE_WORKER_FAILURE;
 	}
 }
  
@@ -344,7 +344,7 @@ static vine_result_code_t vine_manager_put_input_file_if_not_cached(struct vine_
 		return VINE_APP_FAILURE;
 	} else {
 		/* Any other type, just record dummy values for size and time, until we know better. */
-		info.st_size = f->length;
+		info.st_size = f->size;
 		info.st_mtime = time(0);
 	}
 
@@ -417,15 +417,15 @@ vine_result_code_t vine_manager_put_task(struct vine_manager *q, struct vine_wor
 	if(result!=VINE_SUCCESS) return result;
 
 	if(target) {
-		vine_manager_send(q,w, "mini_task %lld %s %d %o\n",(long long)target->mini_task->task_id,target->cached_name,target->length,0777);
+		vine_manager_send(q,w, "mini_task %lld %s %lld %o\n",(long long)target->mini_task->task_id,target->cached_name,(long long)target->size,0777);
 	} else {
 		vine_manager_send(q,w, "task %lld\n",(long long)t->task_id);
 	}
-	
+
 	if(!command_line) {
 		command_line = t->command_line;
 	}
-	
+
 	long long cmd_len = strlen(command_line);
 	vine_manager_send(q,w, "cmd %lld\n", (long long) cmd_len);
 	link_putlstring(w->link, command_line, cmd_len, time(0) + q->short_timeout);


### PR DESCRIPTION
Getting ahead of compiler warnings as we were using int where a size_t was expected.

Also, changed vine_file_length to vine_file_size, as length really only made sense for buffers of chars.