### PR TITLE
Rename file flags

### DIFF
--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -98,10 +98,8 @@ class Task(object):
             pass
 
     @staticmethod
-    def _determine_mount_flags(cache=False, watch=False, failure_only=False, success_only=False):
-        flags = VINE_NOCACHE
-        if cache:
-            flags |= VINE_CACHE
+    def _determine_mount_flags(watch=False, failure_only=False, success_only=False):
+        flags = VINE_TRANSFER_ALWAYS
         if watch:
             flags |= VINE_WATCH
         if failure_only:
@@ -112,11 +110,13 @@ class Task(object):
 
     @staticmethod
     def _determine_file_flags(cache=False, peer_transfer=False):
-        flags = VINE_NOCACHE|VINE_PEER_NOSHARE
-        if cache:
+        flags = VINE_CACHE_NEVER
+        if cache is True or cache == "workflow":
             flags |= VINE_CACHE
-        if peer_transfer:
-            flags |= VINE_PEER_SHARE
+        if cache == "always":
+            flags |= VINE_CACHE_ALWAYS
+        if not peer_transfer:
+            flags |= VINE_PEER_NOSHARE
         return flags
 
     ##
@@ -203,10 +203,10 @@ class Task(object):
     # For example:
     # @code
     # # The following are equivalent
-    # >>> task.add_input_file("/etc/hosts", cache = True)
-    # >>> task.add_input_file("/etc/hosts", "hosts", cache = True)
+    # >>> task.add_input_file("/etc/hosts")
+    # >>> task.add_input_file("/etc/hosts", "hosts")
     # @endcode
-    def add_input_file(self, local_name, remote_name=None, cache=False):
+    def add_input_file(self, local_name, remote_name=None):
         # swig expects strings:
         if local_name:
             local_name = str(local_name)
@@ -216,7 +216,7 @@ class Task(object):
         else:
             remote_name = os.path.basename(local_name)
 
-        flags = Task._determine_mount_flags(cache)
+        flags = Task._determine_mount_flags()
         return vine_task_add_input_file(self._task, local_name, remote_name, flags)
 
     ##
@@ -229,9 +229,9 @@ class Task(object):
     #
     # For example:
     # @code
-    # >>> task.add_input_url("http://www.google.com/","google.txt",cache=True)
+    # >>> task.add_input_url("http://www.google.com/","google.txt")
     # @endcode
-    def add_input_url(self, url, remote_name, cache=False):
+    def add_input_url(self, url, remote_name):
         # swig expects strings
         if remote_name:
             remote_name = str(remote_name)
@@ -239,7 +239,7 @@ class Task(object):
         if url:
             url = str(url)
 
-        flags = Task._determine_mount_flags(cache)
+        flags = Task._determine_mount_flags()
         return vine_task_add_input_url(self._task, url, remote_name, flags)
 
     ##
@@ -258,12 +258,12 @@ class Task(object):
     # >>> mini_task = Task("curl http://www.apnews.com > output.txt");
     # >>> mini_task.add_output_file("output.txt","output.txt");
     # >>> # Attach the output of the mini-task as the input of a main task:
-    # >>> task.add_input_mini_task(mini_task,"infile.txt",cache=True)
+    # >>> task.add_input_mini_task(mini_task, "infile.txt")
     # @endcode
-    def add_input_mini_task(self, mini_task, remote_name, cache=False):
+    def add_input_mini_task(self, mini_task, remote_name):
         if remote_name:
             remote_name = str(remote_name)
-        flags = Task._determine_mount_flags(cache=cache)
+        flags = Task._determine_mount_flags()
         # The minitask must be duplicated, because the C object becomes "owned"
         # by the parent task and will be deleted when the parent task goes away.
         copy_of_mini_task = vine_task_clone(mini_task._task)
@@ -282,12 +282,12 @@ class Task(object):
     # @code
     # >>> url = m.declare_url(http://somewhere.edu/data.tgz)
     # >>> f = m.declare_untar(url)
-    # >>> task.add_input(f,"data",cache=True)
+    # >>> task.add_input(f,"data")
     # @endcode
-    def add_input(self, file, remote_name, cache=None, failure_only=None):
+    def add_input(self, file, remote_name):
         # SWIG expects strings
         remote_name = str(remote_name)
-        flags = Task._determine_mount_flags(cache=cache, failure_only=None)
+        flags = Task._determine_mount_flags()
         return vine_task_add_input(self._task, file._file, remote_name, flags)
 
     ##
@@ -306,10 +306,10 @@ class Task(object):
     # @param buffer         The contents of the buffer to pass as input.
     # @param remote_name    The name of the remote file to create.
     # @param cache          Whether the file should be cached at workers (True/False)
-    def add_input_buffer(self, buffer, remote_name, cache=False):
+    def add_input_buffer(self, buffer, remote_name):
         if remote_name:
             remote_name = str(remote_name)
-        flags = Task._determine_mount_flags(cache)
+        flags = Task._determine_mount_flags()
         return vine_task_add_input_buffer(self._task, buffer, len(buffer), remote_name, flags)
 
     ##
@@ -326,10 +326,10 @@ class Task(object):
     # For example:
     # @code
     # # The following are equivalent
-    # >>> task.add_input_file("/etc/hosts", cache = True)
-    # >>> task.add_input_file("/etc/hosts", "hosts", cache = True)
+    # >>> task.add_input_file("/etc/hosts")
+    # >>> task.add_input_file("/etc/hosts", "hosts")
     # @endcode
-    def add_output_file(self, local_name, remote_name=None, cache=False, watch=False, failure_only=False, success_only=False):
+    def add_output_file(self, local_name, remote_name=None, watch=False, failure_only=False, success_only=False):
         if local_name:
             local_name = str(local_name)
 
@@ -338,7 +338,7 @@ class Task(object):
         else:
             remote_name = os.path.basename(local_name)
 
-        flags = Task._determine_mount_flags(cache=cache, watch=watch, failure_only=failure_only, success_only=success_only)
+        flags = Task._determine_mount_flags(watch=watch, failure_only=failure_only, success_only=success_only)
         return vine_task_add_output_file(self._task, local_name, remote_name, flags)
 
     ##
