### PR TITLE
Vine: Partial fix of resources for serverless feature.

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -1011,5 +1011,14 @@ class LibraryTask(Task):
         Task.__init__(self, fn)
         self.provides_library(name)
 
+        # Set some default resources to a library task so it doesn't consume whole worker.
+        # Values below are arbitrary and should be changed as appropriate.
+        self._default_cores = 1
+        self._default_memory = 1000
+        self._default_disk = 1000
+
+        self.set_cores(self._default_cores)
+        self.set_memory(self._default_memory)
+        self.set_disk(self._default_disk)
 
 # vim: set sts=4 sw=4 ts=4 expandtab ft=python:

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -1011,14 +1011,4 @@ class LibraryTask(Task):
         Task.__init__(self, fn)
         self.provides_library(name)
 
-        # Set some default resources to a library task so it doesn't consume whole worker.
-        # Values below are arbitrary and should be changed as appropriate.
-        self._default_cores = 1
-        self._default_memory = 1000
-        self._default_disk = 1000
-
-        self.set_cores(self._default_cores)
-        self.set_memory(self._default_memory)
-        self.set_disk(self._default_disk)
-
 # vim: set sts=4 sw=4 ts=4 expandtab ft=python:

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2521,6 +2521,11 @@ struct rmsummary *vine_manager_choose_resources_for_task(
 			use_whole_worker = 1;
 		} else if (max_proportion > 0) {
 			use_whole_worker = 0;
+			
+			// adjust max_proportion so that an integer number of tasks fit the worker.
+			if (q->proportional_whole_tasks) {
+			    max_proportion = 1.0 / (floor(1.0 / max_proportion));
+			}
 
 			/* when cores are unspecified, they are set to 0 if gpus are specified.
 			 * Otherwise they get a proportion according to specified
@@ -3548,7 +3553,10 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 	q->worker_retrievals = 1;
 
 	q->proportional_resources = 1;
-	q->proportional_whole_tasks = 1;
+	
+	/* This option assumes all tasks have similar resource needs. 
+	 * Turn off by default. */
+	q->proportional_whole_tasks = 0;
 
 	q->allocation_default_mode = VINE_ALLOCATION_MODE_FIXED;
 	q->categories = hash_table_create(0, 0);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2521,10 +2521,10 @@ struct rmsummary *vine_manager_choose_resources_for_task(
 			use_whole_worker = 1;
 		} else if (max_proportion > 0) {
 			use_whole_worker = 0;
-			
+
 			// adjust max_proportion so that an integer number of tasks fit the worker.
 			if (q->proportional_whole_tasks) {
-			    max_proportion = 1.0 / (floor(1.0 / max_proportion));
+				max_proportion = 1.0 / (floor(1.0 / max_proportion));
 			}
 
 			/* when cores are unspecified, they are set to 0 if gpus are specified.
@@ -3553,8 +3553,8 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 	q->worker_retrievals = 1;
 
 	q->proportional_resources = 1;
-	
-	/* This option assumes all tasks have similar resource needs. 
+
+	/* This option assumes all tasks have similar resource needs.
 	 * Turn off by default. */
 	q->proportional_whole_tasks = 0;
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2478,7 +2478,7 @@ static int build_poll_table(struct vine_manager *q)
  * @param w The worker info structure.
  * @param t The task structure.
  * @return A pointer to a struct rmsummary describing the chosen resources for the given task.
-*/
+ */
 
 struct rmsummary *vine_manager_choose_resources_for_task(
 		struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
@@ -2519,8 +2519,7 @@ struct rmsummary *vine_manager_choose_resources_for_task(
 		 * run on any available worker. */
 		if (max_proportion > 1) {
 			use_whole_worker = 1;
-		} 
-		else if (max_proportion > 0) {
+		} else if (max_proportion > 0) {
 			use_whole_worker = 0;
 
 			/* when cores are unspecified, they are set to 0 if gpus are specified.
@@ -2533,7 +2532,7 @@ struct rmsummary *vine_manager_choose_resources_for_task(
 						MAX(limits->cores,
 								floor(w->resources->cores.largest * max_proportion)));
 			}
-			
+
 			/* unspecified gpus are always 0 */
 			if (limits->gpus < 0) {
 				limits->gpus = 0;
@@ -4182,7 +4181,7 @@ int vine_submit(struct vine_manager *q, struct vine_task *t)
  * @param w The worker info structure.
  * @param name The name of the library to be sent.
  * @return 1 if the operation succeeds, 0 otherwise.
-*/
+ */
 
 static int vine_manager_send_library_to_worker(struct vine_manager *q, struct vine_worker_info *w, const char *name)
 {
@@ -4245,7 +4244,7 @@ static void vine_manager_send_library_to_workers(struct vine_manager *q, const c
 		if (stoptime < time(0)) {
 			return;
 		}
-		
+
 		/* If the worker id is not 0, then it is ready to receive work from the manager.
 		 * See @report_worker_ready in ../worker/vine_worker.c */
 		if (!w->workerid) {
@@ -4256,11 +4255,9 @@ static void vine_manager_send_library_to_workers(struct vine_manager *q, const c
 		if (!vine_manager_find_library_on_worker(q, w, name)) {
 			if (vine_manager_send_library_to_worker(q, w, name)) {
 				debug(D_VINE, "Sending library %s to worker %s\n", name, w->workerid);
-			}
-			else {
+			} else {
 				debug(D_VINE, "Failed to send library %s to worker %s\n", name, w->workerid);
 			}
-			
 		}
 	}
 }

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2473,22 +2473,29 @@ static int build_poll_table(struct vine_manager *q)
 }
 
 /*
-Determine the resources to allocate for a given task when assigned to a specific worker.
+ * Determine the resources to allocate for a given task when assigned to a specific worker.
+ * @param q The manager structure.
+ * @param w The worker info structure.
+ * @param t The task structure.
+ * @return A pointer to a struct rmsummary describing the chosen resources for the given task.
 */
 
 struct rmsummary *vine_manager_choose_resources_for_task(
 		struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
 {
-
+	/* Compute the minimum and maximum resources for this task. */
 	const struct rmsummary *min = vine_manager_task_resources_min(q, t);
 	const struct rmsummary *max = vine_manager_task_resources_max(q, t);
 
 	struct rmsummary *limits = rmsummary_create(-1);
-
 	rmsummary_merge_override_basic(limits, max);
 
 	int use_whole_worker = 1;
+
+	/* Proportionally assign the worker's resources to the task if configured. */
 	if (q->proportional_resources) {
+
+		/* Compute the proportion of the worker the task shall have across resource types. */
 		double max_proportion = -1;
 		if (w->resources->cores.largest > 0) {
 			max_proportion = MAX(max_proportion, limits->cores / w->resources->cores.largest);
@@ -2506,13 +2513,14 @@ struct rmsummary *vine_manager_choose_resources_for_task(
 			max_proportion = MAX(max_proportion, limits->gpus / w->resources->gpus.largest);
 		}
 
-		// if max_proportion > 1, then the task does not fit the worker for the
-		// specified resources. For the unspecified resources we use the whole
-		// worker as not to trigger a warning when checking for tasks that can't
-		// run on any available worker.
+		/* If max_proportion > 1, then the task does not fit the worker for the
+		 * specified resources. For the unspecified resources we use the whole
+		 * worker as not to trigger a warning when checking for tasks that can't
+		 * run on any available worker. */
 		if (max_proportion > 1) {
 			use_whole_worker = 1;
-		} else if (max_proportion > 0) {
+		} 
+		else if (max_proportion > 0) {
 			use_whole_worker = 0;
 
 			/* when cores are unspecified, they are set to 0 if gpus are specified.
@@ -2525,9 +2533,9 @@ struct rmsummary *vine_manager_choose_resources_for_task(
 						MAX(limits->cores,
 								floor(w->resources->cores.largest * max_proportion)));
 			}
-
+			
+			/* unspecified gpus are always 0 */
 			if (limits->gpus < 0) {
-				/* unspecified gpus are always 0 */
 				limits->gpus = 0;
 			}
 
@@ -2544,17 +2552,17 @@ struct rmsummary *vine_manager_choose_resources_for_task(
 		}
 	}
 
+	/* If no resource was specified, using whole worker. */
 	if (limits->cores < 1 && limits->gpus < 1 && limits->memory < 1 && limits->disk < 1) {
-		/* no resource was specified, using whole worker */
 		use_whole_worker = 1;
 	}
-
+	/* At least one specified resource would use the whole worker, thus
+	 * using whole worker for all unspecified resources. */
 	if ((limits->cores > 0 && limits->cores >= w->resources->cores.largest) ||
 			(limits->gpus > 0 && limits->gpus >= w->resources->gpus.largest) ||
 			(limits->memory > 0 && limits->memory >= w->resources->memory.largest) ||
 			(limits->disk > 0 && limits->disk >= w->resources->disk.largest)) {
-		/* at least one specified resource would use the whole worker, thus
-		 * using whole worker for all unspecified resources. */
+
 		use_whole_worker = 1;
 	}
 
@@ -4167,10 +4175,13 @@ int vine_submit(struct vine_manager *q, struct vine_task *t)
 	return (t->task_id);
 }
 
-/*
-Send a given library by name to the target worker.
-This involves duplicating the prototype task in q->libraries
-and then sending the copy as a (mostly) normal task.
+/* Send a given library by name to the target worker.
+ * This involves duplicating the prototype task in q->libraries
+ * and then sending the copy as a (mostly) normal task.
+ * @param q The manager structure.
+ * @param w The worker info structure.
+ * @param name The name of the library to be sent.
+ * @return 1 if the operation succeeds, 0 otherwise.
 */
 
 static int vine_manager_send_library_to_worker(struct vine_manager *q, struct vine_worker_info *w, const char *name)
@@ -4183,12 +4194,13 @@ static int vine_manager_send_library_to_worker(struct vine_manager *q, struct vi
 	/* Duplicate the original task */
 	struct vine_task *t = vine_task_copy(original);
 
+	/* Check if this library task can fit in this worker. */
 	if (!check_worker_against_task(q, w, t)) {
 		vine_task_delete(t);
 		return 0;
 	}
 
-	/* Give it a unique taskid if library fits the worker*/
+	/* Give it a unique taskid if library fits the worker. */
 	t->task_id = q->next_task_id++;
 
 	/* Add reference to task when adding it to primary table. */
@@ -4197,7 +4209,7 @@ static int vine_manager_send_library_to_worker(struct vine_manager *q, struct vi
 	/* Send the task to the worker in the usual way. */
 	commit_task_to_worker(q, w, t);
 
-	/* Make the special log recordings for the library */
+	/* Make the special log recordings for the library. */
 	vine_txn_log_write_library_update(q, w, t->task_id, VINE_LIBRARY_SENT);
 
 	return 1;
@@ -4219,6 +4231,10 @@ static struct vine_task *vine_manager_find_library_on_worker(
 	return 0;
 }
 
+/* Send the library task to all known workers.
+ * @param q 		The manager structure.
+ * @param name 		The name of the library task.
+ * @param stoptime 	When to stop sending libraries to workers. */
 static void vine_manager_send_library_to_workers(struct vine_manager *q, const char *name, time_t stoptime)
 {
 	char *worker_key;
@@ -4226,11 +4242,17 @@ static void vine_manager_send_library_to_workers(struct vine_manager *q, const c
 
 	HASH_TABLE_ITERATE(q->worker_table, worker_key, w)
 	{
-		if (stoptime < time(0))
+		if (stoptime < time(0)) {
 			return;
-		/* XXX I think this is testing something about worker validity. */
-		if (!w->workerid)
+		}
+		
+		/* If the worker id is not 0, then it is ready to receive work from the manager.
+		 * See @report_worker_ready in ../worker/vine_worker.c */
+		if (!w->workerid) {
 			continue;
+		}
+
+		/* Send the library task to the worker if possible. */
 		if (!vine_manager_find_library_on_worker(q, w, name)) {
 			if (vine_manager_send_library_to_worker(q, w, name)) {
 				debug(D_VINE, "Sending library %s to worker %s\n", name, w->workerid);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2515,12 +2515,6 @@ struct rmsummary *vine_manager_choose_resources_for_task(
 		} else if (max_proportion > 0) {
 			use_whole_worker = 0;
 
-			// adjust max_proportion so that an integer number of tasks fit the
-			// worker.
-			if (q->proportional_whole_tasks) {
-				max_proportion = 1.0 / (floor(1.0 / max_proportion));
-			}
-
 			/* when cores are unspecified, they are set to 0 if gpus are specified.
 			 * Otherwise they get a proportion according to specified
 			 * resources. Tasks will get at least one core. */

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -49,7 +49,7 @@ resources availability, features, blocklist, and all other relevant factors.
 Used by all scheduling methods for basic compatibility.
 */
 
-static int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
+int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
 {
 	/* worker has not reported any resources yet */
 	if (w->resources->tag < 0)

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -50,39 +50,39 @@ int check_fixed_location_worker(struct vine_manager *m, struct vine_worker_info 
  * @param w The worker info structure.
  * @param t The task structure.
  * @return 0 if the task is not compatible with the worker, 1 otherwise.
-*/
+ */
 
 int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
 {
 	/* worker has not reported any resources yet */
 	if (w->resources->tag < 0 || w->resources->workers.total < 1) {
 		return 0;
-    }
-	
-    /* Don't send tasks to this worker if it is in draining mode (no more tasks). */
-    if (w->draining) {
+	}
+
+	/* Don't send tasks to this worker if it is in draining mode (no more tasks). */
+	if (w->draining) {
 		return 0;
 	}
 
-    /* Don't send tasks if the factory is used and has too many connected workers. */
+	/* Don't send tasks if the factory is used and has too many connected workers. */
 	if (w->factory_name) {
 		struct vine_factory_info *f = vine_factory_info_lookup(q, w->factory_name);
 		if (f && f->connected_workers > f->max_workers)
 			return 0;
 	}
 
-    /* Check if worker is blocked from the manager. */
+	/* Check if worker is blocked from the manager. */
 	if (vine_blocklist_is_blocked(q, w->hostname)) {
 		return 0;
 	}
 
-    /* Compute the resources to allocate to this task. */
+	/* Compute the resources to allocate to this task. */
 	struct rmsummary *l = vine_manager_choose_resources_for_task(q, w, t);
 
 	struct vine_resources *r = w->resources;
 	int ok = 1;
 
-    /* Make sure worker has available resources to run this task. */
+	/* Make sure worker has available resources to run this task. */
 	if (r->disk.inuse + l->disk > r->disk.total) { /* No overcommit disk */
 		ok = 0;
 	}
@@ -119,12 +119,12 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 		}
 	}
 
-    /* If the worker is not the one the task wants. */
+	/* If the worker is not the one the task wants. */
 	if (t->has_fixed_locations && !check_fixed_location_worker(q, w, t)) {
 		ok = 0;
 	}
 
-    /* If the worker doesn't have the features the task requires. */
+	/* If the worker doesn't have the features the task requires. */
 	if (t->feature_list) {
 		if (!w->features) {
 			ok = 0;

--- a/taskvine/src/manager/vine_schedule.h
+++ b/taskvine/src/manager/vine_schedule.h
@@ -21,5 +21,5 @@ This module is private to the manager and should not be invoked by the end user.
 struct vine_worker_info *vine_schedule_task_to_worker( struct vine_manager *q, struct vine_task *t );
 void vine_schedule_check_for_large_tasks( struct vine_manager *q );
 int vine_schedule_check_fixed_location(struct vine_manager *q, struct vine_task *t);
-
+int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t);
 #endif

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -104,6 +104,7 @@ struct vine_task {
 	int refcount;                                          /**< Number of remaining references to this object. */
 };
 
+void vine_task_delete(struct vine_task *t);
 /* Add a reference to an existing task object, return the same object. */
 struct vine_task * vine_task_clone( struct vine_task *t );
 

--- a/taskvine/test/TR_vine_python_serverless.sh
+++ b/taskvine/test/TR_vine_python_serverless.sh
@@ -42,7 +42,7 @@ run()
 	# wait at most 15 seconds for vine to find a port.
 	wait_for_file_creation $PORT_FILE 15
 
-	run_taskvine_worker $PORT_FILE worker.log
+	run_taskvine_worker $PORT_FILE worker.log --cores 2 --memory 2000 --disk 2000
 
 	# wait for vine to exit.
 	wait_for_file_creation $STATUS_FILE 15

--- a/taskvine/test/TR_vine_python_serverless.sh
+++ b/taskvine/test/TR_vine_python_serverless.sh
@@ -16,8 +16,8 @@ check_needed()
 {
 	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
 
-	# Poncho currently requires ast.unpase to serialize the function,
-	# which only became available in Python 3.11.  Some older platforms
+	# Poncho currently requires ast.unparse to serialize the function,
+	# which only became available in Python 3.9.  Some older platforms
 	# (e.g. almalinux8) will not have this natively.
 	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "from ast import unparse" || return 1
 

--- a/taskvine/test/vine_python_serverless.py
+++ b/taskvine/test/vine_python_serverless.py
@@ -28,6 +28,10 @@ def main():
     print("Creating library from functions...")
 
     libtask = q.create_library_from_functions('test-library', divide, double, add_env=False)
+    libtask.set_cores(1)
+    libtask.set_memory(1000)
+    libtask.set_disk(1000)
+
     q.install_library(libtask)
 
     print("Submitting function call tasks...")

--- a/taskvine/test/vine_python_serverless.py
+++ b/taskvine/test/vine_python_serverless.py
@@ -36,9 +36,15 @@ def main():
 
     for i in range(0,tasks): 
         s_task = vine.FunctionCall('test-library', 'divide', 2, 2**2)
+        s_task.set_cores(1)
+        s_task.set_memory(1000)
+        s_task.set_disk(1000)
         q.submit(s_task)
     
         s_task = vine.FunctionCall('test-library', 'double', 3)
+        s_task.set_cores(1)
+        s_task.set_memory(1000)
+        s_task.set_disk(1000)
         q.submit(s_task)
 
     print("Waiting for results...")


### PR DESCRIPTION
This PR made the following changes:
- Set default resources for library tasks so these tasks will have resources accounted for. The values are arbitrary and need further consideration.
- Remove max_proportion adjustment in `vine_manager_choose_resources_for_task`. This code assumes all tasks have the same resource box and thus tries to round resources. This is not true when library task uses few resources (e.g., 1 core) and function call tasks use arbitrary resources.
- Add check for library tasks when sending them to workers. This check is needed in case worker doesn't have available resources.
- Log library sending operation appropriately.
- Make `check_worker_against_task` available to be used in `vine_manager.c`.
- Fix resources for worker and tasks in serverless test script.

Warning: this setup won't work if function calls don't specify the right amount of resources. Also current implementation only allows 1 function call per library. 

Todo: clean design of resources for serverless.