### PR TITLE
Vine: fix #3445

### DIFF
--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -323,9 +323,9 @@ static int do_worker_transfer( struct vine_cache *c, const char *source_url, con
 		}
 	}
 	
-	/* XXX A fixed timeout of 300 certainly can't be right! */
+	/* XXX A fixed timeout of 900 certainly can't be right! */
 	
-	if(!vine_transfer_get_any(worker_link, c, path, time(0) + 300))
+	if(!vine_transfer_get_any(worker_link, c, path, time(0) + 900))
 	{
 		*error_message = string_format("Could not transfer file %s from worker %s:%d", path, addr, port_num);
 		link_close(worker_link);

--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -323,9 +323,9 @@ static int do_worker_transfer( struct vine_cache *c, const char *source_url, con
 		}
 	}
 	
-	/* XXX A fixed timeout of 120 certainly can't be right! */
+	/* XXX A fixed timeout of 300 certainly can't be right! */
 	
-	if(!vine_transfer_get_any(worker_link, c, path, time(0) + 120))
+	if(!vine_transfer_get_any(worker_link, c, path, time(0) + 300))
 	{
 		*error_message = string_format("Could not transfer file %s from worker %s:%d", path, addr, port_num);
 		link_close(worker_link);

--- a/taskvine/src/worker/vine_transfer.c
+++ b/taskvine/src/worker/vine_transfer.c
@@ -219,31 +219,17 @@ static int vine_transfer_get_file_internal( struct link *lnk, const char *filena
 
 	int64_t actual = link_stream_to_fd(lnk, fd, length, stoptime);
 
-    int transferred_file_invalid = 0;
-
     /* sync file */
     if (fsync(fd)) {
         debug(D_VINE, "Failed to fsync file - %s (%s)\n", filename, strerror(errno));
-        transferred_file_invalid = 1;
     }
 
     if (close(fd)) {
         debug(D_VINE, "Failed to close file - %s (%s)\n", filename, strerror(errno));
-        transferred_file_invalid = 1;
-    }
-
-    if (transferred_file_invalid) {
-        if (remove(filename)) {
-            debug(D_VINE, "Failed to remove file - %s (%s)\n", filename, strerror(errno));
-        }
-        return 0;
     }
 
     if(actual!=length) {
 		debug(D_VINE, "Failed to put file - %s (%s)\n", filename, strerror(errno));
-        if (remove(filename)) {
-            debug(D_VINE, "Failed to remove file - %s (%s)\n", filename, strerror(errno));
-        }
 		return 0;
 	}
 
@@ -352,7 +338,16 @@ int vine_transfer_get_dir( struct link *lnk, struct vine_cache *cache, const cha
 	int64_t totalsize = 0;
 	char * cached_path = vine_cache_full_path(cache,dirname);
 	int r = vine_transfer_get_dir_internal(lnk,cached_path,&totalsize,stoptime);
-	if(r) vine_cache_addfile(cache,totalsize,0755,dirname);
+	if(r) {
+        vine_cache_addfile(cache,totalsize,0755,dirname);
+    }
+    else {
+        // Remove entire directory if any file in it isn't properly set up.
+        if (remove(cached_path)) {
+            debug(D_VINE, "Can't remove invalid directory %s: (%s)", cached_path, strerror(errno));
+        }
+    }
+
 	free(cached_path);
 	return r;
 }
@@ -361,7 +356,15 @@ int vine_transfer_get_file( struct link *lnk, struct vine_cache *cache, const ch
 {
 	char * cached_path = vine_cache_full_path(cache,filename);
 	int r = vine_transfer_get_file_internal(lnk,cached_path,length,mode,stoptime);
-	if(r) vine_cache_addfile(cache,length,mode,filename);
+	if(r) {
+        vine_cache_addfile(cache,length,mode,filename);
+    }
+    else {
+        // Remove the file if there's any problem with getting it.
+        if (remove(cached_path)) {
+            debug(D_VINE, "Can't remove invalid file %s: (%s)", cached_path, strerror(errno));
+        }
+    }
 	free(cached_path);
 	return r;
 }
@@ -373,7 +376,16 @@ int vine_transfer_get_any( struct link *lnk, struct vine_cache *cache, const cha
 	send_message(lnk,"get %s\n",filename);
 	char * cache_root = vine_cache_full_path(cache,"");
 	int r = vine_transfer_get_any_internal(lnk,cache_root,&totalsize,stoptime);
-	if(r) vine_cache_addfile(cache,totalsize,0755,filename);
+	if(r) {
+        vine_cache_addfile(cache,totalsize,0755,filename);
+    }
+    else {
+        // Remove the file or directory if there's any problem with getting it.
+        char* cached_path = string_format("%s/%s", cache_root, filename);
+        if (remove(cached_path)) {
+            debug(D_VINE, "Can't remove invalid any %s: (%s)", cached_path, strerror(errno));
+        }
+    }
 	free(cache_root);
 	return r;
 }


### PR DESCRIPTION
This PR fix #3445 by fsyncing and removing invalid files appropriately.
Also transfer timeout is bumped up to 300 seconds, which should serve fine for 5 GBs per transfer at ND.