### PR TITLE
Adds vine_declare_chirp

### DIFF
--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -1990,6 +1990,7 @@ class Manager(object):
     #
     # @param self    The manager to register this file
     # @param path    The path to the local file
+    # @return A file object to use in @ref Task.add_input or @ref Task.add_output
     def declare_file(self, path):
         f = vine_declare_file(self._taskvine, path)
         return File(f)
@@ -1999,6 +2000,7 @@ class Manager(object):
     # output of a task, and may be consumed by other tasks.
     #
     # @param manager    The manager to register this file
+    # @return A file object to use in @ref Task.add_input or @ref Task.add_output
     def declare_temp(self):
         f = vine_declare_temp(self._taskvine)
         return File(f)
@@ -2008,6 +2010,7 @@ class Manager(object):
     #
     # @param self    The manager to register this file
     # @param url     The url of the file.
+    # @return A file object to use in @ref Task.add_input
     def declare_url(self, url):
         url = str(url)
         f = vine_declare_url(self._taskvine, url)
@@ -2018,6 +2021,7 @@ class Manager(object):
     #
     # @param self    The manager to register this file
     # @param buffer  The contents of the buffer, or None for an empty output buffer
+    # @return A file object to use in @ref Task.add_input
     #
     # For example:
     # @code
@@ -2039,6 +2043,7 @@ class Manager(object):
     #
     # @param self     The manager to register this file
     # @param minitask The task to execute in order to produce a file
+    # @return A file object to use in @ref Task.add_input
     def declare_minitask(self, minitask):
         f = vine_declare_mini_task(self._taskvine, minitask._task)
         return File(f)
@@ -2048,6 +2053,7 @@ class Manager(object):
     #
     # @param manager    The manager to register this file
     # @param tarball    The file object to un-tar
+    # @return A file object to use in @ref Task.add_input
     def declare_untar(self, tarball):
         f = vine_declare_untar(self._taskvine, tarball._file)
         return File(f)
@@ -2057,6 +2063,7 @@ class Manager(object):
     #
     # @param self    The manager to register this file
     # @param package The poncho or conda-pack environment tarball
+    # @return A file object to use in @ref Task.add_input
     def declare_poncho(self, package):
         f = vine_declare_poncho(self._taskvine, package._file)
         return File(f)
@@ -2066,6 +2073,7 @@ class Manager(object):
     #
     # @param self    The manager to register this file
     # @param starch  The startch .sfx file
+    # @return A file object to use in @ref Task.add_input
     def declare_starch(self, starch):
         f = vine_declare_starch(self._taskvine, starch._file)
         return File(f)
@@ -2079,6 +2087,7 @@ class Manager(object):
     #               environment variable X509_USER_PROXY and the file
     #               "$TMPDIR/$UID" are considered in that order. If no proxy is
     #               present, the transfer is tried without authentication.
+    # @return A file object to use in @ref Task.add_input
     def declare_xrootd(self, source, proxy=None):
         proxy_c = None
         if proxy:

--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -2086,6 +2086,21 @@ class Manager(object):
         f = vine_declare_xrootd(self._taskvine, source, proxy_c)
         return File(f)
 
+    ##
+    # Declare a file from accessible from an xrootd server.
+    #
+    # @param self   The manager to register this file.
+    # @param server The chirp server address of the form "hostname[:port"]"
+    # @param source The name of the file in the server
+    # @param ticket If not NULL, a file object that provides a chirp an authentication ticket
+    # @return A file object to use in @ref Task.add_input
+    def declare_chirp(self, server, source, ticket=None):
+        ticket_c = None
+        if ticket:
+            ticket_c = ticket._file
+        f = vine_declare_chirp(self._taskvine, server, source, ticket_c)
+        return File(f)
+
 
 
 

--- a/taskvine/src/examples/vine_example_chirp.py
+++ b/taskvine/src/examples/vine_example_chirp.py
@@ -4,10 +4,10 @@
 # This software is distributed under the GNU General Public License.
 # See the file COPYING for details.
 
