### PR TITLE
pythontask: add call to disable serialization of output

### DIFF
--- a/taskvine/test/TR_vine_python_no_serialization.sh
+++ b/taskvine/test/TR_vine_python_no_serialization.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -e
+
+. ../../dttools/test/test_runner_common.sh
+
+import_config_val CCTOOLS_PYTHON_TEST_EXEC
+import_config_val CCTOOLS_PYTHON_TEST_DIR
+
+export PYTHONPATH=$(pwd)/../../test_support/python_modules/${CCTOOLS_PYTHON_TEST_DIR}:$PYTHONPATH
+export PATH=$(dirname "${CCTOOLS_PYTHON_TEST_EXEC}"):$PATH
+
+STATUS_FILE=vine.status
+PORT_FILE=vine.port
+
+check_needed()
+{
+	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import cloudpickle"  || return 1
+
+	return 0
+}
+
+prepare()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+
+	return 0
+}
+
+run()
+{
+	# send makeflow to the background, saving its exit status.
+	( ${CCTOOLS_PYTHON_TEST_EXEC} vine_python_no_serialization.py $PORT_FILE; echo $? > $STATUS_FILE) &
+
+	# wait at most 5 seconds for vine to find a port.
+	wait_for_file_creation $PORT_FILE 5
+
+	run_ds_worker $PORT_FILE worker.log
+
+	# wait for vine to exit.
+	wait_for_file_creation $STATUS_FILE 5
+
+	# retrieve makeflow exit status
+	status=$(cat $STATUS_FILE)
+	if [ $status -ne 0 ]
+	then
+		exit 1
+	fi
+
+	exit 0
+}
+
+clean()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+
+	rm -rf vine-run-info
+
+	exit 0
+}
+
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/taskvine/test/vine_python_no_serialization.py
+++ b/taskvine/test/vine_python_no_serialization.py
@@ -1,0 +1,39 @@
+#! /usr/bin/env python
+
+import sys
+import ndcctools.taskvine as vine
+
+port_file = None
+try:
+    port_file = sys.argv[1]
+except IndexError:
+    sys.stderr.write("Usage: {} PORTFILE\n".format(sys.argv[0]))
+    raise
+
+
+# Define a function to invoke remotely
+def my_fun():
+    print("the function")
+    return "look ma no serialization".encode('utf8')
+
+
+# Create a new m
+m = vine.Manager(port=[9123, 9130])
+print("listening on port {}".format(m.port))
+with open(port_file, "w") as f:
+    f.write(str(m.port))
+
+# Submit several tasks for execution:
+print("submitting tasks...")
+t = vine.PythonTask(my_fun)
+t.disable_output_serialization()
+m.submit(t)
+
+while not m.empty():
+    t = m.wait(5)
+    if t:
+        if t.successful():
+            print(t.output)
+            assert t.output == "look ma no serialization".encode('utf8')
+        else:
+            print(f"Something went wrong with the task: {t.result}\nstdout: {t.std_output}")


### PR DESCRIPTION
The use case is functions that already serialized its output object (i.e. coffea, which gives a compressed output. Serializing it again is just a waste of potentially a lot of memory).