### PR TITLE
CCTools: add necessary package dependencies to development environment

### DIFF
--- a/doc/manuals/install/index.md
+++ b/doc/manuals/install/index.md
@@ -91,7 +91,7 @@ a new `cctools-dev` environment via Conda:
 
 ```sh
 unset PYTHONPATH
-conda create -y -n cctools-dev -c conda-forge --strict-channel-priority python=3 gcc_linux-64 gxx_linux-64 gdb m4 perl swig make zlib libopenssl-static openssl conda-pack
+conda create -y -n cctools-dev -c conda-forge --strict-channel-priority python=3 gcc_linux-64 gxx_linux-64 gdb m4 perl swig make zlib libopenssl-static openssl conda-pack packaging cloudpickle
 conda activate cctools-dev
 ```
 


### PR DESCRIPTION
`packaging` is for poncho, `cloudpickle` is for DaskVine.