### PR TITLE
Vine: Serverless: Track Assignment of Functions to Libraries

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -196,6 +196,15 @@ class Task(object):
         return cvine.vine_task_provides_library(self._task, library_name)
     
     ##
+    # Set the number of concurrent functions a library can run.
+    # This is not needed for regular tasks.
+    #
+    # @param self Reference to the current task object.
+    # @param nslots The maximum number of concurrent functions this library can run.
+    def set_function_slots(self, nslots):
+        return cvine.vine_task_set_function_slots(self._task, nslots)
+        
+    ##
     # Set the worker selection scheduler for task.
     #
     # @param self       Reference to the current task object.

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -268,6 +268,13 @@ void vine_task_needs_library( struct vine_task *t, const char *name );
 void vine_task_provides_library( struct vine_task *t, const char *name );
 
 
+/** Set the number of concurrent functions a library can run.
+@param t A task object.
+@param nslots The maximum number of concurrent functions this library can run.
+*/
+void vine_task_set_function_slots( struct vine_task *t, int nslots );
+
+
 /** Add a general file object as a input to a task.
 @param t A task object.
 @param f A file object, created by @ref vine_declare_file, @ref vine_declare_url, @ref vine_declare_buffer, @ref vine_declare_mini_task.

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -499,6 +499,7 @@ vine_result_code_t vine_manager_put_task(struct vine_manager *q, struct vine_wor
 
 	if (t->provides_library) {
 		vine_manager_send(q, w, "provides_library %s\n", t->provides_library);
+		vine_manager_send(q, w, "function_slots %d\n", t->function_slots);
 	}
 
 	vine_manager_send(q, w, "category %s\n", t->category);

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -77,12 +77,15 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 	}
 
 	/* If this is a function task needing a library, see if a library is available. */
-	/* XXX Note that we are not yet counting the number of invocations per worker. */
 
 	if (t->needs_library) {
-		if (vine_manager_find_library_on_worker(q, w, t->needs_library)) {
+		/* Find a library on that worker. */
+		struct vine_task *lt = vine_manager_find_library_on_worker(q, w, t->needs_library);
+		/* Does that library have available slots? */
+		if(lt && lt->function_slots > lt->function_slots_inuse) {
 			/* keep going */
 		} else {
+			/* Function cannot run here at all. */
 			return 0;
 		}
 	}

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -55,7 +55,9 @@ struct vine_task *vine_task_create(const char *command_line)
 	t->worker_selection_algorithm = VINE_SCHEDULE_UNSET;
 
 	t->state = VINE_TASK_UNKNOWN;
-
+	t->function_slots = 1;
+	t->function_slots_inuse = 0;
+	
 	t->result = VINE_RESULT_UNKNOWN;
 	t->exit_code = -1;
 
@@ -84,6 +86,8 @@ void vine_task_clean(struct vine_task *t)
 	t->bytes_sent = 0;
 	t->bytes_received = 0;
 	t->bytes_transferred = 0;
+
+	t->function_slots_inuse = 0;
 
 	free(t->output);
 	t->output = NULL;
@@ -191,7 +195,8 @@ struct vine_task *vine_task_copy(const struct vine_task *task)
 	new->output_mounts = vine_task_mount_list_copy(task->output_mounts);
 	new->env_list = vine_task_string_list_copy(task->env_list);
 	new->feature_list = vine_task_string_list_copy(task->feature_list);
-
+	new->function_slots = task->function_slots;
+	
 	/* Scheduling features of task are copied. */
 	new->resource_request = task->resource_request;
 	vine_task_set_scheduler(new, task->worker_selection_algorithm);
@@ -243,6 +248,11 @@ void vine_task_provides_library(struct vine_task *t, const char *library_name)
 	if (library_name) {
 		t->provides_library = xxstrdup(library_name);
 	}
+}
+
+void vine_task_set_function_slots( struct vine_task *t, int nslots )
+{
+	t->function_slots = nslots;
 }
 
 void vine_task_set_env_var(struct vine_task *t, const char *name, const char *value)

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -41,7 +41,8 @@ struct vine_task {
 
 	char *needs_library;         /**< If this is a FunctionTask, the name of the library used */
 	char *provides_library;      /**< If this is a LibraryTask, the name of the library provided. */
-
+	int   function_slots;        /**< If this is a LibraryTask, the max concurrent functions. */
+	
 	struct list *input_mounts;    /**< The mounted files expected as inputs. */
 	struct list *output_mounts;   /**< The mounted files expected as outputs. */
 	struct list *env_list;       /**< Environment variables applied to the task. */
@@ -60,7 +61,8 @@ struct vine_task {
 	int try_count;               /**< The number of times the task has been dispatched to a worker. If larger than max_retries, the task failes with @ref VINE_RESULT_MAX_RETRIES. */
 	int exhausted_attempts;      /**< Number of times the task failed given exhausted resources. */
 	int workers_slow;            /**< Number of times this task has been terminated for running too long. */
-
+	int function_slots_inuse;    /**< If a library, the number of functions currently running. */
+		
 	/***** Results of task once it has reached completion. *****/
 
 	vine_result_t result;          /**< The result of the task (see @ref vine_result_t */

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -96,9 +96,7 @@ struct vine_process *vine_process_create(struct vine_task *task, vine_process_ty
 	p->tmpdir = string_format("%s/.taskvine.tmp", p->sandbox);
 	p->output_file_name = string_format("%s/.taskvine.stdout", p->sandbox);
 
-	/* Until told otherwise, no more than one function per library. */
 	p->functions_running = 0;
-	p->max_functions_running = 1;
 
 	/* Note that create_dir recursively creates parents, so a single one is sufficient. */
 

--- a/taskvine/src/worker/vine_process.h
+++ b/taskvine/src/worker/vine_process.h
@@ -57,7 +57,6 @@ struct vine_process {
 
 	/* If this is a library process, the number of functions it is currently running. */
 	int functions_running;
-	int max_functions_running;
 	
 	/* expected disk usage by the process. If no cache is used, it is the same as in task. */
 	int64_t disk;

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1183,7 +1183,7 @@ struct vine_process *find_library_for_function(const char *library_name)
 	ITABLE_ITERATE(procs_running, task_id, p)
 	{
 		if (!strcmp(p->task->provides_library, library_name)) {
-			if (p->functions_running < p->max_functions_running) {
+			if (p->functions_running < p->task->function_slots) {
 				return p;
 			}
 		}


### PR DESCRIPTION
Each library task now has a certain number of function slots (by default one) assigned by`vine_task_set_function_slots`

Each function task is now assigned a specific library task during scheduling, up to the limit of the number of slots.

The manager will now only dispatch as many function calls as actually fit to the available library slots.

The worker main loop will only dispatch function calls up to the slot limit.

**BUT NOTE** that the library invocation protocol in `vine_process` does not yet admit multiple invocations per worker.