### PR TITLE
Vine: Add flake8 to lint Python code of TaskVine

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,6 +29,7 @@ jobs:
     strategy: 
       matrix:
         os-name: ['centos7', 'almalinux8', 'ubuntu20.04']
+    needs: lint
     steps:
       - name: checkout CCTools from branch head
         if: github.event_name != 'workflow_dispatch'
@@ -65,6 +66,7 @@ jobs:
     timeout-minutes: 30
     env:
       CCTOOLS_OUTPUT: ${{ format('cctools-{0}-x86_64-{1}.tar.gz', github.event.inputs.version, 'osx-11') }}
+    needs: lint
     steps:
       - name: checkout CCTools from branch head
         if: github.event_name != 'workflow_dispatch'
@@ -101,6 +103,7 @@ jobs:
     timeout-minutes: 30
     env:
       CCTOOLS_OUTPUT: ${{ format('cctools-{0}-x86_64-linux-conda.tar.gz', github.event.inputs.version) }}
+    needs: lint
     steps:
       - name: checkout CCTools from branch head
         if: github.event_name != 'workflow_dispatch'
@@ -132,3 +135,17 @@ jobs:
           commit: ${{ steps.vars.output.tag_sha }}
           tag: ${{ github.event.inputs.tag }}
 
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: checkout CCTools from branch head
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v3
+      - name: checkout CCTools from tag
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.tag }}
+      - name: lint code
+        run: ${GITHUB_WORKSPACE}/packaging/lint/lint.sh

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 cctools.test.log
 cctools.test.tmp
 cctools.test.fail
+cctools.lint.out
 configure.rerun
 config.mk
 *.pyc

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,10 @@ install: $(INSTALL_PACKAGES)
 test: $(CCTOOLS_PACKAGES)
 	./run_all_tests.sh
 
+lint: config.mk
+	@$(MAKE) -C taskvine lint
+
 rpm:
 	./packaging/rpm/rpm_creator.sh $(RPM_VERSION) $(RPM_RELEASE)
 
-.PHONY: $(CCTOOLS_PACKAGES) $(INSTALL_PACKAGES) $(CLEAN_PACKAGES) all clean install test rpm
+.PHONY: $(CCTOOLS_PACKAGES) $(INSTALL_PACKAGES) $(CLEAN_PACKAGES) all clean install test lint rpm

--- a/doc/manuals/install/index.md
+++ b/doc/manuals/install/index.md
@@ -58,7 +58,7 @@ a new `cctools-dev` environment via Conda:
 
 ```sh
 unset PYTHONPATH
-conda create -y -n cctools-dev -c conda-forge --strict-channel-priority python=3 gcc_linux-64 gxx_linux-64 gdb m4 perl swig make zlib libopenssl-static openssl conda-pack packaging cloudpickle
+conda create -y -n cctools-dev -c conda-forge --strict-channel-priority python=3 gcc_linux-64 gxx_linux-64 gdb m4 perl swig make zlib libopenssl-static openssl conda-pack packaging cloudpickle flake8
 conda activate cctools-dev
 ```
 

--- a/packaging/lint/README.md
+++ b/packaging/lint/README.md
@@ -1,0 +1,2 @@
+This lint script performs a source code lint only using necessary 
+dependencies from conda.

--- a/packaging/lint/lint.sh
+++ b/packaging/lint/lint.sh
@@ -1,0 +1,46 @@
+#! /bin/bash
+
+set -xe
+
+# Save the dir from which the script was called
+ORG_DIR=$(pwd)
+
+# Find cctools src directory
+CCTOOLS_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+
+# Ensure we end up in the directory we started regardless of how the script
+# ends.
+function finish {
+    cd ${ORG_DIR}
+}
+trap finish EXIT
+
+# Fix for local environment at ND: unset PYTHONPATH to ignore existing python installs.
+export PYTHONPATH=
+
+# Activate the Conda shell hooks without starting a new shell.
+CONDA_BASE=$(conda info --base)
+. $CONDA_BASE/etc/profile.d/conda.sh
+
+# Install only necessary dependencies for linting purpose:
+conda create -y -n cctools-lint -c conda-forge --strict-channel-priority make flake8
+conda activate cctools-lint
+
+# Leave out some items that are research prototypes.
+DISABLED_SYS=$(echo --without-system-{parrot,prune,umbrella,weaver})
+DISABLED_LIB=$(echo --with-{readline,fuse,perl}-path\ no)
+
+# Now build and configure in the normal way.
+./configure --strict ${DISABLED_SYS} ${DISABLED_LIB} "$@"
+[[ -f config.mk ]] && make clean
+echo === Contents of config.mk ===
+cat config.mk
+
+if ! make lint &> cctools.lint.out
+then
+    echo === Contents of cctools.lint.out ===
+    cat cctools.lint.out
+    exit 1
+else
+    exit 0
+fi

--- a/taskvine/Makefile
+++ b/taskvine/Makefile
@@ -24,4 +24,7 @@ $(TEST_TARGETS):
 	@$(MAKE) -C $(@:test-%=%) test
 test: $(TEST_TARGETS)
 
