### PR TITLE
Vine: Re-Create Lost Temporary Files

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -24,6 +24,13 @@ the cluster.
 
 <img src=images/architecture.svg>
 
+The TaskVine system is naturally robust.  While an application is running,
+workers may be added or removed as computing resources become available.
+Newly added workers will gradually accumulate data within the cluster.
+Removed (or failed) workers are handled gracefully, and tasks will be
+retried elsewhere as needed.  If a worker failure results in the loss
+of files, tasks will be re-executed as necessary to re-create them.
+
 TaskVine manager applications can be written in Python or C
 on Linux or OSX platforms.  Individual tasks can be simple
 Python functions, complex Unix applications, or serverless function
@@ -47,8 +54,7 @@ Tasks share a common set of options.  Each task can be labelled with the resourc
 (CPU cores, GPU devices, memory, disk space) that it needs to execute.  This allows each worker to pack the appropriate
 number of tasks.  For example, a worker running on a 64-core machine could run 32 dual-core tasks, 16 four-core tasks,
 or any other combination that adds up to 64 cores.  If you don't know the resources needed, you can enable
-Automatic 
-a resource monitor to track and report what each task uses.
+an automatic resource monitor to track and report what each task uses.
 
 TaskVine is easy to deploy on existing HPC and cloud facilities.
 The worker processes are self-contained executables, and TaskVine
@@ -219,6 +225,8 @@ visible within the manager application.
 used to capture the output of a task, and then serve as the input
 of a later task.  Temporary files exist only within the cluster
 for the duration of a workflow, and are deleted when no longer needed.
+If a temporary file is unexpectedly lost due to the crash or failure
+of a worker, then the task that created it will be re-executed.
 
 If it is necessary to unpack a file before it is used,
 use the `declare_untar` transformation to wrap the file definition.

--- a/dttools/src/histogram.c
+++ b/dttools/src/histogram.c
@@ -47,22 +47,14 @@ struct histogram *histogram_create(double bucket_size) {
 	return h;
 }
 
