### PR TITLE
Vine: Fix Input Missing Condition

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -1084,12 +1084,18 @@ static int fetch_output_from_worker(struct vine_manager *q, struct vine_worker_i
 		return 0;
 	}
 
-	// Start receiving output...
 	t->time_when_retrieval = timestamp_get();
 
-	if (t->result == VINE_RESULT_RESOURCE_EXHAUSTION) {
+	/* Determine what subset of outputs to retrieve based on status. */
+
+	if (t->result == VINE_RESULT_INPUT_MISSING) {
+		/* If inputs were missing, the worker didn't run the task, so don't bother with outputs. */
+		result = VINE_SUCCESS;
+	} else if (t->result == VINE_RESULT_RESOURCE_EXHAUSTION) {
+		/* If resources were exhausted, only the monitor file was created. */
 		result = vine_manager_get_monitor_output_file(q, w, t);
 	} else {
+		/* Otherwise get all the output files, even if there was an error. */
 		result = vine_manager_get_output_files(q, w, t);
 	}
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -1090,17 +1090,16 @@ static int fetch_output_from_worker(struct vine_manager *q, struct vine_worker_i
 
 	switch (t->result) {
 	case VINE_RESULT_INPUT_MISSING:
-		/* If inputs were missing, the worker didn't run the task, so don't bother with outputs. */
+	case VINE_RESULT_FORSAKEN:
+		/* If the worker didn't run the task don't bother fetching outputs. */
 		result = VINE_SUCCESS;
 		break;
-	case VINE_RESULT_FORSAKEN:
-		reap_task_from_worker(q, w, t, VINE_TASK_RETRIEVED);
-		return VINE_SUCCESS;
-		break;
 	case VINE_RESULT_RESOURCE_EXHAUSTION:
+		/* On resource exhaustion, just get the monitor files to figure out what happened. */
 		result = vine_manager_get_monitor_output_file(q, w, t);
 		break;
 	default:
+		/* Otherwise get all of the output files. */
 		result = vine_manager_get_output_files(q, w, t);
 		break;
 	}


### PR DESCRIPTION
## Proposed changes

If a task is given an invalid input file (e.g. bad url), the worker would correctly return the task to the manager
with "input missing" but the manager would then attempt to fetch the output files, and conclude "output missing".
This fix skips output fetching when input is missing.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
