### PR TITLE
Poncho no k option

### DIFF
--- a/doc/man/m4/poncho_package_run.m4
+++ b/doc/man/m4/poncho_package_run.m4
@@ -26,11 +26,13 @@ SECTION(OPTIONS)
 
 OPTIONS_BEGIN
 OPTION_ARG(e, environment, file)   Conda environment as a tar file. (Required.)
-OPTION_ARG(d, unpack-to, dir)      Directory to unpack the environment. If not given, a temporary directory is used.
+OPTION_ARG(u, unpack-to, dir)      Directory to unpack the environment. If not given, a temporary directory is used.
 OPTION_ARG(w, wait-for-lock, secs) Number of seconds to wait to get a writing lock on PARAM(dir). Default is 300.
-OPTION_ARG(w, wait-for-lock, secs) Number of seconds to wait to get a writing lock on PARAM(dir). Default is 300.
+OPTION_FLAG(d, debug) Print debug messages.
+OPTION_FLAG_LONG(help-env-creation) Show instructions to create conda environments as tar files.
 OPTION_FLAG(h, help)                Show the help screen.
 OPTIONS_END
+
 SECTION(EXIT STATUS)
 
 On success, returns 0. On failure, returns non-zero.

--- a/doc/man/md/poncho_package_run.md
+++ b/doc/man/md/poncho_package_run.md
@@ -48,10 +48,12 @@ If the argument to --unpack-to does not exist, then it is created as an empty di
 
 
 - **-e**,**--environment=_&lt;file&gt;_**<br />   Conda environment as a tar file. (Required.)
-- **-d**,**--unpack-to=_&lt;dir&gt;_**<br />      Directory to unpack the environment. If not given, a temporary directory is used.
+- **-u**,**--unpack-to=_&lt;dir&gt;_**<br />      Directory to unpack the environment. If not given, a temporary directory is used.
 - **-w**,**--wait-for-lock=_&lt;secs&gt;_**<br /> Number of seconds to wait to get a writing lock on _&lt;dir&gt;_. Default is 300.
-- **-w**,**--wait-for-lock=_&lt;secs&gt;_**<br /> Number of seconds to wait to get a writing lock on _&lt;dir&gt;_. Default is 300.
+- **-d**,**--debug**<br /> Print debug messages.
+- **--help-env-creation**<br /> Show instructions to create conda environments as tar files.
 - **-h**,**--help**<br />                Show the help screen.
+
 
 ## EXIT STATUS
 

--- a/poncho/src/poncho_package_run
+++ b/poncho/src/poncho_package_run
@@ -25,7 +25,6 @@ usage() {
     echo " -w, --wait-for-lock <secs> Number of seconds to wait to get a writing lock"
     echo "                            on <dir>. Default is 300"
     echo " -d, --debug                Print debug messages."
-    echo " -k, --keep-alive           Keeps unpacked and activated environment alive after execution"
     echo " --help-env-creation        Show instructions to create conda environments as tar files."
     echo " -h, --help                 Show this help screen."
     echo "command and args            Command to execute inside the given environment."
@@ -106,9 +105,6 @@ parse_arguments() {
                 shift
                 LOCK_WAIT="$1"
                 ;;
-	    -k | --keep-alive)
-		export PONCHO_KEEP_ALIVE=yes
-		;;
             --)
                 shift
                 break
@@ -158,7 +154,6 @@ function cleanup {
 }
 
 
-PONCHO_KEEP_ALIVE=no
 COMMAND_MISSING=no
 
 parse_arguments "$@"
@@ -171,13 +166,7 @@ shift ${arg_counsumed}
 ENV_NAME_IS_DIR=no
 UNPACK_IS_TMP=no
 
-if [[ "${PONCHO_KEEP_ALIVE}" = no ]]
-then
-    trap cleanup EXIT
-else
-    logmsg unpacked environment will be kept alive
-fi
-	
+trap cleanup EXIT
 
 if [[ -d "${ENV_NAME}" ]]
 then

--- a/poncho/src/poncho_package_run
+++ b/poncho/src/poncho_package_run
@@ -129,8 +129,8 @@ parse_arguments() {
 
     if [[ $# -lt 1 ]]
     then
-	logmsg No command was specified no command will be executed!
-        PONCHO_NO_COMMAND=yes
+        logmsg No command was specified no command will be executed!
+        COMMAND_MISSING=yes
     fi
 
     final_arg_count=$#
@@ -159,7 +159,7 @@ function cleanup {
 
 
 PONCHO_KEEP_ALIVE=no
-PONCHO_NO_COMMAND=no
+COMMAND_MISSING=no
 
 parse_arguments "$@"
 
@@ -281,7 +281,7 @@ then
 fi
 
 # Finally run the command line:
-if [[ "${PONCHO_NO_COMMAND}" = no ]]
+if [[ "${COMMAND_MISSING}" = no ]]
 then
     logmsg executing command line: "${@}"
     "${@}"


### PR DESCRIPTION
## Proposed changes

Removes -k option from poncho_package_create, as it is already covered by -u DIR and -e DIR. With -k, a user would have to figure out the random name of the directory.

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