-void histogram_clear(struct histogram *h) {
-
-	uint64_t key;
-	struct box_count *box;
-
-	itable_firstkey(h->buckets);
-	while(itable_nextkey(h->buckets, &key, (void **) &box)) {
-		free(box);
-	}
+void histogram_clear(struct histogram *h)
+{
+	itable_clear(h->buckets,free);
 
 	h->total_count = 0;
 	h->max_value   = 0;
 	h->min_value   = 0;
 	h->mode        = 0;
-
-	itable_clear(h->buckets);
 }
 
 void histogram_delete(struct histogram *h) {

--- a/dttools/src/itable.c
+++ b/dttools/src/itable.c
@@ -50,7 +50,7 @@ struct itable *itable_create(int bucket_count)
 	return h;
 }
 
-void itable_clear(struct itable *h)
+void itable_clear( struct itable *h, void (*delete_func)( void *) )
 {
 	struct entry *e, *f;
 	int i;
@@ -58,6 +58,7 @@ void itable_clear(struct itable *h)
 	for(i = 0; i < h->bucket_count; i++) {
 		e = h->buckets[i];
 		while(e) {
+			if(delete_func) delete_func(e->value);
 			f = e->next;
 			free(e);
 			e = f;
@@ -71,7 +72,7 @@ void itable_clear(struct itable *h)
 
 void itable_delete(struct itable *h)
 {
-	itable_clear(h);
+	itable_clear(h,0);
 	free(h->buckets);
 	free(h);
 }

--- a/dttools/src/itable.h
+++ b/dttools/src/itable.h
@@ -56,11 +56,11 @@ ITABLE_ITERATE(h,key,value) {
 struct itable *itable_create(int buckets);
 
 /** Remove all entries from an integer table.
-Note that this function will not delete all of the objects contained within the integer table.
 @param h The integer table to delete.
+@param delete_func If non-null, will be invoked on each object to delete it.
 */
 
-void itable_clear(struct itable *h);
+void itable_clear( struct itable *h, void (*delete_func)(void*) );
 
 /** Delete an integer table.
 Note that this function will not delete all of the objects contained within the integer table.

--- a/dttools/test/test_runner_common.sh
+++ b/dttools/test/test_runner_common.sh
@@ -116,7 +116,7 @@ run_wq_worker()
 	return 0
 }
 
-run_ds_worker()
+run_taskvine_worker()
 {
 	local port_file=$1
 	shift

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -238,13 +238,6 @@ vine_task_set_command
 */
 struct vine_task *vine_task_create(const char *full_command);
 
-/** Create a copy of a task
-Create a functionally identical copy of a task that
-can be re-submitted via @ref vine_submit.
-@return A new task object
-*/
-struct vine_task *vine_task_clone(const struct vine_task *task);
-
 /** Delete a task.
 This may be called on tasks after they are returned from @ref vine_wait.
 @param t The task to delete.

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -29,6 +29,11 @@ int vine_file_delete(struct vine_file *f)
 			return f->refcount;
 		}
 
+		if(f->refcount<0) {
+			notice(D_VINE,"vine_file_delete: prevented multiple-free of file");
+			return 0;
+		}
+	
 		vine_task_delete(f->mini_task);
 		vine_task_delete(f->recovery_task);
 		free(f->source);

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -30,7 +30,6 @@ int vine_file_delete(struct vine_file *f)
 		}
 
 		vine_task_delete(f->mini_task);
-		vine_task_delete(f->created_by);
 		free(f->source);
 		free(f->cached_name);
 		free(f->data);
@@ -89,15 +88,9 @@ struct vine_file *vine_file_create( const char *source, const char *cached_name,
 		}
 	}
 
-	/* file has been created, but it is not referenced by any task, or manager yet. */
-	f->refcount = 0;
+	f->refcount = 1;
 
 	return f;
-}
-
-void vine_file_created_by( struct vine_file *f, struct vine_task *t )
-{
-	f->created_by = vine_task_clone(t);
 }
 
 /* Make a reference counted copy of a file object. */

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -30,6 +30,7 @@ int vine_file_delete(struct vine_file *f)
 		}
 
 		vine_task_delete(f->mini_task);
+		vine_task_delete(f->recovery_task);
 		free(f->source);
 		free(f->cached_name);
 		free(f->data);
@@ -56,6 +57,7 @@ struct vine_file *vine_file_create( const char *source, const char *cached_name,
 	f->type = type;
 	f->size = size;
 	f->mini_task = mini_task;
+	f->recovery_task = 0;
 	f->flags = flags;
 
 	if(data) {

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -30,6 +30,7 @@ int vine_file_delete(struct vine_file *f)
 		}
 
 		vine_task_delete(f->mini_task);
+		vine_task_delete(f->created_by);
 		free(f->source);
 		free(f->cached_name);
 		free(f->data);
@@ -92,6 +93,11 @@ struct vine_file *vine_file_create( const char *source, const char *cached_name,
 	f->refcount = 0;
 
 	return f;
+}
+
+void vine_file_created_by( struct vine_file *f, struct vine_task *t )
+{
+	f->created_by = vine_task_clone(t);
 }
 
 /* Make a reference counted copy of a file object. */

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -44,9 +44,12 @@ struct vine_file {
 	struct vine_task *mini_task; // Mini task used to generate the desired output file.
 	int refcount;       // Number of references from a task object, delete when zero.
 	vine_file_flags_t flags; // whether or not to transfer this file between workers.
+	struct vine_task *created_by; // Pointer back to task that created this file.
 };
 
 struct vine_file * vine_file_create( const char *source, const char *cached_name, const char *data, size_t size, vine_file_t type, struct vine_task *mini_task, vine_file_flags_t flags);
+
+void vine_file_created_by( struct vine_file *f, struct vine_task *t );
 
 struct vine_file * vine_file_substitute_url( struct vine_file *f, const char *source );
 

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -37,14 +37,14 @@ typedef enum {
 
 struct vine_file {
 	vine_file_t type;   // Type of data source: VINE_FILE, VINE_BUFFER, VINE_URL, etc.
+	vine_file_flags_t flags; // whether or not to transfer this file between workers.
 	char *source;       // Name of source file, url, buffer.
 	char *cached_name;  // Name of file in the worker's cache directory.
 	size_t size;        // Length of source data, if known.
 	char *data;         // Raw data for an input or output buffer.
 	struct vine_task *mini_task; // Mini task used to generate the desired output file.
+	struct vine_task *recovery_task; // For temp files, a copy of the task that created it.
 	int refcount;       // Number of references from a task object, delete when zero.
-	vine_file_flags_t flags; // whether or not to transfer this file between workers.
-	int created_by_task_id; // If an output file, identify the task that created it.
 };
 
 struct vine_file * vine_file_create( const char *source, const char *cached_name, const char *data, size_t size, vine_file_t type, struct vine_task *mini_task, vine_file_flags_t flags);

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -44,12 +44,9 @@ struct vine_file {
 	struct vine_task *mini_task; // Mini task used to generate the desired output file.
 	int refcount;       // Number of references from a task object, delete when zero.
 	vine_file_flags_t flags; // whether or not to transfer this file between workers.
-	struct vine_task *created_by; // Pointer back to task that created this file.
 };
 
 struct vine_file * vine_file_create( const char *source, const char *cached_name, const char *data, size_t size, vine_file_t type, struct vine_task *mini_task, vine_file_flags_t flags);
-
-void vine_file_created_by( struct vine_file *f, struct vine_task *t );
 
 struct vine_file * vine_file_substitute_url( struct vine_file *f, const char *source );
 

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -44,6 +44,7 @@ struct vine_file {
 	struct vine_task *mini_task; // Mini task used to generate the desired output file.
 	int refcount;       // Number of references from a task object, delete when zero.
 	vine_file_flags_t flags; // whether or not to transfer this file between workers.
+	int created_by_task_id; // If an output file, identify the task that created it.
 };
 
 struct vine_file * vine_file_create( const char *source, const char *cached_name, const char *data, size_t size, vine_file_t type, struct vine_task *mini_task, vine_file_flags_t flags);

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -57,4 +57,22 @@ struct vine_worker_info *vine_file_replica_table_find_worker(struct vine_manager
 	return 0;
 }
 
+/*
+Determine if this file is cached *anywhere* in the system.
+XXX Note that this implementation is another inefficient linear search.
+*/
+
+int vine_file_replica_table_exists_somewhere( struct vine_manager *q, const char *cachename )
+{
+	char *key;
+	struct vine_worker_info *w;
+	struct vine_file_replica *r;
+	
+	HASH_TABLE_ITERATE(q->worker_table, key, w) {
+		r = hash_table_lookup(w->current_files,cachename);
+		if(r) return 1;
+	}
+
+	return 0;
+}
 

--- a/taskvine/src/manager/vine_file_replica_table.h
+++ b/taskvine/src/manager/vine_file_replica_table.h
@@ -23,5 +23,8 @@ struct vine_file_replica *vine_file_replica_table_lookup(struct vine_worker_info
 
 struct vine_worker_info *vine_file_replica_table_find_worker(struct vine_manager *q, const char *cachename);
 
+int vine_file_replica_table_exists_somewhere( struct vine_manager *q, const char *cachename );
+
+
 #endif
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3416,6 +3416,9 @@ void vine_delete(struct vine_manager *q)
 	hash_table_clear(q->file_table,(void*)vine_file_delete);
 	hash_table_delete(q->file_table);
 
+	itable_clear(q->tasks,(void*)vine_task_delete);
+	itable_delete(q->tasks);
+
 	char *key;
 	struct category *c;
 	HASH_TABLE_ITERATE(q->categories,key,c) {
@@ -3425,8 +3428,6 @@ void vine_delete(struct vine_manager *q)
 
 	list_delete(q->ready_list);
 	hash_table_delete(q->libraries);
-	itable_delete(q->tasks);
-
 	hash_table_delete(q->workers_with_available_results);
 
 	list_clear(q->task_info_list,(void*)vine_task_info_delete);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2751,7 +2751,8 @@ static void vine_manager_consider_recovery_task( struct vine_manager *q, struct 
 		break;
 	case VINE_TASK_DONE:
 		/* The recovery task previously ran to completion, so it must be reset and resubmitted. */
-		vine_task_clean(rt);
+		/* Note that the recovery task has already "left" the manager and so we do not manipulate internal state here. */
+		vine_task_reset(rt);
 		vine_submit(q,rt);
 		break;
 	case VINE_TASK_CANCELED:

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3741,8 +3741,8 @@ static int task_request_count( struct vine_manager *q, const char *category, cat
 
 int vine_submit(struct vine_manager *q, struct vine_task *t)
 {
-	if(t->task_id > 0) {
-		fatal("TaskVine: Sorry, you cannot submit the same task (%lld) (%s) twice!",t->task_id,t->command_line);
+	if(t->state!=VINE_TASK_UNKNOWN) {
+		fatal("TaskVine: Sorry, you cannot submit the same task (%d) (%s) twice!",t->task_id,t->command_line);
 	}
 
 	/* Issue warnings if the files are set up strangely. */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3719,8 +3719,9 @@ static vine_task_state_t change_task_state( struct vine_manager *q, struct vine_
 			break;
 		case VINE_TASK_DONE:
 		case VINE_TASK_CANCELED:
-			/* tasks are freed when returned to user, thus we remove them from our local record */
+			/* Task was cloned when entered into our own table, so delete a reference on removal. */
 			itable_remove(q->tasks, t->task_id); 
+			vine_task_delete(t);
 			break;
 		default:
 			/* do nothing */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5067,15 +5067,13 @@ struct vine_file *vine_manager_declare_file(struct vine_manager *m, struct vine_
 	if(previous) {
 		/* If declared before, use the previous instance. */
 		vine_file_delete(f);
-		f = previous;
+		f = vine_file_clone(previous);
 	} else {
 		/* Otherwise add it to the table. */
 		hash_table_insert(m->file_table, f->cached_name, f );
 	}
 
-	/* Either way, increase the refcount of the file and return it. */
-	
-	return vine_file_clone(f);
+	return f;
 }
 
 struct vine_file *vine_declare_file( struct vine_manager *m, const char *source, vine_file_flags_t flags)

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -735,7 +735,6 @@ static void update_catalog(struct vine_manager *q, int force_update )
 static void cleanup_worker(struct vine_manager *q, struct vine_worker_info *w)
 {
 	struct vine_task *t;
-	struct rmsummary *r;
 	uint64_t task_id;
 
 	if(!q || !w) return;
@@ -755,15 +754,10 @@ static void cleanup_worker(struct vine_manager *q, struct vine_worker_info *w)
 		itable_firstkey(w->current_tasks);
 	}
 
-	ITABLE_ITERATE(w->current_tasks_boxes,task_id,r) {
-		rmsummary_delete(r);
-	}
-
-	itable_clear(w->current_tasks);
-	itable_clear(w->current_tasks_boxes);
+	itable_clear(w->current_tasks,0);
+	itable_clear(w->current_tasks_boxes,(void*)rmsummary_delete);
 
 	w->finished_tasks = 0;
-
 
 	char *cached_name = NULL;
 	struct vine_file_replica *info = NULL;
@@ -3430,8 +3424,8 @@ void vine_delete(struct vine_manager *q)
 	hash_table_delete(q->categories);
 
 	list_delete(q->ready_list);
-	itable_delete(q->tasks);
 	hash_table_delete(q->libraries);
+	itable_delete(q->tasks);
 
 	hash_table_delete(q->workers_with_available_results);
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2750,15 +2750,11 @@ static void vine_manager_consider_recovery_task( struct vine_manager *q, struct 
 		/* The recovery task is in the process of running, just wait until it is done. */
 		break;
 	case VINE_TASK_DONE:
+	case VINE_TASK_CANCELED:
 		/* The recovery task previously ran to completion, so it must be reset and resubmitted. */
 		/* Note that the recovery task has already "left" the manager and so we do not manipulate internal state here. */
 		vine_task_reset(rt);
 		vine_submit(q,rt);
-		break;
-	case VINE_TASK_CANCELED:
-		/* If the producing task was cancelled, then this one should be too. */
-		/* XXX problem here is that cancelled tasks are not returned by wait() */
-		fatal("recovery task %d cancelled!\n",rt->task_id);
 		break;
 	}
 }

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3128,8 +3128,6 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 
 	getcwd(q->workingdir,PATH_MAX);
 
-	q->next_task_id = 1;
-
 	q->ready_list = list_create();
 
 	q->tasks          = itable_create(0);
@@ -3747,12 +3745,6 @@ int vine_submit(struct vine_manager *q, struct vine_task *t)
 		fatal("TaskVine: Sorry, you cannot submit the same task (%lld) (%s) twice!",t->task_id,t->command_line);
 	}
 
-	/* Assign a unique taskid on submission. */
-	t->task_id = q->next_task_id;
-
-	/* Increment task_id. So we get a unique task_id for every submit. */
-	q->next_task_id++;
-
 	/* Issue warnings if the files are set up strangely. */
 	vine_task_check_consistency(t);
 
@@ -3783,8 +3775,6 @@ static int vine_manager_send_library_to_worker(struct vine_manager *q, struct vi
 
 	// setup the Library Task by copying the original and giving it a unique taskid
 	struct vine_task *t = vine_task_copy(hash_table_lookup(q->libraries, name));
-	t->task_id = q->next_task_id;
-	q->next_task_id++;
 	t->hostname = xxstrdup(w->hostname);
 	t->addrport = xxstrdup(w->addrport);
 	t->worker = w;
@@ -4986,11 +4976,11 @@ struct category *vine_category_lookup_or_create(struct vine_manager *q, const ch
 
 int vine_set_task_id_min(struct vine_manager *q, int minid) {
 
-	if(minid > q->next_task_id) {
-		q->next_task_id = minid;
+	if(minid > vine_task_next_task_id) {
+		vine_task_next_task_id = minid;
 	}
 
-	return q->next_task_id;
+	return vine_task_next_task_id;
 }
 
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3813,8 +3813,8 @@ int vine_submit(struct vine_manager *q, struct vine_task *t)
 
 static int vine_manager_send_library_to_worker(struct vine_manager *q, struct vine_worker_info *w, const char *name) {
 
-	// setup the Library Task by cloning the original and giving it a unique taskid
-	struct vine_task *t = vine_task_clone(hash_table_lookup(q->libraries, name));
+	// setup the Library Task by copying the original and giving it a unique taskid
+	struct vine_task *t = vine_task_copy(hash_table_lookup(q->libraries, name));
 	t->task_id = q->next_task_id;
 	q->next_task_id++;
 	t->hostname = xxstrdup(w->hostname);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3622,7 +3622,8 @@ static vine_task_state_t change_task_state( struct vine_manager *q, struct vine_
 		case VINE_TASK_DONE:
 		case VINE_TASK_CANCELED:
 			/* tasks are freed when returned to user, thus we remove them from our local record */
-			itable_remove(q->tasks, t->task_id);
+			/* No longer remove tasks on completion. */
+			/* itable_remove(q->tasks, t->task_id); */
 			break;
 		default:
 			/* do nothing */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5097,19 +5097,17 @@ struct vine_file *vine_manager_declare_file(struct vine_manager *m, struct vine_
 	struct vine_file *previous = vine_manager_lookup_file(m, f->cached_name);
 
 	if(previous) {
-	/* This file has been declared before. We delete the new instance and
-	 * return previous. */
+		/* If declared before, use the previous instance. */
 		vine_file_delete(f);
 		f = previous;
 	} else {
-		hash_table_insert(m->file_table, f->cached_name, f);
-
-		/* This is a new file. Increase refcount to keep track of the reference
-		 * from the manager. */
-		f->refcount += 1;
+		/* Otherwise add it to the table. */
+		hash_table_insert(m->file_table, f->cached_name, f );
 	}
 
-	return f;
+	/* Either way, increase the refcount of the file and return it. */
+	
+	return vine_file_clone(f);
 }
 
 struct vine_file *vine_declare_file( struct vine_manager *m, const char *source, vine_file_flags_t flags)

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -123,6 +123,7 @@ struct vine_manager {
 
 	/* Internal state modified by the manager */
 
+	int next_task_id;       /* Next integer task_id to be assigned to a created task. */
 	int num_tasks_left;    /* Optional: Number of tasks remaining, if given by user.  @ref vine_set_num_tasks */
 	int busy_waiting_flag; /* Set internally in main loop if no messages were processed -> wait longer. */
 

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -123,7 +123,6 @@ struct vine_manager {
 
 	/* Internal state modified by the manager */
 
- 	int next_task_id;       /* Next integer task_id to be assigned to a created task. */
 	int num_tasks_left;    /* Optional: Number of tasks remaining, if given by user.  @ref vine_set_num_tasks */
 	int busy_waiting_flag; /* Set internally in main loop if no messages were processed -> wait longer. */
 

--- a/taskvine/src/manager/vine_mount.c
+++ b/taskvine/src/manager/vine_mount.c
@@ -38,7 +38,7 @@ void vine_mount_delete( struct vine_mount *m )
 	free(m);
 }
 
-struct vine_mount * vine_mount_clone( struct vine_mount *m )
+struct vine_mount * vine_mount_copy( struct vine_mount *m )
 {
 	if(!m) return 0;
 	return vine_mount_create(vine_file_clone(m->file),m->remote_name,m->flags,vine_file_clone(m->substitute));

--- a/taskvine/src/manager/vine_mount.c
+++ b/taskvine/src/manager/vine_mount.c
@@ -15,7 +15,10 @@ See the file COPYING for details.
 struct vine_mount * vine_mount_create( struct vine_file *file, const char *remote_name, vine_mount_flags_t flags, struct vine_file *substitute )
 {
 	struct vine_mount *m = malloc(sizeof(*m));
-	m->file = file;
+
+	/* Add a reference each time a file is connected. */
+	m->file = vine_file_clone(file);
+
 	if(remote_name) {
 		m->remote_name = xxstrdup(remote_name);
 	} else {
@@ -23,9 +26,6 @@ struct vine_mount * vine_mount_create( struct vine_file *file, const char *remot
 	}
 	m->flags = flags;
 	m->substitute = substitute;
-
-	/* Add a reference each time a file is connected. */
-	m->file->refcount++;
 
 	return m;
 }

--- a/taskvine/src/manager/vine_mount.h
+++ b/taskvine/src/manager/vine_mount.h
@@ -25,7 +25,7 @@ struct vine_mount {
 };
 
 struct vine_mount * vine_mount_create( struct vine_file *f, const char *remote_name, vine_mount_flags_t flags, struct vine_file *substitute );
-struct vine_mount * vine_mount_clone( struct vine_mount *m );
+struct vine_mount * vine_mount_copy( struct vine_mount *m );
 void vine_mount_delete( struct vine_mount *m );
 
 #endif

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -68,7 +68,7 @@ struct vine_task *vine_task_create(const char *command_line)
 	return t;
 }
 
-void vine_task_clean( struct vine_task *t, int full_clean )
+void vine_task_clean( struct vine_task *t )
 {
 	t->time_when_commit_start = 0;
 	t->time_when_commit_end   = 0;
@@ -91,22 +91,6 @@ void vine_task_clean( struct vine_task *t, int full_clean )
 
 	free(t->addrport);
 	t->addrport = NULL;
-
-	if(full_clean) {
-		t->resource_request = CATEGORY_ALLOCATION_FIRST;
-		t->try_count = 0;
-		t->exhausted_attempts = 0;
-		t->workers_slow = 0;
-
-		t->time_workers_execute_all = 0;
-		t->time_workers_execute_exhaustion = 0;
-		t->time_workers_execute_failure = 0;
-
-		rmsummary_delete(t->resources_measured);
-		rmsummary_delete(t->resources_allocated);
-		t->resources_measured  = rmsummary_create(-1);
-		t->resources_allocated = rmsummary_create(-1);
-	}
 
 	/* If result is never updated, then it is mark as a failure. */
 	t->result = VINE_RESULT_UNKNOWN;

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -63,7 +63,7 @@ struct vine_task *vine_task_create(const char *command_line)
 	t->resources_measured  = rmsummary_create(-1);
 	t->resources_allocated = rmsummary_create(-1);
 
-	t->refcount = 0;
+	t->refcount = 1;
 	
 	return t;
 }
@@ -425,8 +425,6 @@ void vine_task_add_output( struct vine_task *t, struct vine_file *f, const char 
 	}
 
 	struct vine_mount *m = vine_mount_create(f,remote_name,flags,0);
-
-	vine_file_created_by(f,t);
 
 	list_push_tail(t->output_mounts, m);
 }

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -39,6 +39,7 @@ struct vine_task *vine_task_create(const char *command_line)
 	memset(t, 0, sizeof(*t));
 
 	t->task_id = vine_task_next_task_id++;
+	t->type = VINE_TASK_TYPE_STANDARD;
 	
 	/* REMEMBER: Any memory allocation done in this function should have a
 	 * corresponding copy in vine_task_copy. Otherwise we get
@@ -139,6 +140,7 @@ struct vine_task *vine_task_copy( const struct vine_task *task )
 	struct vine_task *new = vine_task_create(task->command_line);
 
 	new->task_id = vine_task_next_task_id++;
+	new->type = task->type;
 	
 	/* Static features of task are copied. */
 	if(task->coprocess) vine_task_set_coprocess(new,task->tag);
@@ -432,8 +434,6 @@ void vine_task_add_output( struct vine_task *t, struct vine_file *f, const char 
 
 	struct vine_mount *m = vine_mount_create(f,remote_name,flags,0);
 
-	m->file->created_by_task_id = t->task_id;
-	
 	list_push_tail(t->output_mounts, m);
 }
 

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -96,7 +96,28 @@ void vine_task_clean( struct vine_task *t )
 
 	/* If result is never updated, then it is mark as a failure. */
 	t->result = VINE_RESULT_UNKNOWN;
-	t->state = VINE_TASK_READY;
+}
+
+void vine_task_reset( struct vine_task *t )
+{
+	vine_task_clean(t);
+
+	t->resource_request = CATEGORY_ALLOCATION_FIRST;
+	t->try_count = 0;
+	t->exhausted_attempts = 0;
+	t->workers_slow = 0;
+
+	t->time_workers_execute_all = 0;
+	t->time_workers_execute_exhaustion = 0;
+	t->time_workers_execute_failure = 0;
+
+	rmsummary_delete(t->resources_measured);
+	rmsummary_delete(t->resources_allocated);
+	t->resources_measured  = rmsummary_create(-1);
+	t->resources_allocated = rmsummary_create(-1);
+
+	t->task_id = 0;
+	t->state = VINE_TASK_UNKNOWN;
 }
 
 static struct list *vine_task_mount_list_copy(struct list *list)

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -27,6 +27,8 @@ See the file COPYING for details.
 #include <math.h>
 #include "random.h"
 
+int vine_task_next_task_id = 1;
+
 struct vine_task *vine_task_create(const char *command_line)
 {
 	struct vine_task *t = malloc(sizeof(*t));
@@ -36,6 +38,8 @@ struct vine_task *vine_task_create(const char *command_line)
 	}
 	memset(t, 0, sizeof(*t));
 
+	t->task_id = vine_task_next_task_id++;
+	
 	/* REMEMBER: Any memory allocation done in this function should have a
 	 * corresponding copy in vine_task_copy. Otherwise we get
 	 * double-free segfaults. */
@@ -134,6 +138,8 @@ struct vine_task *vine_task_copy( const struct vine_task *task )
 
 	struct vine_task *new = vine_task_create(task->command_line);
 
+	new->task_id = vine_task_next_task_id++;
+	
 	/* Static features of task are copied. */
 	if(task->coprocess) vine_task_set_coprocess(new,task->tag);
 	if(task->tag) vine_task_set_tag(new, task->tag);
@@ -426,6 +432,8 @@ void vine_task_add_output( struct vine_task *t, struct vine_file *f, const char 
 
 	struct vine_mount *m = vine_mount_create(f,remote_name,flags,0);
 
+	m->file->created_by_task_id = t->task_id;
+	
 	list_push_tail(t->output_mounts, m);
 }
 

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -433,30 +433,35 @@ void vine_task_add_input_file(struct vine_task *t, const char *local_name, const
 {
 	struct vine_file *f = vine_file_local(local_name, 0);
 	vine_task_add_input(t,f,remote_name,flags);
+	vine_file_delete(f); /* symmetric create/delete needed for reference counting. */
 }
 
 void vine_task_add_output_file(struct vine_task *t, const char *local_name, const char *remote_name, vine_mount_flags_t flags)
 {
 	struct vine_file *f = vine_file_local(local_name, 0);
 	vine_task_add_output(t,f,remote_name,flags);
+	vine_file_delete(f); /* symmetric create/delete needed for reference counting. */
 }
 
 void vine_task_add_input_url(struct vine_task *t, const char *file_url, const char *remote_name, vine_mount_flags_t flags)
 {
 	struct vine_file *f = vine_file_url(file_url, 0);
 	vine_task_add_input(t,f,remote_name,flags);
+	vine_file_delete(f); /* symmetric create/delete needed for reference counting. */
 }
 
 void vine_task_add_empty_dir( struct vine_task *t, const char *remote_name )
 {
 	struct vine_file *f = vine_file_empty_dir();
 	vine_task_add_input(t,f,remote_name,0);
+	vine_file_delete(f); /* symmetric create/delete needed for reference counting. */
 }
 
 void vine_task_add_input_buffer(struct vine_task *t, const char *data, int length, const char *remote_name, vine_mount_flags_t flags)
 {
 	struct vine_file *f = vine_file_buffer(data,length,0);
 	vine_task_add_input(t,f,remote_name,flags);
+	vine_file_delete(f); /* symmetric create/delete needed for reference counting. */
 }
 
 void vine_task_add_input_mini_task(struct vine_task *t, struct vine_task *mini_task, const char *remote_name, vine_mount_flags_t flags)
@@ -464,6 +469,7 @@ void vine_task_add_input_mini_task(struct vine_task *t, struct vine_task *mini_t
 	/* XXX mini task must have a single output file */
 	struct vine_file *f = vine_file_mini_task(mini_task, 0);
 	vine_task_add_input(t,f,remote_name,flags);
+	vine_file_delete(f); /* symmetric create/delete needed for reference counting. */
 }
 
 void vine_task_add_environment(struct vine_task *t, struct vine_file *environment_file) {

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -27,8 +27,6 @@ See the file COPYING for details.
 #include <math.h>
 #include "random.h"
 
-int vine_task_next_task_id = 1;
-
 struct vine_task *vine_task_create(const char *command_line)
 {
 	struct vine_task *t = malloc(sizeof(*t));
@@ -38,7 +36,6 @@ struct vine_task *vine_task_create(const char *command_line)
 	}
 	memset(t, 0, sizeof(*t));
 
-	t->task_id = vine_task_next_task_id++;
 	t->type = VINE_TASK_TYPE_STANDARD;
 	
 	/* REMEMBER: Any memory allocation done in this function should have a
@@ -139,7 +136,9 @@ struct vine_task *vine_task_copy( const struct vine_task *task )
 
 	struct vine_task *new = vine_task_create(task->command_line);
 
-	new->task_id = vine_task_next_task_id++;
+	/* Reset the task ID so that this will get a new one at submit time. */
+	new->task_id = 0;
+
 	new->type = task->type;
 	
 	/* Static features of task are copied. */

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -577,6 +577,11 @@ void vine_task_delete(struct vine_task *t)
 
 	t->refcount--;
 	if(t->refcount>0) return;
+
+	if(t->refcount<0) {
+		notice(D_VINE,"vine_task_delete: prevented multiple-free of task %d",t->task_id);
+		return;
+	}
 	
 	free(t->command_line);
 	free(t->coprocess);

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -21,10 +21,16 @@ End user may only use the API described in taskvine.h
 
 #include <stdint.h>
 
+typedef enum {
+      VINE_TASK_TYPE_STANDARD,    /**< A normal task that should be returned to the user. */
+      VINE_TASK_TYPE_RECOVERY,    /**< A failure recovery task that should not be returned to the user. */
+} vine_task_type_t;
+
 struct vine_task {
         /***** Fixed properties of task at submit time. ******/
 
-        int task_id;                  /**< A unique task id number. */
+        int task_id;                 /**< A unique task id number. */
+	vine_task_type_t type;       /**< The type of the task. */
 	char *command_line;          /**< The program(s) to execute, as a shell command line. */
 	char *coprocess;             /**< The name of the coprocess name in the worker that executes this task. For regular tasks it is NULL. */
 	char *tag;                   /**< An optional user-defined logical name for the task. */

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -102,7 +102,7 @@ struct vine_task * vine_task_copy( const struct vine_task *t );
 
 int  vine_task_set_result(struct vine_task *t, vine_result_t new_result);
 void vine_task_set_resources(struct vine_task *t, const struct rmsummary *rm);
-void vine_task_clean( struct vine_task *t, int full_clean );
+void vine_task_clean( struct vine_task *t );
 void vine_task_check_consistency( struct vine_task *t );
 
 const char *vine_task_state_to_string( vine_task_state_t task_state );

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -120,4 +120,6 @@ void vine_task_add_input_mini_task(struct vine_task *t, struct vine_task *mini_t
 void vine_task_add_input_buffer(struct vine_task *t, const char *data, int length, const char *remote_name, vine_mount_flags_t flags);
 void vine_task_add_empty_dir( struct vine_task *t, const char *remote_name );
 
+extern int vine_task_next_task_id;
+
 #endif

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -126,6 +126,4 @@ void vine_task_add_input_mini_task(struct vine_task *t, struct vine_task *mini_t
 void vine_task_add_input_buffer(struct vine_task *t, const char *data, int length, const char *remote_name, vine_mount_flags_t flags);
 void vine_task_add_empty_dir( struct vine_task *t, const char *remote_name );
 
-extern int vine_task_next_task_id;
-
 #endif

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -106,9 +106,15 @@ struct vine_task * vine_task_clone( struct vine_task *t );
 /* Deep-copy an existing task object, return a pointer to a new object. */
 struct vine_task * vine_task_copy( const struct vine_task *t );
 
+/* Hard-reset a completed task back to an initial state so that it can be submitted again. */
+void vine_task_reset( struct vine_task *t );
+
+/* Soft-reset a not-yet-completed task so that it can be attempted on a different worker. */
+void vine_task_clean( struct vine_task *t );
+
 int  vine_task_set_result(struct vine_task *t, vine_result_t new_result);
 void vine_task_set_resources(struct vine_task *t, const struct rmsummary *rm);
-void vine_task_clean( struct vine_task *t );
+
 void vine_task_check_consistency( struct vine_task *t );
 
 const char *vine_task_state_to_string( vine_task_state_t task_state );

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -90,7 +90,15 @@ struct vine_task {
 
 	int has_fixed_locations;                               /**< Whether at least one file was added with the VINE_FIXED_LOCATION flag. Task fails immediately if no
 															 worker can satisfy all the strict inputs of the task. */
+
+	int refcount;                                          /**< Number of remaining references to this object. */
 };
+
+/* Add a reference to an existing task object, return the same object. */
+struct vine_task * vine_task_clone( struct vine_task *t );
+
+/* Deep-copy an existing task object, return a pointer to a new object. */
+struct vine_task * vine_task_copy( const struct vine_task *t );
 
 int  vine_task_set_result(struct vine_task *t, vine_result_t new_result);
 void vine_task_set_resources(struct vine_task *t, const struct rmsummary *rm);

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -102,7 +102,7 @@ int active_timeout = 3600;
 static int init_backoff_interval = 1;
 
 // Maximum value for backoff interval (in seconds) when worker fails to connect to a manager.
-static int max_backoff_interval = 60;
+static int max_backoff_interval = 8;
 
 // Absolute end time (in useconds) for worker, worker is killed after this point.
 static timestamp_t end_time = 0;

--- a/taskvine/test/TR_vine_python.sh
+++ b/taskvine/test/TR_vine_python.sh
@@ -45,7 +45,7 @@ run()
 	# wait at most 15 seconds for vine to find a port.
 	wait_for_file_creation $PORT_FILE 15
 
-	run_ds_worker $PORT_FILE worker.log
+	run_taskvine_worker $PORT_FILE worker.log
 
 	# wait for vine to exit.
 	wait_for_file_creation $STATUS_FILE 15

--- a/taskvine/test/TR_vine_python_no_serialization.sh
+++ b/taskvine/test/TR_vine_python_no_serialization.sh
@@ -36,7 +36,7 @@ run()
 	# wait at most 5 seconds for vine to find a port.
 	wait_for_file_creation $PORT_FILE 5
 
-	run_ds_worker $PORT_FILE worker.log
+	run_taskvine_worker $PORT_FILE worker.log
 
 	# wait for vine to exit.
 	wait_for_file_creation $STATUS_FILE 5

--- a/taskvine/test/TR_vine_python_task.sh
+++ b/taskvine/test/TR_vine_python_task.sh
@@ -36,7 +36,7 @@ run()
 	# wait at most 5 seconds for vine to find a port.
 	wait_for_file_creation $PORT_FILE 5
 
-	run_ds_worker $PORT_FILE worker.log
+	run_taskvine_worker $PORT_FILE worker.log
 
 	# wait for vine to exit.
 	wait_for_file_creation $STATUS_FILE 5

--- a/taskvine/test/TR_vine_python_temp_files.sh
+++ b/taskvine/test/TR_vine_python_temp_files.sh
@@ -36,7 +36,7 @@ run()
 	# wait at most 5 seconds for vine to find a port.
 	wait_for_file_creation $PORT_FILE 5
 
-	run_ds_worker $PORT_FILE worker.log
+	run_taskvine_worker $PORT_FILE worker.log
 
 	# wait for vine to exit.
 	wait_for_file_creation $STATUS_FILE 5

--- a/taskvine/test/TR_vine_ssl.sh
+++ b/taskvine/test/TR_vine_ssl.sh
@@ -54,7 +54,7 @@ run()
 	# wait at most 15 seconds for the command to find a port.
 	wait_for_file_creation $PORT_FILE 15
 
-	run_ds_worker $PORT_FILE worker.log --ssl
+	run_taskvine_worker $PORT_FILE worker.log --ssl
 
 	# wait for command to exit.
 	wait_for_file_creation $STATUS_FILE 15

--- a/taskvine/test/TR_vine_tag.sh
+++ b/taskvine/test/TR_vine_tag.sh
@@ -33,7 +33,7 @@ run()
 	# wait at most 15 seconds for vine to find a port.
 	wait_for_file_creation $PORT_FILE 15
 
-	run_ds_worker $PORT_FILE worker.log
+	run_taskvine_worker $PORT_FILE worker.log
 
 	# wait for vine to exit.
 	wait_for_file_creation $STATUS_FILE 15

--- a/taskvine/test/vine_test.py
+++ b/taskvine/test/vine_test.py
@@ -102,12 +102,6 @@ if __name__ == "__main__":
     t = q.wait(wait_time)
     report_task(t, "success", 0, [path.join(test_dir, output_name)])
 
-    # same task as above, but testing resubmission on final state
-    for i in range(3):
-        q.submit(t)
-        t = q.wait(5)
-    report_task(t, "success", 0, [path.join(test_dir, output_name)])
-
     # same simple task, but now we send the directory as an input
     output_name = next_output_name()
     t = vine.Task(f"cd my_dir && ./{exec_name} {input_name} 2>&1 > {output_name}")

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -1184,7 +1184,6 @@ static void cleanup_worker(struct work_queue *q, struct work_queue_worker *w)
 {
 	char *key, *value;
 	struct work_queue_task *t;
-	struct rmsummary *r;
 	uint64_t taskid;
 
 	if(!q || !w) return;
@@ -1210,13 +1209,10 @@ static void cleanup_worker(struct work_queue *q, struct work_queue_worker *w)
 		itable_firstkey(w->current_tasks);
 	}
 
-	itable_firstkey(w->current_tasks_boxes);
-	while(itable_nextkey(w->current_tasks_boxes, &taskid, (void **) &r)) {
-		rmsummary_delete(r);
-	}
+	itable_clear(w->current_tasks,0);
 
-	itable_clear(w->current_tasks);
-	itable_clear(w->current_tasks_boxes);
+	itable_clear(w->current_tasks_boxes,(void*)rmsummary_delete);
+
 	w->finished_tasks = 0;
 }
 


### PR DESCRIPTION
Maintain all tasks and files in manager, even after completion.
Still needs to be refined so that both are deleted when needed.