### PR TITLE
File flags fixes

### DIFF
--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -2151,11 +2151,12 @@ class Manager(object):
     # @param share   Whether the file can be transfered between workers when
     #                peer transfers are enabled (see @ref enable_peer_transfers). Default is True.
     # @return A file object to use in @ref Task.add_input
-    def declare_chirp(self, server, source, ticket=None):
+    def declare_chirp(self, server, source, ticket=None, cache=False, share=True):
         ticket_c = None
         if ticket:
             ticket_c = ticket._file
-        f = vine_declare_chirp(self._taskvine, server, source, ticket_c)
+        flags = Task._determine_file_flags(cache, share)
+        f = vine_declare_chirp(self._taskvine, server, source, ticket_c, flags)
         return File(f)
 
 

--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -2002,12 +2002,12 @@ class Manager(object):
     # @param cache   If True or 'workflow', cache the file at workers for reuse
     #                until the end of the workflow. If 'always', the file is cache until the
     #                end-of-life of the worker. Default is False (file is not cache).
-    # @param share   Whether the file can be transfered between workers when
+    # @param peer_transfer   Whether the file can be transfered between workers when
     #                peer transfers are enabled (see @ref enable_peer_transfers). Default is True.
     # @return
     # A file object to use in @ref Task.add_input or @ref Task.add_output
-    def declare_file(self, path, cache=False, share=True):
-        flags = Task._determine_file_flags(cache, share)
+    def declare_file(self, path, cache=False, peer_transfer=True):
+        flags = Task._determine_file_flags(cache, peer_transfer)
         f = vine_declare_file(self._taskvine, path, flags)
         return File(f)
 
@@ -2019,7 +2019,7 @@ class Manager(object):
     # @param cache   If True or 'workflow', cache the file at workers for reuse
     #                until the end of the workflow. If 'always', the file is cache until the
     #                end-of-life of the worker. Default is False (file is not cache).
-    # @param share   Whether the file can be transfered between workers when
+    # @param peer_transfer   Whether the file can be transfered between workers when
     #                peer transfers are enabled (see @ref enable_peer_transfers). Default is True.
     # @return A file object to use in @ref Task.add_input or @ref Task.add_output
     def declare_temp(self):
@@ -2034,11 +2034,11 @@ class Manager(object):
     # @param cache   If True or 'workflow', cache the file at workers for reuse
     #                until the end of the workflow. If 'always', the file is cache until the
     #                end-of-life of the worker. Default is False (file is not cache).
-    # @param share   Whether the file can be transfered between workers when
+    # @param peer_transfer   Whether the file can be transfered between workers when
     #                peer transfers are enabled (see @ref enable_peer_transfers). Default is True.
     # @return A file object to use in @ref Task.add_input
-    def declare_url(self, url, cache=False, share=True):
-        flags = Task._determine_file_flags(cache, share)
+    def declare_url(self, url, cache=False, peer_transfer=True):
+        flags = Task._determine_file_flags(cache, peer_transfer)
         url = str(url)
         f = vine_declare_url(self._taskvine, url, flags)
         return File(f)
@@ -2051,7 +2051,7 @@ class Manager(object):
     # @param cache   If True or 'workflow', cache the file at workers for reuse
     #                until the end of the workflow. If 'always', the file is cache until the
     #                end-of-life of the worker. Default is False (file is not cache).
-    # @param share   Whether the file can be transfered between workers when
+    # @param peer_transfer   Whether the file can be transfered between workers when
     #                peer transfers are enabled (see @ref enable_peer_transfers). Default is True.
     # @return A file object to use in @ref Task.add_input
     #
@@ -2062,10 +2062,10 @@ class Manager(object):
     # >>> print(f.contents())
     # >>> "hello pirate ♆"
     # @endcode
-    def declare_buffer(self, buffer=None, cache=False, share=True):
+    def declare_buffer(self, buffer=None, cache=False, peer_transfer=True):
         # because of the swig typemap, vine_declare_buffer(m, buffer, size) is changed
         # to a function with just two arguments.
-        flags = Task._determine_file_flags(cache, share)
+        flags = Task._determine_file_flags(cache, peer_transfer)
         if isinstance(buffer, str):
             buffer = bytes(buffer, "utf-8")
         f = vine_declare_buffer(self._taskvine, buffer, flags)
@@ -2077,8 +2077,8 @@ class Manager(object):
     # @param self     The manager to register this file
     # @param minitask The task to execute in order to produce a file
     # @return A file object to use in @ref Task.add_input
