### PR TITLE
rework enable_monitoring API

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1803,6 +1803,7 @@ change.
 | proportional-resources | If set to 0, do not assign resources proportionally to tasks. The default is to use proportions. (See [task resources.](#task-resources) | 1 |
 | proportional-whole-tasks | Round up resource proportions such that only an integer number of tasks could be fit in the worker. The default is to use proportions. (See [task resources.](#task-resources) | 1 |
 | hungry-minimum          | Smallest number of waiting tasks in the queue before declaring it hungry | 10 |
+| monitor-interval        | Maximum number of seconds between resource monitor measurements. If less than 1, use default. | 5 |
 | resource-submit-multiplier | Assume that workers have `resource x resources-submit-multiplier` available.<br> This overcommits resources at the worker, causing tasks to be sent to workers that cannot be immediately executed.<br>The extra tasks wait at the worker until resources become available. | 1 |
 | wait-for-workers        | Do not schedule any tasks until `wait-for-workers` are connected. | 0 |
 | wait-retrieve-many      | Rather than immediately returning when a task is done, `m.wait(timeout)` retrieves and dispatches as many tasks<br> as `timeout` allows. Warning: This may exceed the capacity of the manager to receive results. | 0 |

--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -878,16 +878,30 @@ these limits. You can enable monitoring and enforcement as follows:
     # Measure the resources used by tasks, but do not terminate tasks that go above
     # declared resources:
     m.enable_monitoring(watchdog=False)
+
+    # Measure the resources used by tasks, but do not terminate tasks that go
+    # above declared resources, and generate a time series per task. These time
+    # series are written to the logs directory `vine-logs/time-series`.
+    # Use with caution, as time series for long running tasks may be in the
+    # order of gigabytes. 
+    vine_enable_monitoring(m,watchdog=False,time_series=True)
     ```
 
 === "C"
     ```C
-    # Measure the resources used by tasks, and terminate tasks that go above their
-    # resources:
+    /* Measure the resources used by tasks, and terminate tasks that go above their
+    resources: */
+    vine_enable_monitoring(m,1,0)
+
+    /* Measure the resources used by tasks, but do not terminate tasks that go above
+    declared resources: */
     vine_enable_monitoring(m,0,0)
 
-    # Measure the resources used by tasks, but do not terminate tasks that go above
-    # declared resources:
+    /* Measure the resources used by tasks, but do not terminate tasks that go
+    above # declared resources, and generate a time series per task. These time
+    series are written to the logs directory `vine-logs/time-series`.
+    Use with caution, as time series for long running tasks may be in the
+    order of gigabytes. */
     vine_enable_monitoring(m,0,1)
     ```
 
@@ -944,7 +958,7 @@ report format is JSON, as its filename has the form
 === "C"
     ```C
     struct vine_task *t = vine_task_create(...);
-    vine_set_monitor_output("my-resources-output");
+    vine_task_set_monitor_output(t, "my-resources-output");
     ...
     int taskid = vine_submti(m, t);
     ```

--- a/dttools/src/jx.c
+++ b/dttools/src/jx.c
@@ -132,7 +132,7 @@ struct jx * jx_objectv( const char *key, struct jx *value, ... ) {
 
 	while(key) {
 		assert(value);
-		jx_insert(object,jx_string(xxstrdup(key)),value);
+		jx_insert(object,jx_string(key),value);
 		key = va_arg(args,char *);
 		value = va_arg(args,struct jx *);
 	}

--- a/dttools/src/rmonitor_poll.c
+++ b/dttools/src/rmonitor_poll.c
@@ -886,6 +886,7 @@ struct rmsummary *rmonitor_measure_process(pid_t pid) {
 	struct rmsummary *tr = rmsummary_create(-1);
 
 	struct rmonitor_process_info p;
+	memset(&p, 0, sizeof(p));
 	p.pid = pid;
 
 	err = rmonitor_poll_process_once(&p);

--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -1165,13 +1165,11 @@ class Manager(object):
 
     ##
     ## Enables resource monitoring for tasks. The resources measured are
-    # available in the resources_measured member of the respective vine_task. A
-    # file VINE_RUNTIME_INFO_DIR/vine-logs/monitor/resources.log is also
-    # generated with resources per task.
+    # available in the resources_measured member of the respective vine_task.
     # @param self   Reference to the current manager object.
     # @param watchdog If not 0, kill tasks that exhaust declared resources.
     # @param time_series If not 0, generate a time series of resources per task
-    # in VINE_RUNTIME_INFO_DIR/vine-logs/monitor/ (WARNING: for long running
+    # in VINE_RUNTIME_INFO_DIR/vine-logs/time-series/ (WARNING: for long running
     # tasks these files may reach gigabyte sizes. This function is mostly used
     # for debugging.)
     #

--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -1581,6 +1581,7 @@ class Manager(object):
     # - "long-timeout" Set the minimum timeout when sending a brief message to a foreman. (default=1h)
     # - "category-steady-n-tasks" Set the number of tasks considered when computing category buckets.
     # - "hungry-minimum" Mimimum number of tasks to consider manager not hungry. (default=10)
+    # - monitor-interval Maximum number of seconds between resource monitor measurements. If less than 1, use default (5s).
     # - "wait-for-workers" Mimimum number of workers to connect before starting dispatching tasks. (default=0)
     # - "wait_retrieve_many" Parameter to alter how vine_wait works. If set to 0, vine_wait breaks out of the while loop whenever a task changes to VINE_TASK_DONE (wait_retrieve_one mode). If set to 1, vine_wait does not break, but continues recieving and dispatching tasks. This occurs until no task is sent or recieved, at which case it breaks out of the while loop (wait_retrieve_many mode). (default=0)
     # @param value The value to set the parameter to.

--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -1164,17 +1164,23 @@ class Manager(object):
         return vine_task_state(self._taskvine, task_id)
 
     ##
-    # Enables resource monitoring of tasks in the manager, and writes a summary
-    # per task to the directory given. Additionally, all summaries are
-    # consolidate into the file all_summaries-PID.log
+    ## Enables resource monitoring for tasks. The resources measured are
+    # available in the resources_measured member of the respective vine_task. A
+    # file VINE_RUNTIME_INFO_DIR/vine-logs/monitor/resources.log is also
+    # generated with resources per task.
+    # @param self   Reference to the current manager object.
+    # @param watchdog If not 0, kill tasks that exhaust declared resources.
+    # @param time_series If not 0, generate a time series of resources per task
+    # in VINE_RUNTIME_INFO_DIR/vine-logs/monitor/ (WARNING: for long running
+    # tasks these files may reach gigabyte sizes. This function is mostly used
+    # for debugging.)
     #
     # Returns 1 on success, 0 on failure (i.e., monitoring was not enabled).
     #
     # @param self   Reference to the current manager object.
-    # @param dirname    Directory name for the monitor output.
     # @param watchdog   If True (default), kill tasks that exhaust their declared resources.
-    def enable_monitoring(self, dirname=None, watchdog=True):
-        return vine_enable_monitoring(self._taskvine, dirname, watchdog)
+    def enable_monitoring(self, watchdog=True, time_series=False):
+        return vine_enable_monitoring(self._taskvine, watchdog, time_series)
 
     ##
     # As @ref enable_monitoring, but it also generates a time series and a

--- a/taskvine/src/manager/Makefile
+++ b/taskvine/src/manager/Makefile
@@ -23,6 +23,7 @@ SOURCES = \
 	vine_blocklist.c \
 	vine_current_transfers.c \
 	vine_file_replica_table.c \
+	vine_fair.c \
 	vine_runtime_dir.c
 
 PUBLIC_HEADERS = taskvine.h

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -872,7 +872,7 @@ resources_measured from vine_task is updated.  @return 1 on success, 0 if
 @param watchdog if not 0, kill tasks that exhaust declared resources.
 @return 1 on success, o if monitoring was not enabled.
 */
-int vine_enable_monitoring(struct vine_manager *m, char *monitor_output_directory, int watchdog);
+int vine_enable_monitoring(struct vine_manager *m, const char *monitor_output_directory, int watchdog);
 
 /** Enables resource monitoring on the give manager.
 As @ref vine_enable_monitoring, but it generates a time series and a
@@ -883,7 +883,7 @@ gigabyte sizes. This function is mostly used for debugging.)
 @param watchdog if not 0, kill tasks that exhaust declared resources.
 @return 1 on success, 0 if monitoring was not enabled.
 */
-int vine_enable_monitoring_full(struct vine_manager *m, char *monitor_output_directory, int watchdog);
+int vine_enable_monitoring_full(struct vine_manager *m, const char *monitor_output_directory, int watchdog);
 
 /** Enable taskvine peer transfers to be scheduled by the manager **/
 int vine_enable_peer_transfers(struct vine_manager *m);

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -860,12 +860,11 @@ void vine_set_name(struct vine_manager *m, const char *name);
 const char *vine_get_name(struct vine_manager *m);
 
 /** Enables resource monitoring for tasks. The resources measured are available
-in the resources_measured member of the respective vine_task. A file
-VINE_RUNTIME_INFO_DIR/vine-logs/monitor/resources.log is also generated with resources per task.
+in the resources_measured member of the respective vine_task.
 @param m A manager object
 @param watchdog If not 0, kill tasks that exhaust declared resources.
 @param time_series If not 0, generate a time series of resources per task in
-VINE_RUNTIME_INFO_DIR/vine-logs/monitor/ (WARNING: for long running tasks these
+VINE_RUNTIME_INFO_DIR/vine-logs/time-series/ (WARNING: for long running tasks these
 files may reach gigabyte sizes. This function is mostly used for debugging.)
 @return 1 on success, 0 if monitoring could not be enabled.
 */
@@ -1119,6 +1118,7 @@ void vine_set_manager_preferred_connection(struct vine_manager *m, const char *p
  - "keepalive-interval" Set the minimum number of seconds to wait before sending new keepalive checks to workers. (default=300)
  - "keepalive-timeout" Set the minimum number of seconds to wait for a keepalive response from worker before marking it as dead. (default=30)
  - "short-timeout" Set the minimum timeout when sending a brief message to a single worker. (default=5s)
+ - "monitor-interval" Maximum number of seconds between resource monitor measurements. If less than 1, use default (5s). (default=5)
  - "category-steady-n-tasks" Set the number of tasks considered when computing category buckets.
  - "hungry-minimum" Mimimum number of tasks to consider manager not hungry. (default=10)
  - "wait-for-workers" Mimimum number of workers to connect before starting dispatching tasks. (default=0)

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -859,31 +859,17 @@ void vine_set_name(struct vine_manager *m, const char *name);
 */
 const char *vine_get_name(struct vine_manager *m);
 
-/** Enables resource monitoring on the give manager.
-It generates a resource summary per task, which is written to the given
-directory. It also creates all_summaries-PID.log, that consolidates all
-summaries into a single. If monitor_output_dirname is NULL, vine_task is
-updated with the resources measured, and no summary file is kept unless
-explicitely given by vine_task's monitor_output_file.
+/** Enables resource monitoring for tasks. The resources measured are available
+in the resources_measured member of the respective vine_task. A file
+VINE_RUNTIME_INFO_DIR/vine-logs/monitor/resources.log is also generated with resources per task.
 @param m A manager object
-@param monitor_output_directory The name of the output directory. If NULL,
-summaries are kept only when monitor_output_directory is set per task, but
-resources_measured from vine_task is updated.  @return 1 on success, 0 if
-@param watchdog if not 0, kill tasks that exhaust declared resources.
-@return 1 on success, o if monitoring was not enabled.
+@param watchdog If not 0, kill tasks that exhaust declared resources.
+@param time_series If not 0, generate a time series of resources per task in
+VINE_RUNTIME_INFO_DIR/vine-logs/monitor/ (WARNING: for long running tasks these
+files may reach gigabyte sizes. This function is mostly used for debugging.)
+@return 1 on success, 0 if monitoring could not be enabled.
 */
-int vine_enable_monitoring(struct vine_manager *m, const char *monitor_output_directory, int watchdog);
-
-/** Enables resource monitoring on the give manager.
-As @ref vine_enable_monitoring, but it generates a time series and a
-monitor debug file (WARNING: for long running tasks these files may reach
-gigabyte sizes. This function is mostly used for debugging.)
-@param m A manager object.
-@param monitor_output_directory The name of the output directory.
-@param watchdog if not 0, kill tasks that exhaust declared resources.
-@return 1 on success, 0 if monitoring was not enabled.
-*/
-int vine_enable_monitoring_full(struct vine_manager *m, const char *monitor_output_directory, int watchdog);
+int vine_enable_monitoring(struct vine_manager *m, int watchdog, int time_series);
 
 /** Enable taskvine peer transfers to be scheduled by the manager **/
 int vine_enable_peer_transfers(struct vine_manager *m);

--- a/taskvine/src/manager/vine_fair.c
+++ b/taskvine/src/manager/vine_fair.c
@@ -9,7 +9,6 @@ See the file COPYING for details.
 #include "debug.h"
 #include "jx_pretty_print.h"
 #include "rmonitor.h"
-//#include "rmonitor_types.h"
 #include "rmonitor_poll.h"
 #include "xxmalloc.h"
 

--- a/taskvine/src/manager/vine_fair.c
+++ b/taskvine/src/manager/vine_fair.c
@@ -1,0 +1,66 @@
+/*
+Copyright (C) 2023- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include "vine_runtime_dir.h"
+
+#include "debug.h"
+#include "jx_pretty_print.h"
+#include "rmonitor.h"
+//#include "rmonitor_types.h"
+#include "rmonitor_poll.h"
+#include "xxmalloc.h"
+
+void vine_fair_write_workflow_info(struct vine_manager *m) {
+	struct jx *mi = jx_objectv(
+			"@id", jx_string("managerInfo"),
+			"@name", jx_string("Manager description"),
+			NULL);
+
+	if(getlogin()) {
+		jx_insert_string(mi, "userId", getlogin());
+	}
+
+	if(m->name) {
+		jx_insert_string(mi, "managerName", m->name);
+	}
+
+	if(m->monitor_mode != VINE_MON_DISABLED) {
+		rmonitor_measure_process_update_to_peak(m->measured_local_resources, getpid());
+
+		if(!m->measured_local_resources->exit_type) {
+			m->measured_local_resources->exit_type = xxstrdup("normal");
+		}
+
+		jx_insert(mi, jx_string("managerUsedLocalResources"), rmsummary_to_json(m->measured_local_resources, 1));
+	}
+
+	struct jx *jv = jx_objectv(
+			"@id", jx_string("http://ccl.cse.nd.edu/software/taskvine"),
+			"@type", jx_string("ComputerLanguage"),
+			"name", jx_string("TaskVine"),
+			"identifier", jx_objectv("@id", jx_string("http://ccl.cse.nd.edu/software/taskvine"), NULL),
+			"url", jx_objectv("@id", jx_string("http://ccl.cse.nd.edu/software/taskvine"), NULL),
+			NULL);
+
+	struct jx *g = jx_arrayv(jv, mi, NULL);
+	struct jx *w = jx_objectv(
+			"@context", jx_string("https://w3id.org/ro/crate/1.1/context"),
+			"@graph", g,
+			NULL);
+
+	char *workflow = vine_get_runtime_path_log(m, "workflow.json");
+	FILE *info_file  = fopen(workflow, "w");
+	if(info_file) {
+		jx_pretty_print_stream(w, info_file);
+		fclose(info_file);
+	} else {
+		warn(D_VINE, "Could not open monitor log file for writing: '%s'\n", workflow);
+	}
+
+	free(workflow);
+	jx_delete(w);
+}
+

--- a/taskvine/src/manager/vine_fair.h
+++ b/taskvine/src/manager/vine_fair.h
@@ -1,0 +1,17 @@
+/*
+Copyright (C) 2023- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include "vine_manager.h"
+
+
+//TODO: Eventually vine_write_workflow_info should generate enough metadata to
+//conform to https://workflows.community/groups/fair
+
+
+//TODO: add API call for custom FAIR metadata
+
+void vine_fair_write_workflow_info(struct vine_manager *m);
+

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3264,7 +3264,7 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 	return q;
 }
 
-int vine_enable_monitoring(struct vine_manager *q, char *monitor_output_directory, int watchdog)
+int vine_enable_monitoring(struct vine_manager *q, const char *monitor_output_directory, int watchdog)
 {
 	if(!q)
 		return 0;
@@ -3313,8 +3313,16 @@ int vine_enable_monitoring(struct vine_manager *q, char *monitor_output_director
 	return 1;
 }
 
-int vine_enable_monitoring_full(struct vine_manager *q, char *monitor_output_directory, int watchdog) {
-	int status = vine_enable_monitoring(q, monitor_output_directory, 1);
+int vine_enable_monitoring_full(struct vine_manager *q, const char *monitor_output_directory, int watchdog) {
+	char *dir = NULL;
+	if(monitor_output_directory) {
+		dir = xxstrdup(monitor_output_directory);
+	} else {
+		dir = vine_get_runtime_path_log(q, "monitor");
+	}
+
+	int status = vine_enable_monitoring(q, dir, 1);
+	free(dir);
 
 	if(status) {
 		q->monitor_mode = VINE_MON_FULL;
@@ -3327,8 +3335,7 @@ int vine_enable_monitoring_full(struct vine_manager *q, char *monitor_output_dir
 	return status;
 }
 
-int vine_enable_peer_transfers(struct vine_manager *q) 
-{
+int vine_enable_peer_transfers(struct vine_manager *q) {
 	debug(D_VINE, "Peer Transfers enabled");
 	q->peer_transfers_enabled = 1;
 	return 1;

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -145,16 +145,14 @@ struct vine_manager {
 	/* Logging configuration. */
 
     char *runtime_directory;
-	FILE *perf_logfile; /* Performance logfile for tracking metrics by time. */
-	FILE *txn_logfile;  /* Transaction logfile for recording every event of interest. */
+	FILE *perf_logfile;        /* Performance logfile for tracking metrics by time. */
+	FILE *txn_logfile;         /* Transaction logfile for recording every event of interest. */
 
 	/* Resource monitoring configuration. */
 
 	vine_monitoring_mode_t monitor_mode;
-	FILE *monitor_file;
-	char *monitor_output_directory;
 	char *monitor_exe;
-    int *monitor_interval;
+    int monitor_interval;
 
 	struct rmsummary *measured_local_resources;
 	struct rmsummary *current_max_worker;

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -153,8 +153,8 @@ struct vine_manager {
 	vine_monitoring_mode_t monitor_mode;
 	FILE *monitor_file;
 	char *monitor_output_directory;
-	char *monitor_summary_filename;
 	char *monitor_exe;
+    int *monitor_interval;
 
 	struct rmsummary *measured_local_resources;
 	struct rmsummary *current_max_worker;
@@ -239,7 +239,7 @@ int vine_enable_transactions_log(struct vine_manager *m, const char *logfile);
 
 
 /* The expected format of files created by the resource monitor.*/
-#define RESOURCE_MONITOR_TASK_LOCAL_NAME "vine-%d-task-%d"
+#define RESOURCE_MONITOR_TASK_LOCAL_NAME "vine-task-%d"
 #define RESOURCE_MONITOR_REMOTE_NAME "cctools-monitor"
 #define RESOURCE_MONITOR_REMOTE_NAME_EVENTS RESOURCE_MONITOR_REMOTE_NAME "events.json"
 

--- a/taskvine/src/tools/vine_benchmark.c
+++ b/taskvine/src/tools/vine_benchmark.c
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
 
 	if(monitor_flag) {
 		unlink_recursive("vine_benchmark_monitor");
-		vine_enable_monitoring(q, "vine_benchmark_monitorr", 1);
+		vine_enable_monitoring(q, 1, 0);
 		vine_set_category_mode(q, NULL, VINE_ALLOCATION_MODE_MAX_THROUGHPUT);
 	}
 

--- a/taskvine/test/TR_vine_valgrind.sh
+++ b/taskvine/test/TR_vine_valgrind.sh
@@ -67,7 +67,7 @@ EOF
 
 clean()
 {
-	rm -f manager.script vine_benchmark_info manager.port manager.exitcode manager.valgrind worker.log worker.exitcode worker.valgrind output.* input.*
+	rm -rf manager.script vine_benchmark_info manager.port manager.exitcode manager.valgrind worker.log worker.exitcode worker.valgrind output.* input.*
 }
 
 dispatch "$@"


### PR DESCRIPTION
Changes `vine_enable_monitoring(m, dir, watchdog)` to  `vine_enable_monitoring(m, watchdog, series)`.  If series is 1, then time and debug information per task is written to  vine-logs/time-series. With this change, `vine_enable_monitoring_full` was made redundant and has been removed.

This pr also writes the resources measured for the manager to `vine-logs/workflow.json`, which eventually should comply with FAIR metadata requirements.

@tphung3 It also adds vine_tune(m, "monitor-interval", s); where s is an integer to set the interval of the rmonitor.