@@ -357,10 +357,10 @@ class Task(object):
     # >>> file = m.declare_file("output.txt")
     # >>> task.add_output(file,"out")
     # @endcode
-    def add_output(self, file, remote_name, watch=False, cache=False, failure_only=None, success_only=None):
+    def add_output(self, file, remote_name, watch=False, failure_only=None, success_only=None):
         # SWIG expects strings
         remote_name = str(remote_name)
-        flags = Task._determine_mount_flags(cache, watch, failure_only, success_only)
+        flags = Task._determine_mount_flags(watch, failure_only, success_only)
         return vine_task_add_output(self._task, file._file, remote_name, flags)
 
     ##
@@ -848,8 +848,8 @@ class PythonTask(Task):
             self._command = self._python_function_command()
             vine_task_set_command(self._task, self._command)
 
-            self.add_input_file(self._env_file, cache=True)
-            self.add_input_file(self._pp_run, cache=True)
+            self.add_input_file(self._env_file)
+            self.add_input_file(self._pp_run)
 
     def __del__(self):
         try:
@@ -879,10 +879,10 @@ class PythonTask(Task):
         return command
 
     def _add_IO_files(self):
-        self.add_input_file(os.path.join(self._tmpdir, self._wrapper), cache=True)
-        self.add_input_file(os.path.join(self._tmpdir, self._func_file), cache=False)
-        self.add_input_file(os.path.join(self._tmpdir, self._args_file), cache=False)
-        self.add_output_file(os.path.join(self._tmpdir, self._out_file), cache=False)
+        self.add_input_file(os.path.join(self._tmpdir, self._wrapper))
+        self.add_input_file(os.path.join(self._tmpdir, self._func_file))
+        self.add_input_file(os.path.join(self._tmpdir, self._args_file))
+        self.add_output_file(os.path.join(self._tmpdir, self._out_file))
 
     ##
     # creates the wrapper script which will execute the function. pickles output.
@@ -1999,8 +1999,14 @@ class Manager(object):
     #
     # @param self    The manager to register this file
     # @param path    The path to the local file
-    # @return A file object to use in @ref Task.add_input or @ref Task.add_output
-    def declare_file(self, path, cache=False, share=False):
+    # @param cache   If True or 'workflow', cache the file at workers for reuse
+    #                until the end of the workflow. If 'always', the file is cache until the
+    #                end-of-life of the worker. Default is False (file is not cache).
+    # @param share   Whether the file can be transfered between workers when
+    #                peer transfers are enabled (see @ref enable_peer_transfers). Default is True.
+    # @return
+    # A file object to use in @ref Task.add_input or @ref Task.add_output
+    def declare_file(self, path, cache=False, share=True):
         flags = Task._determine_file_flags(cache, share)
         f = vine_declare_file(self._taskvine, path, flags)
         return File(f)
@@ -2010,6 +2016,11 @@ class Manager(object):
     # output of a task, and may be consumed by other tasks.
     #
     # @param manager    The manager to register this file
+    # @param cache   If True or 'workflow', cache the file at workers for reuse
+    #                until the end of the workflow. If 'always', the file is cache until the
+    #                end-of-life of the worker. Default is False (file is not cache).
+    # @param share   Whether the file can be transfered between workers when
+    #                peer transfers are enabled (see @ref enable_peer_transfers). Default is True.
     # @return A file object to use in @ref Task.add_input or @ref Task.add_output
     def declare_temp(self):
         f = vine_declare_temp(self._taskvine)
@@ -2020,8 +2031,13 @@ class Manager(object):
     #
     # @param self    The manager to register this file
     # @param url     The url of the file.
+    # @param cache   If True or 'workflow', cache the file at workers for reuse
+    #                until the end of the workflow. If 'always', the file is cache until the
+    #                end-of-life of the worker. Default is False (file is not cache).
+    # @param share   Whether the file can be transfered between workers when
+    #                peer transfers are enabled (see @ref enable_peer_transfers). Default is True.
     # @return A file object to use in @ref Task.add_input
-    def declare_url(self, url, cache=False, share=False):
+    def declare_url(self, url, cache=False, share=True):
         flags = Task._determine_file_flags(cache, share)
         url = str(url)
         f = vine_declare_url(self._taskvine, url, flags)
@@ -2032,6 +2048,11 @@ class Manager(object):
     #
     # @param self    The manager to register this file
     # @param buffer  The contents of the buffer, or None for an empty output buffer
+    # @param cache   If True or 'workflow', cache the file at workers for reuse
+    #                until the end of the workflow. If 'always', the file is cache until the
+    #                end-of-life of the worker. Default is False (file is not cache).
+    # @param share   Whether the file can be transfered between workers when
+    #                peer transfers are enabled (see @ref enable_peer_transfers). Default is True.
     # @return A file object to use in @ref Task.add_input
     #
     # For example:
@@ -2041,7 +2062,7 @@ class Manager(object):
     # >>> print(f.contents())
     # >>> "hello pirate ♆"
     # @endcode
-    def declare_buffer(self, buffer=None, cache=False, share=False):
+    def declare_buffer(self, buffer=None, cache=False, share=True):
         # because of the swig typemap, vine_declare_buffer(m, buffer, size) is changed
         # to a function with just two arguments.
         flags = Task._determine_file_flags(cache, share)
@@ -2056,7 +2077,7 @@ class Manager(object):
     # @param self     The manager to register this file
     # @param minitask The task to execute in order to produce a file
     # @return A file object to use in @ref Task.add_input
-    def declare_minitask(self, minitask, cache=False, share=False):
+    def declare_minitask(self, minitask, cache=False, share=True):
         flags = Task._determine_file_flags(cache, share)
         f = vine_declare_mini_task(self._taskvine, minitask._task, flags)
         return File(f)
@@ -2067,7 +2088,7 @@ class Manager(object):
     # @param manager    The manager to register this file
     # @param tarball    The file object to un-tar
     # @return A file object to use in @ref Task.add_input
