### PR TITLE
Vine: Simplify Cancel

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1266,10 +1266,10 @@ environment.
 ### Task Cancellations
 
 This feature is useful in workflows where there are redundant tasks or tasks
-that become obsolete as other tasks finish. Tasks that have been submitted can
-be cancelled and immediately retrieved without waiting for TaskVine to
-return them in `vine_wait`. The tasks to cancel can be identified by
-either their `taskid` or `tag`. For example:
+that become obsolete as other tasks finish.  Tasks can be removed either
+by either `task_id` or `tag`.  Tasks removed in this way will still be
+returned in the usual way via `wait` with a `result` of `VINE_RESULT_CANCELLED`.
+For example:
 
 === "Python"
     ```python
@@ -1285,11 +1285,11 @@ either their `taskid` or `tag`. For example:
 
     taskid = m.submit(t)
 
-    # cancel task by id. Return the canceled task.
-    t = m.cancel_by_taskid(taskid)
+    # cancel task by id.
+    m.cancel_by_taskid(taskid)
 
-    # or cancel task by tag. Return the canceled task.
-    t = m.cancel_by_tasktag("my-tag")
+    # or cancel task by tag.
+    m.cancel_by_tasktag("my-tag")
     ```
 
 === "C"
@@ -1300,20 +1300,20 @@ either their `taskid` or `tag`. For example:
 
     int taskid = vine_submit(m, t);
 
-    // cancel task by id. Return the canceled task.
-    t = vine_cancel_by_taskid(m, taskid);
+    // cancel task by id.
+    vine_cancel_by_taskid(m, taskid);
 
-    # or cancel task by tag. Return the canceled task.
-    t = vine_cancel_by_tasktag(m, "my-tag");
+    # or cancel task by tag.
+    vine_cancel_by_tasktag(m, "my-tag");
     ```
 
 
 !!! note
     If several tasks have the same tag, only one of them is cancelled. If you
     want to cancel all the tasks with the same tag, you can use loop until
-    `cancel_by_task` does not return a task, as in:
+    `cancel_by_task` returns zero:
 ```
