### PR TITLE
Accounted for PythonTaskNoResult in Python abstractions

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1041,6 +1041,8 @@ class Manager(object):
                     n += 1
                     break
 
+        results=[elem if isinstance(elem, list) else [elem] for elem in results]
+        
         return [item for elem in results for item in elem]
 
     ##
@@ -1107,6 +1109,8 @@ class Manager(object):
                     n += 1
                     break
 
+        results=[elem if isinstance(elem, list) else [elem] for elem in results]
+        
         return [item for elem in results for item in elem]
 
     ##
@@ -1202,6 +1206,8 @@ class Manager(object):
                     n += 1
                     break
 
+        results=[elem if isinstance(elem, list) else [elem] for elem in results]
+        
         return [item for elem in results for item in elem]
 
     ##
@@ -1259,6 +1265,8 @@ class Manager(object):
                     n += 1
                     break
 
+        results=[elem if isinstance(elem, list) else [elem] for elem in results]
+        
         return [item for elem in results for item in elem]
 
     ##


### PR DESCRIPTION
map and pair will now include PythonTaskNoResult as an output in the list of results rather than causing an error.  I left tree_reduce alone because since the list is meant to be reduced to one element, I thought it made sense that one PythonTaskNoResult should cause an error for the whole thing.