### PR TITLE
vine: do not break out of mount loop when looking for transfers

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2659,7 +2659,6 @@ static int vine_manager_transfer_capacity_available(struct vine_manager *q, stru
 				m->substitute = vine_file_substitute_url(m->file,peer_source);
 				free(peer_source);
 				found_match = 1;
-				break;
 			}
 		}
 


### PR DESCRIPTION
The break was a remnant a loop that used to live there.  

For #3252 