### PR TITLE
Vine: fix vine_plot_txn_log

### DIFF
--- a/taskvine/src/tools/vine_plot_txn_log
+++ b/taskvine/src/tools/vine_plot_txn_log
@@ -336,7 +336,7 @@ class ParseTxn:
         if not self.check_task_range(task_id):
             return
 
-        if event == "WAITING":
+        if event == "READY":
             (category, allocation, attempt_number, arg) = arg.split()
             self.cm.task_last_attempt[task_id] = attempt_number
 
@@ -347,7 +347,7 @@ class ParseTxn:
         ca["last_state"] = event
         ca["last_state_time"] = time
 
-        if event == "WAITING":
+        if event == "READY":
             ca["task_id"] = task_id
             ca["attempt_number"] = attempt_number
             ca["category"] = category
@@ -444,7 +444,7 @@ class TxnPlot:
             if spec == "dispatched-first-task":
                 origin = m.tasks["time_commit_start"].min()
             elif spec == "waiting-first-task":
-                origin = m.tasks["WAITING"].min()
+                origin = m.tasks["READY"].min()
             elif spec == "connected-first-worker":
                 origin = m.workers["CONNECTION"].min()
             elif spec == "start-manager":


### PR DESCRIPTION
## Proposed changes

Change "WAITING" state to "READY", broken in #3494 

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