-    def declare_untar(self, tarball, cache=False, share=False):
+    def declare_untar(self, tarball, cache=False, share=True):
         flags = Task._determine_file_flags(cache, share)
         f = vine_declare_untar(self._taskvine, tarball._file, flags)
         return File(f)
@@ -2078,7 +2099,7 @@ class Manager(object):
     # @param self    The manager to register this file
     # @param package The poncho or conda-pack environment tarball
     # @return A file object to use in @ref Task.add_input
-    def declare_poncho(self, package, cache=False, share=False):
+    def declare_poncho(self, package, cache=False, share=True):
         flags = Task._determine_file_flags(cache, share)
         f = vine_declare_poncho(self._taskvine, package._file, flags)
         return File(f)
@@ -2089,7 +2110,7 @@ class Manager(object):
     # @param self    The manager to register this file
     # @param starch  The startch .sfx file
     # @return A file object to use in @ref Task.add_input
-    def declare_starch(self, starch, cache=False, share=False):
+    def declare_starch(self, starch, cache=False, share=True):
         flags = Task._determine_file_flags(cache, share)
         f = vine_declare_starch(self._taskvine, starch._file, flags)
         return File(f)
@@ -2103,8 +2124,13 @@ class Manager(object):
     #               environment variable X509_USER_PROXY and the file
     #               "$TMPDIR/$UID" are considered in that order. If no proxy is
     #               present, the transfer is tried without authentication.
+    # @param cache   If True or 'workflow', cache the file at workers for reuse
+    #                until the end of the workflow. If 'always', the file is cache until the
+    #                end-of-life of the worker. Default is False (file is not cache).
+    # @param share   Whether the file can be transfered between workers when
+    #                peer transfers are enabled (see @ref enable_peer_transfers). Default is True.
     # @return A file object to use in @ref Task.add_input
-    def declare_xrootd(self, source, proxy=None, cache=False, share=False):
+    def declare_xrootd(self, source, proxy=None, cache=False, share=True):
         proxy_c = None
         if proxy:
             proxy_c = proxy._file
@@ -2119,6 +2145,11 @@ class Manager(object):
     # @param server The chirp server address of the form "hostname[:port"]"
     # @param source The name of the file in the server
     # @param ticket If not NULL, a file object that provides a chirp an authentication ticket
+    # @param cache   If True or 'workflow', cache the file at workers for reuse
+    #                until the end of the workflow. If 'always', the file is cache until the
+    #                end-of-life of the worker. Default is False (file is not cache).
+    # @param share   Whether the file can be transfered between workers when
+    #                peer transfers are enabled (see @ref enable_peer_transfers). Default is True.
     # @return A file object to use in @ref Task.add_input
     def declare_chirp(self, server, source, ticket=None):
         ticket_c = None

--- a/taskvine/src/examples/vine_example.py
+++ b/taskvine/src/examples/vine_example.py
@@ -59,13 +59,13 @@ if __name__ == "__main__":
         # Note that when adding a file, we have to name its local name
         # (e.g. gzip_path), and its remote name (e.g. "gzip"). Unlike the
         # following line, more often than not these are the same.
-        t.add_input_file(gzip_path, "gzip", cache=True)
+        t.add_input(m.declare_file(gzip_path, cache=True), "gzip")
 
         # files to be compressed are different across all tasks, so we do not
         # cache them. This is, of course, application specific. Sometimes you may
         # want to cache an output file if is the input of a later task.
-        t.add_input_file(infile, "infile", cache=False)
-        t.add_output_file(outfile, "outfile", cache=False)
+        t.add_input(m.declare_file(infile, cache=False), "infile")
+        t.add_output(m.declare_file(outfile, cache=False), "outfile")
 
         # Once all files has been specified, we are ready to submit the task to the queue.
         q.submit(t)

--- a/taskvine/src/examples/vine_example_blast.c
+++ b/taskvine/src/examples/vine_example_blast.c
@@ -88,22 +88,24 @@ int main(int argc, char *argv[])
 	vine_enable_peer_transfers(m);
 
 	printf("Declaring files...");
-	struct vine_file *blast_url = vine_declare_url(m, BLAST_URL, VINE_PEER_SHARE);
-	struct vine_file *landm_url = vine_declare_url(m, LANDMARK_URL, VINE_PEER_SHARE);
+	struct vine_file *blast_url = vine_declare_url(m, BLAST_URL, VINE_CACHE);
+	struct vine_file *landm_url = vine_declare_url(m, LANDMARK_URL, VINE_CACHE);
 
