### PR TITLE
fix mini task flags

### DIFF
--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -162,7 +162,7 @@ struct vine_file * vine_file_untar( struct vine_file *f, vine_file_flags_t flags
 	struct vine_task *t = vine_task_create("mkdir output && tar xf input -C output");
 	vine_task_add_input(t,f,"input",0);
 	vine_task_add_output(t,vine_file_local("output", flags),"output",0);
-	return vine_file_mini_task(t, 0);
+	return vine_file_mini_task(t, flags);
 }
 
 struct vine_file * vine_file_poncho( struct vine_file *f, vine_file_flags_t flags )
@@ -173,7 +173,7 @@ struct vine_file * vine_file_poncho( struct vine_file *f, vine_file_flags_t flag
 
 	vine_task_add_input(t, f, "package.tar.gz", 0);
 	vine_task_add_output(t, vine_file_local("output", flags), "output", 0);
-	return vine_file_mini_task(t, 0);
+	return vine_file_mini_task(t, flags);
 }
 
 struct vine_file * vine_file_starch( struct vine_file *f, vine_file_flags_t flags )
@@ -181,7 +181,7 @@ struct vine_file * vine_file_starch( struct vine_file *f, vine_file_flags_t flag
 	struct vine_task *t = vine_task_create("SFX_DIR=output SFX_EXTRACT_ONLY=1 ./package.sfx");
 	vine_task_add_input(t,f,"package.sfx",0);
 	vine_task_add_output(t,vine_file_local("output", flags),"output",0);
-	return vine_file_mini_task(t, 0);
+	return vine_file_mini_task(t, flags);
 }
 
 
@@ -233,7 +233,7 @@ struct vine_file * vine_file_xrootd( const char *source, struct vine_file *proxy
 
 	free(command);
 
-	return vine_file_mini_task(t, 0);
+	return vine_file_mini_task(t, flags);
 }
 
 
@@ -259,7 +259,7 @@ struct vine_file * vine_file_chirp( const char *server, const char *source, stru
 
 	free(command);
 
-	return vine_file_mini_task(t, 0);
+	return vine_file_mini_task(t, flags);
 }
 
 


### PR DESCRIPTION
They were dropped between declaring the file and actually creating the file.