### PR TITLE
vine: do not consider more than ready tasks

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3073,8 +3073,10 @@ static int send_one_task(struct vine_manager *q)
 	int tasks_considered = 0;
 	timestamp_t now = timestamp_get();
 
+	int tasks_to_consider = MIN(list_size(q->ready_list), q->attempt_schedule_depth);
+
 	while ((t = list_rotate(q->ready_list))) {
-		if (tasks_considered++ > q->attempt_schedule_depth) {
+		if (tasks_considered++ > tasks_to_consider) {
 			return 0;
 		}
 


### PR DESCRIPTION
if max depth > waiting tasks then tasks would be considered repeteadly for dispatch.


- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
