### PR TITLE
vine dask: rework graph process not to destroy dask optimizations

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
@@ -108,7 +108,7 @@ class DaskVineDag:
         dependencies = set()
         if self.graph_keyp(sexpr):
             dependencies.add(sexpr)
-            self._depth_of[sexpr] = min(depth, self._depth_of)
+            self._depth_of[sexpr] = min(depth, self._depth_of[sexpr])
         elif not DaskVineDag.symbolp(sexpr):
             for sub in sexpr:
                 dependencies.update(self.find_dependencies(sub, depth + 1))

--- a/taskvine/src/examples/vine_example_dask_graph.py
+++ b/taskvine/src/examples/vine_example_dask_graph.py
@@ -67,7 +67,7 @@ is constructed by dask.""")
 
     # checkpoint at even levels when nodes have at least one children
     def checkpoint(dag, key):
-        if dag.depth_of(key) % 2 == 0 and dag.nchildren_of(key) > 0:
+        if dag.depth_of(key) % 2 == 0 and len(dag.get_children(key)) > 0:
             print(f"checkpoint for {key}")
             return True
         return False


### PR DESCRIPTION
Now a PythonTask can execute full sexprs from dask. The previous mode, flattening the graph, can still be used by passing low_memory_mode=True to `get`.