### PR TITLE
vine: clean mount list on reset

### DIFF
--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -46,6 +46,7 @@ typedef enum {
 	VINE_WATCH = 2,           /**< Watch the output file and send back changes as the task runs. */
 	VINE_FAILURE_ONLY = 4,    /**< Only return this output file if the task failed.  (Useful for returning large log files.) */
 	VINE_SUCCESS_ONLY = 8,    /**< Only return this output file if the task succeeded. */
+	VINE_RETRACT_ON_RESET = 16  /**< Remove this file from the mount lists if the task is reset. */
 } vine_mount_flags_t;
 
 /** Control caching and sharing behavior of file objects.

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3980,11 +3980,13 @@ void vine_disable_monitoring(struct vine_manager *q)
 
 void vine_monitor_add_files(struct vine_manager *q, struct vine_task *t)
 {
-	vine_task_add_input(t, q->monitor_exe, RESOURCE_MONITOR_REMOTE_NAME, 0);
+	vine_task_add_input(t, q->monitor_exe, RESOURCE_MONITOR_REMOTE_NAME, VINE_RETRACT_ON_RESET);
 
 	char *summary = monitor_file_name(q, t, ".summary", 0);
-	vine_task_add_output(
-			t, vine_declare_file(q, summary, VINE_CACHE_NEVER), RESOURCE_MONITOR_REMOTE_NAME ".summary", 0);
+	vine_task_add_output(t,
+			vine_declare_file(q, summary, VINE_CACHE_NEVER),
+			RESOURCE_MONITOR_REMOTE_NAME ".summary",
+			VINE_RETRACT_ON_RESET);
 	free(summary);
 
 	if (q->monitor_mode & VINE_MON_FULL) {
@@ -3994,11 +3996,11 @@ void vine_monitor_add_files(struct vine_manager *q, struct vine_task *t)
 		vine_task_add_output(t,
 				vine_declare_file(q, debug, VINE_CACHE_NEVER),
 				RESOURCE_MONITOR_REMOTE_NAME ".debug",
-				0);
+				VINE_RETRACT_ON_RESET);
 		vine_task_add_output(t,
 				vine_declare_file(q, series, VINE_CACHE_NEVER),
 				RESOURCE_MONITOR_REMOTE_NAME ".series",
-				0);
+				VINE_RETRACT_ON_RESET);
 
 		free(debug);
 		free(series);

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -106,6 +106,21 @@ void vine_task_clean(struct vine_task *t)
 	t->current_resource_box = 0;
 }
 
+static void retract_mounts_on_reset(struct list *mount_list)
+{
+	int mount_count = list_size(mount_list);
+	while (mount_count > 0) {
+		mount_count--;
+		struct vine_mount *m = list_pop_head(mount_list);
+		if (m->flags & VINE_RETRACT_ON_RESET) {
+			vine_mount_delete(m);
+			continue;
+		}
+
+		list_push_tail(mount_list, m);
+	}
+}
+
 void vine_task_reset(struct vine_task *t)
 {
 	vine_task_clean(t);
@@ -129,6 +144,9 @@ void vine_task_reset(struct vine_task *t)
 
 	t->task_id = 0;
 	t->state = VINE_TASK_INITIAL;
+
+	retract_mounts_on_reset(t->input_mounts);
+	retract_mounts_on_reset(t->output_mounts);
 }
 
 static struct list *vine_task_mount_list_copy(struct list *list)


### PR DESCRIPTION
## Proposed changes

Adds the mount flag VINE_RETRACT_ON_RESET to remove files from the mount lists when the task is reset. This is helpful for mounts that vine adds internally for submission (like monitoring files).

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