-    def declare_minitask(self, minitask, cache=False, share=True):
-        flags = Task._determine_file_flags(cache, share)
+    def declare_minitask(self, minitask, cache=False, peer_transfer=True):
+        flags = Task._determine_file_flags(cache, peer_transfer)
         f = vine_declare_mini_task(self._taskvine, minitask._task, flags)
         return File(f)
 
@@ -2088,8 +2088,8 @@ class Manager(object):
     # @param manager    The manager to register this file
     # @param tarball    The file object to un-tar
     # @return A file object to use in @ref Task.add_input
-    def declare_untar(self, tarball, cache=False, share=True):
-        flags = Task._determine_file_flags(cache, share)
+    def declare_untar(self, tarball, cache=False, peer_transfer=True):
+        flags = Task._determine_file_flags(cache, peer_transfer)
         f = vine_declare_untar(self._taskvine, tarball._file, flags)
         return File(f)
 
@@ -2099,8 +2099,8 @@ class Manager(object):
     # @param self    The manager to register this file
     # @param package The poncho or conda-pack environment tarball
     # @return A file object to use in @ref Task.add_input
-    def declare_poncho(self, package, cache=False, share=True):
-        flags = Task._determine_file_flags(cache, share)
+    def declare_poncho(self, package, cache=False, peer_transfer=True):
+        flags = Task._determine_file_flags(cache, peer_transfer)
         f = vine_declare_poncho(self._taskvine, package._file, flags)
         return File(f)
 
@@ -2110,8 +2110,8 @@ class Manager(object):
     # @param self    The manager to register this file
     # @param starch  The startch .sfx file
     # @return A file object to use in @ref Task.add_input
-    def declare_starch(self, starch, cache=False, share=True):
-        flags = Task._determine_file_flags(cache, share)
+    def declare_starch(self, starch, cache=False, peer_transfer=True):
+        flags = Task._determine_file_flags(cache, peer_transfer)
         f = vine_declare_starch(self._taskvine, starch._file, flags)
         return File(f)
 
@@ -2127,14 +2127,14 @@ class Manager(object):
     # @param cache   If True or 'workflow', cache the file at workers for reuse
     #                until the end of the workflow. If 'always', the file is cache until the
     #                end-of-life of the worker. Default is False (file is not cache).
-    # @param share   Whether the file can be transfered between workers when
+    # @param peer_transfer   Whether the file can be transfered between workers when
     #                peer transfers are enabled (see @ref enable_peer_transfers). Default is True.
     # @return A file object to use in @ref Task.add_input
-    def declare_xrootd(self, source, proxy=None, cache=False, share=True):
+    def declare_xrootd(self, source, proxy=None, cache=False, peer_transfer=True):
         proxy_c = None
         if proxy:
             proxy_c = proxy._file
-        flags = Task._determine_file_flags(cache, share)
+        flags = Task._determine_file_flags(cache, peer_transfer)
         f = vine_declare_xrootd(self._taskvine, source, proxy_c, flags)
         return File(f)
 
@@ -2148,14 +2148,14 @@ class Manager(object):
     # @param cache   If True or 'workflow', cache the file at workers for reuse
     #                until the end of the workflow. If 'always', the file is cache until the
     #                end-of-life of the worker. Default is False (file is not cache).
-    # @param share   Whether the file can be transfered between workers when
+    # @param peer_transfer   Whether the file can be transfered between workers when
     #                peer transfers are enabled (see @ref enable_peer_transfers). Default is True.
     # @return A file object to use in @ref Task.add_input
-    def declare_chirp(self, server, source, ticket=None, cache=False, share=True):
+    def declare_chirp(self, server, source, ticket=None, cache=False, peer_transfer=True):
         ticket_c = None
         if ticket:
             ticket_c = ticket._file
-        flags = Task._determine_file_flags(cache, share)
+        flags = Task._determine_file_flags(cache, peer_transfer)
         f = vine_declare_chirp(self._taskvine, server, source, ticket_c, flags)
         return File(f)
 

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -567,6 +567,11 @@ size_t vine_file_size( struct vine_file *f );
 /** Declare a file object from a local file
 @param m A manager object
 @param source The path of the file on the local filesystem
+@param flags Whether to never cache the file at the workers (VINE_CACHE_NEVER,
+the default), to cache it only for the current manager (VINE_CACHE), or to
+cache it for the lifetime of the worker (VINE_CACHE_ALWAYS). Cache flags can be
+or'ed (|) with VINE_PEER_NOSHARE if the file should not be transferred among
+workers when peer transfers are enabled (@ref vine_enable_peer_transfers).
 @return A file object to use in @ref vine_task_add_input, and @ref vine_task_add_output
 */
 struct vine_file * vine_declare_file( struct vine_manager *m, const char *source, vine_file_flags_t flags );
