### PR TITLE
Vine: Make conservative disk estimates when the amount of disk is not given to worker

### DIFF
--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -159,7 +159,7 @@ static struct vine_resources *total_resources = 0;
 
 /* When the amount of disk is not specified, manually set the reporting disk to
  * this percentage of the measured disk. This safeguards the fact that disk measurements
- * are estimates and thus may unncessarily forsaken tasks with unspecified resources. 
+ * are estimates and thus may unncessarily forsaken tasks with unspecified resources.
  * Defaults to 90%. */
 static int disk_percent = 90;
 
@@ -326,8 +326,7 @@ static void measure_worker_resources()
 
 	if (manual_disk_option > 0) {
 		r->disk.total = MIN(r->disk.total, manual_disk_option);
-	}
-	else {
+	} else {
 		/* Set the reporting disk to a fraction of the measured disk to avoid
 		 * unnecessarily forsaking tasks with unspecified resources. */
 		manual_disk_option = floor(r->disk.total * disk_percent / 100);
@@ -1147,7 +1146,7 @@ static int task_resources_fit_now(struct vine_task *t)
 {
 	return (cores_allocated + t->resources_requested->cores <= total_resources->cores.total) &&
 	       (memory_allocated + t->resources_requested->memory <= total_resources->memory.total) &&
-		   (disk_allocated + t->resources_requested->disk <= total_resources->disk.total) &&
+	       (disk_allocated + t->resources_requested->disk <= total_resources->disk.total) &&
 	       (gpus_allocated + t->resources_requested->gpus <= total_resources->gpus.total);
 }
 
@@ -1165,8 +1164,7 @@ static int task_resources_fit_eventually(struct vine_task *t)
 	r = total_resources;
 
 	return (t->resources_requested->cores <= r->cores.total) &&
-	       (t->resources_requested->memory <= r->memory.total) &&
-			(t->resources_requested->disk <= r->disk.total) &&
+	       (t->resources_requested->memory <= r->memory.total) && (t->resources_requested->disk <= r->disk.total) &&
 	       (t->resources_requested->gpus <= r->gpus.total);
 }
 
@@ -2098,8 +2096,9 @@ static void show_help(const char *cmd)
 
 	printf(" %-30s Manually set the amount of disk (in MB) reported by this worker.\n", "--disk=<mb>");
 	printf(" %-30s If not given, or less than 1, then try to detect disk space available.\n", "");
-	
-	printf(" %-30s Set the conservative disk reporting percent when amount of disk is unspecified.\n", "--disk-percent=<percent>");
+
+	printf(" %-30s Set the conservative disk reporting percent when amount of disk is unspecified.\n",
+			"--disk-percent=<percent>");
 	printf(" %-30s Defaults to 90.\n", "");
 
 	printf(" %-30s Use loop devices for task sandboxes (default=disabled, requires root access).\n",

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1173,7 +1173,7 @@ struct vine_process *find_library_for_function(const char *library_name)
 
 	ITABLE_ITERATE(procs_running, task_id, p)
 	{
-		if (!strcmp(p->task->provides_library, library_name)) {
+		if (p->task->provides_library && !strcmp(p->task->provides_library, library_name)) {
 			if (p->functions_running < p->task->function_slots) {
 				return p;
 			}

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1175,7 +1175,7 @@ struct vine_process *find_library_for_function(const char *library_name)
 	ITABLE_ITERATE(procs_running, task_id, p)
 	{
 		if (p->task->provides_library && !strcmp(p->task->provides_library, library_name)) {
-			if (p->functions_running < p->task->function_slots) {
+			if (p->library_ready && p->functions_running < p->task->function_slots) {
 				return p;
 			}
 		}

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1154,7 +1154,11 @@ static int task_resources_fit_eventually(struct vine_task *t)
 	r = total_resources;
 
 	return (t->resources_requested->cores <= r->cores.total) &&
-	       (t->resources_requested->memory <= r->memory.total) && (t->resources_requested->disk <= r->disk.total) &&
+	       (t->resources_requested->memory <= r->memory.total) &&
+	       /* XXX removed disk space check due to problems running workers locally or multiple workers on a single
+		* node since default tasks request the entire reported disk space. questionable if this check useful in
+		* practice.*/
+	       (1) && //(t->resources_requested->disk <= r->disk.total) &&
 	       (t->resources_requested->gpus <= r->gpus.total);
 }
 

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1179,7 +1179,7 @@ struct vine_process *find_library_for_function(const char *library_name)
 	ITABLE_ITERATE(procs_running, task_id, p)
 	{
 		if (p->task->provides_library && !strcmp(p->task->provides_library, library_name)) {
-			if (p->library_ready && p->functions_running < p->task->function_slots) {
+			if (p->functions_running < p->task->function_slots) {
 				return p;
 			}
 		}


### PR DESCRIPTION
## Proposed changes

When a task with no resources specified lands on a worker, it is assigned all resources of the worker (see `normalize_resources`). However, later on when the worker checks whether the task can fit the current resources, some resources have been taken away by other tasks, so the current task is too big for the worker and thus it is forsaken.

Example: an unspecified task arrives and is assigned 4 GBs of disk space. It depends on a poncho package of size 300 MBs. Once the poncho package is unpacked, the worker later finds out that its disk capacity is only 4 GBs - 300 MBs, so it forsakens the unspecified task as it thinks it doesn't have enough disk space while the unspecified task should run anyway.

Note that this problem doesn't happen with tasks that are clean, i.e., once their executions are done, their workspaces are wiped and resources are returned. Tasks that have side-effects like minitasks use up some disk space so they interact weirdly with regular tasks with unspecified resources.

This problem goes undetected until now probably because the poncho package is too small (<1 MB) or the task passes the resource check before the worker updates its disk counting.

A check whether library name exists is added to prevent seg fault.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
