### PR TITLE
Sync result msgs

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -1100,7 +1100,6 @@ static int fetch_output_from_worker(struct vine_manager *q, struct vine_worker_i
 		break;
 	}
 
-
 	if (result != VINE_SUCCESS) {
 		debug(D_VINE, "Failed to receive output from worker %s (%s).", w->hostname, w->addrport);
 		handle_failure(q, w, t, result);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -435,7 +435,7 @@ static vine_msg_code_t vine_manager_recv_no_retry(
 		struct vine_manager *q, struct vine_worker_info *w, char *line, size_t length)
 {
 	time_t stoptime;
-	stoptime = time(0) + q->short_timeout;
+	stoptime = time(0) + q->long_timeout;
 
 	int result = link_readline(w->link, line, length, stoptime);
 

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -392,7 +392,6 @@ static int send_keepalive(struct link *manager, int force_resources)
 {
 	send_message(manager, "alive\n");
 	send_resource_update(manager);
-	send_stats_update(manager);
 	return 1;
 }
 
@@ -594,8 +593,6 @@ static void report_task_complete(struct link *manager, struct vine_process *p)
 
 	total_task_execution_time += (p->execution_end - p->execution_start);
 	total_tasks_executed++;
-
-	send_stats_update(manager);
 }
 
 /*
@@ -612,7 +609,6 @@ static void report_tasks_complete(struct link *manager)
 	}
 
 	vine_watcher_send_changes(watcher, manager, time(0) + active_timeout);
-
 	send_message(manager, "end\n");
 
 	results_to_be_sent_msg = 0;
@@ -1490,14 +1486,14 @@ static void work_for_manager(struct link *manager)
 			}
 		}
 
-		if (task_event > 0) {
-			send_stats_update(manager);
-		}
-
 		if (ok && !results_to_be_sent_msg) {
 			if (vine_watcher_check(watcher) || itable_size(procs_complete) > 0) {
 				send_message(manager, "available_results\n");
 				results_to_be_sent_msg = 1;
+			}
+
+			if (task_event > 0) {
+				send_stats_update(manager);
 			}
 		}
 


### PR DESCRIPTION
## Proposed changes

For issue #3500.  The only thing missing from the comments is the symlink to sandboxes. This pr addresses the messages part.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
