### PR TITLE
vine py: SSL fixes

### DIFF
--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -892,6 +892,7 @@ class Manager(object):
         self._task_table = {}
         self._duty_table = {}
         self._info_widget = None
+        self._using_ssl = False
 
         # if we were given a range ports, rather than a single port to try.
         lower, upper = None, None
@@ -917,6 +918,10 @@ class Manager(object):
 
             ssl_key, ssl_cert = self._setup_ssl(ssl)
             self._taskvine = vine_ssl_create(port, ssl_key, ssl_cert)
+
+            if ssl_key:
+                self._using_ssl = True
+
             if not self._taskvine:
                 raise Exception("Could not create manager on port {}".format(port))
 
@@ -992,6 +997,15 @@ class Manager(object):
     @property
     def port(self):
         return vine_port(self._taskvine)
+
+    ##
+    # Whether the manager is using ssl to talk to workers
+    # @code
+    # >>> print(q.using_ssl)
+    # @endcode
+    @property
+    def using_ssl(self):
+        return self._using_ssl
 
     ##
     # Get the staging directory of the manager

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -1181,7 +1181,7 @@ class WorkQueue(object):
         (tmp, cert) = tempfile.mkstemp(dir=staging_directory, prefix="cert")
         os.close(tmp)
 
-        cmd = f"openssl req -x509 -newkey rsa:4096 -keyout {key} -out {cert} x-sha256 -days 365 -nodes -batch".split()
+        cmd = f"openssl req -x509 -newkey rsa:4096 -keyout {key} -out {cert} -sha256 -days 365 -nodes -batch".split()
 
         output = ""
         try:


### PR DESCRIPTION
E.g. in a notebook now you can do:

```python
m = vine.Manager(port=0, ssl=True)
factory = vine.Factory(m)
with factory:
  ...
```

and that creates local workers with ssl with the correct host port.

Also this fixes an incorrect openssl command line, and a sefgault with the incorrect staging dir.
