### PR TITLE
vine, wq: fix double free where tasks were freed before the manager

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -111,15 +111,16 @@ class Task(object):
             pass
 
     def _free(self):
+        if not self._task:
+            return
         if self._manager_will_free:
             return
         if self._manager and self._manager._finalizer.alive and self.id in self._manager._task_table:
             # interpreter is shutting down. Don't delete task here so that manager
             # does not get memory errors
             return
-        if self._task:
-            cvine.vine_task_delete(self._task)
-            self._task = None
+        cvine.vine_task_delete(self._task)
+        self._task = None
 
     @staticmethod
     def _determine_mount_flags(watch=False, failure_only=False, success_only=False, strict_input=False):

--- a/work_queue/src/bindings/python3/ndcctools/work_queue.py
+++ b/work_queue/src/bindings/python3/ndcctools/work_queue.py
@@ -104,13 +104,14 @@ class Task(object):
         self._finalizer = weakref.finalize(self, self._free)
 
     def _free(self):
+        if not self._task:
+            return
         if self._manager and self._manager._finalizer.alive and self.id in self._manager._task_table:
             # interpreter is shutting down. Don't delete task here so that manager
             # does not get memory errors
             return
-        if self._task:
-            work_queue_task_delete(self._task)
-            self._task = None
+        work_queue_task_delete(self._task)
+        self._task = None
 
     @staticmethod
     def _determine_file_flags(flags, cache, failure_only):

--- a/work_queue/src/bindings/python3/ndcctools/work_queue.py
+++ b/work_queue/src/bindings/python3/ndcctools/work_queue.py
@@ -95,16 +95,22 @@ class Task(object):
     def __init__(self, command):
         self._task = None
 
+        self._manager = None  # set on submission
+
         self._task = work_queue_task_create(command)
         if not self._task:
             raise Exception("Unable to create internal Task structure")
 
-        def free():
-            if self._task:
-                work_queue_task_delete(self._task)
-                self._task = None
+        self._finalizer = weakref.finalize(self, self._free)
 
-        self._finalizer = weakref.finalize(self, free)
+    def _free(self):
+        if self._manager and self._manager._finalizer.alive and self.id in self._manager._task_table:
+            # interpreter is shutting down. Don't delete task here so that manager
+            # does not get memory errors
+            return
+        if self._task:
+            work_queue_task_delete(self._task)
+            self._task = None
 
     @staticmethod
     def _determine_file_flags(flags, cache, failure_only):
@@ -973,11 +979,12 @@ class PythonTask(Task):
         super(PythonTask, self).__init__(self._command)
         self._specify_IO_files()
 
-        def free():
-            if self._tmpdir and os.path.exists(self._tmpdir):
-                shutil.rmtree(self._tmpdir)
-        self._finalizer = weakref.finalize(self, free)
+        self._finalizer = weakref.finalize(self, self._free)
 
+    def _free(self):
+        if self._tmpdir and os.path.exists(self._tmpdir):
+            shutil.rmtree(self._tmpdir)
+        super()._free()
 
     ##
     # returns the result of a python task as a python variable
@@ -1157,15 +1164,16 @@ class WorkQueue(object):
         except Exception as e:
             raise Exception("Unable to create internal Work Queue structure: {}".format(e))
         finally:
-            def free(self):
-                if self._work_queue:
-                    if self._shutdown:
-                        self.shutdown_workers(0)
-                    self._update_status_display(force=True)
-                    work_queue_delete(self._work_queue)
-                    self._work_queue = None
-            self._finalizer = weakref.finalize(self, free)
+            self._finalizer = weakref.finalize(self, self._free)
         self._update_status_display()
+
+    def _free(self):
+        if self._work_queue:
+            if self._shutdown:
+                self.shutdown_workers(0)
+            self._update_status_display(force=True)
+            work_queue_delete(self._work_queue)
+            self._work_queue = None
 
     def __enter__(self):
         return self
@@ -1857,6 +1865,7 @@ class WorkQueue(object):
             task.specify_buffer(json.dumps(task._event), "infile")
         taskid = work_queue_submit(self._work_queue, task._task)
         self._task_table[taskid] = task
+        task._manager = self
         return taskid
 
     ##


### PR DESCRIPTION
Quirk of python where finalizers are called in the order they were defined on exit, regardless of the reference count. If there were active tasks, this meant that the finalizer of a task would free it, and then the manager would try to do the same from C.

Now tasks check if the manager finalizer is still alive, and whether the manager knows about the task.