### PR TITLE
Vine: Library Task communicates with Vine Worker using pipes instead of stdin/stdout.

### DIFF
--- a/poncho/src/poncho/library_network_code.py
+++ b/poncho/src/poncho/library_network_code.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2022 The University of Notre Dame
+# This software is distributed under the GNU General Public License.
+# See the file COPYING for details.
+
+
+def library_network_code():
+    import json
+    import os
+    import sys
+
+    def remote_execute(func):
+        def remote_wrapper(event):
+            kwargs = event["fn_kwargs"]
+            args = event["fn_args"]
+            try:
+                response = {
+                    "Result": func(*args, **kwargs),
+                    "StatusCode": 200
+                }
+            except Exception as e:
+                response = {
+                    "Result": str(e),
+                    "StatusCode": 500
+                }
+            return response
+        return remote_wrapper
+
+    read, write = os.pipe()
+
+    def send_configuration(config):
+        config_string = json.dumps(config)
+        config_cmd = f"{len(config_string) + 1}\n{config_string}\n"
+        sys.stdout.write(config_cmd)
+        sys.stdout.flush()
+
+    def main():
+        config = {
+            "name": name(),
+        }
+        send_configuration(config)
+        while True:
+            while True:
+                # wait for message from worker about what function to execute
+                try:
+                    line = input()
+                # if the worker closed the pipe connected to the input of this process, we should just exit
+                except EOFError:
+                    sys.exit(0)
+                function_name, event_size, function_sandbox = line.split(" ", maxsplit=2)
+                if event_size:
+                    # receive the bytes containing the event and turn it into a string
+                    event_str = input()
+                    if len(event_str) != int(event_size):
+                        print(event_str, len(event_str), event_size, file=sys.stderr)
+                        print("Size of event does not match what was sent: exiting", file=sys.stderr)
+                        sys.exit(1)
+                    # turn the event into a python dictionary
+                    event = json.loads(event_str)
+                    # see if the user specified an execution method
+                    exec_method = event.get("remote_task_exec_method", None)
+                    if exec_method == "direct":
+                        library_sandbox = os.getcwd()
+                        try:
+                            os.chdir(function_sandbox)
+                            response = json.dumps(globals()[function_name](event))
+                        except Exception as e:
+                            print(f'Library code: Function call failed due to {e}', file=sys.stderr)
+                            sys.exit(1)
+                        finally:
+                            os.chdir(library_sandbox)
+                    else:
+                        p = os.fork()
+                        if p == 0:
+                            os.chdir(function_sandbox)
+                            response = globals()[function_name](event)
+                            os.write(write, json.dumps(response).encode("utf-8"))
+                            os._exit(0)
+                        elif p < 0:
+                            print(f'Library code: unable to fork to execute {function_name}', file=sys.stderr)
+                            response = {
+                                "Result": "unable to fork",
+                                "StatusCode": 500
+                            }
+                        else:
+                            max_read = 65536
+                            chunk = os.read(read, max_read).decode("utf-8")
+                            all_chunks = [chunk]
+                            while (len(chunk) >= max_read):
+                                chunk = os.read(read, max_read).decode("utf-8")
+                                all_chunks.append(chunk)
+                            response = "".join(all_chunks)
+                            os.waitpid(p, 0)
+                    print(response, flush=True)
+        return 0

