### PR TITLE
Vine:  Fix worker crash when using serverless.

### DIFF
--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -52,8 +52,9 @@ Create temporary directories inside as well.
 
 extern char * workspace;
 
+/* XXX These structures should be passed as params rather than externed. */
 extern struct list *library_list;
-extern struct hash_table *library_ids;
+extern struct hash_table *library_task_ids;
 
 static int create_sandbox_dir( struct vine_process *p )
 {
@@ -428,9 +429,9 @@ int vine_process_measure_disk(struct vine_process *p, int max_time_on_measuremen
 
 char * vine_process_get_library_name( struct vine_process *p) {
 	char *library_name;
-	int library_id;
-	HASH_TABLE_ITERATE(library_ids,library_name,library_id) {
-		if (library_id == p->task->task_id) {
+	int *library_task_id;
+	HASH_TABLE_ITERATE(library_task_ids,library_name,library_task_id) {
+		if (*library_task_id == p->task->task_id) {
 			return library_name;
 		}
 	}

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -199,8 +199,13 @@ static struct itable *procs_complete = NULL;
 // Table of current transfers and their id
 static struct hash_table *current_transfers = NULL;
 
-//User specified features this worker provides.
+/*
+Table of user-specified features.
+The key represents the name of the feature.
+The corresponding value is just a pointer to feature_dummy and can be ignored.
+*/
 static struct hash_table *features = NULL;
+static const char *feature_dummy = "dummy";
 
 static int results_to_be_sent_msg = 0;
 
@@ -532,7 +537,7 @@ static int start_process( struct vine_process *p, struct link *manager )
 		HASH_TABLE_ITERATE(library_task_ids,library_name,library_task_id) {
 			if (*library_task_id == p->task->task_id){
 				list_push_tail(coprocess_list, p->coprocess);
-				hash_table_insert(features, library_name, (void **) 1);
+				hash_table_insert(features, library_name, feature_dummy);
 				send_features(manager);
 				send_message(manager, "info library-update %d %d\n", p->task->task_id, VINE_LIBRARY_STARTED);
 				send_resource_update(manager);
@@ -2132,7 +2137,7 @@ int main(int argc, char *argv[])
 			show_help(argv[0]);
 			return 0;
 		case LONG_OPT_FEATURE:
-			hash_table_insert(features, optarg, (void **) 1);
+			hash_table_insert(features, optarg, feature_dummy);
 			break;
 		case LONG_OPT_PARENT_DEATH:
 			initial_ppid = getppid();
@@ -2179,7 +2184,7 @@ int main(int argc, char *argv[])
 
 	char *gpu_name = gpu_name_get();
 	if(gpu_name) {
-		hash_table_insert(features, gpu_name, (void **) 1);
+		hash_table_insert(features, gpu_name, feature_dummy);
 		free(gpu_name);
 	}
 

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1048,7 +1048,8 @@ static int handle_manager(struct link *manager)
 	char transfer_id[VINE_LINE_MAX];
 	int64_t length;
 	int64_t task_id = 0;
-	int mode, r, n;
+	int mode, n;
+	int r = 0;
 
 	if(recv_message(manager, line, sizeof(line), idle_stoptime )) {
 		if(sscanf(line,"task %" SCNd64, &task_id)==1) {

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1101,18 +1101,7 @@ static int handle_manager(struct link *manager)
 			int * library_task_id = hash_table_lookup(library_task_ids, library_name);
 			if(library_task_id) {
 				debug(D_VINE,"rx: killing library %s %d", library_name, *library_task_id);
-				struct vine_process *p = itable_lookup(procs_table,*library_task_id);
-				if(p) {
-					kill(p->pid,SIGKILL);
-					/* Note that the process will still be waited for. */
-				}
-				list_remove(library_list, library_name);
-				hash_table_remove(features, library_name);
-				hash_table_remove(library_task_ids, library_name);
-				list_remove(coprocess_list,p->coprocess);
-				/* XXX I think do_kill duplicates the above work. */
 				r = do_kill(*library_task_id);
-				free(library_task_id);
 			}			
 		} else if(!strncmp(line, "release", 8)) {
 			r = do_release();


### PR DESCRIPTION
Addresses #3434.  The are some other infelicities in the serverless code, but keeping the fix focused for now.