### PR TITLE
return file buffer contents as bytes object

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/file.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/file.py
@@ -40,7 +40,7 @@ class File(object):
     #
     # @param self       A file object.
     def contents(self):
-        return cvine.vine_file_contents(self._file)
+        return cvine.vine_file_contents_as_bytes(self._file)
 
     ##
     # Return the size of a file object, in bytes.

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1455,7 +1455,7 @@ class Manager(object):
     # @code
     # >>> s = "hello pirate ♆"
     # >>> f = m.declare_buffer(bytes(s, "utf-8"))
-    # >>> print(f.contents())
+    # >>> print(bytes.decode(f.contents(), "utf-8"))
     # >>> "hello pirate ♆"
     # @endcode
     def declare_buffer(self, buffer=None, cache=False, peer_transfer=True):

--- a/taskvine/src/bindings/python3/taskvine.i
+++ b/taskvine/src/bindings/python3/taskvine.i
@@ -63,6 +63,12 @@ into a swig function f(data) */
 }
 %typemap(doc) const char *data, int length "$1_name: a readable buffer (e.g. a bytes object)"
 
+%inline %{
+    PyObject *vine_file_contents_as_bytes(struct vine_file *f) {
+        return PyBytes_FromStringAndSize(vine_file_contents(f), vine_file_size(f));
+    }
+%}
+
 %include "stdint.i"
 %include "int_sizes.h"
 %include "timestamp.h"


### PR DESCRIPTION
This seems to work:

```python
import ndcctools.taskvine as vine
import cloudpickle

m = vine.DaskVine(name="test", port=0)

b = m.declare_buffer(cloudpickle.dumps({"a": 0}))
print(type(b.contents()))

c=cloudpickle.loads(b.contents())
print(c)

s="hello pirate ♆"
b2=m.declare_buffer(bytes(s, "utf-8"))
print(bytes.decode(b2.contents(), "utf-8"))
```

```shell
# output
<class 'bytes'>
{'a': 0}
hello pirate ♆
```