### PR TITLE
vine: correctly change the state on exhaust resubmit

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -1036,7 +1036,6 @@ static void read_measured_resources(struct vine_manager *q, struct vine_task *t)
 		/* if no resources were measured, then we don't overwrite the return
 		 * status, and mark the task as with error from monitoring. */
 		t->resources_measured = rmsummary_create(-1);
-		vine_task_set_result(t, VINE_RESULT_RMONITOR_ERROR);
 	}
 
 	/* remove summary file, unless it is kept explicitly by the task */
@@ -1131,45 +1130,6 @@ static int fetch_output_from_worker(struct vine_manager *q, struct vine_worker_i
 	// now have evidence that worker is not slow (e.g., it was probably the
 	// previous task that was slow).
 	w->alarm_slow_worker = 0;
-
-	if (t->result == VINE_RESULT_RESOURCE_EXHAUSTION) {
-		if (t->resources_measured && t->resources_measured->limits_exceeded) {
-			struct jx *j = rmsummary_to_json(t->resources_measured->limits_exceeded, 1);
-			if (j) {
-				char *str = jx_print_string(j);
-				debug(D_VINE,
-						"Task %d exhausted resources on %s (%s): %s\n",
-						t->task_id,
-						w->hostname,
-						w->addrport,
-						str);
-				free(str);
-				jx_delete(j);
-			}
-		} else {
-			debug(D_VINE,
-					"Task %d exhausted resources on %s (%s), but not resource usage was available.\n",
-					t->task_id,
-					w->hostname,
-					w->addrport);
-		}
-
-		struct category *c = vine_category_lookup_or_create(q, t->category);
-		category_allocation_t next = category_next_label(c,
-				t->resource_request,
-				/* resource overflow */ 1,
-				t->resources_requested,
-				t->resources_measured);
-
-		if (next == CATEGORY_ALLOCATION_ERROR) {
-			debug(D_VINE, "Task %d failed given max resource exhaustion.\n", t->task_id);
-		} else {
-			debug(D_VINE, "Task %d resubmitted using new resource allocation.\n", t->task_id);
-			t->resource_request = next;
-			change_task_state(q, t, VINE_TASK_READY);
-			return 1;
-		}
-	}
 
 	/* print warnings if the task ran for a very short time (1s) and exited with common non-zero status */
 	if (t->result == VINE_RESULT_SUCCESS && t->time_workers_execute_last < 1000000) {
@@ -2769,6 +2729,53 @@ static void commit_task_to_worker(struct vine_manager *q, struct vine_worker_inf
 	}
 }
 
+/* 1 if task resubmitted, 0 otherwise */
+static int resubmit_task_on_exhaustion(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
+{
+	if (t->result != VINE_RESULT_RESOURCE_EXHAUSTION) {
+		return 0;
+	}
+
+	if (t->resources_measured && t->resources_measured->limits_exceeded) {
+		struct jx *j = rmsummary_to_json(t->resources_measured->limits_exceeded, 1);
+		if (j) {
+			char *str = jx_print_string(j);
+			debug(D_VINE,
+					"Task %d exhausted resources on %s (%s): %s\n",
+					t->task_id,
+					w->hostname,
+					w->addrport,
+					str);
+			free(str);
+			jx_delete(j);
+		}
+	} else {
+		debug(D_VINE,
+				"Task %d exhausted resources on %s (%s), but not resource usage was available.\n",
+				t->task_id,
+				w->hostname,
+				w->addrport);
+	}
+
+	struct category *c = vine_category_lookup_or_create(q, t->category);
+	category_allocation_t next = category_next_label(c,
+			t->resource_request,
+			/* resource overflow */ 1,
+			t->resources_requested,
+			t->resources_measured);
+
+	if (next == CATEGORY_ALLOCATION_ERROR) {
+		debug(D_VINE, "Task %d failed given max resource exhaustion.\n", t->task_id);
+	} else {
+		debug(D_VINE, "Task %d resubmitted using new resource allocation.\n", t->task_id);
+		t->resource_request = next;
+		change_task_state(q, t, VINE_TASK_READY);
+		return 1;
+	}
+
+	return 0;
+}
+
 /*
 Collect a completed task from a worker, and then update
 all auxiliary data structures to remove the association
@@ -2825,7 +2832,11 @@ static void reap_task_from_worker(
 	switch (t->type) {
 	case VINE_TASK_TYPE_STANDARD:
 	case VINE_TASK_TYPE_RECOVERY:
-		change_task_state(q, t, new_state);
+		if (new_state != VINE_TASK_RETRIEVED ||
+				!resubmit_task_on_exhaustion(
+						q, w, t)) { // if exhaustion, then task may go to ready state
+			change_task_state(q, t, new_state);
+		}
 		break;
 	case VINE_TASK_TYPE_LIBRARY:
 		change_task_state(q, t, VINE_TASK_RETRIEVED);


### PR DESCRIPTION
## Proposed changes

Fixes incorrect change of task state when resubmitting after exhaustion.

## Post-change actions

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.