### PR TITLE
remove env_replace utility from libdttools build

### DIFF
--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -43,7 +43,6 @@ SOURCES = \
 	dpopen.c \
 	elfheader.c \
 	envtools.c \
-	env_replace.c \
 	fast_popen.c \
 	fd.c \
 	file_cache.c \


### PR DESCRIPTION
If a user does not provide a main function in their taskvine or work queue program, the linker may pick this up instead causing some confusing output. 