### PR TITLE
vine: track fixed location tasks

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4058,8 +4058,7 @@ static vine_task_state_t change_task_state(struct vine_manager *q, struct vine_t
 	case VINE_TASK_DONE:
 	case VINE_TASK_CANCELED:
 		/* Task was cloned when entered into our own table, so delete a reference on removal. */
-		if(t->has_fixed_locations)
-		{
+		if (t->has_fixed_locations) {
 			q->fixed_location_in_queue--;
 		}
 		vine_taskgraph_log_write_task(q, t);
@@ -4657,12 +4656,12 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 		// expired tasks
 		BEGIN_ACCUM_TIME(q, time_internal);
 		result = expire_waiting_tasks(q);
-		
+
 		// only check for fixed location if any are present (high overhead)
-		if(q->fixed_location_in_queue) {
+		if (q->fixed_location_in_queue) {
 			result |= enforce_waiting_fixed_locations(q);
 		}
-		
+
 		END_ACCUM_TIME(q, time_internal);
 		if (result) {
 			// expired or ended at least one task

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -127,6 +127,7 @@ struct vine_manager {
 	/* Internal state modified by the manager */
 
 	int next_task_id;       /* Next integer task_id to be assigned to a created task. */
+	int fixed_location_in_queue; /* Number of fixed location tasks currently being managed */
 	int num_tasks_left;    /* Optional: Number of tasks remaining, if given by user.  @ref vine_set_num_tasks */
 	int busy_waiting_flag; /* Set internally in main loop if no messages were processed -> wait longer. */
 


### PR DESCRIPTION
Avoid overhead of enforce_fixed_location unless there are relevant tasks in the queue