### PR TITLE
Fix proportional resources and resource multiplier

### DIFF
--- a/taskvine/src/tools/vine_plot_txn_log
+++ b/taskvine/src/tools/vine_plot_txn_log
@@ -381,9 +381,9 @@ class TxnPlot:
         self.legend = {
                 "workers lifetime": 'C9',
                 "tasks executing": 'C0',
-                "tasks waiting for cache": 'C7',
+                "tasks waiting at worker": 'C7',
                 "tasks lost on disconnection": 'C8',
-                "tasks waiting retrieval": 'C2',
+                "results waiting retrieval": 'C2',
                 "tasks failures": 'red',
                 "cache updates": 'C1',
                 "inputs from manager": 'C3',
@@ -513,13 +513,13 @@ class TxnPlotTasks(TxnPlot):
 
         self.bh(fig, dt.index, dt["time_commit_end"],  dt["time_worker_start"] - dt["time_commit_end"], self.legend["cache updates"], edgecolor=None)
 
-        del self.legend["tasks waiting for cache"] # already covered above
+        del self.legend["tasks waiting at worker"] # already covered above
 
         self.bh(fig, lt.index, lt["time_commit_end"],  lt["last_state_time"] - lt["time_commit_end"], self.legend["tasks lost on disconnection"], edgecolor=None)
 
         self.bh(fig, dt.index, dt["time_worker_start"],  dt["time_worker_end"] - dt["time_worker_start"], self.legend["tasks executing"], edgecolor=None)
 
-        self.bh(fig, dt.index, dt["time_worker_end"],  dt["RETRIEVED"] - dt["time_worker_end"], self.legend["tasks waiting retrieval"], edgecolor=None)
+        self.bh(fig, dt.index, dt["time_worker_end"],  dt["RETRIEVED"] - dt["time_worker_end"], self.legend["results waiting retrieval"], edgecolor=None)
 
         del self.legend["tasks failures"] # already covered above
 
@@ -553,12 +553,12 @@ class TxnPlotWorkers(TxnPlot):
         cu = worker[worker["size_output_mgr"] > 0]
         self.bh(fig, base_slot+1, cu["RETRIEVED"]-cu["time_output_mgr"], cu["time_output_mgr"], self.legend["outputs to manager"])
 
-        self.bh(fig, y, worker["RUNNING"], worker["last_state_time"]-worker["RUNNING"], self.legend["tasks waiting for cache"])
+        self.bh(fig, y, worker["RUNNING"], worker["last_state_time"]-worker["RUNNING"], self.legend["tasks waiting at worker"])
 
         self.bh(fig, dt["slot"], dt["time_worker_start"], dt["time_worker_end"]-dt["time_worker_start"], self.legend["tasks executing"])
         self.bh(fig, lt["slot"], lt["time_commit_end"],  lt["last_state_time"] - lt["time_commit_end"], self.legend["tasks lost on disconnection"])
 
-        self.bh(fig, dt["slot"], dt["time_worker_end"], dt["RETRIEVED"]-dt["time_worker_end"], self.legend["tasks waiting retrieval"])
+        self.bh(fig, dt["slot"], dt["time_worker_end"], dt["RETRIEVED"]-dt["time_worker_end"], self.legend["results waiting retrieval"])
 
         ft = dt[(dt["reason"] != "SUCCESS") | ((dt["reason"] == "SUCCESS") & (dt["exit_code"] != 0))]
         self.bh(fig, ft["slot"], ft["RETRIEVED"] - 0.5, 0.5, self.legend["tasks failures"])

--- a/taskvine/test/vine_alloc_test.py
+++ b/taskvine/test/vine_alloc_test.py
@@ -3,8 +3,10 @@
 # taskvine python binding tests
 # tests for missing/recursive inputs/outputs.
 
-import sys
 import taskvine as vine
+
+import sys
+import math
 
 def check_task(category, category_mode, max, min, expected):
     q.set_category_resources_max(category, max)
@@ -38,6 +40,10 @@ port_file = None
 try:
     port_file = sys.argv[1]
     (worker_cores, worker_memory, worker_disk, worker_gpus) = (int(sys.argv[i]) for i in range(2,6))
+
+    if worker_disk % worker_cores != 0 or worker_memory % worker_cores != 0:
+        sys.stderr.write("For this test, the number of worker's cores should divide evenly the worker's memory and disk.\n".format(sys.argv[0]))
+
 except IndexError:
     sys.stderr.write("Usage: {} PORTFILE WORKER_CORES WORKER_MEMORY WORKER_DISK\n".format(sys.argv[0]))
     raise
@@ -60,6 +66,8 @@ worker.debug="all"
 worker.debug_file="factory.log"
 
 with worker:
+    q.tune("force-proportional-resources", 0)
+
     r = {'cores': 1, 'memory': 2, 'disk': 3, 'gpus': 4}
     check_task('all_specified', vine.VINE_ALLOCATION_MODE_FIXED, max = r, min = {}, expected = r)
 
@@ -81,17 +89,12 @@ with worker:
             min = {},
             expected = {'cores': worker_cores, 'memory': worker_memory, 'disk': worker_disk, 'gpus': 0})
 
