### PR TITLE
Build: Skip Python Tests on MacOS-11 (Python2)

### DIFF
--- a/taskvine/test/TR_vine_allocations.sh
+++ b/taskvine/test/TR_vine_allocations.sh
@@ -15,6 +15,11 @@ PORT_FILE=vine.port
 check_needed()
 {
 	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
+
+	# In some limited build circumstances (e.g. macos build on github),
+	# poncho doesn't work due to lack of conda-pack or cloudpickle
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import conda_pack" || return 1
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import cloudpickle" || return 1
 }
 
 prepare()

--- a/taskvine/test/TR_vine_python.sh
+++ b/taskvine/test/TR_vine_python.sh
@@ -15,6 +15,11 @@ PORT_FILE=vine.port
 check_needed()
 {
 	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
+
+	# In some limited build circumstances (e.g. macos build on github),
+	# poncho doesn't work due to lack of conda-pack or cloudpickle
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import conda_pack" || return 1
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import cloudpickle" || return 1
 }
 
 prepare()

--- a/taskvine/test/TR_vine_python_serverless.sh
+++ b/taskvine/test/TR_vine_python_serverless.sh
@@ -22,8 +22,9 @@ check_needed()
 	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "from ast import unparse" || return 1
 
 	# In some limited build circumstances (e.g. macos build on github),
-	# poncho doesn't work due to lack of conda-pack
+	# poncho doesn't work due to lack of conda-pack or cloudpickle
 	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import conda_pack" || return 1
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import cloudpickle" || return 1
 
         return 0
 }

--- a/taskvine/test/TR_vine_python_ssl.sh
+++ b/taskvine/test/TR_vine_python_ssl.sh
@@ -19,6 +19,11 @@ check_needed()
 {
 	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
 	[ "${CCTOOLS_OPENSSL_AVAILABLE}" = yes ] || return 1
+
+	# In some limited build circumstances (e.g. macos build on github),
+	# poncho doesn't work due to lack of conda-pack or cloudpickle
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import conda_pack" || return 1
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import cloudpickle" || return 1
 }
 
 prepare()

--- a/taskvine/test/TR_vine_python_tag.sh
+++ b/taskvine/test/TR_vine_python_tag.sh
@@ -15,6 +15,11 @@ PORT_FILE=vine.port
 check_needed()
 {
 	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
+
+	# In some limited build circumstances (e.g. macos build on github),
+	# poncho doesn't work due to lack of conda-pack or cloudpickle
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import conda_pack" || return 1
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import cloudpickle" || return 1
 }
 
 prepare()


### PR DESCRIPTION
## Proposed changes

Modify task vine-python tests to skip if cloudpickle/conda-pack are not present.  This is necessary to pass tests on macOS-11 base platform which has some ancient Python 2.

## Post-change actions

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments

We need to move up from macOS-11 to a newer Mac platform, and bring in appropriate python dependencies.  But that will be another PR.



