### PR TITLE
Fix imports in doc example

### DIFF
--- a/doc/manuals/taskvine/examples/functional.py
+++ b/doc/manuals/taskvine/examples/functional.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Example of how to use taskvine high order functions
-import taskvine as vine
+import ndcctools.taskvine as vine
 
 def main():
     # Set up queue

--- a/doc/manuals/taskvine/examples/functions.py
+++ b/doc/manuals/taskvine/examples/functions.py
@@ -1,6 +1,6 @@
 # Quick start example of taskvine with python functions
 
-import taskvine as vine
+import ndcctools.taskvine as vine
 
 # Define a function to invoke remotely.
 def my_sum(x, y):

--- a/doc/manuals/taskvine/examples/quickstart.py
+++ b/doc/manuals/taskvine/examples/quickstart.py
@@ -1,10 +1,10 @@
 # Quick start example of taskvine with python functions
 
 # Import the taskvine library.
-import taskvine as vine
+import ndcctools.taskvine as vine
 
-# Create a new manager, listening on port 9123.
-m = vine.Manager(9123)
+# Create a new manager
+m = vine.Manager([9123,9129])
 print(f"Listening on port {m.port}")
 
 # Declare a common input file to be shared by multiple tasks.

--- a/doc/manuals/taskvine/examples/vine_example_apptainer_env.py
+++ b/doc/manuals/taskvine/examples/vine_example_apptainer_env.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-import taskvine as vine
+import ndcctools.taskvine as vine
 
 import subprocess
 import argparse


### PR DESCRIPTION
examples used deprecated import statements "import taskvine as vine" instead of "import ndcctools.taskvine as vine"