### PR TITLE
Catalog: Perform TCP Updates in Background Process

### DIFF
--- a/batch_job/src/vine_factory.c
+++ b/batch_job/src/vine_factory.c
@@ -1013,7 +1013,7 @@ static void mainloop( struct batch_queue *queue )
 
 		char *update_str = jx_print_string(j);
 		debug(D_VINE, "Sending status to the catalog server(s) at %s ...", catalog_host);
-		catalog_query_send_update(catalog_host, update_str);
+		catalog_query_send_update(catalog_host,update_str,0);
 		print_stats(j);
 		free(update_str);
 		jx_delete(j);

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -1022,7 +1022,7 @@ static void mainloop( struct batch_queue *queue )
 
 		char *update_str = jx_print_string(j);
 		debug(D_WQ, "Sending status to the catalog server(s) at %s ...", catalog_host);
-		catalog_query_send_update(catalog_host, update_str);
+		catalog_query_send_update(catalog_host,update_str,0);
 		print_stats(j);
 		free(update_str);
 		jx_delete(j);

--- a/chirp/src/chirp_server.c
+++ b/chirp/src/chirp_server.c
@@ -245,7 +245,10 @@ static int update_all_catalogs(const char *url)
 
 	char *message = jx_print_string(j);
 
-	list_iterate(catalog_host_list, (list_op_t) catalog_query_send_update, message);
+	const char *host;
+	LIST_ITERATE(catalog_host_list,host) {
+		catalog_query_send_update(item,message,CATALOG_UPDATE_BACKGROUND);
+	}
 
 	free(message);
 	jx_delete(j);

--- a/chirp/src/chirp_server.c
+++ b/chirp/src/chirp_server.c
@@ -247,7 +247,7 @@ static int update_all_catalogs(const char *url)
 
 	const char *host;
 	LIST_ITERATE(catalog_host_list,host) {
-		catalog_query_send_update(item,message,CATALOG_UPDATE_BACKGROUND);
+		catalog_query_send_update(host,message,CATALOG_UPDATE_BACKGROUND);
 	}
 
 	free(message);

--- a/deltadb/src/catalog_server.c
+++ b/deltadb/src/catalog_server.c
@@ -217,7 +217,11 @@ static void update_all_catalogs()
 	char *text = jx_print_string(j);
 	jx_delete(j);
 
-	list_iterate(outgoing_host_list, (list_op_t) catalog_query_send_update, text);
+	const char *host;
+	LIST_ITERATE(outgoing_host_list,host) {
+		catalog_query_send_update(host,text,CATALOG_UPDATE_BACKGROUND);
+	}
+
 	free(text);
 }
 

--- a/dttools/src/catalog_query.c
+++ b/dttools/src/catalog_query.c
@@ -26,6 +26,7 @@ See the file COPYING for details.
 #include "zlib.h"
 #include "macros.h"
 #include "b64.h"
+#include "fd.h"
 
 struct catalog_query {
 	struct jx *data;
@@ -312,6 +313,11 @@ static int catalog_update_protocol()
 	}
 }
 
