### PR TITLE
Vine: Properly check if minitask has its input files staged in.

### DIFF
--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -234,7 +234,12 @@ int vine_process_execute_and_wait( struct vine_task *task, struct vine_cache *ca
 {
 	struct vine_process *p = vine_process_create(task);
 
-	vine_sandbox_stagein(p,cache,manager);
+	if (!vine_sandbox_stagein(p,cache,manager)) {
+		debug(D_VINE, "Can't stage input files for task %d.", p->task->task_id);
+		p->task = 0;
+		vine_process_delete(p);
+		return 0;
+	}
 	
 	pid_t pid = vine_process_execute(p);
 	if(pid>0) {

--- a/taskvine/src/worker/vine_transfer.c
+++ b/taskvine/src/worker/vine_transfer.c
@@ -226,20 +226,10 @@ static int vine_transfer_get_file_internal( struct link *lnk, const char *filena
 		return 0;
 	}
 	
-    int fsync_invalid = 0;
-    if (fsync(fd)<0) {
-        debug(D_VINE, "Failed to fsync file - %s (%s)\n", filename, strerror(errno));
-        fsync_invalid = 1;
-    }
-
 	if(close(fd)<0) {
 		debug(D_VINE, "Failed to close file - %s (%s)\n", filename, strerror(errno));
 		return 0;
 	}
-
-    if (fsync_invalid) {
-        return 0;
-    }
 
 	chmod(filename,mode);
 

--- a/taskvine/src/worker/vine_transfer.c
+++ b/taskvine/src/worker/vine_transfer.c
@@ -226,6 +226,11 @@ static int vine_transfer_get_file_internal( struct link *lnk, const char *filena
 		return 0;
 	}
 	
+    if (fsync(fd)<0) {
+        debug(D_VINE, "Failed to fsync file - %s (%s)\n", filename, strerror(errno));
+        return 0;
+    }
+
 	if(close(fd)<0) {
 		debug(D_VINE, "Failed to close file - %s (%s)\n", filename, strerror(errno));
 		return 0;

--- a/taskvine/src/worker/vine_transfer.c
+++ b/taskvine/src/worker/vine_transfer.c
@@ -226,15 +226,20 @@ static int vine_transfer_get_file_internal( struct link *lnk, const char *filena
 		return 0;
 	}
 	
+    int fsync_invalid = 0;
     if (fsync(fd)<0) {
         debug(D_VINE, "Failed to fsync file - %s (%s)\n", filename, strerror(errno));
-        return 0;
+        fsync_invalid = 1;
     }
 
 	if(close(fd)<0) {
 		debug(D_VINE, "Failed to close file - %s (%s)\n", filename, strerror(errno));
 		return 0;
 	}
+
+    if (fsync_invalid) {
+        return 0;
+    }
 
 	chmod(filename,mode);
 


### PR DESCRIPTION
Mini tasks or any tasks that are run with `execute_and_wait` have the problem of executing regardless of the status of staged-in files. This PR fixes this and walks back on the `fsync` as it is not relevant. The previous situation where `fsync` apparently fixes the issue in #3348 is random and depends entirely on whether a worker transferring input files to a mini task on another worker fails or not, (e.g., sometimes workers are not evicted and sometimes they are.)

This PR is RTM.