### PR TITLE
vine: Add resource monitor, track fds to test with valgrind

### DIFF
--- a/dttools/src/category.c
+++ b/dttools/src/category.c
@@ -186,6 +186,8 @@ static void category_clear_histogram(struct histogram *h) {
 		}
 	}
 
+	free(buckets);
+
 	histogram_clear(h);
 }
 

--- a/dttools/src/debug.c
+++ b/dttools/src/debug.c
@@ -31,6 +31,7 @@ extern void debug_file_size (off_t size);
 extern int debug_file_path (const char *path);
 extern void debug_file_rename (const char *suffix);
 extern int debug_file_reopen (void);
+extern int debug_file_close (void);
 
 static void (*debug_write) (int64_t flags, const char *str) = debug_stderr_write;
 static pid_t (*debug_getpid) (void) = getpid;
@@ -334,6 +335,11 @@ void debug_reopen(void)
 {
 	if (debug_file_reopen() == -1)
 		fatal("could not reopen debug log: %s", strerror(errno));
+}
+
+void debug_close(void)
+{
+	debug_file_close();
 }
 
 /* vim: set noexpandtab tabstop=4: */

--- a/dttools/src/debug.h
+++ b/dttools/src/debug.h
@@ -251,6 +251,10 @@ void debug_rename(const char *suffix);
 */
 void debug_reopen(void);
 
+/** Close the debug stream (only for disk files, no stderr or stdout).
+*/
+void debug_close(void);
+
 /* LDEBUG likes debug, but also print the code location.
  * NOTE: the caller of this macro must supply at least one argument after the format string.
  */

--- a/dttools/src/debug_file.c
+++ b/dttools/src/debug_file.c
@@ -36,7 +36,9 @@ int debug_file_reopen (void)
 	int rc;
 	if (strlen(file_path)) {
 		int flags;
-		close(file_fd);
+		if(file_fd > 2) {
+			close(file_fd);
+		}
 		CATCHUNIX(file_fd = open(file_path, O_CREAT|O_APPEND|O_WRONLY|O_NOCTTY, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP));
 		CATCHUNIX(flags = fcntl(file_fd, F_GETFD));
 		flags |= FD_CLOEXEC;
@@ -64,6 +66,9 @@ void debug_file_write (INT64_T flags, const char *str)
 	 * new logs. The stat on the filename and inode comparison catches this
 	 * after one lost debug message.
 	 */
+	if(file_fd <= -1) {
+		return;
+	}
 
 	if (file_size_max > 0) {
 		struct stat info;
@@ -110,6 +115,14 @@ void debug_file_rename (const char *suffix)
 		string_nformat(old, sizeof(old), "%s.%s", file_path, suffix);
 		rename(file_path, old);
 		debug_file_reopen();
+	}
+}
+
+void debug_file_close ()
+{
+	if(file_fd > 2) {
+		close(file_fd);
+		file_fd = -1;
 	}
 }
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -981,7 +981,6 @@ static void read_measured_resources(struct vine_manager *q, struct vine_task *t)
 	t->resources_measured = rmsummary_parse_file_single(summary);
 
 	if(t->resources_measured) {
-		t->resources_measured->category = xxstrdup(t->category);
 		t->exit_code = t->resources_measured->exit_status;
 
 		/* cleanup noise in cores value, otherwise small fluctuations trigger new

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3441,6 +3441,8 @@ void vine_delete(struct vine_manager *q)
 
 	debug(D_VINE, "manager end\n");
 
+	debug_close();
+
 	free(q);
 }
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3228,6 +3228,7 @@ int vine_enable_monitoring(struct vine_manager *q, int watchdog, int series)
 	}
 
 	q->monitor_exe = vine_declare_file(q, exe, VINE_CACHE_ALWAYS);
+	free(exe);
 
 	if(series) {
 		char *series_file = vine_get_runtime_path_log(q, "time-series");

--- a/taskvine/test/TR_vine_valgrind.sh
+++ b/taskvine/test/TR_vine_valgrind.sh
@@ -6,7 +6,7 @@ export PATH=../src/tools:../src/worker:$PATH
 
 export CORES=4
 export TASKS=20
-export VALGRIND="valgrind --error-exitcode=1 --leak-check=full --show-leak-kinds=definite,indirect,possible --track-origins=yes"
+export VALGRIND="valgrind --error-exitcode=1 --leak-check=full --show-leak-kinds=definite,indirect,possible --track-origins=yes --track-fds=yes"
 
 check_needed()
 {
@@ -31,7 +31,7 @@ quit
 EOF
 
 	echo "starting manager"
-	(${VALGRIND} --log-file=manager.valgrind -- vine_benchmark -Z manager.port < manager.script; echo $? > manager.exitcode ) &
+	(${VALGRIND} --log-file=manager.valgrind -- vine_benchmark -m -Z manager.port < manager.script; echo $? > manager.exitcode ) &
 
 	echo "waiting for manager to get ready"
 	wait_for_file_creation manager.port 15

--- a/taskvine/test/TR_vine_valgrind.sh
+++ b/taskvine/test/TR_vine_valgrind.sh
@@ -55,18 +55,18 @@ EOF
 		echo "valgrind did not found errors with the manager."
 	else
 		echo "valgrind found errors with the manager."
-		[ -f manager.valgrind ] && cat manager.valgrind
 		overall=1
 	fi
+	[ -f manager.valgrind ] && cat manager.valgrind
 
 	if [ "$worker" = 0 ]
 	then
 		echo "valgrind did not found errors with the worker."
 	else
 		echo "valgrind found errors with the worker"
-		[ -f worker.valgrind ] && cat worker.valgrind
 		overall=1
 	fi
+	[ -f worker.valgrind ] && cat worker.valgrind
 
 	return ${overall}
 }

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1778,7 +1778,6 @@ void read_measured_resources(struct work_queue *q, struct work_queue_task *t) {
 	t->resources_measured = rmsummary_parse_file_single(summary);
 
 	if(t->resources_measured) {
-		t->resources_measured->category = xxstrdup(t->category);
 		t->return_status = t->resources_measured->exit_status;
 
 		/* cleanup noise in cores value, otherwise small fluctuations trigger new


### PR DESCRIPTION
Given valgrind report, fix long standing issue where reopening the log would print an error for closing fd -1.
Fixes a couple of mem leaks on vine cleanup related to monitoring.
Fixes mem leak in vine and wq where category was being overwritten. 

Related to @BarrySlyDelgado  report, vine_benchmark seems to be fine with respect to file descriptors. The blast example may be triggering something that vine_benchmark is not picking up.

Note: fd leaks is not treated by valgrind as an error. The output of the test needs to be inspected to see this report.