### PR TITLE
__del__ to finalize

### DIFF
--- a/chirp/src/bindings/python3/ndcctools/chirp.py
+++ b/chirp/src/bindings/python3/ndcctools/chirp.py
@@ -14,6 +14,7 @@
 import os
 import time
 import json
+import weakref
 
 from .cchirp import *
 
@@ -58,11 +59,10 @@ class Client(object):
         if self.identity == '':
             raise AuthenticationFailure(authentication)
 
-    def __exit__(self, exception_type, exception_value, traceback):
-        chirp_reli_disconnect(self.hostport)
+        self._finalizer = weakref.finalize(self, chirp_reli_disconnect, self.hostport)
 
-    def __del__(self):
-        chirp_reli_disconnect(self.hostport)
+    def __exit__(self, exception_type, exception_value, traceback):
+        self._finalizer()
 
     def __stoptime(self, absolute_stop_time=None, timeout=None):
         if timeout is None:


### PR DESCRIPTION
Better solution to #3097

Instead of using `__del__`, which is called in unpredictable ways, use `weakref.finalize`, which guaranteed to be called once per object before the globals are deleted.