### PR TITLE
metadata cache names for vine_files that are not CACHE_ALWAYS

### DIFF
--- a/taskvine/src/manager/vine_cached_name.c
+++ b/taskvine/src/manager/vine_cached_name.c
@@ -279,7 +279,7 @@ char *vine_meta_name(const struct vine_file *f, ssize_t *totalsize ){
 
 	if(path_disk_size_info_get(f->source, &size, &number_of_files)) return 0;
 
-	char *meta = string_format("%s-%ld-%s", f->source, size, mtime);
+	char *meta = string_format("%s-%"PRIu64"-%s", f->source, size, mtime);
 
 	char *metahash = md5_of_string(meta);
 	

--- a/taskvine/src/manager/vine_cached_name.c
+++ b/taskvine/src/manager/vine_cached_name.c
@@ -273,7 +273,7 @@ char *vine_meta_name(const struct vine_file *f, ssize_t *totalsize ){
 
 	if(stat(f->source, &info)) return 0;
 	char *mtime = ctime(&info.st_mtime);
-	char *meta = string_format("%s-%ld-%s", f->source, info.st_size, mtime);
+	char *meta = string_format("%s-%"PRIu64"-%s", f->source, info.st_size, mtime);
 	char *metahash = md5_of_string(meta);
 	char *name = string_format("file-meta-%s", metahash);
 

--- a/taskvine/src/manager/vine_cached_name.c
+++ b/taskvine/src/manager/vine_cached_name.c
@@ -271,7 +271,6 @@ char *vine_meta_name(const struct vine_file *f, ssize_t *totalsize ){
 	if(f->type != VINE_FILE) return 0;
 
 	struct stat info;
-	unsigned char digest[MD5_DIGEST_LENGTH];
 	int64_t size;
 	int64_t number_of_files;
 
@@ -282,8 +281,8 @@ char *vine_meta_name(const struct vine_file *f, ssize_t *totalsize ){
 
 	char *meta = string_format("%s-%ld-%s", f->source, size, mtime);
 
-	md5_buffer(meta,strlen(meta),digest);
-	char *metahash = strdup(md5_to_string(digest));
+	char *metahash = md5_of_string(meta);
+	
 	char *name = string_format("file-meta-%s", metahash);
 
 	free(metahash);

--- a/taskvine/src/manager/vine_cached_name.c
+++ b/taskvine/src/manager/vine_cached_name.c
@@ -10,7 +10,6 @@ See the file COPYING for details.
 #include "vine_checksum.h"
 
 #include "stringtools.h"
-#include "path_disk_size_info.h"
 #include "md5.h"
 #include "debug.h"
 #include "xxmalloc.h"
@@ -271,18 +270,11 @@ char *vine_meta_name(const struct vine_file *f, ssize_t *totalsize ){
 	if(f->type != VINE_FILE) return 0;
 
 	struct stat info;
-	int64_t size;
-	int64_t number_of_files;
 
 	if(stat(f->source, &info)) return 0;
 	char *mtime = ctime(&info.st_mtime);
-
-	if(path_disk_size_info_get(f->source, &size, &number_of_files)) return 0;
-
-	char *meta = string_format("%s-%"PRIu64"-%s", f->source, size, mtime);
-
+	char *meta = string_format("%s-%ld-%s", f->source, info.st_size, mtime);
 	char *metahash = md5_of_string(meta);
-	
 	char *name = string_format("file-meta-%s", metahash);
 
 	free(metahash);

--- a/taskvine/src/manager/vine_cached_name.h
+++ b/taskvine/src/manager/vine_cached_name.h
@@ -11,6 +11,7 @@ See the file COPYING for details.
 #include <sys/types.h>
 
 char *vine_cached_name( const struct vine_file *f, ssize_t *totalsize );
+char *vine_meta_name( const struct vine_file *f, ssize_t *totalsize );
 char *vine_random_name( const struct vine_file *f, ssize_t *totalsize );
 
 #endif

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -81,7 +81,15 @@ struct vine_file *vine_file_create( const char *source, const char *cached_name,
 			f->cached_name = vine_cached_name(f,&totalsize);
 		}
 		else{
-			f->cached_name = vine_random_name(f,&totalsize);
+			if(f->type == VINE_FILE){
+				f->cached_name = vine_meta_name(f,&totalsize);
+				/* if this is a pending file give it a random name */
+				if(!f->cached_name){
+					f->cached_name = vine_random_name(f,&totalsize);
+				}
+			}else{
+				f->cached_name = vine_random_name(f,&totalsize);
+			}
 		}
 		if(size==0) {
 			f->size = totalsize;

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5091,7 +5091,6 @@ struct vine_file *vine_manager_declare_file(struct vine_manager *m, struct vine_
 	if(!f) {
 		return NULL;
 	}
-
 	assert(f->cached_name);
 	struct vine_file *previous = vine_manager_lookup_file(m, f->cached_name);
 


### PR DESCRIPTION
This is for #3317. VINE_FILEs are given cache names based on their meta data when they are declared with a flag that is not CACHE_ALWAYS. Previously, they were just given a random cache name.