### PR TITLE
Vine: minor fixes for examples

### DIFF
--- a/taskvine/src/examples/vine_example_blast.py
+++ b/taskvine/src/examples/vine_example_blast.py
@@ -143,6 +143,6 @@ with all the same tasks on the worker.""",
                     f"task {t.id} completed with an executin error, exit code {t.exit_code}"
                 )
             else:
-                print(f"task {t.id} failed with status {t.result_string}")
+                print(f"task {t.id} failed with status {t.result}")
 
     print("all tasks complete!")

--- a/taskvine/src/examples/vine_example_chirp.py
+++ b/taskvine/src/examples/vine_example_chirp.py
@@ -98,6 +98,6 @@ if __name__ == "__main__":
             elif t.completed():
                 print(f"task {t.id} completed with an executin error, exit code {t.exit_code}")
             else:
-                print(f"task {t.id} failed with status {t.result_string}")
+                print(f"task {t.id} failed with status {t.result}")
 
     print("all tasks complete!")

--- a/taskvine/src/examples/vine_example_dask_awk_array.py
+++ b/taskvine/src/examples/vine_example_dask_awk_array.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
         nargs="?",
         type=str,
         help="name to assign to the manager.",
-        default=f"vine-blast-{getpass.getuser()}",
+        default=f"vine-dask-awkward{getpass.getuser()}",
     )
     parser.add_argument(
         "--port",

--- a/taskvine/src/examples/vine_example_dask_delayed.py
+++ b/taskvine/src/examples/vine_example_dask_delayed.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
         nargs="?",
         type=str,
         help="name to assign to the manager.",
-        default=f"vine-blast-{getpass.getuser()}",
+        default=f"vine-dask-delayed-{getpass.getuser()}",
     )
     parser.add_argument(
         "--port",

--- a/taskvine/src/examples/vine_example_dask_graph.py
+++ b/taskvine/src/examples/vine_example_dask_graph.py
@@ -40,7 +40,7 @@ is constructed by dask.""")
         nargs="?",
         type=str,
         help="name to assign to the manager.",
-        default=f"vine-blast-{getpass.getuser()}",
+        default=f"vine-dask-graph-{getpass.getuser()}",
     )
     parser.add_argument(
         "--port",

--- a/taskvine/src/examples/vine_example_fixed_location.py
+++ b/taskvine/src/examples/vine_example_fixed_location.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
             if t.successful():
                 print(f"task {t.id} -unsorted list- done on {t.addrport}")
             else:
-                print(f"task {t.id} -unsorted list- failed with status: {t.result_string}")
+                print(f"task {t.id} -unsorted list- failed with status: {t.result}")
 
     # now we sort the lists generated in the worker that they live
     temporary_sorted_lists = {}
@@ -72,7 +72,7 @@ if __name__ == "__main__":
                 print(f"task sorted list {t.id} done on {t.addrport}")
                 tasks_of_worker[t.addrport].append(t.id)
             else:
-                print(f"task sorted list {t.id} failed with status: {t.result_string}")
+                print(f"task sorted list {t.id} failed with status: {t.result}")
 
     # we are done with the unsorted lists and we remove them from the cluster
     for f in temporary_unsorted_lists.values():
@@ -97,7 +97,7 @@ if __name__ == "__main__":
             if t.successful():
                 print(f"task merge lists {t.id} done on {t.addrport}")
             else:
-                print(f"task merge lists {t.id} failed with status: {t.result_string}")
+                print(f"task merge lists {t.id} failed with status: {t.result}")
 
     # we are done with the sorted lists and we remove them from the cluster
     for f in temporary_sorted_lists.values():
@@ -124,7 +124,7 @@ if __name__ == "__main__":
                 with open("final_output.txt") as f_in:
                     print(f_in.read())
             else:
-                print(f"task final merge {t.id} failed with status: {t.result_string}")
+                print(f"task final merge {t.id} failed with status: {t.result}")
 
     # we are done with the merged lists and we remove them from the cluster
     for f in merge_outputs:

--- a/taskvine/src/examples/vine_example_gutenberg.py
+++ b/taskvine/src/examples/vine_example_gutenberg.py
@@ -84,6 +84,6 @@ if __name__ == "__main__":
             elif t.completed():
                 print(f"task {t.id} completed with an executin error, exit code {t.exit_code}")
             else:
-                print(f"task {t.id} failed with status {t.result_string}")
+                print(f"task {t.id} failed with status {t.result}")
 
     print("all tasks complete!")

--- a/taskvine/src/examples/vine_example_mosaic.py
+++ b/taskvine/src/examples/vine_example_mosaic.py
@@ -47,7 +47,7 @@ def process_result(t):
         elif t.completed():
             print(f"task {t.id} completed with an executin error, exit code {t.exit_code}")
         else:
-            print(f"task {t.id} failed with status {t.result_string}")
+            print(f"task {t.id} failed with status {t.result}")
 
 
 if __name__ == "__main__":

--- a/taskvine/src/examples/vine_example_watch.py
+++ b/taskvine/src/examples/vine_example_watch.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
             elif t.completed():
                 print(f"task {t.id} completed with an executin error, exit code {t.exit_code}")
             else:
-                print(f"task {t.id} failed with status {t.result_string}")
+                print(f"task {t.id} failed with status {t.result}")
 
         # print to the console the contents of the files being watched
         for i in range(n):

--- a/taskvine/src/examples/vine_example_xrootd.py
+++ b/taskvine/src/examples/vine_example_xrootd.py
@@ -119,6 +119,6 @@ if __name__ == "__main__":
             elif t.completed():
                 print(f"task {t.id} completed with an executin error, exit code {t.exit_code}")
             else:
-                print(f"task {t.id} failed with status {t.result_string}")
+                print(f"task {t.id} failed with status {t.result}")
 
     print("all tasks complete!")


### PR DESCRIPTION
Use `result` instead of `result_string`, and fix `set_name` of dask examples.