--- a/poncho/src/poncho/wq_network_code.py
+++ b/poncho/src/poncho/wq_network_code.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2022 The University of Notre Dame
+# This software is distributed under the GNU General Public License.
+# See the file COPYING for details.
+
+
+def wq_network_code():
+    import socket
+    import json
+    import os
+    import sys
+    def remote_execute(func):
+        def remote_wrapper(event):
+            kwargs = event["fn_kwargs"]
+            args = event["fn_args"]
+            try:
+                response = {
+                    "Result": func(*args, **kwargs),
+                    "StatusCode": 200
+                }
+            except Exception as e:
+                response = {
+                    "Result": str(e),
+                    "StatusCode": 500
+                }
+            return response
+        return remote_wrapper
+
+    read, write = os.pipe()
+    def send_configuration(config):
+        config_string = json.dumps(config)
+        config_cmd = f"{len(config_string) + 1}\n{config_string}\n"
+        sys.stdout.write(config_cmd)
+        sys.stdout.flush()
+    def main():
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            # modify the port argument to be 0 to listen on an arbitrary port
+            s.bind(('localhost', 0))
+        except Exception as e:
+            s.close()
+            print(e, file=sys.stderr)
+            sys.exit(1)
+        # information to print to stdout for worker
+        config = {
+                "name": name(),
+                "port": s.getsockname()[1],
+                }
+        send_configuration(config)
+        while True:
+            s.listen()
+            conn, addr = s.accept()
+            print('Network function: connection from {}'.format(addr), file=sys.stderr)
+            while True:
+                # peek at message to find newline to get the size
+                event_size = None
+                line = conn.recv(100, socket.MSG_PEEK)
+                eol = line.find(b'\n')
+                if eol >= 0:
+                    size = eol+1
+                    # actually read the size of the event
+                    input_spec = conn.recv(size).decode('utf-8').split()
+                    function_name = input_spec[0]
+                    task_id = int(input_spec[1])
+                    event_size = int(input_spec[2])
+                try:
+                    if event_size:
+                        # receive the bytes containing the event and turn it into a string
+                        event_str = conn.recv(event_size).decode("utf-8")
+                        # turn the event into a python dictionary
+                        event = json.loads(event_str)
+                        # see if the user specified an execution method
+                        exec_method = event.get("remote_task_exec_method", None)
+                        os.chdir(f"t.{task_id}")
+                        if exec_method == "direct":
+                            response = json.dumps(globals()[function_name](event)).encode("utf-8")
+                        else:
+                            p = os.fork()
+                            if p == 0:
+                                response =globals()[function_name](event)
+                                os.write(write, json.dumps(response).encode("utf-8"))
+                                os._exit(0)
+                            elif p < 0:
+                                print(f'Network function: unable to fork to execute {function_name}', file=sys.stderr)
+                                response = {
+                                    "Result": "unable to fork",
+                                    "StatusCode": 500
+                                }
+                            else:
+                                max_read = 65536
+                                chunk = os.read(read, max_read).decode("utf-8")
+                                all_chunks = [chunk]
+                                while (len(chunk) >= max_read):
+                                    chunk = os.read(read, max_read).decode("utf-8")
+                                    all_chunks.append(chunk)
+                                response = "".join(all_chunks).encode("utf-8")
+                                os.waitpid(p, 0)
+                        response_size = len(response)
+                        size_msg = "{}\n".format(response_size)
+                        # send the size of response
+                        conn.sendall(size_msg.encode('utf-8'))
+                        # send response
+                        conn.sendall(response)
+                        os.chdir("..")
+                        break
+                except Exception as e:
+                    print("Network function encountered exception ", str(e), file=sys.stderr)
+        return 0

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -319,8 +319,8 @@ pid_t vine_process_execute(struct vine_process *p)
 
 	/* Start the performance clock just prior to forking the task. */
 	p->execution_start = timestamp_get();
-
 	p->pid = fork();
+	
 	if (p->pid > 0) {
 		// Make child process the leader of its own process group. This allows
 		// signals to also be delivered to processes forked by the child process.
@@ -405,30 +405,32 @@ pid_t vine_process_execute(struct vine_process *p)
 
 			_exit(0);
 		}
-		/* For process types other than library, set up input/output file desciptors. 
+		/* For process types other than library, set up file desciptors. 
 		 * The library will use the input_fd and output_fd to talk to the manager instead. */
