### PR TITLE
Vine: measure whole directory in stageout 

### DIFF
--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -163,11 +163,11 @@ static int stage_output_file(struct vine_process *p, struct vine_mount *m, struc
 	if (result) {
 		struct stat info;
 		if (stat(cache_path, &info) == 0) {
-			if (S_ISDIR(info.st_mode)) { 
+			if (S_ISDIR(info.st_mode)) {
 				struct path_disk_size_info *state = NULL;
 				path_disk_size_info_get_r(cache_path, -1, &state);
-				int64_t measured_size   = state->last_byte_size_complete;
-				
+				int64_t measured_size = state->last_byte_size_complete;
+
 				vine_cache_addfile(cache, measured_size, info.st_mode, f->cached_name);
 				vine_worker_send_cache_update(manager, f->cached_name, measured_size, 0, 0);
 				path_disk_size_info_delete_state(state);


### PR DESCRIPTION
## Proposed changes

Issue #3504 

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
I have not yet recreated the issue to test if this solves the problem, for now it seems to achieve the intended goal.