### PR TITLE
vine: don't delete recovery tasks

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3015,6 +3015,11 @@ static void vine_manager_consider_recovery_task(
 		 * here. */
 		vine_task_reset(rt);
 		vine_submit(q, rt);
+		notice(D_VINE,
+				"Submitted recovery task %d (%s) to re-create lost temporary file %s.",
+				rt->task_id,
+				rt->command_line,
+				lost_file->cached_name);
 		break;
 	}
 }
@@ -4644,10 +4649,15 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 					goto end_of_loop;
 					break;
 				case VINE_TASK_TYPE_RECOVERY:
+					/* do nothing and let vine_manager_consider_recovery_task do its job */
+					t = 0;
+					continue;
+					break;
 				case VINE_TASK_TYPE_LIBRARY:
 					vine_task_delete(t);
 					t = 0;
 					continue;
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
## Proposed changes

Solution for #3512 

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.