### PR TITLE
Vine: Fix Segfault in Serverless

### DIFF
--- a/taskvine/src/worker/Makefile
+++ b/taskvine/src/worker/Makefile
@@ -11,7 +11,8 @@ SOURCES = \
 	vine_transfer_server.c \
 	vine_process.c \
 	vine_watcher.c \
-	vine_gpus.c
+	vine_gpus.c \
+	vine_worker.c
 
 OBJECTS = $(SOURCES:%.c=%.o)
 PROGRAMS = vine_worker

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -698,6 +698,11 @@ static int reap_completed_function_call(struct vine_process *p, struct link *man
 	if (ok <= 0) {
 		return 0;
 	}
+
+	/* null terminate the buffer before treating it as a string. */
+	buffer_data[ok] = 0;
+
+	/* parse out the taskid of the completed task */
 	uint64_t done_task_id = (uint64_t)strtoul(buffer_data, NULL, 10);
 	debug(D_VINE, "Received result for function %" PRIu64, done_task_id);
 


### PR DESCRIPTION
## Proposed changes

Must null-terminate buffer received from library process before parsing it as a string.  Fixes periodic segfault in worker.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ x ] `make test`       Run local tests prior to pushing.
- [x  ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ x ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ x ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ x ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
