### PR TITLE
use usecs instead of seconds in transfer transactions

### DIFF
--- a/taskvine/src/manager/vine_txn_log.c
+++ b/taskvine/src/manager/vine_txn_log.c
@@ -40,8 +40,8 @@ void vine_txn_log_write_header( struct vine_manager *q )
 	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id CONNECTION host:port\n");
 	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id DISCONNECTION (UNKNOWN|IDLE_OUT|FAST_ABORT|FAILURE|STATUS_WORKER|EXPLICIT)\n");
 	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id RESOURCES {resources}\n");
-	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id CACHE_UPDATE filename sizeinmb wall_time start_time\n");
-	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id TRANSFER (INPUT|OUTPUT) filename sizeinmb wall_time start_time\n");
+	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id CACHE_UPDATE filename size_in_mb wall_time_us start_time_us\n");
+	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id TRANSFER (INPUT|OUTPUT) filename size_in_mb wall_time_us start_time_us\n");
 	fprintf(q->txn_logfile, "# time manager_pid CATEGORY name MAX {resources_max_per_task}\n");
 	fprintf(q->txn_logfile, "# time manager_pid CATEGORY name MIN {resources_min_per_task_per_worker}\n");
 	fprintf(q->txn_logfile, "# time manager_pid CATEGORY name FIRST (FIXED|MAX|MIN_WASTE|MAX_THROUGHPUT) {resources_requested}\n");
@@ -237,31 +237,31 @@ void vine_txn_log_write_worker_resources(struct vine_manager *q, struct vine_wor
 }
 
 
-void vine_txn_log_write_transfer(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct vine_mount *m, struct vine_file *f, size_t size_in_bytes, int time_in_usecs, int start_in_usecs, int is_input )
+void vine_txn_log_write_transfer(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct vine_mount *m, struct vine_file *f, size_t size_in_bytes, timestamp_t time_in_usecs, timestamp_t start_in_usecs, int is_input )
 {
 	struct buffer B;
 	buffer_init(&B);
 	buffer_printf(&B, "WORKER %s TRANSFER ", w->workerid);
 	buffer_printf(&B, is_input ? "INPUT":"OUTPUT");
 	buffer_printf(&B, " %s", m->remote_name);
-	buffer_printf(&B, " %f", size_in_bytes / ((double) MEGABYTE));
-	buffer_printf(&B, " %f", time_in_usecs / ((double) USECOND));
-	buffer_printf(&B, " %f", start_in_usecs / ((double) USECOND));
+	buffer_printf(&B, " %ld", size_in_bytes);
+	buffer_printf(&B, " %lu", time_in_usecs);
+	buffer_printf(&B, " %lu", start_in_usecs);
 
 	vine_txn_log_write(q, buffer_tostring(&B));
 	buffer_free(&B);
 }
 
