### PR TITLE
Add startime io updates

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -307,10 +307,11 @@ static int handle_cache_update( struct vine_manager *q, struct vine_worker_info 
 	char cachename[VINE_LINE_MAX];
 	long long size;
 	long long transfer_time;
+	long long start_time;
 	char id[VINE_LINE_MAX];
 
-	if(sscanf(line,"cache-update %s %lld %lld %s",cachename,&size,&transfer_time, id)==4) {
-		struct vine_file_replica *remote_info = vine_file_replica_table_lookup(w, cachename); 
+	if(sscanf(line,"cache-update %s %lld %lld %lld %s",cachename,&size,&transfer_time,&start_time,id)==5) {
+		struct vine_file_replica *remote_info = vine_file_replica_table_lookup(w, cachename);
 
 		if(!remote_info) {
 			/*
@@ -328,7 +329,7 @@ static int handle_cache_update( struct vine_manager *q, struct vine_worker_info 
 
 		vine_current_transfers_remove(q, id);
 
-		vine_txn_log_write_cache_update(q,w,size,transfer_time,cachename);
+		vine_txn_log_write_cache_update(q,w,size,transfer_time,start_time,cachename);
 	}
 
 	return VINE_MSG_PROCESSED;

--- a/taskvine/src/manager/vine_manager_get.c
+++ b/taskvine/src/manager/vine_manager_get.c
@@ -342,7 +342,7 @@ vine_result_code_t vine_manager_get_output_file( struct vine_manager *q, struct 
 
 		debug(D_VINE, "%s (%s) sent %.2lf MB in %.02lfs (%.02lfs MB/s) average %.02lfs MB/s", w->hostname, w->addrport, total_bytes / 1000000.0, sum_time / 1000000.0, (double) total_bytes / sum_time, (double) w->total_bytes_transferred / w->total_transfer_time);
 
-		vine_txn_log_write_transfer(q, w, t, m, f, total_bytes, sum_time, 0);
+		vine_txn_log_write_transfer(q, w, t, m, f, total_bytes, sum_time, open_time, 0);
 	}
 
 	// If we failed to *transfer* the output file, then that is a hard

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -290,7 +290,7 @@ static vine_result_code_t vine_manager_put_input_file(struct vine_manager *q, st
 
 		// Write to the transaction log.
 		if(f->type == VINE_FILE || f->type == VINE_BUFFER) {
-			vine_txn_log_write_transfer(q, w, t, m, f, total_bytes, elapsed_time, 1);
+			vine_txn_log_write_transfer(q, w, t, m, f, total_bytes, elapsed_time, open_time, 1);
 		}
 
 		// Avoid division by zero below.

--- a/taskvine/src/manager/vine_txn_log.c
+++ b/taskvine/src/manager/vine_txn_log.c
@@ -237,7 +237,7 @@ void vine_txn_log_write_worker_resources(struct vine_manager *q, struct vine_wor
 }
 
 
-void vine_txn_log_write_transfer(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct vine_mount *m, struct vine_file *f, size_t size_in_bytes, int time_in_usecs, int is_input )
+void vine_txn_log_write_transfer(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct vine_mount *m, struct vine_file *f, size_t size_in_bytes, int time_in_usecs, int start_in_usecs, int is_input )
 {
 	struct buffer B;
 	buffer_init(&B);

--- a/taskvine/src/manager/vine_txn_log.c
+++ b/taskvine/src/manager/vine_txn_log.c
@@ -40,8 +40,8 @@ void vine_txn_log_write_header( struct vine_manager *q )
 	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id CONNECTION host:port\n");
 	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id DISCONNECTION (UNKNOWN|IDLE_OUT|FAST_ABORT|FAILURE|STATUS_WORKER|EXPLICIT)\n");
 	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id RESOURCES {resources}\n");
-	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id CACHE_UPDATE filename sizeinmb walltime\n");
-	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id TRANSFER (INPUT|OUTPUT) filename sizeinmb walltime\n");
+	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id CACHE_UPDATE filename sizeinmb wall_time start_time\n");
+	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id TRANSFER (INPUT|OUTPUT) filename sizeinmb wall_time start_time\n");
 	fprintf(q->txn_logfile, "# time manager_pid CATEGORY name MAX {resources_max_per_task}\n");
 	fprintf(q->txn_logfile, "# time manager_pid CATEGORY name MIN {resources_min_per_task_per_worker}\n");
 	fprintf(q->txn_logfile, "# time manager_pid CATEGORY name FIRST (FIXED|MAX|MIN_WASTE|MAX_THROUGHPUT) {resources_requested}\n");

--- a/taskvine/src/manager/vine_txn_log.c
+++ b/taskvine/src/manager/vine_txn_log.c
@@ -246,12 +246,13 @@ void vine_txn_log_write_transfer(struct vine_manager *q, struct vine_worker_info
 	buffer_printf(&B, " %s", m->remote_name);
 	buffer_printf(&B, " %f", size_in_bytes / ((double) MEGABYTE));
 	buffer_printf(&B, " %f", time_in_usecs / ((double) USECOND));
+	buffer_printf(&B, " %f", start_in_usecs / ((double) USECOND));
 
 	vine_txn_log_write(q, buffer_tostring(&B));
 	buffer_free(&B);
 }
 
-void vine_txn_log_write_cache_update(struct vine_manager *q, struct vine_worker_info *w, size_t size_in_bytes, int time_in_usecs, const char *name )
+void vine_txn_log_write_cache_update(struct vine_manager *q, struct vine_worker_info *w, size_t size_in_bytes, int time_in_usecs, int start_in_usecs, const char *name )
 {
 	struct buffer B;
 
@@ -260,6 +261,7 @@ void vine_txn_log_write_cache_update(struct vine_manager *q, struct vine_worker_
 	buffer_printf(&B, " %s", name);
 	buffer_printf(&B, " %f", size_in_bytes / ((double) MEGABYTE));
 	buffer_printf(&B, " %f", time_in_usecs / ((double) USECOND));
+	buffer_printf(&B, " %f", start_in_usecs / ((double) USECOND));
 
 	vine_txn_log_write(q, buffer_tostring(&B));
 	buffer_free(&B);

--- a/taskvine/src/manager/vine_txn_log.h
+++ b/taskvine/src/manager/vine_txn_log.h
@@ -24,7 +24,7 @@ void vine_txn_log_write_manager(struct vine_manager *q, const char *str);
 void vine_txn_log_write_task(struct vine_manager *q, struct vine_task *t);
 void vine_txn_log_write_category(struct vine_manager *q, struct category *c);
 void vine_txn_log_write_worker(struct vine_manager *q, struct vine_worker_info *w, int leaving, vine_worker_disconnect_reason_t reason_leaving);
-void vine_txn_log_write_transfer(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct vine_mount *m, struct vine_file *f, size_t size_in_bytes, int time_in_usecs, int is_input );
+void vine_txn_log_write_transfer(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct vine_mount *m, struct vine_file *f, size_t size_in_bytes, int time_in_usecs, int start_in_usecs, int is_input );
 void vine_txn_log_write_cache_update(struct vine_manager *q, struct vine_worker_info *w, size_t size_in_bytes, int time_in_usecs, const char *name );
 void vine_txn_log_write_worker_resources(struct vine_manager *q, struct vine_worker_info *w);
 void vine_txn_log_write_duty_update(struct vine_manager *q, struct vine_worker_info *w, int duty_id, vine_duty_state_t state);

--- a/taskvine/src/manager/vine_txn_log.h
+++ b/taskvine/src/manager/vine_txn_log.h
@@ -25,7 +25,7 @@ void vine_txn_log_write_task(struct vine_manager *q, struct vine_task *t);
 void vine_txn_log_write_category(struct vine_manager *q, struct category *c);
 void vine_txn_log_write_worker(struct vine_manager *q, struct vine_worker_info *w, int leaving, vine_worker_disconnect_reason_t reason_leaving);
 void vine_txn_log_write_transfer(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct vine_mount *m, struct vine_file *f, size_t size_in_bytes, int time_in_usecs, int start_in_usecs, int is_input );
-void vine_txn_log_write_cache_update(struct vine_manager *q, struct vine_worker_info *w, size_t size_in_bytes, int time_in_usecs, const char *name );
+void vine_txn_log_write_cache_update(struct vine_manager *q, struct vine_worker_info *w, size_t size_in_bytes, int time_in_usecs, int start_in_usecs, const char *name );
 void vine_txn_log_write_worker_resources(struct vine_manager *q, struct vine_worker_info *w);
 void vine_txn_log_write_duty_update(struct vine_manager *q, struct vine_worker_info *w, int duty_id, vine_duty_state_t state);
 

--- a/taskvine/src/tools/vine_plot_txn_log
+++ b/taskvine/src/tools/vine_plot_txn_log
@@ -309,10 +309,10 @@ def parse_workers(log):
             elif event == "RESOURCES":
                 worker_info[worker_id]["resources"].append(time)
             elif event == "CACHE_UPDATE":
-                (filename, sizeinmb, walltime) = arg.split()
+                (filename, sizeinmb, walltime, starttime) = arg.split()
                 worker_info[worker_id]["cache_updates"].append([time, float(walltime)/1000000, filename])
             elif event == "TRANSFER":
-                (direction, filename, sizeinmb, walltime) = arg.split()
+                (direction, filename, sizeinmb, walltime, starttime) = arg.split()
                 if direction == "INPUT":
                     worker_info[worker_id]["input_transfers"].append([time, float(walltime)/1000000])
                 elif direction == "OUTPUT":

--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -118,7 +118,7 @@ void vine_cache_scan(struct vine_cache *c, struct link *manager)
 	char * cachename;
 	HASH_TABLE_ITERATE(c->table, cachename, f){
 		/* XXX the worker doesn't know how long it took to transfer. */
-		vine_worker_send_cache_update(manager,cachename,f->actual_size,0);
+		vine_worker_send_cache_update(manager,cachename,f->actual_size,0,0);
 	}
 }
 
@@ -425,7 +425,7 @@ int vine_cache_ensure( struct vine_cache *c, const char *cachename, struct link 
 			f->actual_size = nbytes;
 			f->complete = 1;
 			debug(D_VINE,"cache: created %s with size %lld in %lld usec",cachename,(long long)f->actual_size,(long long)transfer_time);
-			vine_worker_send_cache_update(manager,cachename,f->actual_size,transfer_time);
+			vine_worker_send_cache_update(manager,cachename,f->actual_size,transfer_time,transfer_start);
 			result = 1;
 		} else {
 			debug(D_VINE,"cache: command succeeded but did not create %s",cachename);

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -112,7 +112,7 @@ static int transfer_output_file( struct vine_process *p, struct vine_mount *m, s
 		struct stat info;
 		if(stat(cache_path,&info)==0) {
 			vine_cache_addfile(cache,info.st_size,info.st_mode,f->cached_name);
-			vine_worker_send_cache_update(manager,f->cached_name,info.st_size,0);
+			vine_worker_send_cache_update(manager,f->cached_name,info.st_size,0,0);
 		} else {
 			// This seems implausible given that the rename/copy succeded, but we still have to check...
 			debug(D_VINE,"output: failed to stat %s: %s",cache_path,strerror(errno));

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -421,12 +421,12 @@ Send an asynchronmous message to the manager indicating that an item was success
 void vine_worker_send_cache_update( struct link *manager, const char *cachename, int64_t size, timestamp_t transfer_time )
 {
 	char *transfer_id = hash_table_remove(current_transfers, cachename);
-	if(transfer_id) {
-		send_message(manager,"cache-update %s %lld %lld %s\n",cachename,(long long)size,(long long)transfer_time, transfer_id);
-		free(transfer_id);
-	} else {
-		send_message(manager,"cache-update %s %lld %lld X\n",cachename,(long long)size,(long long)transfer_time);
+	if(!transfer_id) {
+		transfer_id = xxstrdup("X");
 	}
+
+	send_message(manager,"cache-update %s %lld %lld %s\n",cachename,(long long)size,(long long)transfer_time, transfer_id);
+	free(transfer_id);
 }
 
 /*

--- a/taskvine/src/worker/vine_worker.h
+++ b/taskvine/src/worker/vine_worker.h
@@ -4,7 +4,7 @@
 #include "timestamp.h"
 #include "link.h"
 
-void vine_worker_send_cache_update( struct link *manager, const char *cachename, int64_t size, timestamp_t transfer_time );
+void vine_worker_send_cache_update( struct link *manager, const char *cachename, int64_t size, timestamp_t transfer_time, timestamp_t transfer_start );
 void vine_worker_send_cache_invalid( struct link *manager, const char *cachename, const char *message );
 
 extern int vine_worker_symlinks_enabled;


### PR DESCRIPTION
Adds start time to the transactions log of transfers and cache updates.  

(In one example I ran with blast and 1000 concurrent tasks, the manager was so busy that by the time it read the cache_update, some short tasks had already finished, which messed up the plot.)