-	struct vine_file *software = vine_declare_untar(m, blast_url, VINE_PEER_SHARE);
-	struct vine_file *database = vine_declare_untar(m, landm_url, VINE_PEER_SHARE);
+	struct vine_file *software = vine_declare_untar(m, blast_url, VINE_CACHE);
+	struct vine_file *database = vine_declare_untar(m, landm_url, VINE_CACHE);
 
 	printf("Declaring tasks...");
 	char* query_string;
 	for(i=0;i<TASK_COUNT;i++) {
 		struct vine_task *t = vine_task_create("blastdir/ncbi-blast-2.13.0+/bin/blastp -db landmark -query query.file");
-		
+
 		query_string = make_query();
-		struct vine_file *query = vine_declare_buffer(m, query_string, strlen(query_string), VINE_PEER_SHARE);
-		vine_task_add_input(t, query, "query.file", VINE_NOCACHE);
-		vine_task_add_input(t,software,"blastdir", VINE_CACHE );
-		vine_task_add_input(t,database,"landmark", VINE_CACHE );
+		struct vine_file *query = vine_declare_buffer(m, query_string, strlen(query_string), VINE_CACHE_NEVER);
+		vine_task_add_input(t, query, "query.file", 0);
+
+		vine_task_add_input(t,software,"blastdir", 0);
+		vine_task_add_input(t,database,"landmark", 0);
+
 		vine_task_set_env_var(t,"BLASTDB","landmark");
 
 		int task_id = vine_submit(m, t);

--- a/taskvine/src/examples/vine_example_blast.py
+++ b/taskvine/src/examples/vine_example_blast.py
@@ -47,14 +47,14 @@ if __name__ == "__main__":
 
     print(f"Declaring files...")
 
-    blast_url = m.declare_url("https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-2.13.0+-x64-linux.tar.gz")
+    blast_url = m.declare_url("https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-2.13.0+-x64-linux.tar.gz", cache=True)
     blast = m.declare_untar(blast_url)
 
-    landmark_url = m.declare_url("https://ftp.ncbi.nlm.nih.gov/blast/db/landmark.tar.gz")
+    landmark_url = m.declare_url("https://ftp.ncbi.nlm.nih.gov/blast/db/landmark.tar.gz", cache=True)
     landmark = m.declare_untar(landmark_url)
 
     m.enable_peer_transfers()
-    
+
     print(f"Declaring tasks...")
 
     for i in range(task_count):
@@ -62,10 +62,10 @@ if __name__ == "__main__":
 
         t = vine.Task("blastdir/ncbi-blast-2.13.0+/bin/blastp -db landmark -query query.file")
 
-        t.add_input(query, "query.file", cache=False )
-        t.add_input(blast, "blastdir", cache=True )
+        t.add_input(query, "query.file")
+        t.add_input(blast, "blastdir")
 
-        t.add_input(landmark, "landmark", cache=True )
+        t.add_input(landmark, "landmark")
         t.set_env_var("BLASTDB", value="landmark")
         t.set_cores(1)
 

--- a/taskvine/src/examples/vine_example_chirp.py
+++ b/taskvine/src/examples/vine_example_chirp.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
 
     # define the authentication ticket to use.
     ticket_file = None
-    #ticket_file = m.declare_file("myticket.ticket")
+    #ticket_file = m.declare_file("myticket.ticket", cache=True)
 
     t = vine.PythonTask(count_lines, "mychirp.file")
-    t.add_input(m.declare_chirp(chirp_server, test_filename, ticket_file), "mychirp.file", cache=True)
+    t.add_input(m.declare_chirp(chirp_server, test_filename, ticket_file, cache=True), "mychirp.file")
     t.set_environment(env_with_chirp)
 
     task_id = m.submit(t)

--- a/taskvine/src/examples/vine_example_gutenberg.c
+++ b/taskvine/src/examples/vine_example_gutenberg.c
@@ -69,11 +69,11 @@ int main(int argc, char *argv[])
 	printf("listening on port %d...\n", vine_port(m));
 
 	printf("setting up input files...\n");
-	struct vine_file *script = vine_declare_file(m, "vine_example_gutenberg_script.sh", VINE_PEER_SHARE);
+	struct vine_file *script = vine_declare_file(m, "vine_example_gutenberg_script.sh", VINE_CACHE);
 	struct vine_file *files[URL_COUNT];
 
 	for(i=0;i<URL_COUNT;i++) {
-		files[i] = vine_declare_url(m, urls[i], VINE_PEER_SHARE);
+		files[i] = vine_declare_url(m, urls[i], VINE_CACHE);
 	}
 
 	printf("submitting tasks...\n");
@@ -81,9 +81,9 @@ int main(int argc, char *argv[])
 		for(j=0;j<URL_COUNT;j++) {
 			struct vine_task *t = vine_task_create("./vine_example_gutenberg_script.sh filea.txt fileb.txt");
 
-			vine_task_add_input(t,script,"vine_example_gutenberg_script.sh",VINE_CACHE);
-			vine_task_add_input(t,files[i], "filea.txt", VINE_CACHE);
-			vine_task_add_input(t,files[j], "fileb.txt", VINE_CACHE);
+			vine_task_add_input(t, script, "vine_example_gutenberg_script.sh", 0);
+			vine_task_add_input(t, files[i], "filea.txt", 0);
+			vine_task_add_input(t, files[j], "fileb.txt", 0);
 
 			vine_task_set_cores(t,1);
 

--- a/taskvine/src/examples/vine_example_gutenberg.py
+++ b/taskvine/src/examples/vine_example_gutenberg.py
@@ -48,10 +48,10 @@ if __name__ == "__main__":
     print("listening on port", m.port)
 
     # declare all urls in the manager:
-    urls = map(lambda u: m.declare_url(u), urls_sources)
+    urls = map(lambda u: m.declare_url(u, cache=True), urls_sources)
 
     # script to process the files
-    my_script = m.declare_file("vine_example_gutenberg_script.sh")
+    my_script = m.declare_file("vine_example_gutenberg_script.sh", cache=True)
 
     for (i, url_a) in enumerate(urls):
         for (j, url_b) in enumerate(urls):
@@ -60,10 +60,10 @@ if __name__ == "__main__":
                 continue
 
             t = vine.Task("./my_script file_a.txt file_b.txt")
-            t.add_input(my_script, "my_script", cache=True)
+            t.add_input(my_script, "my_script")
 
-            t.add_input(url_a, "file_a.txt", cache=True)
-            t.add_input(url_b, "file_b.txt", cache=True)
+            t.add_input(url_a, "file_a.txt")
+            t.add_input(url_b, "file_b.txt")
 
             t.set_cores(1)
 

--- a/taskvine/src/examples/vine_example_minitask.c
+++ b/taskvine/src/examples/vine_example_minitask.c
@@ -35,12 +35,12 @@ int main(int argc, char *argv[])
 	printf("listening on port %d...\n", vine_port(m));
 
 
-	struct vine_file *url = vine_declare_url(m, CCTOOLS_URL, VINE_PEER_SHARE);
-	struct vine_file *package = vine_declare_untar(m, url, VINE_PEER_SHARE);
+	struct vine_file *url = vine_declare_url(m, CCTOOLS_URL, VINE_CACHE);
+	struct vine_file *package = vine_declare_untar(m, url, VINE_CACHE);
 
 	for(i=0;i<10;i++) {
 		struct vine_task *task = vine_task_create("ls -lR cctools | wc -l");
-		vine_task_add_input(task,package,"cctools",VINE_CACHE);
+		vine_task_add_input(task,package,"cctools",0);
 		int task_id = vine_submit(m, task);
 
 		printf("submitted task (id# %d): %s\n", task_id, vine_task_get_command(task) );

--- a/taskvine/src/examples/vine_example_mosaic.c
+++ b/taskvine/src/examples/vine_example_mosaic.c
@@ -69,8 +69,8 @@ int main(int argc, char *argv[])
 
 	vine_enable_peer_transfers(m);
 
-	struct vine_file *convert = vine_declare_file(m, "convert.sfx", VINE_PEER_SHARE);
-	struct vine_file *image = vine_declare_url(m, "https://upload.wikimedia.org/wikipedia/commons/7/74/A-Cat.jpg", VINE_PEER_SHARE);
+	struct vine_file *convert = vine_declare_file(m, "convert.sfx", VINE_CACHE);
+	struct vine_file *image = vine_declare_url(m, "https://upload.wikimedia.org/wikipedia/commons/7/74/A-Cat.jpg", VINE_CACHE);
 
 	struct vine_file *temp_file[36];
 
@@ -86,9 +86,9 @@ int main(int argc, char *argv[])
 
 		t = vine_task_create(command);
 
-		vine_task_add_input(t,convert,"convert.sfx",VINE_CACHE);
-		vine_task_add_input(t,image,"cat.jpg", VINE_CACHE );
-		vine_task_add_output(t,temp_file[i],outfile,VINE_CACHE);
+		vine_task_add_input(t,convert,"convert.sfx",0);
+		vine_task_add_input(t,image,"cat.jpg",0);
+		vine_task_add_output(t,temp_file[i],outfile,0);
 
 		vine_task_set_cores(t,1);
 
@@ -120,11 +120,11 @@ int main(int argc, char *argv[])
 	for(i=0;i<36;i++) {
 		char filename[256];
 		sprintf(filename,"%d.cat.jpg",i);
-		vine_task_add_input(t,temp_file[i],filename,VINE_NOCACHE);
+		vine_task_add_input(t,temp_file[i],filename,0);
 	}
 
-	vine_task_add_input(t,vine_declare_file(m,"montage.sfx",VINE_PEER_SHARE),"montage.sfx",VINE_CACHE);
-	vine_task_add_output(t,vine_declare_file(m,"mosaic.jpg",VINE_PEER_SHARE),"mosaic.jpg",VINE_NOCACHE);
+	vine_task_add_input(t,vine_declare_file(m,"montage.sfx",VINE_CACHE),"montage.sfx",0);
+	vine_task_add_output(t,vine_declare_file(m,"mosaic.jpg",VINE_CACHE_NEVER),"mosaic.jpg",0);
 
 	int task_id = vine_submit(m,t);
 	printf("Submitted task (id# %d): %s\n", task_id, vine_task_get_command(t) );

--- a/taskvine/src/examples/vine_example_mosaic.py
+++ b/taskvine/src/examples/vine_example_mosaic.py
@@ -62,18 +62,18 @@ if __name__ == "__main__":
     for i in range(0, 36):
         temp_files.append(m.declare_temp())
 
-    montage_file = m.declare_file("montage.sfx")
-    convert_file = m.declare_file("convert.sfx")
-    image_file = m.declare_url("https://upload.wikimedia.org/wikipedia/commons/7/74/A-Cat.jpg")
+    montage_file = m.declare_file("montage.sfx", cache=True)
+    convert_file = m.declare_file("convert.sfx", cache=True)
+    image_file = m.declare_url("https://upload.wikimedia.org/wikipedia/commons/7/74/A-Cat.jpg", cache=True)
 
     for i in range(0, 36):
         outfile = str(i) + ".cat.jpg"
         command = f"./convert.sfx -swirl {i*10} cat.jpg output.jpg"
 
         t = vine.Task(command)
-        t.add_input(convert_file, "convert.sfx", cache=True)
-        t.add_input(image_file,"cat.jpg",cache=True)
-        t.add_output(temp_files[i],"output.jpg",cache=True)
+        t.add_input(convert_file, "convert.sfx")
+        t.add_input(image_file,"cat.jpg")
+        t.add_output(temp_files[i],"output.jpg")
 
         t.set_cores(1)
 
@@ -90,11 +90,12 @@ if __name__ == "__main__":
 
     print("Combining images into mosaic.jpg...")
     t = vine.Task("montage `ls *.cat.jpg | sort -n` -tile 6x6 -geometry 128x128+0+0 mosaic.jpg")
-    t.add_input(montage_file, "montage.sfx", cache=True)
+    t.add_input(montage_file, "montage.sfx")
 
     for i in range(0, 36):
-        t.add_input(temp_files[i],f"{i*10}.cat.jpg",cache=False)
-    t.add_output_file("mosaic.jpg", cache=False)
+        t.add_input(temp_files[i],f"{i*10}.cat.jpg")
+
+    t.add_output_file(m.declare_file("mosaic.jpg"))
     m.submit(t)
 
     print("waiting for final task to complete...")

--- a/taskvine/src/examples/vine_example_poncho.c
+++ b/taskvine/src/examples/vine_example_poncho.c
@@ -32,17 +32,17 @@ int main(int argc, char *argv[])
 	}
 	printf("listening on port %d...\n", vine_port(m));
 
-	struct vine_file *script = vine_declare_file(m, "script_example_for_poncho.py", VINE_PEER_SHARE);
+	struct vine_file *script = vine_declare_file(m, "script_example_for_poncho.py", VINE_CACHE);
 
-	struct vine_file *poncho_tarball = vine_declare_file(m, "package.tar.gz", VINE_PEER_SHARE);
-	struct vine_file *poncho_expansion = vine_declare_poncho(m, poncho_tarball, VINE_PEER_SHARE);
+	struct vine_file *poncho_tarball = vine_declare_file(m, "package.tar.gz", VINE_CACHE);
+	struct vine_file *poncho_expansion = vine_declare_poncho(m, poncho_tarball, VINE_CACHE);
 
 	for(i=0;i<5;i++) {
 
 		struct vine_task *task = vine_task_create("python my_script.py");
 
-		vine_task_add_input(task, script, "my_script.py", VINE_CACHE);
-		vine_task_add_input(task, poncho_expansion, "package", VINE_CACHE);
+		vine_task_add_input(task, script, "my_script.py", 0);
+		vine_task_add_input(task, poncho_expansion, "package", 0);
 
 		int task_id = vine_submit(m, task);
 		printf("submitted task (id# %d): %s\n", task_id, vine_task_get_command(task) );

--- a/taskvine/src/examples/vine_example_watch.c
+++ b/taskvine/src/examples/vine_example_watch.c
@@ -44,16 +44,16 @@ int main(int argc, char *argv[])
 	}
 	printf("Listening on port %d...\n", vine_port(m));
 
-	struct vine_file *executable = vine_declare_file(m, "vine_example_watch_trickle.sh", VINE_PEER_SHARE);
+	struct vine_file *executable = vine_declare_file(m, "vine_example_watch_trickle.sh", VINE_CACHE);
 
 	int i;
 	for(i=0;i<10;i++) {
 		char output_name[256];
 		sprintf(output_name,"output.%d",i);
-		struct vine_file *output_file = vine_declare_file(m, output_name, VINE_PEER_SHARE);
+		struct vine_file *output_file = vine_declare_file(m, output_name, VINE_CACHE);
 
 		t = vine_task_create("./vine_example_watch_trickle.sh > output");
-		vine_task_add_input(t, executable, "vine_example_watch_trickle.sh", VINE_CACHE );
+		vine_task_add_input(t, executable, "vine_example_watch_trickle.sh", 0);
 		vine_task_add_output(t, output_file, "output", VINE_WATCH );
 		vine_task_set_cores(t,1);
 		vine_submit(m, t);

--- a/taskvine/src/examples/vine_example_watch.py
+++ b/taskvine/src/examples/vine_example_watch.py
@@ -31,8 +31,8 @@ if __name__ == "__main__":
     for i in range(n):
         t = vine.Task("./vine_example_watch_trickle.sh > output")
 
-        input_script = m.declare_file("vine_example_watch_trickle.sh")
-        t.add_input(input_script, "vine_example_watch_trickle.sh", cache=True)
+        input_script = m.declare_file("vine_example_watch_trickle.sh", cache=True)
+        t.add_input(input_script, "vine_example_watch_trickle.sh")
 
         output = m.declare_file(f"output.{i}")
         t.add_output(output, "output", watch=True)

--- a/taskvine/src/examples/vine_example_xrootd.py
+++ b/taskvine/src/examples/vine_example_xrootd.py
@@ -65,11 +65,11 @@ if __name__ == "__main__":
     # if not give, taskvine will try to find one in the default places
     # (X509_USER_PROXY, or /tmp/x509up_uUID)
     proxy_file = None
-    # proxy_file = vine.declare_file("myproxy.pem")
+    # proxy_file = vine.declare_file("myproxy.pem", cache=True)
 
     for root_file in root_files:
         t = vine.PythonTask(count_events, "myroot.file")
-        t.add_input(m.declare_xrootd(root_file, proxy_file), "myroot.file", cache=True)
+        t.add_input(m.declare_xrootd(root_file, proxy_file, cache=True), "myroot.file")
         t.set_environment(env_with_xrootd)
 
         task_id = m.submit(t)

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -41,22 +41,17 @@ expected events.
 /** Select optional handling for input and output files: caching, unpacking, watching, etc. **/
 
 typedef enum {
-	VINE_NOCACHE  = 0, /**< Do not cache file at execution site. (default) */
-	VINE_CACHE    = 1, /**< Cache file at execution site for later use. */
-	VINE_WATCH    = 2, /**< Watch the output file and send back changes as the task runs. */
-	VINE_FAILURE_ONLY = 4,/**< Only return this output file if the task failed.  (Useful for returning large log files.) */
-	VINE_SUCCESS_ONLY = 8, /**< Only return this output file if the task succeeded. */
+	VINE_TRANSFER_ALWAYS = 0, /**< Always transfer this file when needed (only option for input files, see below for output files). */
+	VINE_WATCH = 1,           /**< Watch the output file and send back changes as the task runs. */
+	VINE_FAILURE_ONLY = 2,    /**< Only return this output file if the task failed.  (Useful for returning large log files.) */
+	VINE_SUCCESS_ONLY = 4,    /**< Only return this output file if the task succeeded. */
 } vine_mount_flags_t;
 
 typedef enum {
-	VINE_PEER_SHARE = 1, /**< Schedule this file to be shared between peers where available. (default) **/
-	VINE_PEER_NOSHARE = 2, /**< Do not schedule this file to be shared between peers. **/
-	VINE_CACHE_NEVER = 4, /**< File remains in cache until consumed. **/
-	VINE_CACHE_WORKFLOW = 8, /**< File remains in cache until workflow ends (default). **/
-	VINE_CACHE_ALWAYS = 16, /**< File remains in cache until the worker teminates. **/
-	/*
-	 * Move caching flags to here
-	 */
+	VINE_CACHE_NEVER = 0,  /**< Do not cache file at execution site. (default) */
+	VINE_CACHE = 1,        /**< File remains in cache until workflow ends. */
+	VINE_CACHE_ALWAYS = 3, /**< File remains in cache until the worker teminates. **/
+	VINE_PEER_NOSHARE = 4  /**< Schedule this file to be shared between peers where available. See @vine_enable_peer_transfers **/
 } vine_file_flags_t;
 
 /** Select overall scheduling algorithm for matching tasks to workers. */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -928,11 +928,10 @@ static void delete_task_output_files(struct vine_manager *q, struct vine_worker_
 }
 
 /* Delete only the uncacheable output files of a given task. */
-
 static void delete_uncacheable_files( struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t )
 {
-	delete_worker_files(q, w, t->input_mounts, VINE_CACHE_ALWAYS | VINE_CACHE_WORKFLOW );
-	delete_worker_files(q, w, t->output_mounts, VINE_CACHE_ALWAYS | VINE_CACHE_WORKFLOW );
+	delete_worker_files(q, w, t->input_mounts, VINE_CACHE);
+	delete_worker_files(q, w, t->output_mounts, VINE_CACHE);
 }
 
 /* Determine the resource monitor file name that should be associated with this task. */
@@ -1393,7 +1392,7 @@ static vine_result_code_t get_result(struct vine_manager *q, struct vine_worker_
 
 	if(task_status == VINE_RESULT_FORSAKEN) {
 		// Delete any input files that are not to be cached.
-		delete_worker_files(q, w, t->input_mounts, VINE_CACHE_ALWAYS | VINE_CACHE_WORKFLOW );
+		delete_worker_files(q, w, t->input_mounts, VINE_CACHE);
 
 		/* task will be resubmitted, so we do not update any of the execution stats */
 		reap_task_from_worker(q, w, t, VINE_TASK_READY);
@@ -2633,7 +2632,7 @@ static int vine_manager_transfer_capacity_available(struct vine_manager *q, stru
 
 		/* If not, then search for an available peer to provide it. */
 		/* Provide a substitute file object to describe the peer. */
-		if((m->file->flags & VINE_PEER_SHARE))
+		if(!(m->file->flags & VINE_PEER_NOSHARE))
 		{
 			if((peer = vine_file_replica_table_find_worker(q, m->file->cached_name)))
 			{
@@ -2968,7 +2967,7 @@ static int cancel_task_on_worker(struct vine_manager *q, struct vine_task *t, vi
 		debug(D_VINE, "Task with id %d has been cancelled at worker %s (%s) and removed.", t->task_id, w->hostname, w->addrport);
 
 		//Delete any input files that are not to be cached.
-		delete_worker_files(q, w, t->input_mounts, VINE_CACHE_ALWAYS | VINE_CACHE_WORKFLOW );
+		delete_worker_files(q, w, t->input_mounts, VINE_CACHE);
 
 		//Delete all output files since they are not needed as the task was cancelled.
 		delete_worker_files(q, w, t->output_mounts, 0);
@@ -3181,7 +3180,7 @@ int vine_enable_monitoring(struct vine_manager *q, int watchdog, int series)
 		return 0;
 	}
 
-	q->monitor_exe = vine_declare_file(q, exe, VINE_PEER_SHARE);
+	q->monitor_exe = vine_declare_file(q, exe, VINE_CACHE_ALWAYS);
 
 	if(series) {
 		char *series_file = vine_get_runtime_path_log(q, "time-series");
@@ -3418,18 +3417,18 @@ void vine_disable_monitoring(struct vine_manager *q) {
 }
 
 void vine_monitor_add_files(struct vine_manager *q, struct vine_task *t) {
-	vine_task_add_input(t, q->monitor_exe, RESOURCE_MONITOR_REMOTE_NAME, VINE_CACHE);
+	vine_task_add_input(t, q->monitor_exe, RESOURCE_MONITOR_REMOTE_NAME, 0);
 
 	char *summary  = monitor_file_name(q, t, ".summary", 0);
-	vine_task_add_output(t, vine_declare_file(q, summary, VINE_PEER_NOSHARE), RESOURCE_MONITOR_REMOTE_NAME ".summary", VINE_NOCACHE);
+	vine_task_add_output(t, vine_declare_file(q, summary, VINE_CACHE_NEVER), RESOURCE_MONITOR_REMOTE_NAME ".summary", 0);
 	free(summary);
 
 	if(q->monitor_mode & VINE_MON_FULL) {
 		char *debug  = monitor_file_name(q, t, ".debug", 1);
 		char *series = monitor_file_name(q, t, ".series", 1);
 
-		vine_task_add_output(t, vine_declare_file(q, debug, VINE_PEER_NOSHARE), RESOURCE_MONITOR_REMOTE_NAME ".debug", VINE_NOCACHE);
-		vine_task_add_output(t, vine_declare_file(q, series, VINE_PEER_NOSHARE), RESOURCE_MONITOR_REMOTE_NAME ".series", VINE_NOCACHE);
+		vine_task_add_output(t, vine_declare_file(q, debug, VINE_CACHE_NEVER), RESOURCE_MONITOR_REMOTE_NAME ".debug", 0);
+		vine_task_add_output(t, vine_declare_file(q, series, VINE_CACHE_NEVER), RESOURCE_MONITOR_REMOTE_NAME ".series",0);
 
 		free(debug);
 		free(series);
@@ -4371,7 +4370,7 @@ struct list * vine_tasks_cancel(struct vine_manager *q)
 		vine_manager_send(q,w,"kill -1\n");
 		ITABLE_ITERATE(w->current_tasks,task_id,t) {
 			//Delete any input files that are not to be cached.
-			delete_worker_files(q, w, t->input_mounts, VINE_CACHE_ALWAYS | VINE_CACHE_WORKFLOW );
+			delete_worker_files(q, w, t->input_mounts, VINE_CACHE);
 
 			//Delete all output files since they are not needed as the task was canceled.
 			delete_worker_files(q, w, t->output_mounts, 0);
@@ -4930,11 +4929,9 @@ void vine_remove_file(struct vine_manager *m, struct vine_file *f)
 			}
 		}
 
-		int should_preserve = 0;
-		int file_cache_flags = 0;
-		//file_cache_flags = f->flags & VINE_CACHE_FOREVER; eventually...
-
-		delete_worker_file(m, w, filename, file_cache_flags, should_preserve);
+		/* when explicitely asked to remove a file, we remove it regardless of
+		 * the cache flags. */
+		delete_worker_file(m, w, filename, 0, 0);
 	}
 
 	if(hash_table_lookup(m->file_table, f->cached_name)) {

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -456,7 +456,7 @@ void vine_task_add_input_url(struct vine_task *t, const char *file_url, const ch
 void vine_task_add_empty_dir( struct vine_task *t, const char *remote_name )
 {
 	struct vine_file *f = vine_file_empty_dir();
-	vine_task_add_input(t,f,remote_name,VINE_NOCACHE);
+	vine_task_add_input(t,f,remote_name,0);
 }
 
 void vine_task_add_input_buffer(struct vine_task *t, const char *data, int length, const char *remote_name, vine_mount_flags_t flags)
@@ -477,7 +477,7 @@ void vine_task_set_snapshot_file(struct vine_task *t, struct vine_file *monitor_
 	assert(monitor_snapshot_file);
 
 	t->monitor_snapshot_file = monitor_snapshot_file;
-	vine_task_add_input(t, monitor_snapshot_file, RESOURCE_MONITOR_REMOTE_NAME_EVENTS, VINE_CACHE);
+	vine_task_add_input(t, monitor_snapshot_file, RESOURCE_MONITOR_REMOTE_NAME_EVENTS, 0);
 }
 
 void vine_task_set_scheduler(struct vine_task *t, vine_schedule_t algorithm)

--- a/taskvine/src/tools/vine_benchmark.c
+++ b/taskvine/src/tools/vine_benchmark.c
@@ -40,7 +40,7 @@ int submit_tasks(struct vine_manager *q, int input_size, int run_time, int outpu
 	sprintf(gen_input_cmd, "dd if=/dev/zero of=%s bs=1048576 count=%d",input_file,input_size);
 	system(gen_input_cmd);
 
-	struct vine_file *input = vine_declare_file(q, input_file, VINE_PEER_SHARE);
+	struct vine_file *input = vine_declare_file(q, input_file, VINE_CACHE);
 
 	/*
 	Note that bs=1m and similar are not portable across various
@@ -52,13 +52,13 @@ int submit_tasks(struct vine_manager *q, int input_size, int run_time, int outpu
 
 		sprintf(output_file, "output.%d",ntasks);
 		sprintf(command, "dd if=/dev/zero of=outfile bs=1048576 count=%d; sleep %d", output_size, run_time );
-		struct vine_file *output = vine_declare_file(q, output_file, VINE_PEER_SHARE);
+		struct vine_file *output = vine_declare_file(q, output_file, VINE_PEER_NOSHARE);
 
 		ntasks++;
 
 		struct vine_task *t = vine_task_create(command);
-		vine_task_add_input(t, input, "infile", VINE_CACHE);
-		vine_task_add_output(t, output, "outfile", VINE_NOCACHE);
+		vine_task_add_input(t, input, "infile", 0);
+		vine_task_add_output(t, output, "outfile", 0);
 		vine_task_set_cores(t,1);
 
 		if(category && strlen(category) > 0)

--- a/taskvine/test/vine_test.py
+++ b/taskvine/test/vine_test.py
@@ -210,46 +210,46 @@ if __name__ == '__main__':
     # Note that we use a local file url of a small tarball to test the mechanism without placing a load on the network.
     f = q.declare_untar(q.declare_url("file://dummy.tar.gz"))
     t = vine.Task("ls -lR cctools | wc -l")
-    t.add_input(f,"cctools",cache=True)
+    t.add_input(f,"cctools")
     q.submit(t)
     t = q.wait(wait_time)
     report_task(t, vine.VINE_RESULT_SUCCESS, 0)
 
     # Create an explicit minitask description to run curl
     minitask = vine.Task("curl https://www.nd.edu -o output");
-    minitask.add_output_file("output","output",cache=True);
+    minitask.add_output_file("output","output")
 
     # Now generate an input file from a shell command:
     t = vine.Task("wc -l infile")
-    t.add_input_mini_task(minitask,"infile",cache=True);
+    t.add_input_mini_task(minitask,"infile")
     q.submit(t)
     t = q.wait(wait_time)
     report_task(t, vine.VINE_RESULT_SUCCESS, 0)
 
     # second time should have it cached (though we can't tell from here)
     t = vine.Task("wc -l infile")
-    t.add_input_mini_task(minitask,"infile",cache=True);
+    t.add_input_mini_task(minitask,"infile")
     q.submit(t)
     t = q.wait(wait_time)
     report_task(t, vine.VINE_RESULT_SUCCESS, 0)
 
     # Now generate an input file from a shell command:
     t = vine.Task("wc -l infile")
-    t.add_input_url("https://www.nd.edu","infile",cache=True)
+    t.add_input_url("https://www.nd.edu","infile")
     q.submit(t)
     t = q.wait(wait_time)
     report_task(t, vine.VINE_RESULT_SUCCESS, 0)
 
     # second time should have it cached (though we can't tell from here)
     t = vine.Task("wc -l infile")
-    t.add_input_url("https://www.nd.edu","infile",cache=True)
+    t.add_input_url("https://www.nd.edu","infile")
     q.submit(t)
     t = q.wait(wait_time)
     report_task(t, vine.VINE_RESULT_SUCCESS, 0)
 
     # generate an invalid remote input file, should get an input missing error.
     t = vine.Task("wc -l infile")
-    t.add_input_url("https://pretty-sure-this-is-not-a-valid-url.com","infile",cache=True)
+    t.add_input_url("https://pretty-sure-this-is-not-a-valid-url.com","infile")
     q.submit(t)
     t = q.wait(wait_time)
     report_task(t, vine.VINE_RESULT_INPUT_MISSING, 1)


### PR DESCRIPTION
`vine_mount_flags_t` and `vine_file_flags_t` had repeated flags related caching. This commit removes all caching related flags in `vine_mount_flags_t`. The "no flags" option in vine_mount_flags_t is the new `VINE_TRANSFER_ALWAYS`. Removing VINE_CACHE from vine_mount_flags_t showed that this mount flag was used in vine_task_add_{in,out}put in all the examples, which was incorrect.
    
file flags where renamed to `VINE_CACHE_NEVER`, `VINE_CACHE`, `VINE_CACHE_ALWAYS`, and `VINE_PEER_NOSHARE`. The main ideas are that `VINE_CACHE&VINE_CACHE_ALWAYS == VINE_CACHE`, and that peer transfer has to be disabled on a per file basis, as we assume that the users want peer transfers as they explicitly have to enable them.
