### PR TITLE
dill to cloudpickle

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1382,7 +1382,7 @@ environment created with [conda-pack](https://conda.github.io/conda-pack/).  A
 minimal environment can be created a follows:
 
 ```sh
-conda create -y -p my-env python=3.8 dill conda
+conda create -y -p my-env python=3.8 cloudpickle conda
 conda install -y -p my-env -c conda-forge conda-pack
 # conda install -y -p my-env pip and conda install other modules, etc.
 conda run -p my-env conda-pack

--- a/doc/manuals/work_queue/index.md
+++ b/doc/manuals/work_queue/index.md
@@ -465,7 +465,7 @@ environment created with [conda-pack](https://conda.github.io/conda-pack/).  A
 minimal environment can be created a follows:
 
 ```sh
-conda create -y -p my-env python=3.8 dill conda
+conda create -y -p my-env python=3.8 cloudpickle conda
 conda install -y -p my-env -c conda-forge conda-pack
 # conda install -y -p my-env pip and conda install other modules, etc.
 conda run -p my-env conda-pack

--- a/taskvine/src/bindings/python3/taskvine.binding.py
+++ b/taskvine/src/bindings/python3/taskvine.binding.py
@@ -728,7 +728,7 @@ class Task(object):
 #
 
 try:
-    import dill
+    import cloudpickle
 
     pythontask_available = True
 except Exception:
@@ -753,7 +753,7 @@ class PythonTask(Task):
     # @param kwargs	keyword arguments used in function to be executed by task
     def __init__(self, func, *args, **kwargs):
         if not pythontask_available:
-            raise RuntimeError("PythonTask is not available. The dill module is missing.")
+            raise RuntimeError("PythonTask is not available. The cloudpickle module is missing.")
 
         self._pp_run = None
         self._output_loaded = False
@@ -797,7 +797,7 @@ class PythonTask(Task):
             if self.successful():
                 try:
                     with open(os.path.join(self._tmpdir, "out_{}.p".format(self._id)), "rb") as f:
-                        self._output = dill.load(f)
+                        self._output = cloudpickle.load(f)
                 except Exception as e:
                     self._output = e
             else:
@@ -816,9 +816,9 @@ class PythonTask(Task):
 
     def _serialize_python_function(self, func, args, kwargs):
         with open(os.path.join(self._tmpdir, self._func_file), "wb") as wf:
-            dill.dump(func, wf, recurse=True)
+            cloudpickle.dump(func, wf)
         with open(os.path.join(self._tmpdir, self._args_file), "wb") as wf:
-            dill.dump([args, kwargs], wf, recurse=True)
+            cloudpickle.dump([args, kwargs], wf)
 
     def _python_function_command(self, remote_env_dir=None):
         if remote_env_dir:
@@ -847,16 +847,16 @@ class PythonTask(Task):
                     """\
                 try:
                     import sys
-                    import dill
+                    import cloudpickle
                 except ImportError:
                     print("Could not execute PythonTask function because a needed module for taskvine was not available.")
                     raise
 
                 (fn, args, out) = sys.argv[1], sys.argv[2], sys.argv[3]
                 with open (fn , 'rb') as f:
-                    exec_function = dill.load(f)
+                    exec_function = cloudpickle.load(f)
                 with open(args, 'rb') as f:
-                    args, kwargs = dill.load(f)
+                    args, kwargs = cloudpickle.load(f)
                 try:
                     exec_out = exec_function(*args, **kwargs)
 
@@ -864,7 +864,7 @@ class PythonTask(Task):
                     exec_out = e
 
                 with open(out, 'wb') as f:
-                    dill.dump(exec_out, f)
+                    cloudpickle.dump(exec_out, f)
 
                 print(exec_out)"""
                 )

--- a/taskvine/src/examples/vine_example_pythontask.py
+++ b/taskvine/src/examples/vine_example_pythontask.py
@@ -21,7 +21,7 @@
 # appropiate  python environment. If this is not the case, an environment file
 # can be specified with: `t.add_environment("env.tar.gz")`, in which
 # env.tar.gz is created with the poncho_package_create tool, and has at least a python
-# installation, with dill.
+# installation, with cloudpickle.
 #
 # A minimal conda environment 'env.tar.gz' can be created with:
 #
