### PR TITLE
Vine: Update blast software url

### DIFF
--- a/taskvine/src/examples/vine_example_blast.c
+++ b/taskvine/src/examples/vine_example_blast.c
@@ -18,7 +18,7 @@ with all the same tasks on the worker.
 #include <errno.h>
 #include <unistd.h>
 
-#define BLAST_URL "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-2.13.0+-x64-linux.tar.gz"
+#define BLAST_URL "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-2.14.0+-x64-linux.tar.gz"
 
 #define LANDMARK_URL "https://ftp.ncbi.nlm.nih.gov/blast/db/landmark.tar.gz"
 
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
 	printf("Declaring tasks...");
 	char* query_string;
 	for(i=0;i<TASK_COUNT;i++) {
-		struct vine_task *t = vine_task_create("blastdir/ncbi-blast-2.13.0+/bin/blastp -db landmark -query query.file");
+		struct vine_task *t = vine_task_create("blastdir/ncbi-blast-2.14.0+/bin/blastp -db landmark -query query.file");
 
 		query_string = make_query();
 

--- a/taskvine/src/examples/vine_example_blast.py
+++ b/taskvine/src/examples/vine_example_blast.py
@@ -102,7 +102,7 @@ with all the same tasks on the worker.""",
 
     print("Declaring files...")
     blast_url = m.declare_url(
-        "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-2.13.0+-x64-linux.tar.gz",
+        "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-2.14.0+-x64-linux.tar.gz",
         cache="always",  # with "always", workers keep this file until they are terminated
     )
     blast = m.declare_untar(blast_url, cache="always")
@@ -117,7 +117,7 @@ with all the same tasks on the worker.""",
     for i in range(args.task_count):
         query = m.declare_buffer(make_query_text(args.query_count))
         t = vine.Task(
-            command="blastdir/ncbi-blast-2.13.0+/bin/blastp -db landmark -query query.file",
+            command="blastdir/ncbi-blast-2.14.0+/bin/blastp -db landmark -query query.file",
             inputs={
                 query: {"remote_name": "query.file"},
                 blast: {"remote_name": "blastdir"},


### PR DESCRIPTION
A new blast version was released and the old link is now dead