### PR TITLE
Vine: Fix disk accounting

### DIFF
--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -328,8 +328,8 @@ static void measure_worker_resources()
 		r->disk.total = MIN(r->disk.total, manual_disk_option);
 	} else {
 		/* Set the reporting disk to a fraction of the measured disk to avoid
-		 * unnecessarily forsaking tasks with unspecified resources. 
-		 * Note that @vine_resources_measure_locally reports that 
+		 * unnecessarily forsaking tasks with unspecified resources.
+		 * Note that @vine_resources_measure_locally reports that
 		 * disk.total = available_disk + disk.inuse, so we leave out disk.inuse in
 		 * the discounting calculation, then add it back in. */
 		r->disk.total -= r->disk.inuse;

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -328,8 +328,12 @@ static void measure_worker_resources()
 		r->disk.total = MIN(r->disk.total, manual_disk_option);
 	} else {
 		/* Set the reporting disk to a fraction of the measured disk to avoid
-		 * unnecessarily forsaking tasks with unspecified resources. */
-		r->disk.total = ceil(r->disk.total * disk_percent / 100);
+		 * unnecessarily forsaking tasks with unspecified resources. 
+		 * Note that @vine_resources_measure_locally reports that 
+		 * disk.total = available_disk + disk.inuse, so we leave out disk.inuse in
+		 * the discounting calculation, then add it back in. */
+		r->disk.total -= r->disk.inuse;
+		r->disk.total = ceil(r->disk.total * disk_percent / 100) + r->disk.inuse;
 	}
 
 	r->disk.inuse = measure_worker_disk();


### PR DESCRIPTION
## Proposed changes

The formula to compute disk total in the codebase is disk.total = disk_available + disk.inuse (see @vine_resources_measure_locally). By introducing a 90% discount we inadvertently discount the disk inuse, leading to incorrect disk total estimate. This change only discounts the disk_available estimate as disk inuse must be reported as-is.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
Note: The disk estimate is very unstable when a poncho tarball unpacks itself, leading to a couple of tasks with unspecified resources being forsaken in the beginning. Once the worker stabilizes then tasks with unspecified resources will be run as usual. 