@@ -575,6 +580,11 @@ struct vine_file * vine_declare_file( struct vine_manager *m, const char *source
 /** Declare a file object from a remote URL.
 @param m A manager object
 @param url The URL address of the object in text form.
+@param flags Whether to never cache the file at the workers (VINE_CACHE_NEVER,
+the default), to cache it only for the current manager (VINE_CACHE), or to
+cache it for the lifetime of the worker (VINE_CACHE_ALWAYS). Cache flags can be
+or'ed (|) with VINE_PEER_NOSHARE if the file should not be transferred among
+workers when peer transfers are enabled (@ref vine_enable_peer_transfers).
 @return A file object to use in @ref vine_task_add_input
 */
 struct vine_file * vine_declare_url( struct vine_manager *m, const char *url, vine_file_flags_t flags );
@@ -586,6 +596,11 @@ struct vine_file * vine_declare_url( struct vine_manager *m, const char *url, vi
 @param proxy A proxy file object (e.g. from @ref vine_file_local) of a X509 proxy to use. If NULL, the
 environment variable X509_USER_PROXY and the file "$TMPDIR/$UID" are considered
 in that order. If no proxy is present, the transfer is tried without authentication.
+@param flags Whether to never cache the file at the workers (VINE_CACHE_NEVER,
+the default), to cache it only for the current manager (VINE_CACHE), or to
+cache it for the lifetime of the worker (VINE_CACHE_ALWAYS). Cache flags can be
+or'ed (|) with VINE_PEER_NOSHARE if the file should not be transferred among
+workers when peer transfers are enabled (@ref vine_enable_peer_transfers).
 @return A file object to use in @ref vine_task_add_input
 */
 struct vine_file * vine_declare_xrootd( struct vine_manager *m, const char *source, struct vine_file *proxy, vine_file_flags_t flags );
@@ -596,6 +611,11 @@ struct vine_file * vine_declare_xrootd( struct vine_manager *m, const char *sour
 @param server The chirp server address of the form "hostname[:port"]"
 @param source The name of the file in the server
 @param ticket If not NULL, a file object that provides a chirp an authentication ticket
+@param flags Whether to never cache the file at the workers (VINE_CACHE_NEVER,
+the default), to cache it only for the current manager (VINE_CACHE), or to
+cache it for the lifetime of the worker (VINE_CACHE_ALWAYS). Cache flags can be
+or'ed (|) with VINE_PEER_NOSHARE if the file should not be transferred among
+workers when peer transfers are enabled (@ref vine_enable_peer_transfers).
 @return A file object to use in @ref vine_task_add_input
 */
 struct vine_file * vine_declare_chirp( struct vine_manager *m, const char *server, const char *source, struct vine_file *ticket, vine_file_flags_t flags );
@@ -615,6 +635,11 @@ struct vine_file * vine_declare_temp( struct vine_manager *m );
 @param name The abstract name of the buffer.
 @param buffer The contents of the buffer.
 @param size The length of the buffer, in bytes.
+@param flags Whether to never cache the file at the workers (VINE_CACHE_NEVER,
+the default), to cache it only for the current manager (VINE_CACHE), or to
+cache it for the lifetime of the worker (VINE_CACHE_ALWAYS). Cache flags can be
+or'ed (|) with VINE_PEER_NOSHARE if the file should not be transferred among
+workers when peer transfers are enabled (@ref vine_enable_peer_transfers).
 @return A file object to use in @ref vine_task_add_input, and @ref vine_task_add_output
 */
 struct vine_file * vine_declare_buffer( struct vine_manager *m, const char *buffer, size_t size, vine_file_flags_t flags );
@@ -638,9 +663,14 @@ Attaches a task definition to produce an input file by running a Unix command.
 This mini-task will be run on demand in order to produce the desired input file.
 This is useful if an input requires some prior step such as transferring,
 renaming, or unpacking to be useful.  A mini-task should be a short-running
-activity with minimal resource consumpion.
+activity with minimal resource consumption.
 @param m A manager object
 @param mini_task The task which produces the file
+@param flags Whether to never cache the output of the mini task at the workers (VINE_CACHE_NEVER,
+the default), to cache it only for the current manager (VINE_CACHE), or to
+cache it for the lifetime of the worker (VINE_CACHE_ALWAYS). Cache flags can be
+or'ed (|) with VINE_PEER_NOSHARE if the file should not be transfered among
+workers when peer transfers are enabled (@ref vine_enable_peer_transfers).
 @return A file object to use in @ref vine_task_add_input
 */
 struct vine_file *vine_declare_mini_task( struct vine_manager *m, struct vine_task *mini_task, vine_file_flags_t flags);
@@ -650,6 +680,10 @@ struct vine_file *vine_declare_mini_task( struct vine_manager *m, struct vine_ta
 The archive may be compressed in any of the ways supported
 by tar, and so this function supports extensions .tar, .tar.gz, .tgz, tar.bz2, and so forth.
 @param m A manager object
+@param flags Whether to never cache the output directory of untar at the workers (VINE_CACHE_NEVER,
+the default), to cache it only for the current manager (VINE_CACHE), or to
+cache it for the lifetime of the worker (VINE_CACHE_ALWAYS). VINE_PEER_NOSHARE
+has no meaning for this declaration, as the output directory is never transferred among workers.
 @return A file object to use in @ref vine_task_add_input
 */
 struct vine_file * vine_declare_untar( struct vine_manager *m, struct vine_file *f, vine_file_flags_t flags);
@@ -658,6 +692,12 @@ struct vine_file * vine_declare_untar( struct vine_manager *m, struct vine_file 
 /** Create a file object by unpacking a poncho package
 @param m A manager object
 @param f A file object corresponding to poncho or conda-pack tarball
+@param flags Whether to never cache the expanded poncho environment at the workers (VINE_CACHE_NEVER,
+the default), to cache it only for the current manager (VINE_CACHE), or to
+cache it for the lifetime of the worker (VINE_CACHE_ALWAYS). VINE_PEER_NOSHARE
+has no meaning for this declaration, as the expanded environment is never
+transferred among workers.
+@return A file object to use in @ref vine_task_add_input
 */
 struct vine_file * vine_declare_poncho( struct vine_manager *m, struct vine_file *f, vine_file_flags_t flags );
 
@@ -665,6 +705,11 @@ struct vine_file * vine_declare_poncho( struct vine_manager *m, struct vine_file
 /** Create a file object by unpacking a starch package.
 @param m A manager object
 @param f A file object representing a sfx archive.
+@param flags Whether to never cache the expanded starch archive at the workers (VINE_CACHE_NEVER,
+the default), to cache it only for the current manager (VINE_CACHE), or to
+cache it for the lifetime of the worker (VINE_CACHE_ALWAYS). VINE_PEER_NOSHARE
+has no meaning for this declaration, as the expanded starch archive is never
+transferred among workers.
 @return A file object to use in @ref vine_task_add_input
 */
 struct vine_file * vine_declare_starch( struct vine_manager *m, struct vine_file *f, vine_file_flags_t flags );

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -598,7 +598,7 @@ struct vine_file * vine_declare_xrootd( struct vine_manager *m, const char *sour
 @param ticket If not NULL, a file object that provides a chirp an authentication ticket
 @return A file object to use in @ref vine_task_add_input
 */
-struct vine_file * vine_declare_chirp( struct vine_manager *m, const char *server, const char *source, struct vine_file *ticket );
+struct vine_file * vine_declare_chirp( struct vine_manager *m, const char *server, const char *source, struct vine_file *ticket, vine_file_flags_t flags );
 
 
 /** Create a scratch file object.

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -226,7 +226,7 @@ struct vine_file * vine_file_xrootd( const char *source, struct vine_file *proxy
 }
 
 
-struct vine_file * vine_file_chirp( const char *server, const char *source, struct vine_file *ticket )
+struct vine_file * vine_file_chirp( const char *server, const char *source, struct vine_file *ticket, vine_file_flags_t flags )
 {
 	char *command = string_format(
 			"chirp_get %s %s %s output.chirp",
@@ -244,7 +244,7 @@ struct vine_file * vine_file_chirp( const char *server, const char *source, stru
 
 	free(command);
 
-	return vine_file_mini_task(t, 0);
+	return vine_file_mini_task(t, flags);
 }
 
 

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -145,9 +145,6 @@ struct vine_file * vine_file_empty_dir()
 
 struct vine_file * vine_file_mini_task( struct vine_task *t, vine_file_flags_t flags )
 {
-	//add no share flag for minitasks, as what it is shared is their output files.
-	flags |= VINE_PEER_NOSHARE;
-
 	return vine_file_create(t->command_line,0,0,0,VINE_MINI_TASK,t,flags);
 }
 
@@ -163,7 +160,7 @@ struct vine_file * vine_file_poncho( struct vine_file *f, vine_file_flags_t flag
 {
 	struct vine_task *t = vine_task_create("./poncho_package_run --unpack-to output -e package.tar.gz");
 	char * poncho_path = path_which("poncho_package_run");
-	vine_task_add_input(t, vine_file_local(poncho_path, 0), "poncho_package_run", 0);
+	vine_task_add_input(t, vine_file_local(poncho_path, VINE_CACHE_ALWAYS), "poncho_package_run", 0);
 	vine_task_add_input(t, f, "package.tar.gz", 0);
 	vine_task_add_output(t, vine_file_local("output", flags), "output", 0);
 	return vine_file_mini_task(t, 0);
@@ -205,7 +202,7 @@ struct vine_file * vine_file_xrootd( const char *source, struct vine_file *proxy
 	if(!proxy) {
 		char *proxy_filename = find_x509_proxy();
 		if(proxy_filename) {
-			proxy = vine_file_local(proxy_filename, 0);
+			proxy = vine_file_local(proxy_filename, VINE_CACHE);
 			free(proxy_filename);
 		}
 	}
@@ -213,7 +210,7 @@ struct vine_file * vine_file_xrootd( const char *source, struct vine_file *proxy
 	char *command = string_format("xrdcp %s output.root", source);
 	struct vine_task *t = vine_task_create(command);
 
-	vine_task_add_output(t,vine_file_local("output.root", 0),"output.root",0);
+	vine_task_add_output(t,vine_file_local("output.root", flags),"output.root",0);
 
 	if(proxy) {
 		vine_task_set_env_var(t, "X509_USER_PROXY", "proxy509");
@@ -222,7 +219,7 @@ struct vine_file * vine_file_xrootd( const char *source, struct vine_file *proxy
 
 	free(command);
 
-	return vine_file_mini_task(t, flags);
+	return vine_file_mini_task(t, 0);
 }
 
 
@@ -236,7 +233,7 @@ struct vine_file * vine_file_chirp( const char *server, const char *source, stru
 
 	struct vine_task *t = vine_task_create(command);
 
-	vine_task_add_output(t,vine_file_local("output.chirp", 0),"output.chirp",0);
+	vine_task_add_output(t,vine_file_local("output.chirp", flags),"output.chirp",0);
 
 	if(ticket) {
 		vine_task_add_input(t,ticket,"ticket.chirp",0);
@@ -244,7 +241,7 @@ struct vine_file * vine_file_chirp( const char *server, const char *source, stru
 
 	free(command);
 
-	return vine_file_mini_task(t, flags);
+	return vine_file_mini_task(t, 0);
 }
 
 

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -65,6 +65,6 @@ struct vine_file *vine_file_untar( struct vine_file *f, vine_file_flags_t flags 
 struct vine_file *vine_file_poncho( struct vine_file *f, vine_file_flags_t flags );
 struct vine_file *vine_file_starch( struct vine_file *f, vine_file_flags_t flags );
 struct vine_file *vine_file_xrootd( const char *source, struct vine_file *proxy, vine_file_flags_t flags );
-struct vine_file *vine_file_chirp( const char *server, const char *source, struct vine_file *ticket );
+struct vine_file *vine_file_chirp( const char *server, const char *source, struct vine_file *ticket, vine_file_flags_t flags );
 
 #endif

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5104,9 +5104,9 @@ struct vine_file *vine_declare_xrootd( struct vine_manager *m, const char *sourc
 	return vine_manager_declare_file(m, t);
 }
 
-struct vine_file * vine_declare_chirp( struct vine_manager *m, const char *server, const char *source, struct vine_file *ticket)
+struct vine_file * vine_declare_chirp( struct vine_manager *m, const char *server, const char *source, struct vine_file *ticket, vine_file_flags_t flags )
 {
-	struct vine_file *t = vine_file_chirp(server, source, ticket);
+	struct vine_file *t = vine_file_chirp(server, source, ticket, flags);
 	return vine_manager_declare_file(m, t);
 }
 


### PR DESCRIPTION
- Added missing flags to declare chirp.
- Renamed `shared` to `peer_transfer` in python bindings (as that the name used in the function that computes the flags.)
- Added documentation to the flags in taskvine.h
- Apply file flags to the output of mini tasks, not to the mini tasks themselves.