### PR TITLE
Vine: option for disabling peer transfers in examples

### DIFF
--- a/taskvine/src/examples/vine_example_blast.py
+++ b/taskvine/src/examples/vine_example_blast.py
@@ -96,8 +96,10 @@ with all the same tasks on the worker.""",
     m = vine.Manager(port=args.port)
     m.set_name(args.name)
 
-    if not args.disable_peer_transfers:
-        m.enable_peer_transfers()
+    if args.disable_peer_transfers:
+        m.disable_peer_transfers()
+    
+    if args.max_concurrent_transfers:
         m.tune("worker-source-max-transfers", args.max_concurrent_transfers)
 
     print("Declaring files...")

--- a/taskvine/src/examples/vine_example_dask_awk_array.py
+++ b/taskvine/src/examples/vine_example_dask_awk_array.py
@@ -87,8 +87,8 @@ if __name__ == "__main__":
     m.set_name(args.name)
     print(f"Listening for workers at port: {m.port}")
 
-    if not args.disable_peer_transfers:
-        m.enable_peer_transfers()
+    if args.disable_peer_transfers:
+        m.disable_peer_transfers()
 
     f = vine.Factory(manager=m)
     f.cores = 4

--- a/taskvine/src/examples/vine_example_dask_delayed.py
+++ b/taskvine/src/examples/vine_example_dask_delayed.py
@@ -70,8 +70,8 @@ if __name__ == "__main__":
     m.set_name(args.name)
     print(f"Listening for workers at port: {m.port}")
 
-    if not args.disable_peer_transfers:
-        m.enable_peer_transfers()
+    if args.disable_peer_transfers:
+        m.disable_peer_transfers()
 
     f = vine.Factory(manager=m)
     f.cores = 4

--- a/taskvine/src/examples/vine_example_dask_graph.py
+++ b/taskvine/src/examples/vine_example_dask_graph.py
@@ -62,8 +62,8 @@ is constructed by dask.""")
     m.set_name(args.name)
     print(f"Listening for workers at port: {m.port}")
 
-    if not args.disable_peer_transfers:
-        m.enable_peer_transfers()
+    if args.disable_peer_transfers:
+        m.disable_peer_transfers()
 
     # checkpoint at even levels when nodes have at least one children
     def checkpoint(dag, key):

--- a/taskvine/src/examples/vine_example_gutenberg.py
+++ b/taskvine/src/examples/vine_example_gutenberg.py
@@ -8,6 +8,7 @@
 # a simple text comparison of each pair of files.
 
 import ndcctools.taskvine as vine
+import argparse
 import sys
 
 urls_sources = [
@@ -50,8 +51,25 @@ exit 0
 """
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="vine_example_gutenberg.py",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "--disable-peer-transfers",
+        action="store_true",
+        help="disable transfers among workers.",
+        default=False,
+    )
+
     m = vine.Manager()
     print("listening on port", m.port)
+
+    args = parser.parse_args()
+
+    if args.disable_peer_transfers:
+        m.disable_peer_transfers()
 
     # declare all urls in the manager:
     urls = map(lambda u: m.declare_url(u, cache=True), urls_sources)

--- a/taskvine/src/examples/vine_example_pythontask.py
+++ b/taskvine/src/examples/vine_example_pythontask.py
@@ -38,14 +38,31 @@
 
 
 import ndcctools.taskvine as vine
+import argparse
 
 def divide(dividend, divisor):
     import math
     return dividend/math.sqrt(divisor)
 
 def main():
+    parser = argparse.ArgumentParser(
+        prog="vine_example_blast.py",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "--disable-peer-transfers",
+        action="store_true",
+        help="disable transfers among workers.",
+        default=False,
+    )
+
     q = vine.Manager(9123)
 
+    args = parser.parse_args()
+
+    if args.disable_peer_transfers:
+        q.disable_peer_transfers()
 
     env_file = None
     # if python environment is missing, create an environment as explained


### PR DESCRIPTION
Now that peer transfers are enabled by default, add/fix the argument option to disable them if needed. 