### PR TITLE
Vine: Improve Serverless

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1512,19 +1512,11 @@ function definitions into a library task `libtask`
     libtask = m.create_library_from_functions("my_library", my_sum, my_mul)
     ```
 
-The library task can be further described by any of options available
-to normal tasks, such as resources or additional input files. Additionally,
-you can specify the number of functions the library can run concurrently by
-setting the number of function slots (default to 1):
+You can optionally specify the number of functions the library can 
+run concurrently by setting the number of function slots (default to 1):
 
 === "Python"
     ```python
-    # regular options
-    libtask.set_cores(1)
-    libtask.set_memory(2000)
-    libtask.set_disk(2000)
-
-    # library-specific options
     libtask.set_function_slots(4)   # maximum 4 concurrent functions
     ```
 

--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1513,13 +1513,19 @@ function definitions into a library task `libtask`
     ```
 
 The library task can be further described by any of options available
-to normal tasks, such as resources or additional input files:
+to normal tasks, such as resources or additional input files. Additionally,
+you can specify the number of functions the library can run concurrently by
+setting the number of function slots (default to 1):
 
 === "Python"
     ```python
+    # regular options
     libtask.set_cores(1)
     libtask.set_memory(2000)
     libtask.set_disk(2000)
+
+    # library-specific options
+    libtask.set_function_slots(4)   # maximum 4 concurrent functions
     ```
 
 Once complete, the library task must be `installed` in the system:

--- a/poncho/src/poncho/library_network_code.py
+++ b/poncho/src/poncho/library_network_code.py
@@ -114,7 +114,7 @@ def library_network_code():
 
     def send_result(out_pipe_fd, task_id):
         buff = bytes(str(task_id), 'utf-8')
-        buff = bytes(len(buff), 'utf-8')+b'\n'+buff
+        buff = bytes(str(len(buff)), 'utf-8')+b'\n'+buff
         os.writev(out_pipe_fd, [buff])
 
     def main():
@@ -150,12 +150,13 @@ def library_network_code():
             rlist, wlist, xlist = select.select([in_pipe_fd], [], [], 0)
             if len(rlist) > 0:
                 pid, func_id = start_function(in_pipe_fd)
-                func_id_to_pid[func_id] = pid
+                pid_to_func_id[pid] = func_id
 
             # check if child exits, noblock
             if len(pid_to_func_id) > 0:
                 c_pid, c_exit_status = os.waitpid(-1, os.WNOHANG)
                 if c_pid > 0:
                     send_result(out_pipe_fd, pid_to_func_id[c_pid])
+                    del pid_to_func_id[c_pid]
                                
         return 0

--- a/poncho/src/poncho/library_network_code.py
+++ b/poncho/src/poncho/library_network_code.py
@@ -61,9 +61,20 @@ def library_network_code():
         os.writev(out_pipe_fd, [bytes(config_cmd, 'utf-8')])
 
     def start_function(in_pipe_fd):
-        buffer_len = int(in_pipe.readline()[:-1])
-
-        line = str(in_pipe.read(buffer_len), encoding='utf-8')
+        buffer_len = b''
+        while True:
+            c = os.read(in_pipe_fd, 1)
+            if c == b'':
+                print('Library code: cant get length', file=sys.stderr)
+                exit(1)
+            elif c == b'\n':
+                break
+            else:
+                buffer_len += c
+        buffer_len = int(buffer_len)
+        
+        line = str(os.read(in_pipe_fd, buffer_len), encoding='utf-8')
+        #line = str(in_pipe.read(buffer_len), encoding='utf-8')
         function_id, function_name, function_sandbox = line.split(" ", maxsplit=2)
         function_id = int(function_id)
         

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -221,12 +221,6 @@ static void vine_process_complete(struct vine_process *p, int status)
 				p->pid,
 				p->exit_code);
 	}
