### PR TITLE
Fix double waiting log

### DIFF
--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -90,7 +90,7 @@ typedef enum {
 /** Possible states of a task, given by @ref vine_task_state */
 
 typedef enum {
-	VINE_TASK_UNKNOWN = 0,       /**< There is no such task **/
+	VINE_TASK_UNKNOWN = 0,       /**< Task has not been submitted to the manager **/
 	VINE_TASK_READY,             /**< Task is ready to be run, waiting in manager **/
 	VINE_TASK_RUNNING,           /**< Task has been dispatched to some worker **/
 	VINE_TASK_WAITING_RETRIEVAL, /**< Task results are available at the worker **/

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -53,7 +53,7 @@ struct vine_task *vine_task_create(const char *command_line)
 	t->resource_request   = CATEGORY_ALLOCATION_FIRST;
 	t->worker_selection_algorithm = VINE_SCHEDULE_UNSET;
 
-	t->state = VINE_TASK_READY;
+	t->state = VINE_TASK_UNKNOWN;
 
 	t->result = VINE_RESULT_UNKNOWN;
 	t->exit_code = -1;

--- a/taskvine/src/manager/vine_txn_log.c
+++ b/taskvine/src/manager/vine_txn_log.c
@@ -202,6 +202,11 @@ void vine_txn_log_write_category(struct vine_manager *q, struct category *c)
 
 void vine_txn_log_write_worker(struct vine_manager *q, struct vine_worker_info *w, int leaving, vine_worker_disconnect_reason_t reason_leaving)
 {
+	if(reason_leaving == VINE_WORKER_DISCONNECT_STATUS_WORKER) {
+		/* status worker should not generate a transaction */
+		return;
+	}
+
 	struct buffer B;
 	buffer_init(&B);
 


### PR DESCRIPTION
Fixes WAITING to WAITING message in log.  Newly tasks should be created with status UNKNOWN.   READY is for task newly submitted.