-# This example shows how to declare an xrootd file so that it can be cached at
+# This example shows how to declare an chirp file so that it can be cached at
 # the workers.
-# It assumes that uproot is installed where workers are executed. If this is
-# not the case, a poncho recipe to construct this environment is:
+# It assumes that chirp is installed where workers are executed. If this is
+# not the case, a poncho recipe to construct this environment is also given.
 #
 
 import taskvine as vine
@@ -23,7 +23,7 @@ def count_lines(chirp_file):
             lines += 1
     return lines
 
-# construct a poncho environment to execute the tasks. only needed if the chirp
+# construct a poncho environment to execute the tasks. Only needed if the chirp
 # executables are not available where the workers execute
 def create_env(env_name):
     import json
@@ -59,8 +59,8 @@ if __name__ == "__main__":
 
     env_with_chirp = None
     # uncomment the following lines only if workers don't have chirp available
-    env_with_chirp = "chirp_py_env.tar.gz"
-    create_env(env_with_chirp)
+    #env_with_chirp = "chirp_py_env.tar.gz"
+    #create_env(env_with_chirp)
 
     m = vine.Manager()
     print("listening on port", m.port)

--- a/taskvine/src/examples/vine_example_chirp.py
+++ b/taskvine/src/examples/vine_example_chirp.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2023- The University of Notre Dame
+# This software is distributed under the GNU General Public License.
+# See the file COPYING for details.
+
+# This example shows how to declare an xrootd file so that it can be cached at
+# the workers.
+# It assumes that uproot is installed where workers are executed. If this is
+# not the case, a poncho recipe to construct this environment is:
+#
+
+import taskvine as vine
+
+import os
+import sys
+
+# define a dummy python task that will be apply to each of the files.
+def count_lines(chirp_file):
+    lines = 0
+    with open(chirp_file) as f:
+        for line in f:
+            lines += 1
+    return lines
+
+# construct a poncho environment to execute the tasks. only needed if the chirp
+# executables are not available where the workers execute
+def create_env(env_name):
+    import json
+    import tempfile
+    import subprocess
+    py_version = f"{sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]}"
+
+    if os.path.exists(env_name):
+        return
+
+    env = {
+            "conda": {
+                "channels": ["conda-forge"],
+                "dependencies": [f"python={py_version}", "dill", "cctools"]
+                }
+            }
+
+    with tempfile.NamedTemporaryFile("w", prefix="poncho-spec", encoding="utf8", dir=os.getcwd()) as f:
+        json.dump(env, f)
+        f.flush()
+        subprocess.run(["poncho_package_create", f.name, env_name], check=True)
+
+
+if __name__ == "__main__":
+
+    try:
+        (chirp_server, test_filename) = sys.argv[1:]
+    except Exception:
+        print(f"Usage: {sys.argv[0]} chirp_server test_filename [auth_ticket_file]")
+        print(f"Prints the number of lines of test_filename from chirp_server")
+        sys.exit(1)
+
+
+    env_with_chirp = None
+    # uncomment the following lines only if workers don't have chirp available
+    env_with_chirp = "chirp_py_env.tar.gz"
+    create_env(env_with_chirp)
+
+    m = vine.Manager()
+    print("listening on port", m.port)
+
+    # define the authentication ticket to use.
+    ticket_file = None
+    #ticket_file = m.declare_file("myticket.ticket")
+
+    t = vine.PythonTask(count_lines, "mychirp.file")
+    t.add_input(m.declare_chirp(chirp_server, test_filename, ticket_file), "mychirp.file", cache=True)
+    t.set_environment(env_with_chirp)
+
+    task_id = m.submit(t)
+    print("submitted task (id# " + str(task_id) + "): count_lines()")
+
+    print("waiting for tasks to complete...")
+    while not m.empty():
+        t = m.wait(5)
+        if t:
+            if t.successful():
+                print(f"task {t.id} processed a file with {t.output} lines")
+            elif t.completed():
+                print(f"task {t.id} completed with an executin error, exit code {t.exit_code}")
+            else:
+                print(f"task {t.id} failed with status {t.result_string}")
+
+    print("all tasks complete!")

