### PR TITLE
Factory cleanup fixes

### DIFF
--- a/batch_job/src/vine_factory.c
+++ b/batch_job/src/vine_factory.c
@@ -406,7 +406,7 @@ static int submit_worker( struct batch_queue *queue )
 	char *worker = string_format("./%s", worker_command);
 	if(using_catalog) {
 		cmd = string_format(
-		"%s -M %s -t %d -C '%s' %s %s %s %s %s %s",
+		"%s --parent-death -M %s -t %d -C '%s' %s %s %s %s %s %s",
 		worker,
 		submission_regex,
 		worker_timeout,
@@ -420,7 +420,7 @@ static int submit_worker( struct batch_queue *queue )
 		);
 	} else {
 		cmd = string_format(
-		"%s %s %d -t %d -C '%s' %s %s %s %s %s",
+		"%s --parent-death %s %d -t %d -C '%s' %s %s %s %s %s",
 		worker,
 		manager_host,
 		manager_port,

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -98,7 +98,10 @@ class Manager(object):
         self._library_table = {}
         self._info_widget = None
         self._using_ssl = False
-        self._staging_explicit = staging_path
+        if staging_path:
+            self._staging_explicit = os.path.join(staging_path, "vine-staging")
+        else:
+            self._staging_explicit = None
 
         # if we were given a range ports, rather than a single port to try.
         lower, upper = None, None
@@ -1657,7 +1660,10 @@ class Factory(object):
 
         self._opts["scratch-dir"] = None
         if manager:
-            self._opts["scratch-dir"] = manager.staging_directory
+            # we really would want to use the staging path of the manager, but
+            # since the manager may cleanup before the factory terminates,
+            # we need to use some other directory.
+            self._opts["scratch-dir"] = os.path.dirname(manager.staging_directory)
 
         def free():
             if self._factory_proc is not None:

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1807,7 +1807,7 @@ class Factory(object):
         self.scratch_dir = tempfile.mkdtemp(prefix="vine-factory-", dir=self.scratch_dir)
         self._scratch_safe_to_delete = True
 
-        atexit.register(lambda: os.path.exists(self.scratch_dir) and shutil.rmtree(self.scratch_dir))
+        atexit.register(lambda: shutil.rmtree(self.scratch_dir, ignore_errors=True))
 
         self._error_file = os.path.join(self.scratch_dir, "error.log")
         self._config_file = os.path.join(self.scratch_dir, "config.json")

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1663,7 +1663,12 @@ class Factory(object):
             if self._factory_proc is not None:
                 self.stop()
             if self._scratch_safe_to_delete and self.scratch_dir and os.path.exists(self.scratch_dir):
-                shutil.rmtree(self.scratch_dir)
+                try:
+                    shutil.rmtree(self.scratch_dir)
+                except OSError:
+                    # if we could not delete it now because some file is being used,
+                    # we leave it for the atexit function
+                    pass
         self._finalizer = weakref.finalize(self, free)
 
     def _set_manager(self, batch_type, manager, manager_host_port, manager_name):

--- a/taskvine/src/manager/vine_runtime_dir.c
+++ b/taskvine/src/manager/vine_runtime_dir.c
@@ -107,6 +107,12 @@ char *vine_runtime_directory_create() {
 	if(!create_dir(tmp, 0755)) {
         return NULL;
     }
+
+	tmp = string_format("%s/../vine-cache", runtime_dir);
+	if(!create_dir(tmp, 0755)) {
+        return NULL;
+    }
+
     register_staging_dir(tmp);
 	free(tmp);
 
@@ -121,16 +127,25 @@ char *vine_runtime_directory_create() {
 }
 
 char *vine_get_runtime_path_log(struct vine_manager *m, const char *path) {
-    return string_format("%s/vine-logs/%s", m->runtime_directory, path ? path : "");
+    return string_format("%s/vine-logs%s%s",
+			m->runtime_directory,
+			path ? "/" : "",
+			path ? path : "");
 }
 
 char *vine_get_runtime_path_staging(struct vine_manager *m, const char *path) {
-    return string_format("%s/staging/%s", m->runtime_directory, path ? path : "");
+    return string_format("%s/staging%s%s",
+			m->runtime_directory,
+			path ? "/" : "",
+			path ? path : "");
 }
 
 char *vine_get_runtime_path_caching(struct vine_manager *m, const char *path) {
     char abs[PATH_MAX];
-    char *tmp = string_format("%s/../vine-cache/%s", m->runtime_directory, path ? path : "");
+    char *tmp = string_format("%s/../vine-cache%s%s",
+			m->runtime_directory,
+			path ? "/" : "",
+			path ? path : "");
     path_collapse(tmp, abs, 1);
     free(tmp);
     return xxstrdup(abs);

--- a/taskvine/src/manager/vine_runtime_dir.c
+++ b/taskvine/src/manager/vine_runtime_dir.c
@@ -107,13 +107,13 @@ char *vine_runtime_directory_create() {
 	if(!create_dir(tmp, 0755)) {
         return NULL;
     }
+    register_staging_dir(tmp);
+	free(tmp);
 
 	tmp = string_format("%s/../vine-cache", runtime_dir);
 	if(!create_dir(tmp, 0755)) {
         return NULL;
     }
-
-    register_staging_dir(tmp);
 	free(tmp);
 
     if(symlink_most_recent) {


### PR DESCRIPTION
Adds --parent-death to workers as a safeguard for the controlling process going away.
Makes factory use a different staging dir to the manager, as the manager may cleanup before the factory terminates.