### PR TITLE
remove message when no coprocess is found with a given state

### DIFF
--- a/taskvine/src/worker/vine_coprocess.c
+++ b/taskvine/src/worker/vine_coprocess.c
@@ -227,11 +227,11 @@ struct vine_coprocess *vine_coprocess_find_state(struct list *coprocess_list, vi
 	struct vine_coprocess *coprocess;
 	LIST_ITERATE(coprocess_list,coprocess){
 		if (coprocess->state == state && !strcmp(coprocess->name, coprocess_name)) {
-			debug(D_VINE, "Found coprocess with valid state with pid: %d\n", coprocess->pid);
+			debug(D_VINE, "Found coprocess with state %d with pid: %d\n", state, coprocess->pid);
 			return coprocess;
 		}
 	}
-	debug(D_VINE, "Found no valid coprocesses for state\n");
+
 	return NULL;
 }
 

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -649,7 +649,7 @@ static int handle_completed_tasks(struct link *manager)
 
 			/* collect the resources associated with the process */
 			reap_process(p,manager);
-			
+
 			/* must reset the table iterator because an item was removed. */
 			itable_firstkey(procs_running);
 		}


### PR DESCRIPTION
The problem is that when no coprocess is ready to run a function, the message spams the log, e.g.:

2023/03/31 07:57:21.58 vine_worker[130168] vine: Found no valid coprocesses for state
2023/03/31 07:57:21.58 vine_worker[130168] vine: Found no valid coprocesses for state
2023/03/31 07:57:21.58 vine_worker[130168] vine: Found no valid coprocesses for state
2023/03/31 07:57:21.59 vine_worker[130168] vine: task 17 (pid 132843) exited normally with exit code 0
2023/03/31 07:57:21.59 vine_worker[130168] vine: Found coprocess with valid state with pid: 131887
2023/03/31 07:57:21.59 vine_worker[130168] vine: input: link /tmp/worker-196886-130168/cache/buffer-rnd-ufmcxlkyzmtwpss -> /tmp/worker-196886-130168/t.18/infile
2023/03/31 07:57:21.59 vine_worker[130168] vine: started process 132851: batch_gradient_descent
2023/03/31 07:57:21.59 vine_worker[130168] vine: Found no valid coprocesses for state
2023/03/31 07:57:21.59 vine_worker[130168] vine: Found no valid