### PR TITLE
Vine: Cleanup resource accounting

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2303,37 +2303,23 @@ Handle a resource update message from the worker by updating local structures.
 static vine_msg_code_t handle_resource(struct vine_manager *q, struct vine_worker_info *w, const char *line)
 {
 	char resource_name[VINE_LINE_MAX];
-	struct vine_resource r;
-
-	int n = sscanf(line, "resource %s %" PRId64, resource_name, &r.total);
+	int64_t total;
+	
+	int n = sscanf(line, "resource %s %" PRId64, resource_name, &total);
 
 	if (n == 2) {
-
-		/* inuse is computed by the manager, so we save it here */
-		int64_t inuse;
-
 		if (!strcmp(resource_name, "cores")) {
-			inuse = w->resources->cores.inuse;
-			w->resources->cores = r;
-			w->resources->cores.inuse = inuse;
+			w->resources->cores.total = total;
 		} else if (!strcmp(resource_name, "memory")) {
-			inuse = w->resources->memory.inuse;
-			w->resources->memory = r;
-			w->resources->memory.inuse = inuse;
+			w->resources->memory.total = total;
 		} else if (!strcmp(resource_name, "disk")) {
-			inuse = w->resources->disk.inuse;
-			w->resources->disk = r;
-			w->resources->disk.inuse = inuse;
+			w->resources->disk.total = total;
 		} else if (!strcmp(resource_name, "gpus")) {
-			inuse = w->resources->gpus.inuse;
-			w->resources->gpus = r;
-			w->resources->gpus.inuse = inuse;
+			w->resources->gpus.total = total;
 		} else if (!strcmp(resource_name, "workers")) {
-			inuse = w->resources->workers.inuse;
-			w->resources->workers = r;
-			w->resources->workers.inuse = inuse;
+			w->resources->workers.total = total;
 		} else if (!strcmp(resource_name, "tag")) {
-			w->resources->tag = r.total;
+			w->resources->tag = total;
 		}
 	} else {
 		return VINE_MSG_FAILURE;

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2305,10 +2305,7 @@ static vine_msg_code_t handle_resource(struct vine_manager *q, struct vine_worke
 	char resource_name[VINE_LINE_MAX];
 	struct vine_resource r;
 
-	int n = sscanf(line,
-			"resource %s %" PRId64,
-			resource_name,
-		        &r.total);
+	int n = sscanf(line, "resource %s %" PRId64, resource_name, &r.total);
 
 	if (n == 2) {
 
@@ -2335,7 +2332,7 @@ static vine_msg_code_t handle_resource(struct vine_manager *q, struct vine_worke
 			inuse = w->resources->workers.inuse;
 			w->resources->workers = r;
 			w->resources->workers.inuse = inuse;
-		} else if(!strcmp(resource_name, "tag")) {
+		} else if (!strcmp(resource_name, "tag")) {
 			w->resources->tag = r.total;
 		}
 	} else {
@@ -2532,8 +2529,7 @@ struct rmsummary *vine_manager_choose_resources_for_task(
 				limits->cores = 0;
 			} else {
 				limits->cores = MAX(1,
-						MAX(limits->cores,
-								floor(w->resources->cores.total * max_proportion)));
+						MAX(limits->cores, floor(w->resources->cores.total * max_proportion)));
 			}
 
 			/* unspecified gpus are always 0 */
@@ -2541,8 +2537,8 @@ struct rmsummary *vine_manager_choose_resources_for_task(
 				limits->gpus = 0;
 			}
 
-			limits->memory = MAX(
-					1, MAX(limits->memory, floor(w->resources->memory.total * max_proportion)));
+			limits->memory =
+					MAX(1, MAX(limits->memory, floor(w->resources->memory.total * max_proportion)));
 
 			/* worker's disk is shared even among tasks that are not running,
 			 * thus the proportion is modified by the current overcommit

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2571,15 +2571,15 @@ struct rmsummary *vine_manager_choose_resources_for_task(
 	} else if (vine_schedule_in_ramp_down(q)) {
 		/* if in ramp down, use all the free space of that worker. note that we don't use
 		 * resource_submit_multiplier, as by definition in ramp down there are more workers than tasks. */
-		limits->cores = limits->gpus > 0 ? 0 : (w->resources->cores.largest - w->resources->cores.inuse);
+		limits->cores = limits->gpus > 0 ? 0 : (w->resources->cores.total - w->resources->cores.inuse);
 
 		/* default gpus is 0 */
 		if (limits->gpus <= 0) {
 			limits->gpus = 0;
 		}
 
-		limits->memory = w->resources->memory.largest - w->resources->memory.inuse;
-		limits->disk = w->resources->disk.largest - w->resources->disk.inuse;
+		limits->memory = w->resources->memory.total - w->resources->memory.inuse;
+		limits->disk = w->resources->disk.total - w->resources->disk.inuse;
 	}
 
 	/* never go below specified min resources. */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4311,7 +4311,7 @@ static void vine_manager_send_library_to_workers(struct vine_manager *q, const c
 			if (vine_manager_send_library_to_worker(q, w, name)) {
 				debug(D_VINE, "Sending library %s to worker %s\n", name, w->workerid);
 			} else {
-				debug(D_VINE, "Failed to send library %s to worker %s\n", name, w->workerid);
+				/* No error here, library might not match the worker. */
 			}
 		}
 	}

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2304,7 +2304,7 @@ static vine_msg_code_t handle_resource(struct vine_manager *q, struct vine_worke
 {
 	char resource_name[VINE_LINE_MAX];
 	int64_t total;
-	
+
 	int n = sscanf(line, "resource %s %" PRId64, resource_name, &total);
 
 	if (n == 2) {

--- a/taskvine/src/manager/vine_manager_summarize.c
+++ b/taskvine/src/manager/vine_manager_summarize.c
@@ -16,9 +16,9 @@ See the file COPYING for details.
 #include <stddef.h>
 #include <stdlib.h>
 
-size_t sort_ds_worker_summary_offset = 0;
+static size_t sort_worker_summary_offset = 0;
 
-static int sort_ds_worker_cmp(const void *a, const void *b)
+static int sort_worker_cmp(const void *a, const void *b)
 {
 	const struct rmsummary *x = *((const struct rmsummary **)a);
 	const struct rmsummary *y = *((const struct rmsummary **)b);
@@ -26,8 +26,8 @@ static int sort_ds_worker_cmp(const void *a, const void *b)
 	double count_x = x->workers;
 	double count_y = y->workers;
 
-	double res_x = rmsummary_get_by_offset(x, sort_ds_worker_summary_offset);
-	double res_y = rmsummary_get_by_offset(y, sort_ds_worker_summary_offset);
+	double res_x = rmsummary_get_by_offset(x, sort_worker_summary_offset);
+	double res_y = rmsummary_get_by_offset(y, sort_worker_summary_offset);
 
 	if (res_x == res_y) {
 		return count_y - count_x;
@@ -37,24 +37,24 @@ static int sort_ds_worker_cmp(const void *a, const void *b)
 }
 
 // function used by other functions
-static void sort_ds_worker_summary(struct rmsummary **worker_data, int count, const char *sortby)
+static void sort_worker_summary(struct rmsummary **worker_data, int count, const char *sortby)
 {
 	if (!strcmp(sortby, "cores")) {
-		sort_ds_worker_summary_offset = offsetof(struct rmsummary, cores);
+		sort_worker_summary_offset = offsetof(struct rmsummary, cores);
 	} else if (!strcmp(sortby, "memory")) {
-		sort_ds_worker_summary_offset = offsetof(struct rmsummary, memory);
+		sort_worker_summary_offset = offsetof(struct rmsummary, memory);
 	} else if (!strcmp(sortby, "disk")) {
-		sort_ds_worker_summary_offset = offsetof(struct rmsummary, disk);
+		sort_worker_summary_offset = offsetof(struct rmsummary, disk);
 	} else if (!strcmp(sortby, "gpus")) {
-		sort_ds_worker_summary_offset = offsetof(struct rmsummary, gpus);
+		sort_worker_summary_offset = offsetof(struct rmsummary, gpus);
 	} else if (!strcmp(sortby, "workers")) {
-		sort_ds_worker_summary_offset = offsetof(struct rmsummary, workers);
+		sort_worker_summary_offset = offsetof(struct rmsummary, workers);
 	} else {
 		debug(D_NOTICE, "Invalid field to sort worker summaries. Valid fields are: cores, memory, disk, gpus, and workers.");
-		sort_ds_worker_summary_offset = offsetof(struct rmsummary, memory);
+		sort_worker_summary_offset = offsetof(struct rmsummary, memory);
 	}
 
-	qsort(&worker_data[0], count, sizeof(struct rmsummary *), sort_ds_worker_cmp);
+	qsort(&worker_data[0], count, sizeof(struct rmsummary *), sort_worker_cmp);
 }
 
 // round to powers of two log scale with 1/n divisions
@@ -125,11 +125,11 @@ struct rmsummary **vine_manager_summarize_workers(struct vine_manager *q)
 
 	hash_table_delete(workers_count);
 
-	sort_ds_worker_summary(worker_data, count, "disk");
-	sort_ds_worker_summary(worker_data, count, "memory");
-	sort_ds_worker_summary(worker_data, count, "gpus");
-	sort_ds_worker_summary(worker_data, count, "cores");
-	sort_ds_worker_summary(worker_data, count, "workers");
+	sort_worker_summary(worker_data, count, "disk");
+	sort_worker_summary(worker_data, count, "memory");
+	sort_worker_summary(worker_data, count, "gpus");
+	sort_worker_summary(worker_data, count, "cores");
+	sort_worker_summary(worker_data, count, "workers");
 
 	return worker_data;
 }

--- a/taskvine/src/manager/vine_protocol.h
+++ b/taskvine/src/manager/vine_protocol.h
@@ -13,7 +13,7 @@ worker, and catalog, but should not be visible to the public user API.
 #ifndef VINE_PROTOCOL_H
 #define VINE_PROTOCOL_H
 
-#define VINE_PROTOCOL_VERSION 2
+#define VINE_PROTOCOL_VERSION 3
 
 #define VINE_LINE_MAX 4096       /**< Maximum length of a vine message line. */
 

--- a/taskvine/src/manager/vine_resources.c
+++ b/taskvine/src/manager/vine_resources.c
@@ -36,7 +36,6 @@ void vine_resources_measure_locally(struct vine_resources *r, const char *disk_p
 	UINT64_T avail, total;
 
 	r->cores.total = load_average_get_cpus();
-	r->cores.largest = r->cores.smallest = r->cores.total;
 
 	/* For disk and memory, we compute the total thinking that the worker is
 	 * not executing by itself, but that it has to share its resources with
@@ -44,31 +43,25 @@ void vine_resources_measure_locally(struct vine_resources *r, const char *disk_p
 
 	host_disk_info_get(disk_path, &avail, &total);
 	r->disk.total = (avail / (UINT64_T)MEGA) + r->disk.inuse; // Free + whatever we are using.
-	r->disk.largest = r->disk.smallest = r->disk.total;
 
 	host_memory_info_get(&avail, &total);
 	r->memory.total = (total / (UINT64_T)MEGA);
-	r->memory.largest = r->memory.smallest = r->memory.total;
 
 	if (!gpu_check) {
 		r->gpus.total = gpu_count_get();
-		r->gpus.largest = r->gpus.smallest = r->gpus.total;
 		gpu_check = 1;
 	}
 
 	r->workers.total = 1;
-	r->workers.largest = r->workers.smallest = r->workers.total;
 }
 
 static void vine_resource_debug(struct vine_resource *r, const char *name)
 {
 	debug(D_VINE,
-			"%8s %6" PRId64 " inuse %6" PRId64 " total %6" PRId64 " smallest %6" PRId64 " largest",
+			"%8s %6" PRId64 " inuse %6" PRId64 " total",
 			name,
 			r->inuse,
-			r->total,
-			r->smallest,
-			r->largest);
+			r->total);
 }
 
 static void vine_resource_send(struct link *manager, struct vine_resource *r, const char *name, time_t stoptime)
@@ -76,11 +69,9 @@ static void vine_resource_send(struct link *manager, struct vine_resource *r, co
 	vine_resource_debug(r, name);
 	link_printf(manager,
 			stoptime,
-			"resource %s %" PRId64 " %" PRId64 " %" PRId64 "\n",
+			"resource %s %" PRId64 "\n",
 			name,
-			r->total,
-			r->smallest,
-			r->largest);
+			r->total);
 }
 
 void vine_resources_send(struct link *manager, struct vine_resources *r, time_t stoptime)
@@ -111,8 +102,6 @@ static void vine_resource_add(struct vine_resource *total, struct vine_resource 
 {
 	total->inuse += r->inuse;
 	total->total += r->total;
-	total->smallest = MIN(total->smallest, r->smallest);
-	total->largest = MAX(total->largest, r->largest);
 }
 
 void vine_resources_add(struct vine_resources *total, struct vine_resources *r)
@@ -128,24 +117,14 @@ void vine_resources_add_to_jx(struct vine_resources *r, struct jx *nv)
 {
 	jx_insert_integer(nv, "workers_inuse", r->workers.inuse);
 	jx_insert_integer(nv, "workers_total", r->workers.total);
-	jx_insert_integer(nv, "workers_smallest", r->workers.smallest);
-	jx_insert_integer(nv, "workers_largest", r->workers.largest);
 	jx_insert_integer(nv, "cores_inuse", r->cores.inuse);
 	jx_insert_integer(nv, "cores_total", r->cores.total);
-	jx_insert_integer(nv, "cores_smallest", r->cores.smallest);
-	jx_insert_integer(nv, "cores_largest", r->cores.largest);
 	jx_insert_integer(nv, "memory_inuse", r->memory.inuse);
 	jx_insert_integer(nv, "memory_total", r->memory.total);
-	jx_insert_integer(nv, "memory_smallest", r->memory.smallest);
-	jx_insert_integer(nv, "memory_largest", r->memory.largest);
 	jx_insert_integer(nv, "disk_inuse", r->disk.inuse);
 	jx_insert_integer(nv, "disk_total", r->disk.total);
-	jx_insert_integer(nv, "disk_smallest", r->disk.smallest);
-	jx_insert_integer(nv, "disk_largest", r->disk.largest);
 	jx_insert_integer(nv, "gpus_inuse", r->gpus.inuse);
 	jx_insert_integer(nv, "gpus_total", r->gpus.total);
-	jx_insert_integer(nv, "gpus_smallest", r->gpus.smallest);
-	jx_insert_integer(nv, "gpus_largest", r->gpus.largest);
 }
 
 /* vim: set noexpandtab tabstop=8: */

--- a/taskvine/src/manager/vine_resources.c
+++ b/taskvine/src/manager/vine_resources.c
@@ -96,6 +96,18 @@ static void vine_resource_add(struct vine_resource *total, struct vine_resource 
 	total->total += r->total;
 }
 
+static void vine_resource_min(struct vine_resource *total, struct vine_resource *r)
+{
+	total->inuse = MIN(total->inuse, r->inuse);
+	total->total = MIN(total->total, r->total);
+}
+
+static void vine_resource_max(struct vine_resource *total, struct vine_resource *r)
+{
+	total->inuse = MAX(total->inuse, r->inuse);
+	total->total = MAX(total->total, r->total);
+}
+
 void vine_resources_add(struct vine_resources *total, struct vine_resources *r)
 {
 	vine_resource_add(&total->workers, &r->workers);
@@ -103,6 +115,24 @@ void vine_resources_add(struct vine_resources *total, struct vine_resources *r)
 	vine_resource_add(&total->disk, &r->disk);
 	vine_resource_add(&total->gpus, &r->gpus);
 	vine_resource_add(&total->cores, &r->cores);
+}
+
+void vine_resources_min(struct vine_resources *total, struct vine_resources *r)
+{
+	vine_resource_min(&total->workers, &r->workers);
+	vine_resource_min(&total->memory, &r->memory);
+	vine_resource_min(&total->disk, &r->disk);
+	vine_resource_min(&total->gpus, &r->gpus);
+	vine_resource_min(&total->cores, &r->cores);
+}
+
+void vine_resources_max(struct vine_resources *total, struct vine_resources *r)
+{
+	vine_resource_max(&total->workers, &r->workers);
+	vine_resource_max(&total->memory, &r->memory);
+	vine_resource_max(&total->disk, &r->disk);
+	vine_resource_max(&total->gpus, &r->gpus);
+	vine_resource_max(&total->cores, &r->cores);
 }
 
 void vine_resources_add_to_jx(struct vine_resources *r, struct jx *nv)

--- a/taskvine/src/manager/vine_resources.c
+++ b/taskvine/src/manager/vine_resources.c
@@ -57,21 +57,13 @@ void vine_resources_measure_locally(struct vine_resources *r, const char *disk_p
 
 static void vine_resource_debug(struct vine_resource *r, const char *name)
 {
-	debug(D_VINE,
-			"%8s %6" PRId64 " inuse %6" PRId64 " total",
-			name,
-			r->inuse,
-			r->total);
+	debug(D_VINE, "%8s %6" PRId64 " inuse %6" PRId64 " total", name, r->inuse, r->total);
 }
 
 static void vine_resource_send(struct link *manager, struct vine_resource *r, const char *name, time_t stoptime)
 {
 	vine_resource_debug(r, name);
-	link_printf(manager,
-			stoptime,
-			"resource %s %" PRId64 "\n",
-			name,
-			r->total);
+	link_printf(manager, stoptime, "resource %s %" PRId64 "\n", name, r->total);
 }
 
 void vine_resources_send(struct link *manager, struct vine_resources *r, time_t stoptime)

--- a/taskvine/src/manager/vine_resources.h
+++ b/taskvine/src/manager/vine_resources.h
@@ -31,6 +31,8 @@ void vine_resources_measure_locally( struct vine_resources *r, const char *works
 void vine_resources_send( struct link *manager, struct vine_resources *r, time_t stoptime );
 void vine_resources_clear( struct vine_resources *r );
 void vine_resources_add( struct vine_resources *total, struct vine_resources *r );
+void vine_resources_min( struct vine_resources *total, struct vine_resources *r );
+void vine_resources_max( struct vine_resources *total, struct vine_resources *r );
 void vine_resources_add_to_jx( struct vine_resources *r, struct jx *j );
 
 #endif

--- a/taskvine/src/manager/vine_resources.h
+++ b/taskvine/src/manager/vine_resources.h
@@ -13,8 +13,6 @@ See the file COPYING for details.
 struct vine_resource {
 	int64_t inuse;
 	int64_t total;
-	int64_t smallest;
-	int64_t largest;
 };
 
 struct vine_resources {

--- a/taskvine/src/manager/vine_resources.h
+++ b/taskvine/src/manager/vine_resources.h
@@ -29,7 +29,6 @@ void vine_resources_delete( struct vine_resources *r );
 void vine_resources_debug( struct vine_resources *r );
 void vine_resources_measure_locally( struct vine_resources *r, const char *workspace );
 void vine_resources_send( struct link *manager, struct vine_resources *r, time_t stoptime );
-void vine_coprocess_resources_send( struct link *manager, struct vine_resources *r, time_t stoptime );
 void vine_resources_clear( struct vine_resources *r );
 void vine_resources_add( struct vine_resources *total, struct vine_resources *r );
 void vine_resources_add_to_jx( struct vine_resources *r, struct jx *j );

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1161,8 +1161,8 @@ static int task_resources_fit_eventually(struct vine_task *t)
 	r = local_resources;
 
 	return (t->resources_requested->cores <= r->cores.total) &&
-	       (t->resources_requested->memory <= r->memory.total) &&
-	       (t->resources_requested->disk <= r->disk.total) && (t->resources_requested->gpus <= r->gpus.total);
+	       (t->resources_requested->memory <= r->memory.total) && (t->resources_requested->disk <= r->disk.total) &&
+	       (t->resources_requested->gpus <= r->gpus.total);
 }
 
 /*

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -154,9 +154,8 @@ static timestamp_t worker_start_time = 0;
 
 static struct vine_watcher *watcher = 0;
 
-static struct vine_resources *local_resources = 0;
-struct vine_resources *total_resources = 0;
-struct vine_resources *total_resources_last = 0;
+/* The resources measured and available at this worker. */
+static struct vine_resources *total_resources = 0;
 
 static int64_t last_task_received = 0;
 
@@ -169,6 +168,7 @@ static time_t manual_wall_time_option = 0;
 /* -1 means not given as a command line option. */
 static int64_t manual_gpus_option = -1;
 
+/* The resources currently allocated to running tasks. */
 static int64_t cores_allocated = 0;
 static int64_t memory_allocated = 0;
 static int64_t disk_allocated = 0;
@@ -296,8 +296,8 @@ static int64_t measure_worker_disk()
 }
 
 /*
-Measure only the resources associated with this particular node
-and apply any operations that override.
+Measure the resources associated with this worker
+and apply any local options that override it.
 */
 
 static void measure_worker_resources()
@@ -307,7 +307,7 @@ static void measure_worker_resources()
 		return;
 	}
 
-	struct vine_resources *r = local_resources;
+	struct vine_resources *r = total_resources;
 
 	vine_resources_measure_locally(r, workspace);
 
@@ -324,8 +324,6 @@ static void measure_worker_resources()
 
 	r->disk.inuse = measure_worker_disk();
 	r->tag = last_task_received;
-
-	memcpy(total_resources, r, sizeof(struct vine_resources));
 
 	vine_gpus_init(r->gpus.total);
 
@@ -356,11 +354,6 @@ Send a message to the manager with my current resources.
 static void send_resource_update(struct link *manager)
 {
 	time_t stoptime = time(0) + active_timeout;
-
-	// assume that cores.total doesn't change
-	// assume that gpus.total doesn't change.
-	total_resources->memory.total = MAX(0, local_resources->memory.total);
-	total_resources->disk.total = MAX(0, local_resources->disk.total);
 
 	// if workers are set to expire in some time, send the expiration time to manager
 	if (manual_wall_time_option > 0) {
@@ -672,10 +665,10 @@ static void normalize_resources(struct vine_process *p)
 
 	if (t->resources_requested->cores < 0 && t->resources_requested->memory < 0 &&
 			t->resources_requested->disk < 0 && t->resources_requested->gpus < 0) {
-		t->resources_requested->cores = local_resources->cores.total;
-		t->resources_requested->memory = local_resources->memory.total;
-		t->resources_requested->disk = local_resources->disk.total;
-		t->resources_requested->gpus = local_resources->gpus.total;
+		t->resources_requested->cores = total_resources->cores.total;
+		t->resources_requested->memory = total_resources->memory.total;
+		t->resources_requested->disk = total_resources->disk.total;
+		t->resources_requested->gpus = total_resources->gpus.total;
 	} else {
 		t->resources_requested->cores = MAX(t->resources_requested->cores, 0);
 		t->resources_requested->memory = MAX(t->resources_requested->memory, 0);
@@ -1141,10 +1134,10 @@ static int task_resources_fit_now(struct vine_task *t)
 {
 	/* XXX removed disk space check due to problems running workers locally or multiple workers on a single node
 	 * since default tasks request the entire reported disk space. questionable if this check useful in practice.*/
-	return (cores_allocated + t->resources_requested->cores <= local_resources->cores.total) &&
-	       (memory_allocated + t->resources_requested->memory <= local_resources->memory.total) &&
-	       (1) && // disk_allocated   + t->resources_requested->disk   <= local_resources->disk.total) &&
-	       (gpus_allocated + t->resources_requested->gpus <= local_resources->gpus.total);
+	return (cores_allocated + t->resources_requested->cores <= total_resources->cores.total) &&
+	       (memory_allocated + t->resources_requested->memory <= total_resources->memory.total) &&
+	       (1) && // disk_allocated   + t->resources_requested->disk   <= total_resources->disk.total) &&
+	       (gpus_allocated + t->resources_requested->gpus <= total_resources->gpus.total);
 }
 
 /*
@@ -1158,7 +1151,7 @@ static int task_resources_fit_eventually(struct vine_task *t)
 {
 	struct vine_resources *r;
 
-	r = local_resources;
+	r = total_resources;
 
 	return (t->resources_requested->cores <= r->cores.total) &&
 	       (t->resources_requested->memory <= r->memory.total) && (t->resources_requested->disk <= r->disk.total) &&
@@ -1231,30 +1224,30 @@ If 0, the worker is using more resources than promised. 1 if resource usage hold
 
 static int enforce_worker_limits(struct link *manager)
 {
-	if (manual_disk_option > 0 && local_resources->disk.inuse > manual_disk_option) {
+	if (manual_disk_option > 0 && total_resources->disk.inuse > manual_disk_option) {
 		fprintf(stderr,
 				"vine_worker: %s used more than declared disk space (--disk - < disk used) %" PRIu64
 				" < %" PRIu64 " MB\n",
 				workspace,
 				manual_disk_option,
-				local_resources->disk.inuse);
+				total_resources->disk.inuse);
 
 		if (manager) {
-			send_message(manager, "info disk_exhausted %lld\n", (long long)local_resources->disk.inuse);
+			send_message(manager, "info disk_exhausted %lld\n", (long long)total_resources->disk.inuse);
 		}
 
 		return 0;
 	}
 
-	if (manual_memory_option > 0 && local_resources->memory.inuse > manual_memory_option) {
+	if (manual_memory_option > 0 && total_resources->memory.inuse > manual_memory_option) {
 		fprintf(stderr,
 				"vine_worker: used more than declared memory (--memory < memory used) %" PRIu64
 				" < %" PRIu64 " MB\n",
 				manual_memory_option,
-				local_resources->memory.inuse);
+				total_resources->memory.inuse);
 
 		if (manager) {
-			send_message(manager, "info memory_exhausted %lld\n", (long long)local_resources->memory.inuse);
+			send_message(manager, "info memory_exhausted %lld\n", (long long)total_resources->memory.inuse);
 		}
 
 		return 0;
@@ -1281,15 +1274,15 @@ static int enforce_worker_promises(struct link *manager)
 		return 0;
 	}
 
-	if (manual_disk_option > 0 && local_resources->disk.total < manual_disk_option) {
+	if (manual_disk_option > 0 && total_resources->disk.total < manual_disk_option) {
 		fprintf(stderr,
 				"vine_worker: has less than the promised disk space (--disk > disk total) %" PRIu64
 				" < %" PRIu64 " MB\n",
 				manual_disk_option,
-				local_resources->disk.total);
+				total_resources->disk.total);
 
 		if (manager) {
-			send_message(manager, "info disk_error %lld\n", (long long)local_resources->disk.total);
+			send_message(manager, "info disk_error %lld\n", (long long)total_resources->disk.total);
 		}
 
 		return 0;
@@ -2337,9 +2330,7 @@ int main(int argc, char *argv[])
 
 	watcher = vine_watcher_create();
 
-	local_resources = vine_resources_create();
 	total_resources = vine_resources_create();
-	total_resources_last = vine_resources_create();
 
 	if (manual_cores_option < 1) {
 		manual_cores_option = load_average_get_cpus();

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -322,11 +322,6 @@ static void measure_worker_resources()
 		r->disk.total = MIN(r->disk.total, manual_disk_option);
 	}
 
-	r->cores.smallest = r->cores.largest = r->cores.total;
-	r->memory.smallest = r->memory.largest = r->memory.total;
-	r->disk.smallest = r->disk.largest = r->disk.total;
-	r->gpus.smallest = r->gpus.largest = r->gpus.total;
-
 	r->disk.inuse = measure_worker_disk();
 	r->tag = last_task_received;
 
@@ -362,13 +357,10 @@ static void send_resource_update(struct link *manager)
 {
 	time_t stoptime = time(0) + active_timeout;
 
+	// assume that cores.total doesn't change
+	// assume that gpus.total doesn't change.
 	total_resources->memory.total = MAX(0, local_resources->memory.total);
-	total_resources->memory.largest = MAX(0, local_resources->memory.largest);
-	total_resources->memory.smallest = MAX(0, local_resources->memory.smallest);
-
 	total_resources->disk.total = MAX(0, local_resources->disk.total);
-	total_resources->disk.largest = MAX(0, local_resources->disk.largest);
-	total_resources->disk.smallest = MAX(0, local_resources->disk.smallest);
 
 	// if workers are set to expire in some time, send the expiration time to manager
 	if (manual_wall_time_option > 0) {
@@ -1168,9 +1160,9 @@ static int task_resources_fit_eventually(struct vine_task *t)
 
 	r = local_resources;
 
-	return (t->resources_requested->cores <= r->cores.largest) &&
-	       (t->resources_requested->memory <= r->memory.largest) &&
-	       (t->resources_requested->disk <= r->disk.largest) && (t->resources_requested->gpus <= r->gpus.largest);
+	return (t->resources_requested->cores <= r->cores.total) &&
+	       (t->resources_requested->memory <= r->memory.total) &&
+	       (t->resources_requested->disk <= r->disk.total) && (t->resources_requested->gpus <= r->gpus.total);
 }
 
 /*


### PR DESCRIPTION
`vine_resource` had vestigial fields `largest` and `smallest` that were a holdover from the WQ foreman and resulted in confusing debug output.