### PR TITLE
on failure to start a transfer server, terminate worker

### DIFF
--- a/taskvine/src/worker/vine_transfer_server.c
+++ b/taskvine/src/worker/vine_transfer_server.c
@@ -98,6 +98,10 @@ void vine_transfer_server_start( struct vine_cache *cache )
 {
 	transfer_link = link_serve(0);
 
+	if(!transfer_link) {
+		fatal("unable to find a port to start a transfer server.");
+	}
+
 	transfer_server_pid = fork();
 	if(transfer_server_pid==0) {
 		// consider closing additional resources here?


### PR DESCRIPTION
same result as the segfault, but at least we mean it this way. Still need #3221 for a more complete solution.