+    q.tune("force-proportional-resources", 1)
     check_task('only_memory',
             vine.VINE_ALLOCATION_MODE_FIXED,
             max = {'memory': worker_memory/2},
             min = {},
             expected = {'cores': worker_cores/2, 'memory': worker_memory/2, 'disk': worker_disk/2, 'gpus': 0})
-
-    check_task('only_cores',
-            vine.VINE_ALLOCATION_MODE_FIXED,
-            max = {'cores': worker_cores},
-            min = {},
-            expected = {'cores': worker_cores, 'memory': worker_memory, 'disk': worker_disk, 'gpus': 0})
 
     check_task('only_memory_w_minimum',
             vine.VINE_ALLOCATION_MODE_FIXED,
@@ -99,28 +102,36 @@ with worker:
             min = {'cores': 3, 'gpus': 2},
             expected = {'cores': 3, 'memory': worker_memory/2, 'disk': worker_disk/2, 'gpus': 2})
 
+    check_task('only_cores',
+            vine.VINE_ALLOCATION_MODE_FIXED,
+            max = {'cores': worker_cores},
+            min = {},
+            expected = {'cores': worker_cores, 'memory': worker_memory, 'disk': worker_disk, 'gpus': 0})
+
     check_task('auto_whole_worker',
             vine.VINE_ALLOCATION_MODE_MIN_WASTE,
             max = {},
             min = {},
             expected = {'cores': worker_cores, 'memory': worker_memory, 'disk': worker_disk, 'gpus': 0})
 
-    check_task('greedy_bucketing',
-            vine.VINE_ALLOCATION_MODE_GREEDY_BUCKETING,
-            max = {},
-            min = {},
-            expected = {'cores': 1, 'memory': 1000, 'disk': 1000, 'gpus': 0})
+    p = 1/worker_cores
+    r = {'cores': 1}
+    e = {'cores': 1, 'memory': math.floor(worker_memory * p), 'disk': math.floor(worker_disk * p), 'gpus': 0}
+    check_task('only_cores_proportional', vine.VINE_ALLOCATION_MODE_FIXED, max = r, min = {}, expected = e)
 
+    p = 2/worker_cores
+    e = {'cores': 2, 'memory': math.floor(worker_memory * p), 'disk': math.floor(worker_disk * p), 'gpus': 0}
     check_task('exhaustive_bucketing',
             vine.VINE_ALLOCATION_MODE_EXHAUSTIVE_BUCKETING,
             max = {},
             min = {},
-            expected = {'cores': 1, 'memory': 1000, 'disk': 1000, 'gpus': 0})
+            expected = e)
 
-    q.set_category_first_allocation_guess('auto_with_guess', {'cores': 1, 'memory': 2, 'disk': 3})
-    check_task('auto_with_guess',
-            vine.VINE_ALLOCATION_MODE_MIN_WASTE,
+    check_task('greedy_bucketing',
+            vine.VINE_ALLOCATION_MODE_GREEDY_BUCKETING,
             max = {},
             min = {},
-            expected = {'cores': 1, 'memory': 2, 'disk': 3, 'gpus': 0})
+            expected = e)
+
+
 


### PR DESCRIPTION
Proportional resources were allocating the whole disk. Since the resource multiplier is not used for disk, no tasks were overcommited to workers. This pr makes it so that the proportion takes into account the multiplier.
