### PR TITLE
Daskvine get function

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
@@ -70,7 +70,7 @@ class DaskVineDag:
         inner[indices[-1]] = value
 
     def __init__(self, dsk):
-        self._dsk = dsk
+        self._dsk = dict(dsk)
 
         # those sexpr from dsk that we need to compute, but flatten
         self._flat = {}

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -77,6 +77,9 @@ class DaskVine(Manager):
 
             self.submit(t)
 
+    def get(self, dsk, keys, **kwargs):
+        return self.dask_execute(dsk, keys, **kwargs)
+
     def dask_execute(self, dsk, keys, **kwargs):
         """Computes the values of the keys in the dask graph dsk"""
 

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -83,9 +83,14 @@ class DaskVine(Manager):
     def dask_execute(self, dsk, keys, **kwargs):
         """Computes the values of the keys in the dask graph dsk"""
 
-        indices = DaskVineDag.find_dask_keys(keys)
+        if isinstance(keys, list):
+            indices = DaskVineDag.find_dask_keys(keys)
+            keys_flatten = indices.keys()
+        else:
+            keys_flatten = [keys]
+
         d = DaskVineDag(dsk)
-        rs = d.set_targets(indices.keys())
+        rs = d.set_targets(keys_flatten)
 
         verbose = kwargs.pop("verbose", False)
 
@@ -102,9 +107,12 @@ class DaskVine(Manager):
                 else:
                     raise Exception(f"task for key {t.key} failed: {t.result}. exit code {t.exit_code}\n{t.output}")
 
-        results = list(keys)
-        for k, ids in indices.items():
-            DaskVineDag.set_dask_result(results, ids, d.get_result(k))
+        if isinstance(keys, list):
+            results = list(keys)
+            for k, ids in indices.items():
+                DaskVineDag.set_dask_result(results, ids, d.get_result(k))
+        else:
+            results = d.get_result(keys)
         return results
 
 


### PR DESCRIPTION
get as a synonym for dask_execute, accept single keys as compute targets.