### PR TITLE
adds cache directory at vine_runtime_info_path/

### DIFF
--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -1034,6 +1034,12 @@ class Manager(object):
         return vine_get_runtime_path_staging(self._taskvine, None)
 
     ##
+    # Get the caching directory of the manager
+    @property
+    def cache_directory(self):
+        return vine_get_runtime_path_caching(self._taskvine, None)
+
+    ##
     # Get manager statistics.
     # @code
     # >>> print(q.stats)

--- a/taskvine/src/manager/vine_runtime_dir.c
+++ b/taskvine/src/manager/vine_runtime_dir.c
@@ -62,6 +62,9 @@ char *vine_runtime_directory_create() {
      * interpreted as a suffix to vine_runtime_info_path.
      *
      * VINE_RUNTIME_INFO_DIR has the subdirectories: logs and staging
+     *
+     * A cache directory is also created as a sibling of VINE_RUNTIME_INFO_DIR.
+     * The intention is that cache is shared between subsequent runs.
      */
 
 	char *runtime_dir = NULL;
@@ -123,6 +126,14 @@ char *vine_get_runtime_path_log(struct vine_manager *m, const char *path) {
 
 char *vine_get_runtime_path_staging(struct vine_manager *m, const char *path) {
     return string_format("%s/staging/%s", m->runtime_directory, path ? path : "");
+}
+
+char *vine_get_runtime_path_caching(struct vine_manager *m, const char *path) {
+    char abs[PATH_MAX];
+    char *tmp = string_format("%s/../vine-cache/%s", m->runtime_directory, path);
+    path_collapse(tmp, abs, 1);
+    free(tmp);
+    return xxstrdup(abs);
 }
 
 void vine_set_runtime_info_path(const char *path) {

--- a/taskvine/src/manager/vine_runtime_dir.h
+++ b/taskvine/src/manager/vine_runtime_dir.h
@@ -25,4 +25,7 @@ char *vine_get_runtime_path_log(struct vine_manager *m, const char *path);
 /* Returns path relative to the staging runtime directory */
 char *vine_get_runtime_path_staging(struct vine_manager *m, const char *path);
 
+/* Returns path relative to the cache runtime directory */
+char *vine_get_runtime_path_caching(struct vine_manager *m, const char *path);
+
 #endif


### PR DESCRIPTION
Adds a cache directory to the runtime dirs.

The motivation is to move directories such as `./vine-library-cache/` (#3170) to   m.cache_directory + `library-cache`