### PR TITLE
adds size input info to running state transaction

### DIFF
--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -71,7 +71,11 @@ void vine_task_clean( struct vine_task *t, int full_clean )
 	t->time_when_commit_start = 0;
 	t->time_when_commit_end   = 0;
 	t->time_when_retrieval    = 0;
+	t->time_when_done = 0;
+
 	t->time_workers_execute_last = 0;
+	t->time_workers_execute_last_start = 0;
+	t->time_workers_execute_last_end = 0;
 
 	t->bytes_sent = 0;
 	t->bytes_received = 0;

--- a/taskvine/src/manager/vine_txn_log.c
+++ b/taskvine/src/manager/vine_txn_log.c
@@ -55,7 +55,15 @@ void vine_txn_log_write_header( struct vine_manager *q )
 }
 
 static struct jx *resources_with_io_report(const struct vine_task *t, const struct rmsummary *s) {
-	struct jx *m = rmsummary_to_json(s, /* only resources */ 1);
+
+	struct jx *m = NULL;
+
+	if(s) {
+		m = rmsummary_to_json(s, /* only resources */ 1);
+	} else {
+		m = jx_object(0);
+	}
+
 	if(t->time_when_commit_start > 0) {
 		/* if time_when_commit_start, then we now for sure the task was
 		 * submitted to some worker, and that bytes sent makes sense. */

--- a/taskvine/src/manager/vine_txn_log.c
+++ b/taskvine/src/manager/vine_txn_log.c
@@ -55,26 +55,26 @@ void vine_txn_log_write_header( struct vine_manager *q )
 }
 
 static struct jx *resources_with_io_report(const struct vine_task *t, const struct rmsummary *s) {
-    struct jx *m = rmsummary_to_json(s, /* only resources */ 1);
-    if(t->time_when_commit_start > 0) {
-        /* if time_when_commit_start, then we now for sure the task was
-         * submitted to some worker, and that bytes sent makes sense. */
+	struct jx *m = rmsummary_to_json(s, /* only resources */ 1);
+	if(t->time_when_commit_start > 0) {
+		/* if time_when_commit_start, then we now for sure the task was
+		 * submitted to some worker, and that bytes sent makes sense. */
 
-        jx_insert(m, jx_string("size_input_mgr"), jx_arrayv(jx_double(t->bytes_sent/((double) MEGABYTE)), jx_string("MB"), NULL));
-        jx_insert(m, jx_string("time_input_mgr"), jx_arrayv(jx_double((t->time_when_commit_end - t->time_when_commit_start)/((double) ONE_SECOND)), jx_string("s"), NULL));
-        jx_insert(m, jx_string("time_commit_end"), jx_arrayv(jx_double(t->time_when_commit_end/((double) ONE_SECOND)), jx_string("s"), NULL));
-        jx_insert(m, jx_string("time_commit_start"), jx_arrayv(jx_double(t->time_when_commit_start/((double) ONE_SECOND)), jx_string("s"), NULL));
-    }
+		jx_insert(m, jx_string("size_input_mgr"), jx_arrayv(jx_double(t->bytes_sent/((double) MEGABYTE)), jx_string("MB"), NULL));
+		jx_insert(m, jx_string("time_input_mgr"), jx_arrayv(jx_double((t->time_when_commit_end - t->time_when_commit_start)/((double) ONE_SECOND)), jx_string("s"), NULL));
+		jx_insert(m, jx_string("time_commit_end"), jx_arrayv(jx_double(t->time_when_commit_end/((double) ONE_SECOND)), jx_string("s"), NULL));
+		jx_insert(m, jx_string("time_commit_start"), jx_arrayv(jx_double(t->time_when_commit_start/((double) ONE_SECOND)), jx_string("s"), NULL));
+	}
 
-    if(t->time_when_retrieval > 0) {
-        /* if time_when_retrieval, then information about execution is available */
-        jx_insert(m, jx_string("size_output_mgr"), jx_arrayv(jx_double(t->bytes_received/((double) MEGABYTE)), jx_string("MB"), NULL));
-        jx_insert(m, jx_string("time_output_mgr"), jx_arrayv(jx_double((t->time_when_done - t->time_when_retrieval)/((double) ONE_SECOND)), jx_string("s"), NULL));
-        jx_insert(m, jx_string("time_worker_end"), jx_arrayv(jx_double(t->time_workers_execute_last_end/((double) ONE_SECOND)), jx_string("s"), NULL));
-        jx_insert(m, jx_string("time_worker_start"), jx_arrayv(jx_double(t->time_workers_execute_last_start/((double) ONE_SECOND)), jx_string("s"), NULL));
-    }
+	if(t->time_when_retrieval > 0) {
+		/* if time_when_retrieval, then information about execution is available */
+		jx_insert(m, jx_string("size_output_mgr"), jx_arrayv(jx_double(t->bytes_received/((double) MEGABYTE)), jx_string("MB"), NULL));
+		jx_insert(m, jx_string("time_output_mgr"), jx_arrayv(jx_double((t->time_when_done - t->time_when_retrieval)/((double) ONE_SECOND)), jx_string("s"), NULL));
+		jx_insert(m, jx_string("time_worker_end"), jx_arrayv(jx_double(t->time_workers_execute_last_end/((double) ONE_SECOND)), jx_string("s"), NULL));
+		jx_insert(m, jx_string("time_worker_start"), jx_arrayv(jx_double(t->time_workers_execute_last_start/((double) ONE_SECOND)), jx_string("s"), NULL));
+	}
 
-    return m;
+	return m;
 }
 
 void vine_txn_log_write_task(struct vine_manager *q, struct vine_task *t)
@@ -90,33 +90,33 @@ void vine_txn_log_write_task(struct vine_manager *q, struct vine_task *t)
 	buffer_printf(&B, "TASK %d %s", t->task_id, vine_task_state_to_string(state));
 
 	if(state == VINE_TASK_UNKNOWN) {
-			/* do not add any info */
+		/* do not add any info */
 	} else if(state == VINE_TASK_READY) {
 		const char *allocation = (t->resource_request == CATEGORY_ALLOCATION_FIRST ? "FIRST_RESOURCES" : "MAX_RESOURCES");
 		buffer_printf(&B, " %s %s %d ", t->category, allocation, t->try_count+1);
 		rmsummary_print_buffer(&B, vine_manager_task_resources_min(q, t), 1);
 	} else if(state == VINE_TASK_CANCELED) {
-			/* do not add any info */
-    } else if (state == VINE_TASK_DONE) {
+		/* do not add any info */
+	} else if(state == VINE_TASK_DONE) {
 		buffer_printf(&B, " %s ", vine_result_string(t->result));
 		buffer_printf(&B, " %d ", t->exit_code);
 	} else if(state == VINE_TASK_RETRIEVED) {
 		buffer_printf(&B, " %s ", vine_result_string(t->result));
 		buffer_printf(&B, " %d ", t->exit_code);
 
-        assert(t->resources_measured);
-        if(t->result == VINE_RESULT_RESOURCE_EXHAUSTION) {
-            rmsummary_print_buffer(&B, t->resources_measured->limits_exceeded, 1);
-            buffer_printf(&B, " ");
-        }
-        else {
-            // no limits broken, thus printing an empty dictionary
-            buffer_printf(&B, " {} ");
-        }
+		assert(t->resources_measured);
+		if(t->result == VINE_RESULT_RESOURCE_EXHAUSTION) {
+			rmsummary_print_buffer(&B, t->resources_measured->limits_exceeded, 1);
+			buffer_printf(&B, " ");
+		}
+		else {
+			// no limits broken, thus printing an empty dictionary
+			buffer_printf(&B, " {} ");
+		}
 
-        struct jx *m = resources_with_io_report(t, t->resources_measured);
-        jx_print_buffer(m, &B);
-        jx_delete(m);
+		struct jx *m = resources_with_io_report(t, t->resources_measured);
+		jx_print_buffer(m, &B);
+		jx_delete(m);
 	} else {
 		struct vine_worker_info *w = t->worker;
 		if(w) {
@@ -127,9 +127,9 @@ void vine_txn_log_write_task(struct vine_manager *q, struct vine_task *t)
 				buffer_printf(&B, " %s ", allocation);
 				const struct rmsummary *box = itable_lookup(w->current_tasks_boxes, t->task_id);
 
-                struct jx *m = resources_with_io_report(t, box);
-                jx_print_buffer(m, &B);
-                jx_delete(m);
+				struct jx *m = resources_with_io_report(t, box);
+				jx_print_buffer(m, &B);
+				jx_delete(m);
 
 				rmsummary_print_buffer(&B, box, 1);
 			} else if(state == VINE_TASK_WAITING_RETRIEVAL) {
@@ -175,12 +175,12 @@ void vine_txn_log_write_category(struct vine_manager *q, struct category *c)
 		case CATEGORY_ALLOCATION_MODE_MAX_THROUGHPUT:
 			mode = "MAX_THROUGHPUT";
 			break;
-        case CATEGORY_ALLOCATION_MODE_GREEDY_BUCKETING:
-            mode = "GREEDY_BUCKETING";
-            break;
-        case CATEGORY_ALLOCATION_MODE_EXHAUSTIVE_BUCKETING:
-            mode = "EXHAUSTIVE_BUCKETING";
-            break;
+		case CATEGORY_ALLOCATION_MODE_GREEDY_BUCKETING:
+			mode = "GREEDY_BUCKETING";
+			break;
+		case CATEGORY_ALLOCATION_MODE_EXHAUSTIVE_BUCKETING:
+			mode = "EXHAUSTIVE_BUCKETING";
+			break;
 		case CATEGORY_ALLOCATION_MODE_FIXED:
 		default:
 			mode = "FIXED";
@@ -291,11 +291,11 @@ void vine_txn_log_write_cache_update(struct vine_manager *q, struct vine_worker_
 void vine_txn_log_write_manager(struct vine_manager *q, const char *event)
 {
 	struct buffer B;
-    int64_t time_from_origin = 0;
+	int64_t time_from_origin = 0;
 
-    if(strcmp("START", event)) {
-        time_from_origin = timestamp_get() - q->stats->time_when_started;
-    }
+	if(strcmp("START", event)) {
+		time_from_origin = timestamp_get() - q->stats->time_when_started;
+	}
 
 	buffer_init(&B);
 	buffer_printf(&B, "MANAGER %d %s %" PRId64, getpid(), event, time_from_origin);
@@ -309,25 +309,27 @@ void vine_txn_log_write_duty_update(struct vine_manager *q, struct vine_worker_i
 	buffer_init(&B);
 	buffer_printf(&B, "DUTY %d", duty_id);
 
-    const char *status = "UNKNOWN";
-    switch(state) {
-        case VINE_DUTY_WAITING:
-            status = "WAITING";
-            break;
-        case VINE_DUTY_SENT:
-            status = "SENT";
-            break;
-        case VINE_DUTY_STARTED:
-            status = "STARTED";
-            break;
-        case VINE_DUTY_FAILURE:
-            status = "FAILURE";
-            break;
-    }
+	const char *status = "UNKNOWN";
+	switch(state) {
+		case VINE_DUTY_WAITING:
+			status = "WAITING";
+			break;
+		case VINE_DUTY_SENT:
+			status = "SENT";
+			break;
+		case VINE_DUTY_STARTED:
+			status = "STARTED";
+			break;
+		case VINE_DUTY_FAILURE:
+			status = "FAILURE";
+			break;
+	}
 
-    buffer_printf(&B, " %s", status);
-    buffer_printf(&B, " %s", w->workerid);
+	buffer_printf(&B, " %s", status);
+	buffer_printf(&B, " %s", w->workerid);
 
 	vine_txn_log_write(q, buffer_tostring(&B));
 	buffer_free(&B);
 }
+
+/* vim: set noexpandtab tabstop=4: */


### PR DESCRIPTION
The motivation is that such info was only available for tasks that were retrieved, but not for tasks lost in a disconnection.

Also, deduplicates resources measured info by only recording it for the retrieved state.