### PR TITLE
WQ: Regenerate serverless script

### DIFF
--- a/work_queue/test/TR_work_queue_remotetask.sh
+++ b/work_queue/test/TR_work_queue_remotetask.sh
@@ -30,9 +30,8 @@ prepare()
 
 run()
 {
-    # ${PONCHO_PACKAGE_SERVERIZE} --src wq_remote_task.py --function add --function multiply --dest serverless_function.py
-
-    # wait_for_file_creation serverless_function.py 5
+	${PONCHO_PACKAGE_SERVERIZE} --src wq_remote_task.py --function add --function multiply --function kwargs_test --function no_arguments_test --function exception_test --dest serverless_function.py --version work_queue
+    wait_for_file_creation serverless_function.py 5
 
     chmod +x serverless_function.py
 


### PR DESCRIPTION
## Proposed changes

The serverless script in wq test is stale. This PR updates it.

## Post-change actions

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.