@@ -30,7 +30,7 @@
 {
     "conda": {
         "channels": ["conda-forge"],
-        "dependencies": ["python=3.X", "dill"]
+        "dependencies": ["python=3.X", "cloudpickle"]
     }
 }
 """

--- a/taskvine/src/examples/vine_example_xrootd.py
+++ b/taskvine/src/examples/vine_example_xrootd.py
@@ -37,7 +37,7 @@ def create_env(env_name):
     env = {
             "conda": {
                 "channels": ["conda-forge"],
-                "dependencies": [f"python={py_version}", "dill", "uproot", "xrootd"]
+                "dependencies": [f"python={py_version}", "cloudpickle", "uproot", "xrootd"]
                 }
             }
 

--- a/taskvine/test/TR_vine_python_task.sh
+++ b/taskvine/test/TR_vine_python_task.sh
@@ -15,7 +15,7 @@ PORT_FILE=vine.port
 check_needed()
 {
 	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
-	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import dill"  || return 1
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import cloudpickle"  || return 1
 
 	return 0
 }

--- a/work_queue/src/bindings/python3/PythonTask_example.py
+++ b/work_queue/src/bindings/python3/PythonTask_example.py
@@ -25,11 +25,11 @@
 # appropiate  python environment. If this is not the case, an environment file
 # can be specified with: `t.specify_environment("env.tar.gz")`, in which
 # env.tar.gz is created with the conda-pack module, and has at least a python
-# installation, the dill module, and the conda module.
+# installation, the cloudpickle module, and the conda module.
 #
 # A minimal conda environment 'my-minimal-env.tar.gz' can be created with:
 #
-# conda create -y -p my-minimal-env python=3.8 dill conda
+# conda create -y -p my-minimal-env python=3.8 cloudpickle conda
 # conda install -y -p my-minimal-env -c conda-forge conda-pack
 # conda install -y -p my-minimal-env pip and conda install other modules, etc.
 # conda run -p my-minimal-env conda-pack

--- a/work_queue/src/bindings/python3/work_queue.binding.py
+++ b/work_queue/src/bindings/python3/work_queue.binding.py
@@ -920,7 +920,7 @@ class Task(object):
 #
 # this class is used to create a python task
 try:
-    import dill
+    import cloudpickle
 
     pythontask_available = True
 except Exception:
@@ -942,7 +942,7 @@ class PythonTask(Task):
         self._tmpdir = tempfile.mkdtemp(dir=staging_directory)
 
         if not pythontask_available:
-            raise RuntimeError("PythonTask is not available. The dill module is missing.")
+            raise RuntimeError("PythonTask is not available. The cloudpickle module is missing.")
 
         self._func_file = os.path.join(self._tmpdir, "function_{}.p".format(self._id))
         self._args_file = os.path.join(self._tmpdir, "args_{}.p".format(self._id))
@@ -973,7 +973,7 @@ class PythonTask(Task):
             if self.result == WORK_QUEUE_RESULT_SUCCESS:
                 try:
                     with open(os.path.join(self._tmpdir, "out_{}.p".format(self._id)), "rb") as f:
-                        self._output = dill.load(f)
+                        self._output = cloudpickle.load(f)
                 except Exception as e:
                     self._output = e
             else:
@@ -1009,9 +1009,9 @@ class PythonTask(Task):
 
     def _serialize_python_function(self, func, args, kwargs):
         with open(self._func_file, "wb") as wf:
-            dill.dump(func, wf, recurse=True)
+            cloudpickle.dump(func, wf)
         with open(self._args_file, "wb") as wf:
-            dill.dump([args, kwargs], wf, recurse=True)
+            cloudpickle.dump([args, kwargs], wf)
 
     def _python_function_command(self):
         if self._env_file:
@@ -1052,16 +1052,16 @@ class PythonTask(Task):
                     """\
                 try:
                     import sys
-                    import dill
+                    import cloudpickle
                 except ImportError:
                     print("Could not execute PythonTask function because a needed module for Work Queue was not available.")
                     raise
 
                 (fn, args, out) = sys.argv[1], sys.argv[2], sys.argv[3]
                 with open (fn , 'rb') as f:
-                    exec_function = dill.load(f)
+                    exec_function = cloudpickle.load(f)
                 with open(args, 'rb') as f:
-                    args, kwargs = dill.load(f)
+                    args, kwargs = cloudpickle.load(f)
                 try:
                     exec_out = exec_function(*args, **kwargs)
 
@@ -1069,7 +1069,7 @@ class PythonTask(Task):
                     exec_out = e
 
                 with open(out, 'wb') as f:
-                    dill.dump(exec_out, f)
+                    cloudpickle.dump(exec_out, f)
 
                 print(exec_out)"""
                 )

--- a/work_queue/test/TR_work_queue_python_task.sh
+++ b/work_queue/test/TR_work_queue_python_task.sh
@@ -16,7 +16,7 @@ PORT_FILE=wq.port
 check_needed()
 {
 	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
-	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import dill" || return 1
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import cloudpickle" || return 1
 
 	return 0
 }

--- a/work_queue/test/TR_work_queue_remotetask.sh
+++ b/work_queue/test/TR_work_queue_remotetask.sh
@@ -15,7 +15,7 @@ PORT_FILE=wq.port
 check_needed()
 {
 	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
-	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import dill" || return 1
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import cloudpickle" || return 1
 
 	return 0
 }


### PR DESCRIPTION
Needed because cloudpickle can serialize some of the objects that dask needs. In the internal use of PythonTask, dill and cloudpickle should be interchangable.

@David-Simonetti-ND I don't think this change affects coprocesses, as I don't think your code relies on particulars of dill.
@tphung3 Is dill used with the parsl integration? I think parsl does its own serialization.