### PR TITLE
Simplify list_rotate

### DIFF
--- a/dttools/src/list.c
+++ b/dttools/src/list.c
@@ -427,40 +427,29 @@ void *list_pop_tail(struct list *l) {
 	return item;
 }
 
-void *list_rotate(struct list *l) {
-	struct list_item *head = NULL;
-	struct list_item *heir = NULL;
-	struct list_item *tail = NULL;
-		
-	struct list_cursor *cur = list_cursor_create(l);
-	
-	// get the head of the list
-	list_seek(cur, 0);
-	head = cur->target; 
+void *list_rotate(struct list *l)
+{
+	// If list is empty, return nothing
+	if(!l->head) return 0;
 
-	// exit if the list is empty, or only one item.
-	if(!head || !list_next(cur)) goto DONE;
+	// If list has a single node, return that value.
+	if(l->head==l->tail) return l->head->data;
 
-	// the next item in the list is the new head 
-	heir = cur->target;	
-	
-	// get the last item
-	list_seek(cur, -1);
-	tail = cur->target;
-	
-	// move head to tail
-	head->prev = tail;
-	head->next = NULL;
-	heir->prev = NULL;
-	tail->next = head;
+	struct list_item *node = l->head;
 
-	// set new head/tail
-	cur->list->head = heir;
-	cur->list->tail = head;
+	// Change head to next item.
+	l->head = node->next;
+	l->head->prev = 0;
 
-	DONE:
-	list_cursor_destroy(cur);
-	return head ? head->data : NULL;
+	// Change node pointers
+	node->prev = l->tail;
+	node->next = 0;
+
+	// Change tail to point to node
+	l->tail->next = node;
+	l->tail = node;
+
+	return node->data;
 }
 
 void *list_peek_head(struct list *l) {


### PR DESCRIPTION
Simplify list_rotate to avoid use of malloc in the inner loop of wq/tv scheduling.