-    while m.cancel_by_taskid("my-tag"):
+    while m.cancel_by_taskid("my-tag")>0:
         pass
 ```
 

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -666,44 +666,51 @@ class Manager(object):
         return cvine.vine_initialize_categories(self._taskvine, rm, filename)
 
     ##
-    # Cancel task identified by its task_id and remove from the given manager.
+    # Cancel task identified by its task_id.
+    # The cancelled task will be returned in the normal way via @ref wait with a result of VINE_RESULT_CANCELLED.
     #
     # @param self   Reference to the current manager object.
     # @param id     The task_id returned from @ref ndcctools.taskvine.manager.Manager.submit.
+    # @return One if the task was found and cancelled, zero otherwise.
+    
     def cancel_by_task_id(self, id):
-        task = None
-        task_pointer = cvine.vine_cancel_by_task_id(self._taskvine, id)
-        if task_pointer:
-            task = self._task_table.pop(int(id))
-        return task
+        return cvine.vine_cancel_by_task_id(self._taskvine, id)
 
     ##
-    # Cancel task identified by its tag and remove from the given manager.
+    # Cancel task identified by its tag.
+    # The cancelled task will be returned in the normal way via @ref wait with a result of VINE_RESULT_CANCELLED.
     #
     # @param self   Reference to the current manager object.
     # @param tag    The tag assigned to task using @ref ndcctools.taskvine.task.Task.set_tag.
+    # @return One if the task was found and cancelled, zero otherwise.
+
     def cancel_by_task_tag(self, tag):
-        task = None
-        task_pointer = cvine.vine_cancel_by_task_tag(self._taskvine, tag)
-        if task_pointer:
-            task = self._task_table.pop(int(id))
-        return task
+        return cvine.vine_cancel_by_task_tag(self._taskvine, tag)
 
     ##
-    # Cancel all tasks of the given category and remove them from the manager.
+    # Cancel all tasks of the given category.
+    # The cancelled tasks will be returned in the normal way via @ref wait with a result of VINE_RESULT_CANCELLED.
     #
     # @param self   Reference to the current manager object.
     # @param category The name of the category to cancel.
+    # @return The total number of tasks cancelled.
     def cancel_by_category(self, category):
-        canceled_tasks = []
-        ids_to_cancel = []
-
+        total = 0
+ 
         for task in self._task_table.values():
             if task.category == category:
-                ids_to_cancel.append(task.id)
+                total += self.cancel_by_task_id(task.id)
 
-        canceled_tasks = [self.cancel_by_task_id(id) for id in ids_to_cancel]
-        return canceled_tasks
+        return total;
+
+    ##
+    # Cancel all tasks.
+    # The cancelled tasks will be returned in the normal way via @ref wait with a result of VINE_RESULT_CANCELLED.
+    #
+    # @param self   Reference to the current manager object.
+    # @return The total number of tasks cancelled.
+    def cancel_all(self):
+        return cvine.vine_cancel_all(self._taskvine)
 
     ##
     # Shutdown workers connected to manager.

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -701,7 +701,7 @@ class Manager(object):
             if task.category == category:
                 total += self.cancel_by_task_id(task.id)
 
-        return total;
+        return total
 
     ##
     # Cancel all tasks.

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -94,17 +94,6 @@ typedef enum {
 	VINE_RESULT_CANCELLED = 11<<3, /**< The task was cancelled by the caller. */
 } vine_result_t;
 
-/** Possible states of a task, given by @ref vine_task_state */
-
-typedef enum {
-	VINE_TASK_INITIAL = 0,       /**< Task has not been submitted to the manager **/
-	VINE_TASK_READY,             /**< Task is ready to be run, waiting in manager **/
-	VINE_TASK_RUNNING,           /**< Task has been dispatched to some worker **/
-	VINE_TASK_WAITING_RETRIEVAL, /**< Task results are available at the worker **/
-	VINE_TASK_RETRIEVED,         /**< Task results are available at the manager **/
-	VINE_TASK_DONE,              /**< Task is done, and returned through vine_wait >**/
-} vine_task_state_t;
-
 /** Select how to allocate resources for similar tasks with @ref vine_set_category_mode */
 
 typedef enum {
@@ -1019,13 +1008,6 @@ char *vine_get_status(struct vine_manager *m, const char *request);
 @return A null terminated array of struct rmsummary. Each summary s indicates the number of s->workers with a certain number of s->cores, s->memory, and s->disk. The array and summaries need to be freed after use to avoid memory leaks.
 */
 struct rmsummary **vine_summarize_workers(struct vine_manager *m);
-
-/** Get the current state of the task.
-@param m A manager object
-@param task_id The task_id of the task.
-@return One of: VINE_TASK(INITIAL|READY|RUNNING|RESULTS|RETRIEVED|DONE)
-*/
-vine_task_state_t vine_task_state(struct vine_manager *m, int task_id);
 
 /** Limit the manager bandwidth when transferring files to and from workers.
 @param m A manager object

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -97,7 +97,7 @@ typedef enum {
 /** Possible states of a task, given by @ref vine_task_state */
 
 typedef enum {
-	VINE_TASK_UNKNOWN = 0,       /**< Task has not been submitted to the manager **/
+	VINE_TASK_INITIAL = 0,       /**< Task has not been submitted to the manager **/
 	VINE_TASK_READY,             /**< Task is ready to be run, waiting in manager **/
 	VINE_TASK_RUNNING,           /**< Task has been dispatched to some worker **/
 	VINE_TASK_WAITING_RETRIEVAL, /**< Task results are available at the worker **/
@@ -1023,7 +1023,7 @@ struct rmsummary **vine_summarize_workers(struct vine_manager *m);
 /** Get the current state of the task.
 @param m A manager object
 @param task_id The task_id of the task.
-@return One of: VINE_TASK(UNKNOWN|READY|RUNNING|RESULTS|RETRIEVED|DONE)
+@return One of: VINE_TASK(INITIAL|READY|RUNNING|RESULTS|RETRIEVED|DONE)
 */
 vine_task_state_t vine_task_state(struct vine_manager *m, int task_id);
 

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -90,7 +90,8 @@ typedef enum {
 	VINE_RESULT_MAX_WALL_TIME       = 7 << 3, /**< The task ran for more than the specified time (relative since running in a worker). **/
 	VINE_RESULT_RMONITOR_ERROR      = 8 << 3, /**< The task failed because the monitor did not produce a summary report. **/
 	VINE_RESULT_OUTPUT_TRANSFER_ERROR = 9 << 3,  /**< The task failed because an output could be transfered to the manager (not enough disk space, incorrect write permissions. */
-	VINE_RESULT_FIXED_LOCATION_MISSING = 10 << 3 /**< The task failed because no worker could satisfy the fixed location input file requirements. */
+	VINE_RESULT_FIXED_LOCATION_MISSING = 10 << 3, /**< The task failed because no worker could satisfy the fixed location input file requirements. */
+	VINE_RESULT_CANCELLED = 11<<3, /**< The task was cancelled by the caller. */
 } vine_result_t;
 
 /** Possible states of a task, given by @ref vine_task_state */
@@ -102,7 +103,6 @@ typedef enum {
 	VINE_TASK_WAITING_RETRIEVAL, /**< Task results are available at the worker **/
 	VINE_TASK_RETRIEVED,         /**< Task results are available at the manager **/
 	VINE_TASK_DONE,              /**< Task is done, and returned through vine_wait >**/
-	VINE_TASK_CANCELED,           /**< Task was canceled before completion **/
 } vine_task_state_t;
 
 /** Select how to allocate resources for similar tasks with @ref vine_set_category_mode */
@@ -1119,25 +1119,28 @@ void vine_set_tasks_left_count(struct vine_manager *m, int ntasks);
 */
 void vine_set_catalog_servers(struct vine_manager *m, const char *hosts);
 
-/** Cancel a submitted task using its task id and remove it from manager.
+/** Cancel a submitted task using its task id.
+The cancelled task will be returned in the normal way via @ref vine_wait with a result of VINE_RESULT_CANCELLED.
 @param m A manager object
 @param id The task_id returned from @ref vine_submit.
-@return The task description of the cancelled task, or null if the task was not found in manager. The returned task must be deleted with @ref vine_task_delete or resubmitted with @ref vine_submit.
+@return True if the task was found in the manager and cancelled, false otherwise.
 */
-struct vine_task *vine_cancel_by_task_id(struct vine_manager *m, int id);
+int vine_cancel_by_task_id(struct vine_manager *m, int id);
 
 /** Cancel a submitted task using its tag and remove it from manager.
+The cancelled task will be returned in the normal way via @ref vine_wait with a result of VINE_RESULT_CANCELLED.
 @param m A manager object
 @param tag The tag name assigned to task using @ref vine_task_set_tag.
-@return The task description of the cancelled task, or null if the task was not found in manager. The returned task must be deleted with @ref vine_task_delete or resubmitted with @ref vine_submit.
+@return True if the task was found in the manager and cancelled, false otherwise.
 */
-struct vine_task *vine_cancel_by_task_tag(struct vine_manager *m, const char *tag);
+int vine_cancel_by_task_tag(struct vine_manager *m, const char *tag);
 
 /** Cancel all submitted tasks and remove them from the manager.
+Each cancelled task will be returned in the normal way via @ref vine_wait with a result of VINE_RESULT_CANCELLED.
 @param m A manager object
-@return A struct list of all of the tasks canceled.  Each task must be deleted with @ref vine_task_delete or resubmitted with @ref vine_submit.
+@return The number of tasks cancelled.
 */
-struct list * vine_tasks_cancel(struct vine_manager *m);
+int vine_cancel_all(struct vine_manager *m);
 
 /** Turn on the debugging log output and send to the named file.
  * (Note it does not need the vine_manager structure, as it is enabled before

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4040,16 +4040,6 @@ static void push_task_to_ready_list(struct vine_manager *q, struct vine_task *t)
 	vine_task_clean(t);
 }
 
-vine_task_state_t vine_task_state(struct vine_manager *q, int task_id)
-{
-	struct vine_task *t = itable_lookup(q->tasks, task_id);
-	if (t) {
-		return t->state;
-	} else {
-		return VINE_TASK_INITIAL;
-	}
-}
-
 /* Changes task state. Returns old state */
 /* State of the task. One of VINE_TASK(UNKNOWN|READY|RUNNING|WAITING_RETRIEVAL|RETRIEVED|DONE) */
 static vine_task_state_t change_task_state(struct vine_manager *q, struct vine_task *t, vine_task_state_t new_state)

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2966,7 +2966,7 @@ static void vine_manager_consider_recovery_task(
 		return;
 
 	switch (rt->state) {
-	case VINE_TASK_UNKNOWN:
+	case VINE_TASK_INITIAL:
 		/* The recovery task has never been run, so submit it now. */
 		vine_submit(q, rt);
 		notice(D_VINE,
@@ -3412,7 +3412,7 @@ static void cancel_task_on_worker(struct vine_manager *q, struct vine_task *t, v
 	struct vine_worker_info *w = t->worker;
 
 	switch (t->state) {
-	case VINE_TASK_UNKNOWN:
+	case VINE_TASK_INITIAL:
 		break;
 
 	case VINE_TASK_READY:
@@ -4046,7 +4046,7 @@ vine_task_state_t vine_task_state(struct vine_manager *q, int task_id)
 	if (t) {
 		return t->state;
 	} else {
-		return VINE_TASK_UNKNOWN;
+		return VINE_TASK_INITIAL;
 	}
 }
 
@@ -4209,7 +4209,7 @@ static int task_request_count(struct vine_manager *q, const char *category, cate
 
 int vine_submit(struct vine_manager *q, struct vine_task *t)
 {
-	if (t->state != VINE_TASK_UNKNOWN) {
+	if (t->state != VINE_TASK_INITIAL) {
 		notice(D_VINE,
 				"vine_submit: you cannot submit the same task (%d) (%s) twice!",
 				t->task_id,

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4058,12 +4058,10 @@ of scheduling, task completion, etc.
 
 static vine_task_state_t change_task_state(struct vine_manager *q, struct vine_task *t, vine_task_state_t new_state)
 {
-
 	vine_task_state_t old_state = t->state;
 
 	t->state = new_state;
 
-	// insert to corresponding table
 	debug(D_VINE,
 			"Task %d state change: %s (%d) to %s (%d)\n",
 			t->task_id,
@@ -4073,6 +4071,9 @@ static vine_task_state_t change_task_state(struct vine_manager *q, struct vine_t
 			new_state);
 
 	switch (new_state) {
+	case VINE_TASK_INITIAL:
+		/* should not happen, do nothing */
+		break;
 	case VINE_TASK_READY:
 		vine_task_set_result(t, VINE_RESULT_UNKNOWN);
 		push_task_to_ready_list(q, t);
@@ -4094,9 +4095,6 @@ static vine_task_state_t change_task_state(struct vine_manager *q, struct vine_t
 		vine_taskgraph_log_write_task(q, t);
 		itable_remove(q->tasks, t->task_id);
 		vine_task_delete(t);
-		break;
-	default:
-		/* do nothing */
 		break;
 	}
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3411,12 +3411,12 @@ static void cancel_task_on_worker(struct vine_manager *q, struct vine_task *t, v
 {
 	struct vine_worker_info *w = t->worker;
 
-	switch(t->state) {
+	switch (t->state) {
 	case VINE_TASK_UNKNOWN:
 		break;
 
 	case VINE_TASK_READY:
-		list_remove(q->ready_list,t);
+		list_remove(q->ready_list, t);
 		change_task_state(q, t, new_state);
 		break;
 
@@ -3424,7 +3424,7 @@ static void cancel_task_on_worker(struct vine_manager *q, struct vine_task *t, v
 
 		// t->worker must be set if in RUNNING state.
 		assert(w);
-		
+
 		// send message to worker asking to kill its task.
 		vine_manager_send(q, w, "kill %d\n", t->task_id);
 		debug(D_VINE,
@@ -3444,14 +3444,14 @@ static void cancel_task_on_worker(struct vine_manager *q, struct vine_task *t, v
 		reap_task_from_worker(q, w, t, new_state);
 
 		break;
-		
+
 	case VINE_TASK_WAITING_RETRIEVAL:
-		list_remove(q->waiting_retrieval_list,t);
+		list_remove(q->waiting_retrieval_list, t);
 		change_task_state(q, t, new_state);
 		break;
 
 	case VINE_TASK_RETRIEVED:
-		list_remove(q->retrieved_list,t);
+		list_remove(q->retrieved_list, t);
 		change_task_state(q, t, new_state);
 		break;
 
@@ -4938,14 +4938,15 @@ int vine_cancel_by_task_id(struct vine_manager *q, int task_id)
 
 	task->result = VINE_RESULT_CANCELLED;
 	q->stats->tasks_cancelled++;
-	
+
 	return 1;
 }
 
 int vine_cancel_by_task_tag(struct vine_manager *q, const char *task_tag)
 {
-	if(!task_tag) return 0;
-	
+	if (!task_tag)
+		return 0;
+
 	struct vine_task *task = find_task_by_tag(q, task_tag);
 	if (task) {
 		return vine_cancel_by_task_id(q, task->task_id);

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -54,7 +54,7 @@ struct vine_task *vine_task_create(const char *command_line)
 	t->resource_request = CATEGORY_ALLOCATION_FIRST;
 	t->worker_selection_algorithm = VINE_SCHEDULE_UNSET;
 
-	t->state = VINE_TASK_UNKNOWN;
+	t->state = VINE_TASK_INITIAL;
 	t->function_slots = 1;
 	t->function_slots_inuse = 0;
 
@@ -128,7 +128,7 @@ void vine_task_reset(struct vine_task *t)
 	t->current_resource_box = 0;
 
 	t->task_id = 0;
-	t->state = VINE_TASK_UNKNOWN;
+	t->state = VINE_TASK_INITIAL;
 }
 
 static struct list *vine_task_mount_list_copy(struct list *list)
@@ -731,8 +731,11 @@ const char *vine_task_state_to_string(vine_task_state_t task_state)
 	const char *str;
 
 	switch (task_state) {
+	case VINE_TASK_INITIAL:
+		str = "INITIAL";
+		break;
 	case VINE_TASK_READY:
-		str = "WAITING";
+		str = "READY";
 		break;
 	case VINE_TASK_RUNNING:
 		str = "RUNNING";
@@ -746,7 +749,6 @@ const char *vine_task_state_to_string(vine_task_state_t task_state)
 	case VINE_TASK_DONE:
 		str = "DONE";
 		break;
-	case VINE_TASK_UNKNOWN:
 	default:
 		str = "UNKNOWN";
 		break;

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -746,9 +746,6 @@ const char *vine_task_state_to_string(vine_task_state_t task_state)
 	case VINE_TASK_DONE:
 		str = "DONE";
 		break;
-	case VINE_TASK_CANCELED:
-		str = "CANCELED";
-		break;
 	case VINE_TASK_UNKNOWN:
 	default:
 		str = "UNKNOWN";

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -27,6 +27,15 @@ typedef enum {
       VINE_TASK_TYPE_LIBRARY,     /**< An internally-created library task that should not be returned to the user. */
 } vine_task_type_t;
 
+typedef enum {
+	VINE_TASK_INITIAL = 0,       /**< Task has not been submitted to the manager **/
+	VINE_TASK_READY,             /**< Task is ready to be run, waiting in manager **/
+	VINE_TASK_RUNNING,           /**< Task has been dispatched to some worker **/
+	VINE_TASK_WAITING_RETRIEVAL, /**< Task results are available at the worker **/
+	VINE_TASK_RETRIEVED,         /**< Task results are available at the manager **/
+	VINE_TASK_DONE,              /**< Task is done, and returned through vine_wait >**/
+} vine_task_state_t;
+
 struct vine_task {
         /***** Fixed properties of task at submit time. ******/
 

--- a/taskvine/src/manager/vine_txn_log.c
+++ b/taskvine/src/manager/vine_txn_log.c
@@ -133,7 +133,7 @@ void vine_txn_log_write_task(struct vine_manager *q, struct vine_task *t)
 
 	buffer_printf(&B, "TASK %d %s", t->task_id, vine_task_state_to_string(state));
 
-	if (state == VINE_TASK_UNKNOWN) {
+	if (state == VINE_TASK_INITIAL) {
 		/* do not add any info */
 	} else if (state == VINE_TASK_READY) {
 		const char *allocation = (t->resource_request == CATEGORY_ALLOCATION_FIRST ? "FIRST_RESOURCES"

--- a/taskvine/src/manager/vine_txn_log.c
+++ b/taskvine/src/manager/vine_txn_log.c
@@ -140,8 +140,6 @@ void vine_txn_log_write_task(struct vine_manager *q, struct vine_task *t)
 											   : "MAX_RESOURCES");
 		buffer_printf(&B, " %s %s %d ", t->category, allocation, t->try_count + 1);
 		rmsummary_print_buffer(&B, vine_manager_task_resources_min(q, t), 1);
-	} else if (state == VINE_TASK_CANCELED) {
-		/* do not add any info */
 	} else if (state == VINE_TASK_DONE) {
 		buffer_printf(&B, " %s ", vine_result_string(t->result));
 		buffer_printf(&B, " %d ", t->exit_code);

--- a/taskvine/test/TR_vine_python_cancel.sh
+++ b/taskvine/test/TR_vine_python_cancel.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+set -e
+
+. ../../dttools/test/test_runner_common.sh
+
+import_config_val CCTOOLS_PYTHON_TEST_EXEC
+import_config_val CCTOOLS_PYTHON_TEST_DIR
+
+export PYTHONPATH=$(pwd)/../../test_support/python_modules/${CCTOOLS_PYTHON_TEST_DIR}:$PYTHONPATH
+
+STATUS_FILE=vine.status
+PORT_FILE=vine.port
+
+
+check_needed()
+{
+	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
+}
+
+prepare()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+
+	return 0
+}
+
+run()
+{
+	# send vine to the background, saving its exit status.
+	(${CCTOOLS_PYTHON_TEST_EXEC} vine_python_cancel.py $PORT_FILE; echo $? > $STATUS_FILE) &
+
+	# wait at most 15 seconds for vine to find a port.
+	wait_for_file_creation $PORT_FILE 15
+
+	run_taskvine_worker $PORT_FILE worker.log
+
+	# wait for vine to exit.
+	wait_for_file_creation $STATUS_FILE 15
+
+	# retrieve vine exit status
+	status=$(cat $STATUS_FILE)
+	if [ $status -ne 0 ]
+	then
+		exit 1
+	fi
+
+	exit 0
+}
+
+clean()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+
+	rm -rf vine-run-info
+
+	exit 0
+}
+
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/taskvine/test/vine_python_cancel.py
+++ b/taskvine/test/vine_python_cancel.py
@@ -1,13 +1,15 @@
 #! /usr/bin/env python3
 
-# taskvine python binding tests
-# tests for submission and cancel of tasks
+# Test of task cancellation in Python.
+# Submit 10 tasks that sleep for 10 seconds.
+# After 3 seconds, cancel all of them.
+# Wait for task return and verify that status was cancelled.
 
 import sys
 import ndcctools.taskvine as vine
 
 ntasks = 10
-tasks_done = 0
+ntasks_cancelled = 0
 
 port_file = None
 try:
@@ -24,7 +26,7 @@ with open(port_file, "w") as f:
 
 print("Submitting {} tasks...".format(ntasks))
     
-for i in range(1,ntasks):
+for i in range(0,ntasks):
     t = vine.Task("sleep 10")
     t.set_cores(1)
     q.submit(t)
@@ -41,7 +43,16 @@ while not q.empty():
     t = q.wait(10)
     if t:
         print("Task {} completed with status {}".format(t.id,t.result))
-        tasks_done+=1
-                            
+        if t.result=="cancelled":
+                ntasks_cancelled+=1
+
+                
+if ntasks_cancelled==ntasks:
+    print("Success: {} of {} tasks cancelled\n".format(ntasks_cancelled,ntasks))
+    sys.exit(0)
+else:
+    print("Failure: {} of {} tasks cancelled\n".format(ntasks_cancelled,ntasks))
+    sys.exit(1)
+    
 
               

--- a/taskvine/test/vine_python_cancel.py
+++ b/taskvine/test/vine_python_cancel.py
@@ -1,0 +1,47 @@
+#! /usr/bin/env python3
+
+# taskvine python binding tests
+# tests for submission and cancel of tasks
+
+import sys
+import ndcctools.taskvine as vine
+
+ntasks = 10
+tasks_done = 0
+
+port_file = None
+try:
+    port_file = sys.argv[1]
+except IndexError:
+    sys.stderr.write("Usage: {} PORTFILE\n".format(sys.argv[0]))
+    raise
+
+q = vine.Manager(port=0)
+
+with open(port_file, "w") as f:
+    print("Writing port {port} to file {file}".format(port=q.port, file=port_file))
+    f.write(str(q.port))
+
+print("Submitting {} tasks...".format(ntasks))
+    
+for i in range(1,ntasks):
+    t = vine.Task("sleep 10")
+    t.set_cores(1)
+    q.submit(t)
+
+print("Waiting for tasks to start...".format(ntasks))
+
+t = q.wait(3)
+
+print("Cancelling all tasks...")
+q.cancel_all()
+
+print("Collecting cancelled tasks...")
+while not q.empty():
+    t = q.wait(10)
+    if t:
+        print("Task {} completed with status {}".format(t.id,t.result))
+        tasks_done+=1
+                            
+
+              


### PR DESCRIPTION
## Proposed changes

The design of task cancellation is problematic because `task_cancel` is a distinct way of returning a completed task, which makes reference counting more complicated.  This change simplifies cancellation, so that cancelled tasks just get put into the RETRIEVED state and are then returned from `wait` like any other task.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments

