### PR TITLE
Vine: Improve Process Abstraction

### DIFF
--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -214,6 +214,8 @@ static char * load_input_file(struct vine_task *t)
 		fatal("error reading file: %s", strerror(errno));
 	}
 
+	fclose(fp);
+	
 	return buf;
 }
 

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -326,10 +326,9 @@ pid_t vine_process_execute(struct vine_process *p )
 			
 			/* Now read back the initialization message so we know it is ready. */
 			if (!vine_process_wait_for_library_startup(p,stoptime)) {
-				fatal("Unable to setup coprocess");
-				/* XXX need better plan for library that fails to start. */
+				/* If it did not, then send kill signal and reap library in main loop. */
+				vine_process_kill(p);
 			}
-
 		} else {
 			/* For any other task type, drop the fds unused by the parent. */
 			close(input_fd);

--- a/taskvine/src/worker/vine_process.h
+++ b/taskvine/src/worker/vine_process.h
@@ -55,6 +55,10 @@ struct vine_process {
 	struct link *library_read_link;
 	struct link *library_write_link;
 
+	/* If this is a library process, the number of functions it is currently running. */
+	int functions_running;
+	int max_functions_running;
+	
 	/* expected disk usage by the process. If no cache is used, it is the same as in task. */
 	int64_t disk;
 
@@ -68,7 +72,6 @@ struct vine_process {
 
 struct vine_process * vine_process_create( struct vine_task *task, vine_process_type_t type );
 pid_t vine_process_execute( struct vine_process *p );
-void  vine_process_set_exit_status( struct vine_process *p, int status );
 int   vine_process_is_complete( struct vine_process *p );
 int   vine_process_wait( struct vine_process *p );
 void  vine_process_kill( struct vine_process *p );

--- a/taskvine/src/worker/vine_process.h
+++ b/taskvine/src/worker/vine_process.h
@@ -69,7 +69,10 @@ struct vine_process {
 struct vine_process * vine_process_create( struct vine_task *task, vine_process_type_t type );
 pid_t vine_process_execute( struct vine_process *p );
 void  vine_process_set_exit_status( struct vine_process *p, int status );
+int   vine_process_is_complete( struct vine_process *p );
+int   vine_process_wait( struct vine_process *p );
 void  vine_process_kill( struct vine_process *p );
+int   vine_process_kill_and_wait( struct vine_process *p );
 void  vine_process_delete( struct vine_process *p );
 
 int   vine_process_execute_and_wait( struct vine_process *p );

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1136,17 +1136,18 @@ static int task_resources_fit_eventually(struct vine_task *t)
 
 /*
 Find a suitable library process that provides the given library name and is ready to be invoked
-XXX need to check on coprocess status -- is it already running something ?
 */
 
-struct vine_process * find_process_by_library_name( const char *library_name )
+struct vine_process * find_library_for_function( const char *library_name )
 {
 	uint64_t task_id;
 	struct vine_process *p;
 
 	ITABLE_ITERATE(procs_running,task_id,p) {
 		if(!strcmp(p->task->provides_library,library_name)) {
-			return p;
+			if(p->functions_running<p->max_functions_running) {
+				return p;
+			}
 		}
 	}
 	return 0;
@@ -1161,7 +1162,7 @@ static int process_ready_to_run_now( struct vine_process *p, struct vine_cache *
 	if(!task_resources_fit_now(p->task)) return 0;
 
 	if(p->task->needs_library) {
-		p->library_process = find_process_by_library_name(p->task->needs_library);
+		p->library_process = find_library_for_function(p->task->needs_library);
 		if(!p->library_process) return 0;
 	}
 


### PR DESCRIPTION
- Move all fork/exec/wait/kill into the process abstraction and use cleanly.
- Keep track of number of functions assigned to each library.
- Fix dangling file descriptor in load_input_file