-.PHONY: $(PHONY_TARGETS) $(CLEAN_TARGETS) $(INSTALL_TARGETS) $(TEST_TARGETS) all clean install test
+lint:
+	@$(MAKE) -C src lint
+
+.PHONY: $(PHONY_TARGETS) $(CLEAN_TARGETS) $(INSTALL_TARGETS) $(TEST_TARGETS) all clean install test lint

--- a/taskvine/src/Makefile
+++ b/taskvine/src/Makefile
@@ -11,7 +11,7 @@ tools: manager
 examples: manager worker tools bindings
 
 $(TARGETS): %:
-	$(MAKE) -C $@
+	$(MAKE) -C $@ $(MAKECMDGOALS)
 
 install:
 	for d in $(TARGETS); do $(MAKE) -C $$d install; done
@@ -19,7 +19,6 @@ install:
 clean:
 	for d in $(TARGETS); do $(MAKE) -C $$d clean; done
 
-test:
-	for d in $(TARGETS); do $(MAKE) -C $$d test; done
+lint: $(TARGETS)
 
-.PHONY: all clean install test $(TARGETS)
+.PHONY: all clean install test lint $(TARGETS)

--- a/taskvine/src/Makefile
+++ b/taskvine/src/Makefile
@@ -19,4 +19,7 @@ install:
 clean:
 	for d in $(TARGETS); do $(MAKE) -C $$d clean; done
 
+test:
+	for d in $(TARGETS); do $(MAKE) -C $$d test; done
+
 .PHONY: all clean install test $(TARGETS)

--- a/taskvine/src/bindings/Makefile
+++ b/taskvine/src/bindings/Makefile
@@ -8,4 +8,7 @@ $(CCTOOLS_SWIG_TASKVINE_BINDINGS):
 
 test: all
 
-.PHONY: all install clean test $(CCTOOLS_SWIG_TASKVINE_BINDINGS)
+lint:
+	@$(MAKE) -C python3 lint
+
+.PHONY: all install clean test lint $(CCTOOLS_SWIG_TASKVINE_BINDINGS)

--- a/taskvine/src/bindings/python3/Makefile
+++ b/taskvine/src/bindings/python3/Makefile
@@ -1,5 +1,5 @@
 include ../../../../config.mk
-include $(CCTOOLS_HOME)/rules.mk
+include ../../../../rules.mk
 
 # Python always uses 'so' for its modules (even on Darwin)
 CCTOOLS_DYNAMIC_SUFFIX = so
@@ -25,6 +25,8 @@ vine_wrap.c: taskvine.i
 $(DSPYTHONSO): vine_wrap.o $(EXTERNAL_DEPENDENCIES)
 
 test:
+
+lint:
 	flake8 --ignore=${NDCCTOOLS_FLAKE8_IGNORE_ERRORS} --exclude=${NDCCTOOLS_FLAKE8_IGNORE_FILES} ndcctools/taskvine/
 
 clean:

--- a/taskvine/src/bindings/python3/Makefile
+++ b/taskvine/src/bindings/python3/Makefile
@@ -6,6 +6,10 @@ CCTOOLS_DYNAMIC_SUFFIX = so
 # SWIG produces code that causes a lot of warnings, so use -w to turn those off.
 LOCAL_CCFLAGS = -w -fPIC -DNDEBUG $(CCTOOLS_PYTHON3_CCFLAGS) -I ../../manager
 LOCAL_LINKAGE = $(CCTOOLS_PYTHON3_LDFLAGS) -lz $(CCTOOLS_OPENSSL_LDFLAGS) $(CCTOOLS_HOME)/taskvine/src/manager/libtaskvine.a $(CCTOOLS_HOME)/dttools/src/libdttools.a
+# List of errors flake8 should ignore when linting, as these errors are about minor formatting.
+NDCCTOOLS_FLAKE8_IGNORE_ERRORS = "E501,E266,E301,E302,E303,E305,W391,W293,W291,E128,E122,E275,E225"
+# List of files flake8 should ignore when linting.
+NDCCTOOLS_FLAKE8_IGNORE_FILES = "cvine.py"
 
 DSPYTHONSO = ndcctools/taskvine/_cvine.$(CCTOOLS_DYNAMIC_SUFFIX)
 LIBRARIES = $(DSPYTHONSO)
@@ -21,6 +25,7 @@ vine_wrap.c: taskvine.i
 $(DSPYTHONSO): vine_wrap.o $(EXTERNAL_DEPENDENCIES)
 
 test:
+	flake8 --ignore=${NDCCTOOLS_FLAKE8_IGNORE_ERRORS} --exclude=${NDCCTOOLS_FLAKE8_IGNORE_FILES} --count ndcctools/taskvine/
 
 clean:
 	rm -rf $(OBJECTS) $(TARGETS) ndcctools/taskvine/cvine.py vine_wrap.c vine_wrap.o *.pyc __pycache__

