### PR TITLE
vine: prefer dispatch option

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -2379,6 +2379,7 @@ change.
 | resource-submit-multiplier | Assume that workers have `resource x resources-submit-multiplier` available.<br> This overcommits resources at the worker, causing tasks to be sent to workers that cannot be immediately executed.<br>The extra tasks wait at the worker until resources become available. | 1 |
 | wait-for-workers        | Do not schedule any tasks until `wait-for-workers` are connected. | 0 |
 | max-retrievals | Sets the max number of tasks to retrieve per manager wait(). If less than 1, the manager prefers to retrieve all completed tasks before dispatching new tasks to workers. | 1 |
+| prefer-dispatch | If 1, try to dispatch tasks even if there are retrieved tasks ready to be reportedas done. | 0 |
 | worker-retrievals | If 1, retrieve all completed tasks from a worker when retrieving results, even if going above the parameter max-retrievals . Otherwise, if 0, retrieve just one task before deciding to dispatch new tasks or connect new workers. | 1 |
 
 

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -211,13 +211,6 @@ struct vine_stats {
 	int64_t min_memory;       /**< The smallest memory size in MB observed among the connected workers. */
 	int64_t min_disk;         /**< The smallest disk space in MB observed among the connected workers. */
 	int64_t min_gpus;         /**< The smallest number of gpus observed among the connected workers. */
-
-	double manager_load;      /**< In the range of [0,1]. If close to 1, then
-                                the manager is at full load and spends most
-                                of its time sending and receiving taks, and
-                                thus cannot accept connections from new
-                                workers. If close to 0, the manager is spending
-                                most of its time waiting for something to happen. */
 };
 
 /** @name Functions - Tasks */

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -185,6 +185,8 @@ struct vine_manager {
 	int max_retrievals;           /* Do at most this number of task retrievals of either receive_one_task or receive_all_tasks_from_worker. If less
                                      than 1, prefer to receive all completed tasks before submitting new tasks. */
 	int worker_retrievals;        /* retrieve all completed tasks from a worker as opposed to recieving one of any completed task*/
+	int prefer_dispatch;          /* try to dispatch tasks even if there are retrieved tasks ready to return  */
+
 	int fetch_factory;            /* If true, manager queries catalog for factory configuration. */
 	int proportional_resources;   /* If true, tasks divide worker resources proportionally. */
 	int proportional_whole_tasks; /* If true, round-up proportions to whole number of tasks. */

--- a/taskvine/src/manager/vine_perf_log.c
+++ b/taskvine/src/manager/vine_perf_log.c
@@ -38,7 +38,7 @@ void vine_perf_log_write_header(struct vine_manager *q)
 			// bandwidth:
 			" bytes_sent bytes_received bandwidth"
 			// resources:
-			" capacity_tasks capacity_cores capacity_memory capacity_disk capacity_instantaneous capacity_weighted manager_load"
+			" capacity_tasks capacity_cores capacity_memory capacity_disk capacity_instantaneous capacity_weighted"
 			" total_cores total_memory total_disk"
 			" committed_cores committed_memory committed_disk"
 			" max_cores max_memory max_disk"
@@ -128,7 +128,6 @@ void vine_perf_log_write_update(struct vine_manager *q, int force)
 	buffer_printf(&B, " %d", s.capacity_disk);
 	buffer_printf(&B, " %d", s.capacity_instantaneous);
 	buffer_printf(&B, " %d", s.capacity_weighted);
-	buffer_printf(&B, " %f", s.manager_load);
 
 	buffer_printf(&B, " %" PRId64, s.total_cores);
 	buffer_printf(&B, " %" PRId64, s.total_memory);


### PR DESCRIPTION
## Proposed changes

adds `m.tune("prefer-dispatch", 1)` which makes the manager dispatch tasks even if there are retrieved tasks ready to be returned.

It cleans up the wait loop, but if not using this new option, the loop should behave as before.

It also eliminates the manager-load stat as it was highly tuned to the wq loop way of returning a task as soon as one was available.  It didn't make sense anymore when receiving tasks in bulk from workers, and dispatching libraries to all the workers.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