-
-	/* If this is a completed function, then decrease the number of funcs on that library. */
-
-	if (p->type == VINE_PROCESS_TYPE_FUNCTION) {
-		p->library_process->functions_running--;
-	}
 }
 
 /*

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -456,8 +456,11 @@ pid_t vine_process_execute(struct vine_process *p)
 		if (p->type != VINE_PROCESS_TYPE_LIBRARY) {
 			execl("/bin/sh", "sh", "-c", p->task->command_line, (char *)0);
 		} else {
-			char *final_command = string_format(
-					"%s --input-fd %d --output-fd %d --worker-pid %d", p->task->command_line, input_fd, output_fd, getppid());
+			char *final_command = string_format("%s --input-fd %d --output-fd %d --worker-pid %d",
+					p->task->command_line,
+					input_fd,
+					output_fd,
+					getppid());
 			execl("/bin/sh", "sh", "-c", final_command, (char *)0);
 		}
 		_exit(127); // Failed to execute the cmd.

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -451,12 +451,13 @@ pid_t vine_process_execute(struct vine_process *p)
 		export_environment(p);
 
 		/* Library task passes the file descriptors to talk to the manager via
-		 * the command line so it requires a special execl. */
+		 * the command line plus the worker pid to wake the worker up
+		 * so it requires a special execl. */
 		if (p->type != VINE_PROCESS_TYPE_LIBRARY) {
 			execl("/bin/sh", "sh", "-c", p->task->command_line, (char *)0);
 		} else {
 			char *final_command = string_format(
-					"%s --input-fd %d --output-fd %d", p->task->command_line, input_fd, output_fd);
+					"%s --input-fd %d --output-fd %d --worker-pid %d", p->task->command_line, input_fd, output_fd, getppid());
 			execl("/bin/sh", "sh", "-c", final_command, (char *)0);
 		}
 		_exit(127); // Failed to execute the cmd.

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -589,6 +589,10 @@ static void reap_process(struct vine_process *p, struct link *manager)
 		p->exit_code = 1;
 	}
 
+	if (p->type == VINE_PROCESS_TYPE_FUNCTION) {
+		p->library_process->functions_running--;
+	}
+
 	itable_remove(procs_running, p->task->task_id);
 	itable_insert(procs_complete, p->task->task_id, p);
 }

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -490,13 +490,17 @@ static void report_worker_ready(struct link *manager)
 	send_keepalive(manager, 1);
 }
 
-/* Send a message containing details of a function call to the relevant library to execute it. 
- * @param p 	The relevant vine_process structure encapsulating a function call. 
+/* Send a message containing details of a function call to the relevant library to execute it.
+ * @param p 	The relevant vine_process structure encapsulating a function call.
  * @return 		1 if the message is successfully sent to the library, 0 otherwise. */
 static int start_function(struct vine_process *p)
 {
 	char *buffer = string_format("%d %s %s", p->task->task_id, p->task->command_line, p->sandbox);
-	ssize_t result = link_printf(p->library_process->library_write_link, time(0) + active_timeout, "%ld\n%s", strlen(buffer), buffer);
+	ssize_t result = link_printf(p->library_process->library_write_link,
+			time(0) + active_timeout,
+			"%ld\n%s",
+			strlen(buffer),
+			buffer);
 	free(buffer);
 	if (result < 0) {
 		return 0;
@@ -543,8 +547,7 @@ static int start_process(struct vine_process *p, struct link *manager)
 		if (ok) {
 			p->library_process->functions_running++;
 		}
-	}
-	else {
+	} else {
 		/* Now start the actual process. */
 		pid = vine_process_execute(p);
 		if (pid < 0)
@@ -672,13 +675,13 @@ static void expire_procs_running()
 	}
 }
 
-/* Receive a message containing a function call id from the library and 
+/* Receive a message containing a function call id from the library and
  * reap the completed function call.
  * @param p			The vine process encapsulating the function call.
  * @param manager	The link to the manager.
  * return 			1 if the operation succeeds, 0 otherwise. */
