### PR TITLE
Vine: Serverless: Match on library name, not feature.

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4202,7 +4202,7 @@ static int vine_manager_send_library_to_worker(struct vine_manager *q, struct vi
 	return 1;
 }
 
-static struct vine_task *vine_manager_find_library_on_worker(
+struct vine_task *vine_manager_find_library_on_worker(
 		struct vine_manager *q, struct vine_worker_info *w, const char *library_name)
 {
 	uint64_t task_id;
@@ -4268,8 +4268,6 @@ void vine_manager_remove_library(struct vine_manager *q, const char *name)
 		struct vine_task *t = vine_manager_find_library_on_worker(q, w, name);
 		if (t) {
 			cancel_task_on_worker(q, t, VINE_TASK_CANCELED);
-			/* XXX shouldn't the worker declare the feature gone? */
-			hash_table_remove(w->features, name);
 		}
 	}
 	hash_table_remove(q->libraries, name);

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -217,6 +217,9 @@ int vine_manager_transfer_time( struct vine_manager *q, struct vine_worker_info 
 const struct rmsummary *vine_manager_task_resources_min(struct vine_manager *q, struct vine_task *t);
 const struct rmsummary *vine_manager_task_resources_max(struct vine_manager *q, struct vine_task *t);
 
+/* Internal: Find a library task running on a specific worker by name. */
+struct vine_task *vine_manager_find_library_on_worker( struct vine_manager *q, struct vine_worker_info *w, const char *library_name);
+
 /* Internal: Enable shortcut of main loop upon child process completion. Needed for Makeflow to interleave local and remote execution. */
 void vine_manager_enable_process_shortcut(struct vine_manager *q);
 

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -75,15 +75,15 @@ static int check_worker_against_task(struct vine_manager *q, struct vine_worker_
 
 	/* If this is a function task needing a library, see if the library has slots available. */
 	/* XXX Note that we are not yet counting the number of invocations per worker. */
-	
-	if(t->needs_library) {
-		if(vine_manager_find_library_on_worker(q,w,t->needs_library)) {
+
+	if (t->needs_library) {
+		if (vine_manager_find_library_on_worker(q, w, t->needs_library)) {
 			/* keep going */
 		} else {
 			return 0;
 		}
 	}
-	
+
 	struct rmsummary *l = vine_manager_choose_resources_for_task(q, w, t);
 	struct vine_resources *r = w->resources;
 

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -73,6 +73,17 @@ static int check_worker_against_task(struct vine_manager *q, struct vine_worker_
 		return 0;
 	}
 
+	/* If this is a function task needing a library, see if the library has slots available. */
+	/* XXX Note that we are not yet counting the number of invocations per worker. */
+	
+	if(t->needs_library) {
+		if(vine_manager_find_library_on_worker(q,w,t->needs_library)) {
+			/* keep going */
+		} else {
+			return 0;
+		}
+	}
+	
 	struct rmsummary *l = vine_manager_choose_resources_for_task(q, w, t);
 	struct vine_resources *r = w->resources;
 

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -221,31 +221,15 @@ void vine_task_set_command(struct vine_task *t, const char *cmd)
 	t->command_line = xxstrdup(cmd);
 }
 
-static void delete_feature(struct vine_task *t, const char *name)
-{
-	struct list_cursor *c = list_cursor_create(t->feature_list);
-
-	char *feature;
-	for (list_seek(c, 0); list_get(c, (void **)&feature); list_next(c)) {
-		if (name && feature && (strcmp(name, feature) == 0)) {
-			list_drop(c);
-		}
-	}
-
-	list_cursor_destroy(c);
-}
-
 void vine_task_needs_library(struct vine_task *t, const char *library_name)
 {
 	if (t->needs_library) {
-		delete_feature(t, t->needs_library);
 		free(t->needs_library);
 		t->needs_library = NULL;
 	}
 
 	if (library_name) {
 		t->needs_library = xxstrdup(library_name);
-		vine_task_add_feature(t, t->needs_library);
 	}
 }
 

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -530,12 +530,9 @@ static int start_process(struct vine_process *p, struct link *manager)
 	if (pid < 0)
 		fatal("unable to fork process for task_id %d!", p->task->task_id);
 
-	/* If this process represents a library, notify the manager of that feature. */
+	/* If this process represents a library, notify the manager that it is running. */
 	if (p->task->provides_library) {
-		hash_table_insert(features, p->task->provides_library, feature_dummy);
-		send_features(manager);
 		send_message(manager, "info library-update %d %d\n", p->task->task_id, VINE_LIBRARY_STARTED);
-		send_resource_update(manager);
 	}
 
 	itable_insert(procs_running, p->task->task_id, p);
@@ -888,11 +885,6 @@ static int do_kill(int task_id)
 		disk_allocated -= p->task->resources_requested->disk;
 		gpus_allocated -= p->task->resources_requested->gpus;
 		vine_gpus_free(task_id);
-
-		if (p->task->provides_library) {
-			hash_table_remove(features, p->task->provides_library);
-			/* XXX how to tell the manager that feature is gone? */
-		}
 	}
 
 	itable_remove(procs_complete, p->task->task_id);


### PR DESCRIPTION
Fixes #3441.  A worker "feature" describes the whole worker, and doesn't have a clear way to remove once activated.  This PR no longer uses "features" to indicate that a serverless library is present.  Instead, the manager directly looks for the presence of a library task where l->provides_library matches t->needs_library.

Note that this PR does not (yet) fix the problem of controlling the number of tasks assigned to a library.  That's a separate problem.
 