### PR TITLE
Poncho: Fix initial value so a variable is json-serializable

### DIFF
--- a/poncho/src/poncho/package_create.py
+++ b/poncho/src/poncho/package_create.py
@@ -348,7 +348,7 @@ def create_conda_spec(poncho_spec, out_dir, local_pip_pkgs):
 
     conda_spec = {}
     conda_spec['channels'] = []
-    conda_spec['dependencies'] = set()
+    conda_spec['dependencies'] = {}
     conda_spec['name'] = 'base'
 
     # packages in the spec that are installed in the current environment with


### PR DESCRIPTION
`set()` is not serializable, so `json.dumps` will fail in certain cases that `conda_spec['dependencies]`'s value is not changed. This is only a bandage fix however, and requires more thinking.