### PR TITLE
DaskVine: set resources, environment, and category per function through dask's compute call

### DIFF
--- a/taskvine/src/examples/vine_example_dask_awk_array.py
+++ b/taskvine/src/examples/vine_example_dask_awk_array.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     f.min_workers = 1
     with f:
         with dask.config.set(scheduler=m.dask_execute):
-            result = distance.compute(resources={"cores": 1})
+            result = distance.compute(resources={"cores": 1}, resources_mode="max")
             print(f"distance = {result}")
         print("Terminating workers...", end="")
     print("done!")


### PR DESCRIPTION
For use, see the  cctools/taskvine/src/examples/vine_example_dask_awk_array.py example.