+/*
+Send a catalog update via a single udp message.
+This is inherently a non-blocking action.
+*/
+
 static void catalog_update_udp( const char *host, const char *address, int port, const char *text )
 {
 	debug(D_DEBUG, "sending update via udp to %s(%s):%d", host, address, port);
@@ -322,6 +328,11 @@ static void catalog_update_udp( const char *host, const char *address, int port,
 	datagram_delete(d);
 }
 
+/*
+Send a catalog update via a tcp connection.
+This is inherently a blocking action and could
+take some time under non-ideal conditions.
+*/
 
 static int catalog_update_tcp( const char *host, const char *address, int port, const char *text )
 {
@@ -339,7 +350,32 @@ static int catalog_update_tcp( const char *host, const char *address, int port, 
 	return 1;
 }
 
-static int catalog_query_send_update_internal( const char *hosts, const char *text, int fail_if_too_big )
+/*
+Send a catalog update via a tcp connection in the background.
+This forks a process to perform an update, so that the main
+program can continue blissfully.
+*/
+
+static int catalog_update_tcp_background( const char *host, const char *address, int port, const char *text )
+{
+	pid_t pid = fork();
+	if(pid==0) {
+		/* release all cloned fds so that we don't interfere with the parent. */
+		fd_nonstd_close();
+		/* then do the update normally. */
+		catalog_update_tcp(host,address,port,text);
+		/* force normal exit without flushing anything */
+		_exit(0);
+	} else if(pid>0) {
+		debug(D_DEBUG, "sending update via tcp to %s(%s):%d (background pid %d)", host, address, port, (int)pid);
+		return 1;
+	} else {
+		debug(D_DEBUG, "unable to fork update process: %s",strerror(errno));
+		return 0;
+	}
+}
+
+int catalog_query_send_update( const char *hosts, const char *text, catalog_update_flags_t flags )
 {
 	size_t compress_limit = 1200;
 	const char *compress_limit_str = getenv("CATALOG_UPDATE_LIMIT");
@@ -362,7 +398,7 @@ static int catalog_query_send_update_internal( const char *hosts, const char *te
 
 		debug(D_DEBUG,"compressed update message from %d to %d bytes",(int)strlen(text),(int)data_length);
 
-		if(data_length>compress_limit && fail_if_too_big && !use_udp) {
+		if(data_length>compress_limit && (flags&CATALOG_UPDATE_CONDITIONAL) && !use_udp) {
 			debug(D_DEBUG,"compressed update message exceeds limit of %d bytes (CATALOG_UPDATE_LIMIT)",(int)compress_limit);
 			return 0;
 		}
@@ -383,7 +419,11 @@ static int catalog_query_send_update_internal( const char *hosts, const char *te
 				catalog_update_udp( host, address, port, text );
 				sent++;
 			} else {
-				sent += catalog_update_tcp( host, address, port+1, text );
+				if(flags&CATALOG_UPDATE_BACKGROUND) {
+					sent += catalog_update_tcp_background( host, address, port+1, text );
+				} else {
+					sent += catalog_update_tcp( host, address, port+1, text );
+				}
 			}
 		} else {
 			debug(D_DEBUG, "unable to lookup address of host: %s", host);
@@ -392,16 +432,6 @@ static int catalog_query_send_update_internal( const char *hosts, const char *te
 
 	free(update_data);
 	return sent;
-}
-
-int catalog_query_send_update(const char *hosts, const char *text)
-{
-	return catalog_query_send_update_internal(hosts,text,0);
-}
-
-int catalog_query_send_update_conditional(const char *hosts, const char *text)
-{
-	return catalog_query_send_update_internal(hosts,text,1);
 }
 
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/catalog_query.h
+++ b/dttools/src/catalog_query.h
@@ -20,6 +20,15 @@ Query the global catalog server for server descriptions.
 #define CATALOG_HOST (getenv("CATALOG_HOST") ? getenv("CATALOG_HOST") : CATALOG_HOST_DEFAULT )
 #define CATALOG_PORT (getenv("CATALOG_PORT") ? atoi(getenv("CATALOG_PORT")) : CATALOG_PORT_DEFAULT )
 
+/** Catalog update control flags.
+These control the behavior of @ref catalog_query_send_updates
+*/
+
+typedef enum {
+      CATALOG_UPDATE_BACKGROUND=1,  /**< Send update via a background process if TCP is selected. */
+      CATALOG_UPDATE_CONDITIONAL=2, /**< Fail if UDP is selected and update is too large to send. */
+} catalog_update_flags_t;
+
 /** Create a catalog query.
 Connects to a catalog server, issues a query, and waits for the results.
 The caller may specify a specific catalog host and port.
@@ -53,16 +62,9 @@ void catalog_query_delete(struct catalog_query *q);
 hosts is a comma delimited list of hosts, each of which can be host or host:port
 @param hosts A list of hosts to which to send updates
 @param text String to send
+@param flags Any combination of CATALOG_UPDATE
 @return The number of updates successfully sent, 
 */
-int catalog_query_send_update(const char *hosts, const char *text);
-
-/** Send update text to the given hosts, but fail if the update text
-cannot be compressed to a suitable size.
-@param hosts A list of hosts to which to send updates
-@param text String to send
-@return The number of updates successfully sent, 
-*/
-int catalog_query_send_update_conditional(const char *hosts, const char *text);
+int catalog_query_send_update(const char *hosts, const char *text, catalog_update_flags_t flags );
 
 #endif

--- a/dttools/src/catalog_update.c
+++ b/dttools/src/catalog_update.c
@@ -122,7 +122,7 @@ int main(int argc, char *argv[]) {
 
 	char *text = jx_print_string(merged);
 
-	if(catalog_query_send_update(host, text) < 1) {
+	if(catalog_query_send_update(host, text, 0) < 1) {
 		fprintf(stderr, "Unable to send update");
 	}
 

--- a/makeflow/src/makeflow_catalog_reporter.c
+++ b/makeflow/src/makeflow_catalog_reporter.c
@@ -79,7 +79,7 @@ int	makeflow_catalog_summary (struct dag *d, char *name, batch_queue_type_t type
   	//creates memory
   	char *text = jx_print_string (j);
 
-  	int resp = catalog_query_send_update (host, text);
+  	int resp = catalog_query_send_update(host,text,CATALOG_UPDATE_BACKGROUND);
 
   	free (text);
   	free (timestring);

--- a/resource_monitor/src/resource_monitor.c
+++ b/resource_monitor/src/resource_monitor.c
@@ -496,7 +496,7 @@ int send_catalog_update(struct rmsummary *s, int force) {
 	char *str = jx_print_string(j);
 
 	debug(D_RMON, "Sending resources snapshot to catalog server(s) at %s ...", catalog_hosts);
-	int status = catalog_query_send_update_conditional(catalog_hosts, str);
+	int status = catalog_query_send_update(catalog_hosts, str, CATALOG_UPDATE_BACKGROUND|CATALOG_UPDATE_CONDITIONAL);
 
 	free(str);
 	jx_delete(j);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -678,12 +678,12 @@ static void update_write_catalog(struct vine_manager *q )
 
 	// Send the buffer.
 	debug(D_VINE, "Advertising manager status to the catalog server(s) at %s ...", q->catalog_hosts);
-	if(!catalog_query_send_update_conditional(q->catalog_hosts, str)) {
+	if(!catalog_query_send_update(q->catalog_hosts, str, CATALOG_UPDATE_BACKGROUND|CATALOG_UPDATE_CONDITIONAL)) {
 
 		// If the send failed b/c the buffer is too big, send the lean version instead.
 		struct jx *lj = manager_lean_to_jx(q);
 		char *lstr = jx_print_string(lj);
-		catalog_query_send_update(q->catalog_hosts,lstr);
+		catalog_query_send_update(q->catalog_hosts,lstr,CATALOG_UPDATE_BACKGROUND);
 		free(lstr);
 		jx_delete(lj);
 	}

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1092,12 +1092,12 @@ void update_write_catalog(struct work_queue *q, struct link *foreman_uplink)
 
 	// Send the buffer.
 	debug(D_WQ, "Advertising manager status to the catalog server(s) at %s ...", q->catalog_hosts);
-	if(!catalog_query_send_update_conditional(q->catalog_hosts, str)) {
+	if(!catalog_query_send_update(q->catalog_hosts, str, CATALOG_UPDATE_BACKGROUND|CATALOG_UPDATE_CONDITIONAL)) {
 
 		// If the send failed b/c the buffer is too big, send the lean version instead.
 		struct jx *lj = queue_lean_to_jx(q,foreman_uplink);
 		char *lstr = jx_print_string(lj);
-		catalog_query_send_update(q->catalog_hosts,lstr);
+		catalog_query_send_update(q->catalog_hosts,lstr,CATALOG_UPDATE_BACKGROUND);
 		free(lstr);
 		jx_delete(lj);
 	}


### PR DESCRIPTION
Works, however it currently has the problem that update processes will accumulate as zombies.
Need to flesh out the `process` module so that we can easily reap only relevant processes of a given type.
