### PR TITLE
add python to path for local tests

### DIFF
--- a/taskvine/test/TR_vine_python_task.sh
+++ b/taskvine/test/TR_vine_python_task.sh
@@ -7,6 +7,7 @@ import_config_val CCTOOLS_PYTHON_TEST_EXEC
 import_config_val CCTOOLS_PYTHON_TEST_DIR
 
 export PYTHONPATH=$(pwd)/../src/bindings/${CCTOOLS_PYTHON_TEST_DIR}:$PYTHONPATH
+export PATH=$(dirname "${CCTOOLS_PYTHON_TEST_EXEC}"):$PATH
 
 STATUS_FILE=vine.status
 PORT_FILE=vine.port

--- a/work_queue/test/TR_work_queue_python_task.sh
+++ b/work_queue/test/TR_work_queue_python_task.sh
@@ -7,6 +7,7 @@ import_config_val CCTOOLS_PYTHON_TEST_EXEC
 import_config_val CCTOOLS_PYTHON_TEST_DIR
 
 export PYTHONPATH=$(pwd)/../src/bindings/${CCTOOLS_PYTHON_TEST_DIR}:$PYTHONPATH
+export PATH=$(dirname "${CCTOOLS_PYTHON_TEST_EXEC}"):$PATH
 
 STATUS_FILE=wq.status
 PORT_FILE=wq.port


### PR DESCRIPTION
In conda-forge build the target python is no longer in the PATH, thus the local workers did not find the correct python version.