-void vine_txn_log_write_cache_update(struct vine_manager *q, struct vine_worker_info *w, size_t size_in_bytes, int time_in_usecs, int start_in_usecs, const char *name )
+void vine_txn_log_write_cache_update(struct vine_manager *q, struct vine_worker_info *w, size_t size_in_bytes, timestamp_t time_in_usecs, timestamp_t start_in_usecs, const char *name )
 {
 	struct buffer B;
 
 	buffer_init(&B);
 	buffer_printf(&B, "WORKER %s CACHE_UPDATE", w->workerid);
 	buffer_printf(&B, " %s", name);
-	buffer_printf(&B, " %f", size_in_bytes / ((double) MEGABYTE));
-	buffer_printf(&B, " %f", time_in_usecs / ((double) USECOND));
-	buffer_printf(&B, " %f", start_in_usecs / ((double) USECOND));
+	buffer_printf(&B, " %ld", size_in_bytes);
+	buffer_printf(&B, " %lu", time_in_usecs);
+	buffer_printf(&B, " %lu", start_in_usecs);
 
 	vine_txn_log_write(q, buffer_tostring(&B));
 	buffer_free(&B);

--- a/taskvine/src/manager/vine_txn_log.c
+++ b/taskvine/src/manager/vine_txn_log.c
@@ -244,9 +244,9 @@ void vine_txn_log_write_transfer(struct vine_manager *q, struct vine_worker_info
 	buffer_printf(&B, "WORKER %s TRANSFER ", w->workerid);
 	buffer_printf(&B, is_input ? "INPUT":"OUTPUT");
 	buffer_printf(&B, " %s", m->remote_name);
-	buffer_printf(&B, " %ld", size_in_bytes);
-	buffer_printf(&B, " %lu", time_in_usecs);
-	buffer_printf(&B, " %lu", start_in_usecs);
+	buffer_printf(&B, " %lld", (long long) size_in_bytes);
+	buffer_printf(&B, " %llu", (unsigned long long) time_in_usecs);
+	buffer_printf(&B, " %llu", (unsigned long long) start_in_usecs);
 
 	vine_txn_log_write(q, buffer_tostring(&B));
 	buffer_free(&B);
@@ -259,9 +259,9 @@ void vine_txn_log_write_cache_update(struct vine_manager *q, struct vine_worker_
 	buffer_init(&B);
 	buffer_printf(&B, "WORKER %s CACHE_UPDATE", w->workerid);
 	buffer_printf(&B, " %s", name);
-	buffer_printf(&B, " %ld", size_in_bytes);
-	buffer_printf(&B, " %lu", time_in_usecs);
-	buffer_printf(&B, " %lu", start_in_usecs);
+	buffer_printf(&B, " %lld", (long long) size_in_bytes);
+	buffer_printf(&B, " %llu", (unsigned long long) time_in_usecs);
+	buffer_printf(&B, " %llu", (unsigned long long) start_in_usecs);
 
 	vine_txn_log_write(q, buffer_tostring(&B));
 	buffer_free(&B);

--- a/taskvine/src/manager/vine_txn_log.h
+++ b/taskvine/src/manager/vine_txn_log.h
@@ -19,13 +19,15 @@ This module is private to the manager and should not be invoked by the end user.
 #include "vine_file.h"
 #include "vine_mount.h"
 
+#include "timestamp.h"
+
 void vine_txn_log_write_header( struct vine_manager *q );
 void vine_txn_log_write_manager(struct vine_manager *q, const char *str);
 void vine_txn_log_write_task(struct vine_manager *q, struct vine_task *t);
 void vine_txn_log_write_category(struct vine_manager *q, struct category *c);
 void vine_txn_log_write_worker(struct vine_manager *q, struct vine_worker_info *w, int leaving, vine_worker_disconnect_reason_t reason_leaving);
-void vine_txn_log_write_transfer(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct vine_mount *m, struct vine_file *f, size_t size_in_bytes, int time_in_usecs, int start_in_usecs, int is_input );
-void vine_txn_log_write_cache_update(struct vine_manager *q, struct vine_worker_info *w, size_t size_in_bytes, int time_in_usecs, int start_in_usecs, const char *name );
+void vine_txn_log_write_transfer(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct vine_mount *m, struct vine_file *f, size_t size_in_bytes, timestamp_t time_in_usecs, timestamp_t start_in_usecs, int is_input );
+void vine_txn_log_write_cache_update(struct vine_manager *q, struct vine_worker_info *w, size_t size_in_bytes, timestamp_t time_in_usecs, timestamp_t start_in_usecs, const char *name );
 void vine_txn_log_write_worker_resources(struct vine_manager *q, struct vine_worker_info *w);
 void vine_txn_log_write_duty_update(struct vine_manager *q, struct vine_worker_info *w, int duty_id, vine_duty_state_t state);
 

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -418,14 +418,14 @@ static int send_keepalive(struct link *manager, int force_resources)
 Send an asynchronmous message to the manager indicating that an item was successfully loaded into the cache, along with its size in bytes and transfer time in usec.
 */
 
-void vine_worker_send_cache_update( struct link *manager, const char *cachename, int64_t size, timestamp_t transfer_time )
+void vine_worker_send_cache_update( struct link *manager, const char *cachename, int64_t size, timestamp_t transfer_time, timestamp_t transfer_start )
 {
 	char *transfer_id = hash_table_remove(current_transfers, cachename);
 	if(!transfer_id) {
 		transfer_id = xxstrdup("X");
 	}
 
-	send_message(manager,"cache-update %s %lld %lld %s\n",cachename,(long long)size,(long long)transfer_time, transfer_id);
+	send_message(manager,"cache-update %s %lld %lld %lld %s\n",cachename,(long long)size,(long long)transfer_time,(long long)transfer_start,transfer_id);
 	free(transfer_id);
 }
 


### PR DESCRIPTION
it makes easy to parse for the plots, as the origin is kept in usecs.

(The plotting tool was incorrectly dividing the wall_time by 1e6 anyway.)