### PR TITLE
DaskVine with files and temp files

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -2250,7 +2250,7 @@ vine_plot_txn_log vine-run-info/most-recent/vine-logs/transactions
 
 TaskVine can be used to execute Dask workflows using a manager as Dask
 scheduler. The class `DaskVine` implements a TaskVine manager that has a
-`dask_execute` that can be used as follows:
+`get` that can be used as follows:
 
 === "Python"
     ```python
@@ -2263,11 +2263,11 @@ scheduler. The class `DaskVine` implements a TaskVine manager that has a
     # Define the dask workflow...
     dask_value = ... 
 
-    # use the manager as the dask scheduler
-    result = dask_value.compute(scheduler=m.dask_execute)
+    # use the manager as the dask scheduler using its get() function
+    result = dask_value.compute(scheduler=m.get)
 
     # or:
-    with dask.config.set(scheduler=m.dask_execute):
+    with dask.config.set(scheduler=m.get):
         result = dask_value.compute()
     ```
 
@@ -2276,6 +2276,8 @@ The `compute` call above may receive the following keyword arguments:
 | Keyword | Description |
 |------------ |---------|
 | environment | A TaskVine file that provides an [environment](#environments) to execute each task. |
+| extra_files | A dictionary of {taskvine.File: "remote_name"} of input files to attach to each task.|
+| lazy_transfer | Whether to bring each result back from the workers (False, default), or keep transient results at workers (True) |
 | resources   | A dictionary to specify [maximum resources](#task-resources), e.g. `{"cores": 1, "memory": 2000"}` |
 | resources\_mode | [Automatic resource management](#automatic-resource-management) to use, e.g., "fixed", "max", or "max throughput"| 
 

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/__init__.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/__init__.py
@@ -52,9 +52,16 @@ from .task import (
     LibraryTask,
     FunctionCall,
 )
-from .dask_executor import DaskVine
-from .dask_dag import DaskVineNoResult
 
+try:
+    from .dask_executorx import DaskVine
+except ImportError as e:
+    print(f"DaskVine not available. Couldn't find module: {e.name}")
+    class DaskVine:
+        exception = ImportError()
+        def __init__(*args, **kwargs):
+            raise DaskVine.exception
+    DaskVine.exception = e
 
 __all__ = [
     "Manager",
@@ -66,5 +73,5 @@ __all__ = [
     "PythonTask",
     "PythonTaskNoResult",
     "DaskVine",
-    "DaskVineNoResult",
 ]
+

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
@@ -212,6 +212,9 @@ class DaskVineDag:
             self.flatten(k)
         return self.get_ready()
 
+    def get_targets(self):
+        return self._targets
+
 
 class DaskVineNoResult(Exception):
     """Exception raised when asking for a result from a computation that has not been performed."""

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
@@ -123,10 +123,11 @@ class DaskVineDag:
         else:
             self._missing_of[key] = set()
             nargs = []
-            if DaskVineDag.fun_callp(sexpr):
-                # if this is a function call, keep the function as is
-                nargs.append(sexpr[0])
-                sexpr = sexpr[1:]
+            if not DaskVineDag.fun_callp(sexpr):
+                # if this is a list, then make it a function call
+                sexpr = (make_list, *sexpr)
+            nargs.append(sexpr[0])
+            sexpr = sexpr[1:]
             for a in sexpr:
                 if DaskVineDag.symbolp(a) and not self.graph_keyp(a):
                     nkey = a
@@ -215,3 +216,12 @@ class DaskVineDag:
 class DaskVineNoResult(Exception):
     """Exception raised when asking for a result from a computation that has not been performed."""
     pass
+
+
+# aux function to make lists from many arguments, a little silly, but list()
+# wants only one argument and list(sometuple) does not work because we want to
+# flatten the tuple.
+def make_list(*args):
+    return args
+
+

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -116,6 +116,28 @@ class DaskVine(Manager):
         return results
 
 
+class DaskVineFile:
+    def __init__(self, file, key, staging_dir):
+        self._file = file
+        assert file
+
+    def load(self):
+        with open(self.staging_path, "rb") as f:
+            return cloudpickle.load(f)
+
+    @property
+    def file(self):
+        return self._file
+
+    @property
+    def staging_path(self):
+        return self._file.source()
+
+    @property
+    def basename(self):
+        return os.path.basename(self.staging_path)
+
+
 class PythonTaskDask(PythonTask):
     def __init__(self, key, fn, *args, **kwargs):
         self._key = key

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/file.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/file.py
@@ -27,6 +27,13 @@ class File(object):
         # to false.
         return True
 
+    def source(self):
+        file_type = getattr(self._file, "type")
+        if file_type == cvine.VINE_FILE:
+            return getattr(self._file, "source")
+        else:
+            return None
+
     ##
     # Return the contents of a file object as a string.
     # Typically used to return the contents of an output buffer.
@@ -41,5 +48,3 @@ class File(object):
     # @param self       A file object.
     def __len__(self):
         return cvine.vine_file_size(self._file)
-
-

--- a/taskvine/src/bindings/python3/taskvine.i
+++ b/taskvine/src/bindings/python3/taskvine.i
@@ -13,6 +13,7 @@
 	#include "timestamp.h"
 	#include "taskvine.h"
     #include "vine_task.h"
+    #include "vine_file.h"
     #include "vine_runtime_dir.h"
 %}
 
@@ -67,5 +68,6 @@ into a swig function f(data) */
 %include "timestamp.h"
 %include "taskvine.h"
 %include "vine_task.h"
+%include "vine_file.h"
 %include "vine_runtime_dir.h"
 

--- a/taskvine/src/examples/vine_example_dask_awk_array.py
+++ b/taskvine/src/examples/vine_example_dask_awk_array.py
@@ -95,8 +95,8 @@ if __name__ == "__main__":
     f.max_workers = 1
     f.min_workers = 1
     with f:
-        with dask.config.set(scheduler=m.dask_execute):
-            result = distance.compute(resources={"cores": 1}, resources_mode="max")
+        with dask.config.set(scheduler=m.get):
+            result = distance.compute(resources={"cores": 1}, resources_mode="max", lazy_transfer=True)
             print(f"distance = {result}")
         print("Terminating workers...", end="")
     print("done!")

--- a/taskvine/src/examples/vine_example_dask_delayed.py
+++ b/taskvine/src/examples/vine_example_dask_delayed.py
@@ -9,7 +9,6 @@
 import ndcctools.taskvine as vine
 import argparse
 import getpass
-import sys
 
 try:
     import dask
@@ -66,7 +65,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    # define a TaskVine manager that has a dask_execute method
+    # define a TaskVine manager that has a get method that executes dask task graphs
     m = vine.DaskVine(port=args.port, ssl=True)
     m.set_name(args.name)
     print(f"Listening for workers at port: {m.port}")
@@ -79,8 +78,8 @@ if __name__ == "__main__":
     f.max_workers = 1
     f.min_workers = 1
     with f:
-        # use the dask_execute method as the scheduler for dask
-        with dask.config.set(scheduler=m.dask_execute):
+        # use the get method as the scheduler for dask
+        with dask.config.set(scheduler=m.get):
             result = t.compute(resources={"cores": 1})  # resources per function call
             print(f"t = {result}")
         print("Terminating workers...", end="")

--- a/taskvine/src/examples/vine_example_dask_graph.py
+++ b/taskvine/src/examples/vine_example_dask_graph.py
@@ -13,6 +13,8 @@ import argparse
 import getpass
 import sys
 
+import traceback
+
 
 from operator import add  # use add function in the example graph
 dsk_graph = {
@@ -72,9 +74,11 @@ is constructed by dask.""")
         print(f"dask graph example is:\n{dsk_graph}")
         print(f"desired keys are {desired_keys}")
 
-        results = m.dask_execute(dsk_graph, ["t", "w"], resources={"cores": 1})  # 1 core per step
-
-        print({(k, v) for k, v in zip(desired_keys, results)})
+        try:
+            results = m.dask_execute(dsk_graph, ["t", "w"], resources={"cores": 1})  # 1 core per step
+            print({(k, v) for k, v in zip(desired_keys, results)})
+        except Exception:
+            traceback.print_exc()
 
         print("Terminating workers...", end="")
 

--- a/taskvine/src/examples/vine_example_dask_graph.py
+++ b/taskvine/src/examples/vine_example_dask_graph.py
@@ -75,7 +75,7 @@ is constructed by dask.""")
         print(f"desired keys are {desired_keys}")
 
         try:
-            results = m.dask_execute(dsk_graph, ["t", "w"], resources={"cores": 1})  # 1 core per step
+            results = m.get(dsk_graph, ["t", "w"], resources={"cores": 1})  # 1 core per step
             print({(k, v) for k, v in zip(desired_keys, results)})
         except Exception:
             traceback.print_exc()


### PR DESCRIPTION
Changed DaskVine to use files to represent results rather than keeping everything in the in memory dag. Otherwise we wouldn't be able to run things like topEFT.

This also allows the use of declare_temp() files by passing the `lazy_transfer=True` to `dask_execute`. 