### PR TITLE
adds __del__ dummy method to WorkQueue

### DIFF
--- a/work_queue/src/bindings/python3/ndcctools/work_queue.py
+++ b/work_queue/src/bindings/python3/ndcctools/work_queue.py
@@ -1179,6 +1179,10 @@ class WorkQueue(object):
             work_queue_delete(self._work_queue)
             self._work_queue = None
 
+    def __del__(self):
+        # method needed because coffea executor pre-2023 calls __del__ explicitly.
+        pass
+
     def __enter__(self):
         return self
 


### PR DESCRIPTION
The issue is that the old wq executor in coffea (currently used in topcoffea) explicitely calls the __del__ method. Since coffea is moving away from this type of executors, it is easier to fix this from the wq side.