### PR TITLE
Build: Run Correctly in Conda Environment

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -119,13 +119,13 @@ jobs:
       - name: Conda-Setup
         run: ${GITHUB_WORKSPACE}/packaging/build-conda/setup.sh
       - name: Configure
-        run: conda run --name cctools-dev ${GITHUB_WORKSPACE}/packaging/build-conda/configure.sh
+        run: ${GITHUB_WORKSPACE}/packaging/build-conda/configure.sh
       - name: Build
-        run: conda run --name cctools-dev ${GITHUB_WORKSPACE}/packaging/build-conda/build.sh
+        run: ${GITHUB_WORKSPACE}/packaging/build-conda/build.sh
       - name: Install
-        run: conda run --name cctools-dev ${GITHUB_WORKSPACE}/packaging/build-conda/install.sh
+        run: ${GITHUB_WORKSPACE}/packaging/build-conda/install.sh
       - name: Test
-        run: conda run --name cctools-dev ${GITHUB_WORKSPACE}/packaging/build-conda/test.sh
+        run: ${GITHUB_WORKSPACE}/packaging/build-conda/test.sh
       - name: Deploy
         uses: ncipollo/release-action@v1
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -103,7 +103,6 @@ jobs:
     timeout-minutes: 60
     env:
       CCTOOLS_OUTPUT: ${{ format('cctools-{0}-x86_64-linux-conda.tar.gz', github.event.inputs.version) }}
-    needs: lint
     steps:
       - name: Checkout CCTools from branch head
         if: github.event_name != 'workflow_dispatch'
@@ -120,13 +119,13 @@ jobs:
       - name: Conda-Setup
         run: ${GITHUB_WORKSPACE}/packaging/build-conda/setup.sh
       - name: Configure
-        run: ${GITHUB_WORKSPACE}/packaging/build-conda/configure.sh
+        run: conda run --name cctools-dev ${GITHUB_WORKSPACE}/packaging/build-conda/configure.sh
       - name: Build
-        run: ${GITHUB_WORKSPACE}/packaging/build-conda/build.sh
+        run: conda run --name cctools-dev ${GITHUB_WORKSPACE}/packaging/build-conda/build.sh
       - name: Install
-        run: ${GITHUB_WORKSPACE}/packaging/build-conda/install.sh
+        run: conda run --name cctools-dev ${GITHUB_WORKSPACE}/packaging/build-conda/install.sh
       - name: Test
-        run: ${GITHUB_WORKSPACE}/packaging/build-conda/test.sh
+        run: conda run --name cctools-dev ${GITHUB_WORKSPACE}/packaging/build-conda/test.sh
       - name: Deploy
         uses: ncipollo/release-action@v1
         if: github.event_name == 'workflow_dispatch'

--- a/packaging/build-conda/build.sh
+++ b/packaging/build-conda/build.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-make
+conda run --name cctools-build make

--- a/packaging/build-conda/configure.sh
+++ b/packaging/build-conda/configure.sh
@@ -5,7 +5,7 @@ DISABLED_SYS=$(echo --without-system-{parrot,prune,umbrella,weaver})
 DISABLED_LIB=$(echo --with-{readline,fuse,perl}-path\ no)
 
 # Now configure in the normal way.
-./configure --strict ${DISABLED_SYS} ${DISABLED_LIB} "$@"
+conda run --name cctools-build ./configure --strict ${DISABLED_SYS} ${DISABLED_LIB} "$@"
 [[ -f config.mk ]] && make clean
 echo === Contents of config.mk ===
 cat config.mk

--- a/packaging/build-conda/install.sh
+++ b/packaging/build-conda/install.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-make install
+conda run --name cctools-build make install

--- a/packaging/build-conda/setup.sh
+++ b/packaging/build-conda/setup.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-conda create --name cctools-dev --yes --quiet --channel conda-forge --strict-channel-priority python=3 gcc_linux-64 gxx_linux-64 gdb m4 perl swig make zlib libopenssl-static openssl conda-pack cloudpickle packaging
+conda create --name cctools-build --yes --quiet --channel conda-forge --strict-channel-priority python=3 gcc_linux-64 gxx_linux-64 gdb m4 perl swig make zlib libopenssl-static openssl conda-pack cloudpickle packaging

--- a/packaging/build-conda/setup.sh
+++ b/packaging/build-conda/setup.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-conda install -y  -c conda-forge --strict-channel-priority python=3 gcc_linux-64 gxx_linux-64 gdb m4 perl swig make zlib libopenssl-static openssl conda-pack cloudpickle packaging
+conda create --name cctools-dev --yes --quiet --channel conda-forge --strict-channel-priority python=3 gcc_linux-64 gxx_linux-64 gdb m4 perl swig make zlib libopenssl-static openssl conda-pack cloudpickle packaging

--- a/packaging/build-conda/test.sh
+++ b/packaging/build-conda/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if ! make test
+if ! conda run --name cctools-build make test
 then
     echo === Contents of cctools.test.fail ===
     cat cctools.test.fail

--- a/packaging/scripts/configure-from-image
+++ b/packaging/scripts/configure-from-image
@@ -41,7 +41,6 @@ fi
 # disable perl bindings (to compile as we do in conda)
 perl_option='--with-perl-path no'
 
-
 # using rpm/deb for cvmfs from cclnd docker containers
 if [[ -n "${CCTOOLS_DOCKER_GITHUB}" ]]
 then
@@ -55,8 +54,12 @@ then
     fi
 fi
 
-# make sure we have nonstandard python packages present
-pip install cloudpickle packaging conda-pack
+# if we are not in a docker container but the base VM,
+# then pip is available so install python packages
+if [[ -z "${CCTOOLS_DOCKER_GITHUB}" ]]
+then
+    pip install cloudpickle packaging conda-pack
+fi
 
 # compile everything
 ./configure --strict $DEP_ARGS ${perl_option} ${python_option} ${cvmfs_option} "$@"

--- a/packaging/scripts/configure-from-image
+++ b/packaging/scripts/configure-from-image
@@ -55,6 +55,8 @@ then
     fi
 fi
 
+# make sure we have nonstandard python packages present
+pip install cloudpickle packaging conda-pack
 
 # compile everything
 ./configure --strict $DEP_ARGS ${perl_option} ${python_option} ${cvmfs_option} "$@"


### PR DESCRIPTION
## Proposed changes

Integration builds were not correctly picking up the installed conda environment, but running in the default conda environment.  This happened to work by accident b/c our tests were skipping over the cases where cloud pickle etc were not available.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
