### PR TITLE
Adds execution environments to tasks

### DIFF
--- a/makeflow/src/starch
+++ b/makeflow/src/starch
@@ -94,9 +94,9 @@ extract() {
 }
 
 run() {
-    # make the extraction directory easily available in run.sh
+    # make the extraction directory easily available in bin/run.sh
     export SFX_DIR
-    $SFX_DIR/run.sh "$@"
+    $SFX_DIR/bin/run.sh "$@"
     SFX_EXIT_STATUS=$?
 }
 
@@ -130,7 +130,7 @@ __ARCHIVE__
 '''
 
 RUN_SH = '''#!/bin/sh
-SFX_DIR=`dirname $0`
+SFX_DIR=$(dirname $( cd -- "$( dirname -- "${{BASH_SOURCE[0]}}" )" &> /dev/null && pwd ))
 
 if [ -d "$SFX_DIR/env" ]; then
     for f in $SFX_DIR/env/*; do
@@ -169,19 +169,31 @@ then
     echo SFX_EXTRACT_ONLY=1  Extract package, but do not run a command.
     echo SFX_KEEP=1          Do not remove extracted package when command finishes.
     echo SFX_DIR=DIR         Extract to DIR, instead of a temporary directory. Implies SFX_KEEP=1
+    echo SFX_ENV=1           Execute the arguments given as a command inside the starch environment
+
     exit 0
 fi
 
 if [ -n "$SFX_EXEC" ]
 then
     $SFX_EXEC "$@"
+elif [ "$SFX_ENV" = 1 ]
+then
+    "$@"
 else
     {cmd} "$@"
 fi
 '''
 
-# Create SFX
+RUN_IN_ENV = '''#!/bin/sh
+export SFX_ENV=1
 
+SFX_DIR=$(dirname $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ))
+
+exec $SFX_DIR/bin/run.sh "$@"
+'''
+
+# Create SFX
 def create_sfx(sfx_path, executables, libraries, data, environments, command):
     """ Create self-extracting executable
 
@@ -189,7 +201,7 @@ def create_sfx(sfx_path, executables, libraries, data, environments, command):
         bin         Executables
         lib         Libraries
         env         Environment Scripts (static)
-        run.sh      Script that contains command
+        bin/run.sh  Script that contains command
     """
 
     tmp_file = NamedTemporaryFile()
@@ -229,14 +241,24 @@ def create_sfx(sfx_path, executables, libraries, data, environments, command):
         logging.debug('    adding environment script: %s (%s)' % (env_name, real_path))
         archive.addfile(env_info, open(real_path, 'rb'))
 
-    run_info = TarInfo('run.sh')
+    run_info = TarInfo('bin/run.sh')
     run_info_data  = RUN_SH.format(cmd=command)
     run_info.mode  = int('755', 8)
     run_info.mtime = time()
     run_info.size  = len(run_info_data)
 
-    logging.debug('adding run.sh...')
+    run_in_env_info = TarInfo('bin/run_in_env')
+    run_in_env_info_data  = RUN_IN_ENV
+    run_in_env_info.mode  = int('755', 8)
+    run_in_env_info.mtime = time()
+    run_in_env_info.size  = len(run_in_env_info_data)
+
+    logging.debug('adding bin/run.sh...')
     archive.addfile(run_info, BytesIO(run_info_data.encode('utf-8')))
+
+    logging.debug('adding bin/run_in_env...')
+    archive.addfile(run_in_env_info, BytesIO(run_in_env_info_data.encode('utf-8')))
+
     archive.close()
 
     logging.debug('creating sfx...')

--- a/makeflow/src/starch
+++ b/makeflow/src/starch
@@ -130,7 +130,7 @@ __ARCHIVE__
 '''
 
 RUN_SH = '''#!/bin/sh
-SFX_DIR=$(dirname $( cd -- "$( dirname -- "$0" )" &> /dev/null && pwd ))
+SFX_DIR=$(dirname $( cd -- "$( dirname -- "$0" )" > /dev/null 2>&1 && pwd ))
 
 if [ -d "$SFX_DIR/env" ]; then
     for f in $SFX_DIR/env/*; do
@@ -188,7 +188,7 @@ fi
 RUN_IN_ENV = '''#!/bin/sh
 export SFX_ENV=1
 
-SFX_DIR=$(dirname $( cd -- "$( dirname -- "$0" )" &> /dev/null && pwd ))
+SFX_DIR=$(dirname $( cd -- "$( dirname -- "$0" )" > /dev/null 2>&1 && pwd ))
 
 exec $SFX_DIR/bin/run.sh "$@"
 '''

--- a/makeflow/src/starch
+++ b/makeflow/src/starch
@@ -130,7 +130,7 @@ __ARCHIVE__
 '''
 
 RUN_SH = '''#!/bin/sh
-SFX_DIR=$(dirname $( cd -- "$( dirname -- "${{BASH_SOURCE[0]}}" )" &> /dev/null && pwd ))
+SFX_DIR=$(dirname $( cd -- "$( dirname -- "$0" )" &> /dev/null && pwd ))
 
 if [ -d "$SFX_DIR/env" ]; then
     for f in $SFX_DIR/env/*; do
@@ -188,7 +188,7 @@ fi
 RUN_IN_ENV = '''#!/bin/sh
 export SFX_ENV=1
 
-SFX_DIR=$(dirname $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ))
+SFX_DIR=$(dirname $( cd -- "$( dirname -- "$0" )" &> /dev/null && pwd ))
 
 exec $SFX_DIR/bin/run.sh "$@"
 '''

--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -2255,19 +2255,27 @@ class Manager(object):
     # @param self   The manager to register this file.
     # @param server The chirp server address of the form "hostname[:port"]"
     # @param source The name of the file in the server
-    # @param ticket If not NULL, a file object that provides a chirp an authentication ticket
+    # @param ticket If not None, a file object that provides a chirp an authentication ticket
+    # @param env    If not None, an environment file (e.g poncho or starch)
+    #               that contains the chirp executables. Otherwise assume chirp is available
+    #               at the worker.
     # @param cache   If True or 'workflow', cache the file at workers for reuse
     #                until the end of the workflow. If 'always', the file is cache until the
     #                end-of-life of the worker. Default is False (file is not cache).
     # @param peer_transfer   Whether the file can be transfered between workers when
     #                peer transfers are enabled (see @ref enable_peer_transfers). Default is True.
     # @return A file object to use in @ref Task.add_input
-    def declare_chirp(self, server, source, ticket=None, cache=False, peer_transfer=True):
+    def declare_chirp(self, server, source, ticket=None, env=None, cache=False, peer_transfer=True):
         ticket_c = None
         if ticket:
             ticket_c = ticket._file
+
+        env_c = None
+        if env:
+            env_c = env._file
+
         flags = Task._determine_file_flags(cache, peer_transfer)
-        f = vine_declare_chirp(self._taskvine, server, source, ticket_c, flags)
+        f = vine_declare_chirp(self._taskvine, server, source, ticket_c, env_c, flags)
         return File(f)
 
 

--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -527,6 +527,16 @@ class Task(object):
         return vine_task_set_snapshot_file(self._task, filename)
 
     ##
+    # Adds an execution environment to the task. The environment file specified
+    # is expected to expand to a directory with a bin/run_in_env file that will wrap
+    # the task command (e.g. a poncho or a starch file). If specified multiple times,
+    # environments are nested in the order given (i.e. first added is the first applied).
+    # @param t A task object.
+    # @param f The environment file.
+    def add_environment(self, f):
+        return vine_task_add_environment(self._task, f._file)
+
+    ##
     # Indicate the number of times the task should be retried. If 0 (the
     # default), the task is tried indefinitely. A task that did not succeed
     # after the given number of retries is returned with result

--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -54,6 +54,11 @@ class File(object):
     def __init__(self, internal_file):
         self._file = internal_file
 
+    def __bool__(self):
+        # We need this because the len of some files is 0, which would evaluate
+        # to false.
+        return True
+
     ##
     # Return the contents of a file object as a string.
     # Typically used to return the contents of an output buffer.

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -642,7 +642,7 @@ or'ed (|) with VINE_PEER_NOSHARE if the file should not be transferred among
 workers when peer transfers are enabled (@ref vine_enable_peer_transfers).
 @return A file object to use in @ref vine_task_add_input
 */
-struct vine_file * vine_declare_chirp( struct vine_manager *m, const char *server, const char *source, struct vine_file *ticket, vine_file_flags_t flags );
+struct vine_file * vine_declare_chirp( struct vine_manager *m, const char *server, const char *source, struct vine_file *ticket, struct vine_file *env, vine_file_flags_t flags );
 
 
 /** Create a scratch file object.

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -554,6 +554,19 @@ For more information, consult the manual of the resource_monitor.
 
 void vine_task_set_snapshot_file(struct vine_task *t, struct vine_file *monitor_snapshot_file);
 
+
+/** Adds an execution environment to the task. The environment file specified
+is expected to expand to a directory with a bin/run_in_env file that will
+wrap the task command (e.g. a poncho or a starch file). If specified multiple
+times, environments are nested in the order given (i.e. first added is the
+first applied).
+@param t A task object.
+@param f The environment file.
+*/
+
+void vine_task_add_environment(struct vine_task *t, struct vine_file *f);
+
+
 //@}
 
 /** @name Functions - Files */
@@ -621,6 +634,7 @@ struct vine_file * vine_declare_xrootd( struct vine_manager *m, const char *sour
 @param server The chirp server address of the form "hostname[:port"]"
 @param source The name of the file in the server
 @param ticket If not NULL, a file object that provides a chirp an authentication ticket
