### PR TITLE
Pin down a version of blast executable

### DIFF
--- a/taskvine/src/examples/vine_example_blast.c
+++ b/taskvine/src/examples/vine_example_blast.c
@@ -18,7 +18,7 @@ with all the same tasks on the worker.
 #include <errno.h>
 #include <unistd.h>
 
-#define BLAST_URL "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-2.13.0+-x64-linux.tar.gz"
+#define BLAST_URL "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.13.0/ncbi-blast-2.13.0+-x64-linux.tar.gz"
 
 #define LANDMARK_URL "https://ftp.ncbi.nlm.nih.gov/blast/db/landmark.tar.gz"
 

--- a/taskvine/src/examples/vine_example_blast.py
+++ b/taskvine/src/examples/vine_example_blast.py
@@ -102,7 +102,7 @@ with all the same tasks on the worker.""",
 
     print("Declaring files...")
     blast_url = m.declare_url(
-        "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-2.13.0+-x64-linux.tar.gz",
+        "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.13.0/ncbi-blast-2.13.0+-x64-linux.tar.gz",
         cache="always",  # with "always", workers keep this file until they are terminated
     )
     blast = m.declare_untar(blast_url, cache="always")


### PR DESCRIPTION
The latest URL is now
`https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-2.14.0+-x64-linux.tar.gz`, which breaks `vine_example_blast.{c,py}`. Pin down specific version of the executable solves the problem.