### PR TITLE
Pythotask remote output

### DIFF
--- a/taskvine/test/TR_vine_python_temp_files.sh
+++ b/taskvine/test/TR_vine_python_temp_files.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -e
+
+. ../../dttools/test/test_runner_common.sh
+
+import_config_val CCTOOLS_PYTHON_TEST_EXEC
+import_config_val CCTOOLS_PYTHON_TEST_DIR
+
+export PYTHONPATH=$(pwd)/../../test_support/python_modules/${CCTOOLS_PYTHON_TEST_DIR}:$PYTHONPATH
+export PATH=$(dirname "${CCTOOLS_PYTHON_TEST_EXEC}"):$PATH
+
+STATUS_FILE=vine.status
+PORT_FILE=vine.port
+
+check_needed()
+{
+	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import cloudpickle"  || return 1
+
+	return 0
+}
+
+prepare()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+
+	return 0
+}
+
+run()
+{
+	# send makeflow to the background, saving its exit status.
+	( ${CCTOOLS_PYTHON_TEST_EXEC} vine_python_temp_files.py $PORT_FILE; echo $? > $STATUS_FILE) &
+
+	# wait at most 5 seconds for vine to find a port.
+	wait_for_file_creation $PORT_FILE 5
+
+	run_ds_worker $PORT_FILE worker.log
+
+	# wait for vine to exit.
+	wait_for_file_creation $STATUS_FILE 5
+
+	# retrieve makeflow exit status
+	status=$(cat $STATUS_FILE)
+	if [ $status -ne 0 ]
+	then
+		exit 1
+	fi
+
+	exit 0
+}
+
+clean()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+
+	rm -rf vine-run-info
+
+	exit 0
+}
+
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/taskvine/test/vine_python_temp_files.py
+++ b/taskvine/test/vine_python_temp_files.py
@@ -1,0 +1,57 @@
+#! /usr/bin/env python
+
+import sys
+import ndcctools.taskvine as vine
+
+port_file = None
+try:
+    port_file = sys.argv[1]
+except IndexError:
+    sys.stderr.write("Usage: {} PORTFILE\n".format(sys.argv[0]))
+    raise
+
+
+# Define functions to invoke remotely
+def fun_a(arg):
+    return f"{arg}"
+
+
+def fun_b(remote_data):
+    import cloudpickle
+    with open(remote_data, "rb") as f:
+        r = cloudpickle.load(f)
+    return f"{r} world!"
+
+
+# Create a new m
+m = vine.Manager(port=[9123, 9130])
+print("listening on port {}".format(m.port))
+with open(port_file, "w") as f:
+    f.write(str(m.port))
+
+t_a = vine.PythonTask(fun_a, "hello")
+t_a.enable_temp_output()
+
+m.submit(t_a)
+while not m.empty():
+    t = m.wait(5)
+    if t and not t.successful():
+        print(f"Something went wrong with task a: {t.result}")
+        sys.exit(1)
+
+# use the output of t_a, which t_b knows is encoded as a remote temp file
+t_b = vine.PythonTask(fun_b, "remote_data")
+t_b.add_input(t_a.output_file, "remote_data")
+m.submit(t_b)
+while not m.empty():
+    t = m.wait(5)
+    if t and not t.successful():
+        print(f"Something went wrong with task b: {t.result}")
+        sys.exit(1)
+
+# we now can remove the temp file from the worker
+m.remove_file(t_a.output_file)
+
+print(f"final output: {t_b.output}")
+
+assert t_b.output == "hello world!"


### PR DESCRIPTION
Adds `t.enable_temp_output()` and `t.output_file` to support temp files in `PythonTask`. 

Needed to show that the dask graph can execute with all the outputs, but the last one remotely.

@dthain I'm not super happy that the `cloudpickle.load` breaks the abstraction in order to load the files, but I don't see a way around it.