-static int reap_completed_function_call(struct vine_process* p, struct link* manager) 
-{			
+static int reap_completed_function_call(struct vine_process *p, struct link *manager)
+{
 	char buffer[VINE_LINE_MAX]; // Buffer to store length of data from library.
 	int ok = 1;
 
@@ -699,9 +702,9 @@ static int reap_completed_function_call(struct vine_process* p, struct link* man
 	debug(D_VINE, "Received result for function %" PRIu64, done_task_id);
 
 	/* Reap the completed function call. */
-	struct vine_process* pp = (struct vine_process*) itable_lookup(procs_table, done_task_id);
+	struct vine_process *pp = (struct vine_process *)itable_lookup(procs_table, done_task_id);
 	reap_process(pp, manager);
-	return ok;	
+	return ok;
 }
 
 /*
@@ -732,7 +735,9 @@ static int handle_completed_tasks(struct link *manager)
 			while (link_usleep(p->library_read_link, 0, 1, 0)) {
 				result_retrieved = reap_completed_function_call(p, manager);
 				if (!result_retrieved) {
-					fatal("Cannot retrieve result for function call %d - %s", p->task->task_id, p->task->command_line);
+					fatal("Cannot retrieve result for function call %d - %s",
+							p->task->task_id,
+							p->task->command_line);
 				}
 			}
 			if (result_retrieved) {

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -498,7 +498,7 @@ int start_function(struct vine_process* p)
 	{
 		if (proc->type == VINE_PROCESS_TYPE_LIBRARY && proc->library_ready && !strcmp(proc->task->provides_library, p->task->needs_library)) {
 			
-			char* buffer = string_format("invoke %d %s %s", p->task->task_id, p->task->command_line, p->sandbox);
+			char* buffer = string_format("%d %s %s", p->task->task_id, p->task->command_line, p->sandbox);
 			link_printf(proc->library_write_link, time(0)+active_timeout, "%ld\n%s", strlen(buffer), buffer);
 			free(buffer);
 			break;

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -544,6 +544,8 @@ static int start_process(struct vine_process *p, struct link *manager)
 	/* Starting a function call is different from starting a standard task, so we return early. */
 	if (t->needs_library) {
 		itable_insert(procs_running, p->task->task_id, p);
+		debug(D_VINE, "started function call %d: %s", p->task->task_id, p->task->command_line);
+		p->library_process->functions_running++;
 		return start_function(p);
 	}
 


### PR DESCRIPTION
## Proposed changes

This PR introduces major fixes and improvements to the serverless facility of TaskVine as follows:
- A function invocation didn't interrupt the vine_worker sleep on the manager link, so each invocation must wait 5 seconds to return. This is because a function invocation isn't a child of the vine_worker. Now the library will send a SIGCHLD signal to the worker upon startup (send after configuration) and function execution completion. Note that the library needs the pid of the vine_worker as the vine_worker is the grandparent of the library instead of the parent. The parent of the library is the shell from exec.
- A function execution will implicitly assume that the necessary parameters are in a file called `infile` and it is supposed to dump results to `outfile`. These files are declared and bound properly to every function invocation.
- To avoid the library spinning on a while loop and wasting 1 core, the library uses the self-pipe trick that turns the SIGCHLD from a function exit into an I/O event from the read end of the pipe.
- The library priorities returning function results over starting functions (start one, get all results if possible.)
- Clean previous function invocation code.
- Library now can run multiple functions. This number is configurable via set_function_slots() API. To do this, the worker sends to the library a message containing the function id, function name, and function sandbox. Once complete, the library sends back to the worker the function id.
- Correct counting of running functions.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
Note that the starting and reaping function process is a bit different as the function process structure doesn't reflect what is really happening. For example, `p->pid` of a function process will be 0 (uninitialized).
