### PR TITLE
dask: fix infinite recursion

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
@@ -154,7 +154,9 @@ class DaskVineDag:
 
             sexpr = self._working_graph[p]
             if self.graph_keyp(sexpr):
-                rs.extend(self.set_result(key, self.get_result(sexpr)))  # case e.g, "x": "y", and we just set the value of "y"
+                rs.extend(
+                    self.set_result(p, self.get_result(sexpr))
+                )  # case e.g, "x": "y", and we just set the value of "y"
             elif self.symbolp(sexpr):
                 rs.extend(self.set_result(p, sexpr))
             else:


### PR DESCRIPTION
Fix for #3393. When recursing on "x": "y" and setting the value of x, we would recurse on x rather than y. This probably came about because a similar function (get_ready) correctly uses x for its cases, and set_result was tailored from a copy-paste of get_ready.