### PR TITLE
vine, wq: ramp down mode

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -2372,6 +2372,7 @@ change.
 | proportional-resources | If set to 0, do not assign resources proportionally to tasks. The default is to use proportions. (See [task resources.](#task-resources) | 1 |
 | proportional-whole-tasks | Round up resource proportions such that only an integer number of tasks could be fit in the worker. The default is to use proportions. (See [task resources.](#task-resources) | 1 |
 | hungry-minimum          | Smallest number of waiting tasks in the manager before declaring it hungry | 10 |
+| hungry-minimum-factor   | Queue is hungry if number of waiting tasks is less than hungry-minumum-factor x (number of workers) | 2 |
 | monitor-interval        | Maximum number of seconds between resource monitor measurements. If less than 1, use default. | 5 |
 | resource-submit-multiplier | Assume that workers have `resource x resources-submit-multiplier` available.<br> This overcommits resources at the worker, causing tasks to be sent to workers that cannot be immediately executed.<br>The extra tasks wait at the worker until resources become available. | 1 |
 | wait-for-workers        | Do not schedule any tasks until `wait-for-workers` are connected. | 0 |

--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -2373,6 +2373,7 @@ change.
 | proportional-whole-tasks | Round up resource proportions such that only an integer number of tasks could be fit in the worker. The default is to use proportions. (See [task resources.](#task-resources) | 1 |
 | hungry-minimum          | Smallest number of waiting tasks in the manager before declaring it hungry | 10 |
 | hungry-minimum-factor   | Queue is hungry if number of waiting tasks is less than hungry-minumum-factor x (number of workers) | 2 |
+| ramp-down-heuristic     | If set to 1 and there are more workers than tasks waiting, then tasks are allocated all the free resources of a worker large enough to run them. If monitoring watchdog is not enabled, then this heuristic has no effect. | 0 |
 | monitor-interval        | Maximum number of seconds between resource monitor measurements. If less than 1, use default. | 5 |
 | resource-submit-multiplier | Assume that workers have `resource x resources-submit-multiplier` available.<br> This overcommits resources at the worker, causing tasks to be sent to workers that cannot be immediately executed.<br>The extra tasks wait at the worker until resources become available. | 1 |
 | wait-for-workers        | Do not schedule any tasks until `wait-for-workers` are connected. | 0 |

--- a/doc/manuals/work_queue/index.md
+++ b/doc/manuals/work_queue/index.md
@@ -2186,6 +2186,7 @@ change.
 | proportional-whole-tasks | Round up resource proportions such that only an integer number of tasks could be fit in the worker. The default is to use proportions. (See [task resources.](#task-resources) | 1 |
 | hungry-minimum          | Smallest number of waiting tasks in the queue before declaring it hungry | 10 |
 | hungry-minimum-factor   | Queue is hungry if number of waiting tasks is less than hungry-minumum-factor x (number of workers) | 2 |
+| ramp-down-heuristic     | If set to 1 and there are more workers than tasks waiting, then tasks are allocated all the free resources of a worker large enough to run them. If monitoring watchdog is not enabled, then this heuristic has no effect. | 0 |
 | resource-submit-multiplier | Assume that workers have `resource x resources-submit-multiplier` available.<br> This overcommits resources at the worker, causing tasks to be sent to workers that cannot be immediately executed.<br>The extra tasks wait at the worker until resources become available. | 1 |
 | wait-for-workers        | Do not schedule any tasks until `wait-for-workers` are connected. | 0 |
 | wait-retrieve-many      | Rather than immediately returning when a task is done, `q.wait(timeout)` retrieves and dispatches as many tasks<br> as `timeout` allows. Warning: This may exceed the capacity of the manager to receive results. | 0 |

--- a/doc/manuals/work_queue/index.md
+++ b/doc/manuals/work_queue/index.md
@@ -2185,6 +2185,7 @@ change.
 | proportional-resources | If set to 0, do not assign resources proportionally to tasks. The default is to use proportions. (See [task resources.](#task-resources) | 1 |
 | proportional-whole-tasks | Round up resource proportions such that only an integer number of tasks could be fit in the worker. The default is to use proportions. (See [task resources.](#task-resources) | 1 |
 | hungry-minimum          | Smallest number of waiting tasks in the queue before declaring it hungry | 10 |
+| hungry-minimum-factor   | Queue is hungry if number of waiting tasks is less than hungry-minumum-factor x (number of workers) | 2 |
 | resource-submit-multiplier | Assume that workers have `resource x resources-submit-multiplier` available.<br> This overcommits resources at the worker, causing tasks to be sent to workers that cannot be immediately executed.<br>The extra tasks wait at the worker until resources become available. | 1 |
 | wait-for-workers        | Do not schedule any tasks until `wait-for-workers` are connected. | 0 |
 | wait-retrieve-many      | Rather than immediately returning when a task is done, `q.wait(timeout)` retrieves and dispatches as many tasks<br> as `timeout` allows. Warning: This may exceed the capacity of the manager to receive results. | 0 |

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -178,6 +178,7 @@ struct vine_manager {
 	int keepalive_interval;	      /* Time between keepalive request transmissions. */
 	int keepalive_timeout;	      /* Keepalive response must be received within this time, otherwise worker disconnected. */
 	int hungry_minimum;           /* Minimum number of waiting tasks to consider queue not hungry. */
+	int hungry_minimum_factor;    /* queue is hungry if number of waiting tasks is less than hungry_minimum_factor * number of connected workers. */
 	int wait_for_workers;         /* Wait for these many workers to connect before dispatching tasks at start of execution. */
 	int attempt_schedule_depth;   /* number of submitted tasks to attempt scheduling before we continue to retrievals */
     int max_retrievals;           /* Do at most this number of task retrievals of either receive_one_task or receive_all_tasks_from_worker. If less

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -181,12 +181,14 @@ struct vine_manager {
 	int hungry_minimum_factor;    /* queue is hungry if number of waiting tasks is less than hungry_minimum_factor * number of connected workers. */
 	int wait_for_workers;         /* Wait for these many workers to connect before dispatching tasks at start of execution. */
 	int attempt_schedule_depth;   /* number of submitted tasks to attempt scheduling before we continue to retrievals */
-    int max_retrievals;           /* Do at most this number of task retrievals of either receive_one_task or receive_all_tasks_from_worker. If less
+	int max_retrievals;           /* Do at most this number of task retrievals of either receive_one_task or receive_all_tasks_from_worker. If less
                                      than 1, prefer to receive all completed tasks before submitting new tasks. */
 	int worker_retrievals;        /* retrieve all completed tasks from a worker as opposed to recieving one of any completed task*/
 	int fetch_factory;            /* If true, manager queries catalog for factory configuration. */
 	int proportional_resources;   /* If true, tasks divide worker resources proportionally. */
 	int proportional_whole_tasks; /* If true, round-up proportions to whole number of tasks. */
+	int ramp_down_heuristic;      /* If true, and there are more workers than tasks waiting, then tasks are allocated all the free resources of a worker large enough to run them.
+																	 If monitoring watchdog is not enabled, then this heuristic has no effect. */
 	double resource_submit_multiplier; /* Factor to permit overcommitment of resources at each worker.  */
 	double bandwidth_limit;            /* Artificial limit on bandwidth of manager<->worker transfers. */
 	int disk_avail_threshold; /* Ensure this minimum amount of available disk space. (in MB) */

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -62,6 +62,30 @@ static struct vine_task *find_library_on_worker_for_task(
 	return 0;
 }
 
+/* Check if queue has entered ramp_down mode (more workers than waiting tasks).
+ * @param q The manager structure.
+ * @return 1 if in ramp down mode, 0 otherwise.
+ */
+
+int vine_schedule_in_ramp_down(struct vine_manager *q)
+{
+	if (!(q->monitor_mode & VINE_MON_WATCHDOG)) {
+		/* if monitoring is not terminating tasks because of resources, ramp down heuristic does not have any
+		 * effect. */
+		return 0;
+	}
+
+	if (!q->ramp_down_heuristic) {
+		return 0;
+	}
+
+	if (hash_table_size(q->worker_table) > list_size(q->ready_list)) {
+		return 1;
+	}
+
+	return 0;
+}
+
 /* Check if this task is compatible with this given worker by considering
  * resources availability, features, blocklist, and all other relevant factors.
  * Used by all scheduling methods for basic compatibility.
@@ -174,6 +198,40 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 	return ok;
 }
 
+// 0 if current_best has more free resources than candidate, 1 else.
+static int candidate_has_worse_fit(struct vine_worker_info *current_best, struct vine_worker_info *candidate)
+{
+	struct vine_resources *b = current_best->resources;
+	struct vine_resources *o = candidate->resources;
+
+	// Total worker order: free cores > free memory > free disk > free gpus
+	int free_delta = (b->cores.total - b->cores.inuse) - (o->cores.total - o->cores.inuse);
+	if (free_delta > 0) {
+		return 1;
+	} else if (free_delta < 0) {
+		return 0;
+	}
+
+	// Same number of free cores...
+	free_delta = (b->memory.total - b->memory.inuse) - (o->memory.total - o->memory.inuse);
+	if (free_delta > 0) {
+		return 1;
+	} else if (free_delta < 0) {
+		return 0;
+	}
+
+	// Same number of free disk...
+	free_delta = (b->disk.total - b->disk.inuse) - (o->disk.total - o->disk.inuse);
+	if (free_delta > 0) {
+		return 1;
+	} else if (free_delta < 0) {
+		return 0;
+	}
+
+	// Number of free resources are the same.
+	return 0;
+}
+
 /*
 Find the worker that has the largest quantity of cached data needed
 by this task, so as to minimize transfer work that must be done
@@ -190,6 +248,8 @@ static struct vine_worker_info *find_worker_by_files(struct vine_manager *q, str
 	uint8_t has_all_files;
 	struct vine_file_replica *remote_info;
 	struct vine_mount *m;
+
+	int ramp_down = vine_schedule_in_ramp_down(q);
 
 	HASH_TABLE_ITERATE(q->worker_table, key, w)
 	{
@@ -209,11 +269,13 @@ static struct vine_worker_info *find_worker_by_files(struct vine_manager *q, str
 			}
 
 			/* Return the worker if it was in possession of all cacheable files */
-			if (has_all_files) {
+			if (has_all_files && !ramp_down) {
 				return w;
 			}
 
-			if (!best_worker || task_cached_bytes > most_task_cached_bytes) {
+			if (!best_worker || task_cached_bytes > most_task_cached_bytes ||
+					(ramp_down && task_cached_bytes == most_task_cached_bytes &&
+							candidate_has_worse_fit(best_worker, w))) {
 				best_worker = w;
 				most_task_cached_bytes = task_cached_bytes;
 			}
@@ -276,41 +338,6 @@ static struct vine_worker_info *find_worker_by_random(struct vine_manager *q, st
 	return w;
 }
 
-// 1 if a < b, 0 if a >= b
-static int compare_worst_fit(struct vine_resources *a, struct vine_resources *b)
-{
-	// Total worker order: free cores > free memory > free disk > free gpus
-	if ((a->cores.total < b->cores.total))
-		return 1;
-
-	if ((a->cores.total > b->cores.total))
-		return 0;
-
-	// Same number of free cores...
-	if ((a->memory.total < b->memory.total))
-		return 1;
-
-	if ((a->memory.total > b->memory.total))
-		return 0;
-
-	// Same number of free memory...
-	if ((a->disk.total < b->disk.total))
-		return 1;
-
-	if ((a->disk.total > b->disk.total))
-		return 0;
-
-	// Same number of free disk...
-	if ((a->gpus.total < b->gpus.total))
-		return 1;
-
-	if ((a->gpus.total > b->gpus.total))
-		return 0;
-
-	// Number of free resources are the same.
-	return 0;
-}
-
 /*
 Find the worker that is the "worst fit" for this task,
 meaning the worker that will have the most resources
@@ -323,26 +350,12 @@ static struct vine_worker_info *find_worker_by_worst_fit(struct vine_manager *q,
 	struct vine_worker_info *w;
 	struct vine_worker_info *best_worker = NULL;
 
-	struct vine_resources bres;
-	struct vine_resources wres;
-
-	memset(&bres, 0, sizeof(struct vine_resources));
-	memset(&wres, 0, sizeof(struct vine_resources));
-
 	HASH_TABLE_ITERATE(q->worker_table, key, w)
 	{
 
 		if (check_worker_against_task(q, w, t)) {
-
-			// Use total field on bres, wres to indicate free resources.
-			wres.cores.total = w->resources->cores.total - w->resources->cores.inuse;
-			wres.memory.total = w->resources->memory.total - w->resources->memory.inuse;
-			wres.disk.total = w->resources->disk.total - w->resources->disk.inuse;
-			wres.gpus.total = w->resources->gpus.total - w->resources->gpus.inuse;
-
-			if (!best_worker || compare_worst_fit(&bres, &wres)) {
+			if (!best_worker || candidate_has_worse_fit(best_worker, w)) {
 				best_worker = w;
-				memcpy(&bres, &wres, sizeof(struct vine_resources));
 			}
 		}
 	}
@@ -368,7 +381,9 @@ static struct vine_worker_info *find_worker_by_time(struct vine_manager *q, stru
 		if (check_worker_against_task(q, w, t)) {
 			if (w->total_tasks_complete > 0) {
 				double t = (w->total_task_time + w->total_transfer_time) / w->total_tasks_complete;
-				if (!best_worker || t < best_time) {
+				if (!best_worker || t < best_time ||
+						(t == best_time && vine_schedule_in_ramp_down(q) &&
+								candidate_has_worse_fit(best_worker, w))) {
 					best_worker = w;
 					best_time = t;
 				}
@@ -378,6 +393,8 @@ static struct vine_worker_info *find_worker_by_time(struct vine_manager *q, stru
 
 	if (best_worker) {
 		return best_worker;
+	} else if (vine_schedule_in_ramp_down(q)) {
+		return find_worker_by_worst_fit(q, t);
 	} else {
 		return find_worker_by_fcfs(q, t);
 	}

--- a/taskvine/src/manager/vine_schedule.h
+++ b/taskvine/src/manager/vine_schedule.h
@@ -21,5 +21,6 @@ This module is private to the manager and should not be invoked by the end user.
 struct vine_worker_info *vine_schedule_task_to_worker( struct vine_manager *q, struct vine_task *t );
 void vine_schedule_check_for_large_tasks( struct vine_manager *q );
 int vine_schedule_check_fixed_location(struct vine_manager *q, struct vine_task *t);
+int vine_schedule_in_ramp_down(struct vine_manager *q);
 int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t);
 #endif

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -244,6 +244,7 @@ struct work_queue {
 	int wait_retrieve_many;
 	int proportional_resources;
 	int proportional_whole_tasks;
+	int ramp_down_heuristic;
 };
 
 struct work_queue_worker {
@@ -3744,6 +3745,23 @@ static work_queue_result_code_t send_input_files( struct work_queue *q, struct w
 	return WQ_SUCCESS;
 }
 
+int in_ramp_down(struct work_queue *q) {
+	if(!(q->monitor_mode & MON_WATCHDOG)) {
+		/* if monitoring is not terminating tasks because of resources, ramp down heuristic does not have any effect. */
+		return 0;
+	}
+
+	if(!q->ramp_down_heuristic) {
+		return 0;
+	}
+
+	if(hash_table_size(q->worker_table) > list_size(q->ready_list)) {
+		return 1;
+	}
+
+	return 0;
+}
+
 static struct rmsummary *task_worker_box_size(struct work_queue *q, struct work_queue_worker *w, struct work_queue_task *t) {
 
 	const struct rmsummary *min = task_min_resources(q, t);
@@ -3843,6 +3861,18 @@ static struct rmsummary *task_worker_box_size(struct work_queue *q, struct work_
 		if(limits->disk <= 0) {
 			limits->disk = w->resources->disk.largest;
 		}
+	} else if(in_ramp_down(q)) {
+		/* if in ramp down, use all the free space of that worker. note that we don't use
+		 * resource_submit_multiplier, as by definition in ramp down there are more workers than tasks. */
+		limits->cores = limits->gpus > 0 ? 0 : (w->resources->cores.largest - w->resources->cores.inuse);
+
+		/* default gpus is 0 */
+		if(limits->gpus <= 0) {
+			limits->gpus = 0;
+		}
+
+		limits->memory = w->resources->memory.largest - w->resources->memory.inuse;
+		limits->disk = w->resources->disk.largest - w->resources->disk.inuse;
 	}
 
 	/* never go below specified min resources. */
@@ -4173,6 +4203,40 @@ static int check_hand_against_task(struct work_queue *q, struct work_queue_worke
 	return ok;
 }
 
+// 0 if current_best has more free resources than candidate, 1 else.
+static int candidate_has_worse_fit(struct work_queue_worker *current_best, struct work_queue_worker *candidate)
+{
+	struct work_queue_resources *b = current_best->resources;
+	struct work_queue_resources *o = candidate->resources;
+
+	//Total worker order: free cores > free memory > free disk > free gpus
+	int free_delta = (b->cores.total - b->cores.inuse) - (o->cores.total - o->cores.inuse);
+	if(free_delta > 0) {
+		return 1;
+	} else if(free_delta < 0) {
+		return 0;
+	}
+
+	//Same number of free cores...
+	free_delta = (b->memory.total - b->memory.inuse) - (o->memory.total - o->memory.inuse);
+	if(free_delta > 0) {
+		return 1;
+	} else if(free_delta < 0) {
+		return 0;
+	}
+
+	//Same number of free disk...
+	free_delta = (b->disk.total - b->disk.inuse) - (o->disk.total - o->disk.inuse);
+	if(free_delta > 0) {
+		return 1;
+	} else if(free_delta < 0) {
+		return 0;
+	}
+
+	//Number of free resources are the same.
+	return 0;
+}
+
 static struct work_queue_worker *find_worker_by_files(struct work_queue *q, struct work_queue_task *t)
 {
 	char *key;
@@ -4196,7 +4260,8 @@ static struct work_queue_worker *find_worker_by_files(struct work_queue *q, stru
 				}
 			}
 
-			if(!best_worker || task_cached_bytes > most_task_cached_bytes) {
+			if (!best_worker || task_cached_bytes > most_task_cached_bytes ||
+					(in_ramp_down(q) && task_cached_bytes == most_task_cached_bytes && candidate_has_worse_fit(best_worker, w))) {
 				best_worker = w;
 				most_task_cached_bytes = task_cached_bytes;
 			}
@@ -4247,67 +4312,18 @@ static struct work_queue_worker *find_worker_by_random(struct work_queue *q, str
 	return w;
 }
 
-// 1 if a < b, 0 if a >= b
-static int compare_worst_fit(struct work_queue_resources *a, struct work_queue_resources *b)
-{
-	//Total worker order: free cores > free memory > free disk > free gpus
-	if((a->cores.total < b->cores.total))
-		return 1;
-
-	if((a->cores.total > b->cores.total))
-		return 0;
-
-	//Same number of free cores...
-	if((a->memory.total < b->memory.total))
-		return 1;
-
-	if((a->memory.total > b->memory.total))
-		return 0;
-
-	//Same number of free memory...
-	if((a->disk.total < b->disk.total))
-		return 1;
-
-	if((a->disk.total > b->disk.total))
-		return 0;
-
-	//Same number of free disk...
-	if((a->gpus.total < b->gpus.total))
-		return 1;
-
-	if((a->gpus.total > b->gpus.total))
-		return 0;
-
-	//Number of free resources are the same.
-	return 0;
-}
-
 static struct work_queue_worker *find_worker_by_worst_fit(struct work_queue *q, struct work_queue_task *t)
 {
 	char *key;
 	struct work_queue_worker *w;
 	struct work_queue_worker *best_worker = NULL;
 
-	struct work_queue_resources bres;
-	struct work_queue_resources wres;
-
-	memset(&bres, 0, sizeof(struct work_queue_resources));
-	memset(&wres, 0, sizeof(struct work_queue_resources));
-
 	hash_table_firstkey(q->worker_table);
 	while(hash_table_nextkey(q->worker_table, &key, (void **) &w)) {
 		if( check_hand_against_task(q, w, t) ) {
-
-			//Use total field on bres, wres to indicate free resources.
-			wres.cores.total   = w->resources->cores.total   - w->resources->cores.inuse;
-			wres.memory.total  = w->resources->memory.total  - w->resources->memory.inuse;
-			wres.disk.total    = w->resources->disk.total    - w->resources->disk.inuse;
-			wres.gpus.total    = w->resources->gpus.total    - w->resources->gpus.inuse;
-
-			if(!best_worker || compare_worst_fit(&bres, &wres))
+			if(!best_worker || candidate_has_worse_fit(best_worker, w))
 			{
 				best_worker = w;
-				memcpy(&bres, &wres, sizeof(struct work_queue_resources));
 			}
 		}
 	}
@@ -4327,7 +4343,7 @@ static struct work_queue_worker *find_worker_by_time(struct work_queue *q, struc
 		if(check_hand_against_task(q, w, t)) {
 			if(w->total_tasks_complete > 0) {
 				double t = (w->total_task_time + w->total_transfer_time) / w->total_tasks_complete;
-				if(!best_worker || t < best_time) {
+				if(!best_worker || t < best_time || (t == best_time && in_ramp_down(q) && candidate_has_worse_fit(best_worker, w))) {
 					best_worker = w;
 					best_time = t;
 				}
@@ -4337,6 +4353,8 @@ static struct work_queue_worker *find_worker_by_time(struct work_queue *q, struc
 
 	if(best_worker) {
 		return best_worker;
+	} else if(in_ramp_down(q)) {
+		return find_worker_by_worst_fit(q, t);
 	} else {
 		return find_worker_by_fcfs(q, t);
 	}
@@ -7413,9 +7431,10 @@ int work_queue_tune(struct work_queue *q, const char *name, double value)
 
 	} else if(!strcmp(name, "force-proportional-resources-whole-tasks") || !strcmp(name, "proportional-whole-tasks")) {
 		q->proportional_whole_tasks = MAX(0, (int)value);
-	} else if (!strcmp(name, "monitor-interval")) {
-		/* 0 means use monitor's default */
-		q->monitor_interval = MAX(0, (int)value);
+
+	} else if (!strcmp(name, "ramp-down-heuristic")) {
+		q->ramp_down_heuristic = MAX(0, (int)value);
+
 	} else {
 		debug(D_NOTICE|D_WQ, "Warning: tuning parameter \"%s\" not recognized\n", name);
 		return -1;


### PR DESCRIPTION
Adds `m.tune("ramp-down-heuristic", 1)`.  When this is enabled and there are more workers than ready tasks, then tasks are allocated all the free resources of a worker.  When looking for workers by files or by time, ties are broken by worst fit.  This mode avoids unnecessary resource exhaustion when there are more workers than tasks. If the monitoring watchdog is not enabled, then this heuristic has no effect. By default it is disabled (set to 0).

It also adds `m.tune("hungry-minimum-factor", 2)`. A manager is hungry if the number of waiting tasks is less than then number of workers times this factor.  By default is set to 2 to avoid ramp-down mode to trigger when the workflow is not really terminating.

With this mode enabled I was able to run the processing+accumulation part of topEFT using the old wq executor in 40 minutes, as the expensive final accumulations are never retried. Together with other advances in taskvine, 30 min processing time should be within reach.

