### PR TITLE
vine:  changes tasks_running to tasks_on_workers for display tables

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5175,26 +5175,10 @@ void vine_get_stats(struct vine_manager *q, struct vine_stats *s)
 	// s->workers_able computed below.
 
 	// info about tasks
-	int ready_tasks = list_size(q->ready_list);
-	int waiting_tasks = list_size(q->waiting_retrieval_list);
-	int running_tasks = itable_size(q->running_table);
-
-	s->tasks_waiting = ready_tasks;
-	s->tasks_with_results = waiting_tasks;
-	s->tasks_on_workers = running_tasks + s->tasks_with_results;
-
-	{
-		// accumulate tasks running, from workers:
-		char *key;
-		struct vine_worker_info *w;
-		s->tasks_running = 0;
-		HASH_TABLE_ITERATE(q->worker_table, key, w) { accumulate_stat(s, w->stats, tasks_running); }
-		/* we rely on workers messages to update tasks_running. such data are
-		 * attached to keepalive messages, thus tasks_running is not always
-		 * current. Here we simply enforce that there can be more tasks_running
-		 * that tasks_on_workers. */
-		s->tasks_running = MIN(s->tasks_running, s->tasks_on_workers);
-	}
+	s->tasks_waiting = list_size(q->ready_list);
+	s->tasks_with_results = list_size(q->waiting_retrieval_list);
+	s->tasks_running = itable_size(q->running_table);
+	s->tasks_on_workers = s->tasks_with_results + s->tasks_running;
 
 	vine_task_info_compute_capacity(q, s);
 


### PR DESCRIPTION
## Proposed changes

tasks_on_workers is accurate for what the manager knows. tasks_running depends on worker messages that may be stale.

## Post-change actions

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