-		int result;
 		if (p->type != VINE_PROCESS_TYPE_LIBRARY) {
-			result = dup2(input_fd, STDIN_FILENO);
+			int result = dup2(input_fd, STDIN_FILENO);
 			if (result < 0)
 				fatal("could not dup input to stdin: %s", strerror(errno));
 
 			result = dup2(output_fd, STDOUT_FILENO);
 			if (result < 0)
 				fatal("could not dup output to stdout: %s", strerror(errno));
-
+			
+			result = dup2(error_fd, STDERR_FILENO);
+			if (result < 0)
+				fatal("could not dup error to stderr: %s", strerror(errno));
 		
-			/* Close redundant file descriptors. */
+			/* Close redundant file descriptors.
+			 * Note that output_fd is the same as error_fd so it's only closed once. */
 			close(input_fd);
-			close(output_fd);
+			close(output_fd);	// no need to close error_fd.
 		}
-
-		/* Setup for stderr is the same for all task types. */
-		result = dup2(error_fd, STDERR_FILENO);
-		if (result < 0)
-			fatal("could not dup error to stderr: %s", strerror(errno));
-		close(error_fd);
-		
+		else {
+			int result = dup2(error_fd, STDERR_FILENO);
+			if (result < 0)
+				fatal("could not dup error to stderr: %s", strerror(errno));
+			close(error_fd);
+		}
 
 		/* For a library task, close the unused sides of the pipes. */
 		if (p->type == VINE_PROCESS_TYPE_LIBRARY) {
@@ -451,10 +453,8 @@ pid_t vine_process_execute(struct vine_process *p)
 			execl("/bin/sh", "sh", "-c", p->task->command_line, (char *)0);
 		}
 		else {
-			char input_fd_str[VINE_LINE_MAX], output_fd_str[VINE_LINE_MAX];
-			sprintf(input_fd_str, "%d", input_fd);
-			sprintf(output_fd_str, "%d", output_fd);
-			execl("/bin/sh", "sh", "-c", p->task->command_line, "--input-fd", input_fd_str, "--output-fd", output_fd_str, (char *)0);
+			char* final_command = string_format("%s --input-fd %d --output-fd %d", p->task->command_line, input_fd, output_fd);
+			execl("/bin/sh", "sh", "-c", final_command, (char*) 0);
 		}
 		_exit(127); // Failed to execute the cmd.
 	}

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -405,24 +405,30 @@ pid_t vine_process_execute(struct vine_process *p)
 
 			_exit(0);
 		}
+		/* For process types other than library, set up input/output file desciptors. 
+		 * The library will use the input_fd and output_fd to talk to the manager instead. */
+		int result;
+		if (p->type != VINE_PROCESS_TYPE_LIBRARY) {
+			result = dup2(input_fd, STDIN_FILENO);
+			if (result < 0)
+				fatal("could not dup input to stdin: %s", strerror(errno));
 
-		/* Otherwise for other process types, set up file desciptors and execute the command. */
+			result = dup2(output_fd, STDOUT_FILENO);
+			if (result < 0)
+				fatal("could not dup output to stdout: %s", strerror(errno));
 
-		int result = dup2(input_fd, STDIN_FILENO);
-		if (result < 0)
-			fatal("could not dup input to stdin: %s", strerror(errno));
+		
+			/* Close redundant file descriptors. */
+			close(input_fd);
+			close(output_fd);
+		}
 
-		result = dup2(output_fd, STDOUT_FILENO);
-		if (result < 0)
-			fatal("could not dup output to stdout: %s", strerror(errno));
-
+		/* Setup for stderr is the same for all task types. */
 		result = dup2(error_fd, STDERR_FILENO);
 		if (result < 0)
 			fatal("could not dup error to stderr: %s", strerror(errno));
-
-		close(input_fd);
-		close(output_fd);
 		close(error_fd);
