### PR TITLE
vine: remove @property from get_metric definition

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -590,7 +590,6 @@ class Task(object):
     # @code
     # >>> print(t.get_metric("total_submissions")
     # @endcode
-    @property
     def get_metric(self, name):
         return cvine.vine_task_get_metric(self._task, name)
 


### PR DESCRIPTION
`t.get_metric` needs an argument, so it can't be a property.