### PR TITLE
adds s = vine_task_get_resources(t, name)

### DIFF
--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -488,12 +488,20 @@ const char * vine_task_get_hostname( struct vine_task *t );
 
 /** Get a performance metric of a completed task.
 @param t A task object.
-@param name The name of a performance metric:
+@param name The name of a performance metric.
 @return The metric value, or zero if an invalid name is given.
 */
 
 int64_t vine_task_get_metric( struct vine_task *t, const char *name );
 
+
+/** Get resource information (e.g., cores, memory, and disk) of a completed task.
+@param t A task object.
+@param name One of: "allocated", "requested", or "measured". For measured resources see @ref vine_enable_monitoring.
+@return The metric value, or zero if an invalid name is given.
+*/
+
+const struct rmsummary *vine_task_get_resources( struct vine_task *t, const char *name );
 
 /** When monitoring, indicates a json-encoded file that instructs the
 monitor to take a snapshot of the task resources. Snapshots appear in the JSON

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -609,7 +609,6 @@ const char * vine_task_get_hostname( struct vine_task *t )
 }
 
 #define METRIC(x) if(!strcmp(name,#x)) return t->x;
-
 int64_t vine_task_get_metric( struct vine_task *t, const char *name )
 {
 	METRIC(time_when_submitted);
@@ -624,6 +623,15 @@ int64_t vine_task_get_metric( struct vine_task *t, const char *name )
 	METRIC(bytes_received);
 	METRIC(bytes_sent);
 	METRIC(bytes_transferred);
+	return 0;
+}
+
+#define RESOURCES(x) if(!strcmp(name,#x)) return t->resources_ ## x;
+const struct rmsummary *vine_task_get_resources( struct vine_task *t, const char *name )
+{
+	RESOURCES(measured);
+	RESOURCES(requested);
+	RESOURCES(allocated);
 	return 0;
 }
 


### PR DESCRIPTION
where name can be one of "allocated", "measured", or "requested"