+@param env    If not NULL, an environment file (e.g poncho or starch) that contains the chirp executables. Otherwise assume chirp is available at the worker.
 @param flags Whether to never cache the file at the workers (VINE_CACHE_NEVER,
 the default), to cache it only for the current manager (VINE_CACHE), or to
 cache it for the lifetime of the worker (VINE_CACHE_ALWAYS). Cache flags can be

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -223,7 +223,7 @@ struct vine_file * vine_file_xrootd( const char *source, struct vine_file *proxy
 }
 
 
-struct vine_file * vine_file_chirp( const char *server, const char *source, struct vine_file *ticket, vine_file_flags_t flags )
+struct vine_file * vine_file_chirp( const char *server, const char *source, struct vine_file *ticket, struct vine_file *env, vine_file_flags_t flags )
 {
 	char *command = string_format(
 			"chirp_get %s %s %s output.chirp",
@@ -237,6 +237,10 @@ struct vine_file * vine_file_chirp( const char *server, const char *source, stru
 
 	if(ticket) {
 		vine_task_add_input(t,ticket,"ticket.chirp",0);
+	}
+
+	if(env) {
+		vine_task_add_environment(t, env);
 	}
 
 	free(command);

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -65,6 +65,6 @@ struct vine_file *vine_file_untar( struct vine_file *f, vine_file_flags_t flags 
 struct vine_file *vine_file_poncho( struct vine_file *f, vine_file_flags_t flags );
 struct vine_file *vine_file_starch( struct vine_file *f, vine_file_flags_t flags );
 struct vine_file *vine_file_xrootd( const char *source, struct vine_file *proxy, vine_file_flags_t flags );
-struct vine_file *vine_file_chirp( const char *server, const char *source, struct vine_file *ticket, vine_file_flags_t flags );
+struct vine_file *vine_file_chirp( const char *server, const char *source, struct vine_file *ticket, struct vine_file *env, vine_file_flags_t flags );
 
 #endif

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5115,9 +5115,9 @@ struct vine_file *vine_declare_xrootd( struct vine_manager *m, const char *sourc
 	return vine_manager_declare_file(m, t);
 }
 
-struct vine_file * vine_declare_chirp( struct vine_manager *m, const char *server, const char *source, struct vine_file *ticket, vine_file_flags_t flags )
+struct vine_file * vine_declare_chirp( struct vine_manager *m, const char *server, const char *source, struct vine_file *ticket, struct vine_file *env, vine_file_flags_t flags )
 {
-	struct vine_file *t = vine_file_chirp(server, source, ticket, flags);
+	struct vine_file *t = vine_file_chirp(server, source, ticket, env, flags);
 	return vine_manager_declare_file(m, t);
 }
 

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -472,6 +472,21 @@ void vine_task_add_input_mini_task(struct vine_task *t, struct vine_task *mini_t
 	vine_task_add_input(t,f,remote_name,flags);
 }
 
+void vine_task_add_environment(struct vine_task *t, struct vine_file *environment_file) {
+
+	assert(environment_file);
+
+	char *env_name = string_format("__vine_env_%s", environment_file->cached_name);
+
+	vine_task_add_input(t, environment_file, env_name, 0);
+
+	char *new_cmd = string_format("%s/bin/run_in_env %s", env_name, t->command_line);
+	vine_task_set_command(t, new_cmd);
+
+	free(env_name);
+}
+
+
 void vine_task_set_snapshot_file(struct vine_task *t, struct vine_file *monitor_snapshot_file) {
 
 	assert(monitor_snapshot_file);


### PR DESCRIPTION
An environment is a vine file that expands to a directory. The directory is expected to a have a `bin/run_in_env` wrapper.
Environments nest, applied in the order they are defined.

I modified starch to have the `bin/run_in_env`, and update the chirp example to show how it works for chirp. (It worked!)

Something nice about this approach is that we can design general mini task that have as an output a directory with the bin/run_in_env wrapper. (E.g. for apptainer, or other execution wrappers.)

@BarrySlyDelgado 
I think we should do something similar to poncho. The poncho environment should include bin/poncho_package_run, and a script bin/run_in_env that knows how to run poncho_package_run for that environment.