--- a/taskvine/src/examples/vine_example_xrootd.py
+++ b/taskvine/src/examples/vine_example_xrootd.py
@@ -7,7 +7,7 @@
 # This example shows how to declare an xrootd file so that it can be cached at
 # the workers.
 # It assumes that uproot is installed where workers are executed. If this is
-# not the case, a poncho recipe to construct this environment is:
+# not the case, a poncho recipe to construct this environment is also given.
 #
 
 import taskvine as vine
@@ -26,7 +26,7 @@ def count_events(root_file):
         return len(h['Events'])
 
 
-# construct a poncho environment to execute the tasks only needed if uproot and
+# construct a poncho environment to execute the tasks. Only needed if uproot and
 # xrootd are not available where the workers execute
 def create_env(env_name):
     import json

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -654,6 +654,16 @@ in that order. If no proxy is present, the transfer is tried without authenticat
 struct vine_file * vine_declare_xrootd( struct vine_manager *m, const char *source, struct vine_file *proxy );
 
 
+/** Create a file object of a remote file accessible from a chirp server.
+@param m A manager object
+@param server The chirp server address of the form "hostname[:port"]"
+@param source The name of the file in the server
+@param ticket If not NULL, a file object that provides a chirp an authentication ticket
+@return A file object to use in @ref vine_task_add_input
+*/
+struct vine_file * vine_declare_chirp( struct vine_manager *m, const char *server, const char *source, struct vine_file *ticket );
+
+
 /** Create a scratch file object.
 A scratch file has no initial content, but is created
 as the output of a task, and may be consumed by other tasks.

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -220,4 +220,26 @@ struct vine_file * vine_file_xrootd( const char *source, struct vine_file *proxy
 }
 
 
+struct vine_file * vine_file_chirp( const char *server, const char *source, struct vine_file *ticket )
+{
+	char *command = string_format(
+			"chirp_get %s %s %s output.chirp",
+			ticket ? "--tickets=ticket.chirp" : "",
+			server,
+			source);
+
+	struct vine_task *t = vine_task_create(command);
+
+	vine_task_add_output(t,vine_file_local("output.chirp"),"output.chirp",VINE_CACHE);
+
+	if(ticket) {
+		vine_task_add_input(t,ticket,"ticket.chirp",VINE_CACHE);
+	}
+
+	free(command);
+
+	return vine_file_mini_task(t);
+}
+
+
 /* vim: set noexpandtab tabstop=4: */

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -224,7 +224,7 @@ struct vine_file * vine_file_chirp( const char *server, const char *source, stru
 {
 	char *command = string_format(
 			"chirp_get %s %s %s output.chirp",
-			ticket ? "--tickets=ticket.chirp" : "",
+			ticket ? "--auth=ticket --tickets=ticket.chirp" : "",
 			server,
 			source);
 

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -66,5 +66,6 @@ struct vine_file *vine_file_untar( struct vine_file *f );
 struct vine_file *vine_file_poncho( struct vine_file *f );
 struct vine_file *vine_file_starch( struct vine_file *f );
 struct vine_file *vine_file_xrootd( const char *source, struct vine_file *proxy );
+struct vine_file *vine_file_chirp( const char *server, const char *source, struct vine_file *ticket );
 
 #endif

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5041,5 +5041,11 @@ struct vine_file *vine_declare_xrootd( struct vine_manager *m, const char *sourc
 	return vine_manager_declare_file(m, t);
 }
 
+struct vine_file * vine_declare_chirp( struct vine_manager *m, const char *server, const char *source, struct vine_file *ticket )
+{
+	struct vine_file *t = vine_file_chirp(server, source, ticket);
+	return vine_manager_declare_file(m, t);
+}
+
 
 /* vim: set noexpandtab tabstop=4: */


### PR DESCRIPTION
E.g.:

```C
m.declare_chirp(chirp_server, filename, ticket_file)
```
If ticket_file is not given, then try the default auths.


I was able to run the blast example using a chirp server as the source instead of the http urls.