### PR TITLE
Vine: Fix background catalog update

### DIFF
--- a/dttools/src/catalog_query.c
+++ b/dttools/src/catalog_query.c
@@ -362,12 +362,11 @@ and that the main process will not have to handle an asynchronous
 static int catalog_update_tcp_background( const char *host, const char *address, int port, const char *text )
 {
 	pid_t pid = fork();
+	pid_t grandpid;
 	if(pid==0) {
-		pid_t grandpid = fork();
+		grandpid = fork();
 		if(grandpid==0) {
-			/* release all cloned fds so that we don't interfere with the parent. */
-			fd_nonstd_close();
-			/* then do the update normally. */
+			/* grandchild sends catalog update. */
 			catalog_update_tcp(host,address,port,text);
 			/* grandchild process exits after sending update. */
 			_exit(0);
@@ -376,7 +375,8 @@ static int catalog_update_tcp_background( const char *host, const char *address,
 			_exit(0);
 		}
 	} else if(pid>0) {
-		debug(D_DEBUG, "sending update via tcp to %s(%s):%d (background pid %d)", host, address, port, (int)pid);
+		debug(D_DEBUG, "sending update via tcp to %s(%s):%d (background pid %d)", host, address, port, (int)grandpid);
+		/* wait for child, not for grandchild. */
 		pid_t result = waitpid(pid,0,0);
 		if(result!=pid) {
 			debug(D_DEBUG,"unable to wait for child process %d! (%s)",pid,strerror(errno));


### PR DESCRIPTION
Problem: Running `vine_example_blast` will show two lines of errors: `Couldn't write to debug file: Bad file descriptor`. This is due to the grandchild process in `catalog_query.c` writing to the closed debug file.

Temporary solution: Let grandchild process writes to the same file descriptor. This might create race conditions to the debug file however.. 