### PR TITLE
manager: use finalizer on exit method to avoid double free

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -194,7 +194,7 @@ class Manager(object):
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
-        self._free_manager()
+        self._finalizer()
 
     ##
     # Get the project name of the manager.


### PR DESCRIPTION
(which was the whole point of using finalizers, sigh.)