--- a/taskvine/src/bindings/python3/Makefile
+++ b/taskvine/src/bindings/python3/Makefile
@@ -25,7 +25,7 @@ vine_wrap.c: taskvine.i
 $(DSPYTHONSO): vine_wrap.o $(EXTERNAL_DEPENDENCIES)
 
 test:
-	flake8 --ignore=${NDCCTOOLS_FLAKE8_IGNORE_ERRORS} --exclude=${NDCCTOOLS_FLAKE8_IGNORE_FILES} --count ndcctools/taskvine/
+	flake8 --ignore=${NDCCTOOLS_FLAKE8_IGNORE_ERRORS} --exclude=${NDCCTOOLS_FLAKE8_IGNORE_FILES} ndcctools/taskvine/
 
 clean:
 	rm -rf $(OBJECTS) $(TARGETS) ndcctools/taskvine/cvine.py vine_wrap.c vine_wrap.o *.pyc __pycache__

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -2,44 +2,18 @@
 from . import cvine
 from concurrent.futures import Executor
 from concurrent.futures import Future
-from ndcctools.resource_monitor import (
-    rmsummary_delete,
-    rmsummary_create,
-    rmsummaryArray_getitem,
-    delete_rmsummaryArray,
-)
-
-from .display import JupyterDisplay
-from .file import File
 from .task import (
-    FunctionCall,
-    LibraryTask,
     PythonTask,
-    Task,
+    PythonTaskNoResult,
 )
 from .manager import (
     Factory,
     Manager,
 )
-from .utils import (
-    set_port_range,
-    get_c_constant,
-)
 
-import atexit
-import errno
-import itertools
-import json
-import math
 import os
-import pathlib
-import shutil
-import subprocess
-import sys
 import textwrap
 import tempfile
-import time
-import weakref
 
 try:
     import cloudpickle
@@ -86,7 +60,7 @@ class Executor(Executor):
         if self.factory:
             return self.factory.__setattr__(name, value)
 
-    def get(self):
+    def get(self, name):
         if self.factory:
             return self.factory.__getattr__(name)
 ##

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -856,7 +856,7 @@ class Manager(object):
         # ensure poncho python library is available
         try:
             from ndcctools.poncho import package_serverize
-        except:
+        except ImportError:
             raise ModuleNotFoundError("The poncho module is not available. Cannot create Library.")
 
         # positional arguments are the list of functions to include in the library
@@ -892,7 +892,7 @@ class Manager(object):
         if init_command:
             t = LibraryTask(f"{init_command} python ./library_code.py", name)
         else:
-            t = LibraryTask(f"python ./library_code.py", name)
+            t = LibraryTask("python ./library_code.py", name)
 
         # declare the environment
         if add_env:
@@ -915,9 +915,6 @@ class Manager(object):
     #                        to a poncho environment.
     # @returns               A task to be used with @ref ndcctools.taskvine.manager.Manager.install_library.
     def create_library_from_serverized_files(self, name, library_path, env=None):
-        # Delay loading of poncho until here, to avoid bringing in conda-pack etc unless needed.
-        from ndcctools.poncho import package_serverize
-
         t = LibraryTask("python ./library_code.py", name)
         if env:
             if isinstance(env, str):

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -11,7 +11,6 @@
 from . import cvine
 from .file import File
 
-import time
 import copy
 import json
 import os

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -11,6 +11,7 @@
 from . import cvine
 from .file import File
 
+import time
 import copy
 import json
 import os

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -10,7 +10,6 @@
 # See the file COPYING for details.
 from . import cvine
 from .file import File
-import time
 
 import copy
 import json

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -10,7 +10,7 @@
 # See the file COPYING for details.
 from . import cvine
 from .file import File
-from concurrent.futures import Future
+import time
 
 import copy
 import json

--- a/taskvine/src/examples/Makefile
+++ b/taskvine/src/examples/Makefile
@@ -22,4 +22,6 @@ clean:
 
 test: all
 
-.PHONY: all clean install test
+lint:
+
+.PHONY: all clean install test lint

--- a/taskvine/src/manager/Makefile
+++ b/taskvine/src/manager/Makefile
@@ -49,4 +49,6 @@ clean:
 
 test: all
 
-.PHONY: all clean install test 
+lint:
+
+.PHONY: all clean install test lint 

--- a/taskvine/src/tools/Makefile
+++ b/taskvine/src/tools/Makefile
@@ -22,4 +22,6 @@ clean:
 
 test: all
 
-.PHONY: all clean install test
+lint:
+
+.PHONY: all clean install test lint

--- a/taskvine/src/worker/Makefile
+++ b/taskvine/src/worker/Makefile
@@ -30,4 +30,6 @@ clean:
 
 test: all
 
-.PHONY: all clean install test
+lint:
+
+.PHONY: all clean install test lint


### PR DESCRIPTION
This PR made the following changes:
- Edit CI workflow so linting is performed first then regular build and test follows.
- Edit code to comply with flake8.
- Correct several `Makefile` to enable `flake8` linting tests.
- Add flake8 to dev environment so other contributors can run `make test`.

This PR partially addresses issue #3451 by using `flake8`.

Note: linting is currently supported for TaskVine's Python wrapper code.