+		
 
 		/* For a library task, close the unused sides of the pipes. */
 		if (p->type == VINE_PROCESS_TYPE_LIBRARY) {
@@ -439,7 +445,17 @@ pid_t vine_process_execute(struct vine_process *p)
 		/* Finally, add things that were explicitly given in the task description. */
 		export_environment(p);
 
-		execl("/bin/sh", "sh", "-c", p->task->command_line, (char *)0);
+		/* Library task passes the file descriptors to talk to the manager via
+		 * the command line so it requires a special execl. */
+		if (p->type != VINE_PROCESS_TYPE_LIBRARY) {
+			execl("/bin/sh", "sh", "-c", p->task->command_line, (char *)0);
+		}
+		else {
+			char input_fd_str[VINE_LINE_MAX], output_fd_str[VINE_LINE_MAX];
+			sprintf(input_fd_str, "%d", input_fd);
+			sprintf(output_fd_str, "%d", output_fd);
+			execl("/bin/sh", "sh", "-c", p->task->command_line, "--input-fd", input_fd_str, "--output-fd", output_fd_str, (char *)0);
+		}
 		_exit(127); // Failed to execute the cmd.
 	}
 

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -320,7 +320,7 @@ pid_t vine_process_execute(struct vine_process *p)
 	/* Start the performance clock just prior to forking the task. */
 	p->execution_start = timestamp_get();
 	p->pid = fork();
-	
+
 	if (p->pid > 0) {
 		// Make child process the leader of its own process group. This allows
 		// signals to also be delivered to processes forked by the child process.
@@ -405,7 +405,7 @@ pid_t vine_process_execute(struct vine_process *p)
 
 			_exit(0);
 		}
-		/* For process types other than library, set up file desciptors. 
+		/* For process types other than library, set up file desciptors.
 		 * The library will use the input_fd and output_fd to talk to the manager instead. */
 		if (p->type != VINE_PROCESS_TYPE_LIBRARY) {
 			int result = dup2(input_fd, STDIN_FILENO);
@@ -415,17 +415,16 @@ pid_t vine_process_execute(struct vine_process *p)
 			result = dup2(output_fd, STDOUT_FILENO);
 			if (result < 0)
 				fatal("could not dup output to stdout: %s", strerror(errno));
-			
+
 			result = dup2(error_fd, STDERR_FILENO);
 			if (result < 0)
 				fatal("could not dup error to stderr: %s", strerror(errno));
-		
+
 			/* Close redundant file descriptors.
 			 * Note that output_fd is the same as error_fd so it's only closed once. */
 			close(input_fd);
-			close(output_fd);	// no need to close error_fd.
-		}
-		else {
+			close(output_fd); // no need to close error_fd.
+		} else {
 			int result = dup2(error_fd, STDERR_FILENO);
 			if (result < 0)
 				fatal("could not dup error to stderr: %s", strerror(errno));
@@ -451,10 +450,10 @@ pid_t vine_process_execute(struct vine_process *p)
 		 * the command line so it requires a special execl. */
 		if (p->type != VINE_PROCESS_TYPE_LIBRARY) {
 			execl("/bin/sh", "sh", "-c", p->task->command_line, (char *)0);
-		}
-		else {
-			char* final_command = string_format("%s --input-fd %d --output-fd %d", p->task->command_line, input_fd, output_fd);
-			execl("/bin/sh", "sh", "-c", final_command, (char*) 0);
+		} else {
+			char *final_command = string_format(
+					"%s --input-fd %d --output-fd %d", p->task->command_line, input_fd, output_fd);
+			execl("/bin/sh", "sh", "-c", final_command, (char *)0);
 		}
 		_exit(127); // Failed to execute the cmd.
 	}


### PR DESCRIPTION
Currently Library Task is using stdin/stdout to communicate with worker processes to get data and return results. If a function call prints something out to stdout however, then the communication is corrupted. This fix changes Library Task to use proper pipes to talk with vine worker.
There's also some minor code refactoring and comment editing/adding.