### PR TITLE
vine: conditional worker timeout

### DIFF
--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -61,10 +61,27 @@ struct vine_worker_info *vine_file_replica_table_find_worker(struct vine_manager
 }
 
 /*
-Determine if this file is cached *anywhere* in the system.
+Count number of replicas of a file in the system.
 XXX Note that this implementation is another inefficient linear search.
 */
 
+int vine_file_replica_table_count_replicas(struct vine_manager *q, const char *cachename)
+{
+	char *key;
+	struct vine_worker_info *w;
+	struct vine_file_replica *r;
+	int c = 0;
+	
+	HASH_TABLE_ITERATE(q->worker_table, key, w)
+	{
+		r = hash_table_lookup(w->current_files, cachename);
+		if (r) c++;
+	}
+	return c;
+}
+
+/*
+ */
 int vine_file_replica_table_exists_somewhere(struct vine_manager *q, const char *cachename)
 {
 	char *key;

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -71,11 +71,12 @@ int vine_file_replica_table_count_replicas(struct vine_manager *q, const char *c
 	struct vine_worker_info *w;
 	struct vine_file_replica *r;
 	int c = 0;
-	
+
 	HASH_TABLE_ITERATE(q->worker_table, key, w)
 	{
 		r = hash_table_lookup(w->current_files, cachename);
-		if (r) c++;
+		if (r)
+			c++;
 	}
 	return c;
 }

--- a/taskvine/src/manager/vine_file_replica_table.h
+++ b/taskvine/src/manager/vine_file_replica_table.h
@@ -27,6 +27,8 @@ struct vine_worker_info *vine_file_replica_table_find_worker(struct vine_manager
 
 int vine_file_replica_table_exists_somewhere( struct vine_manager *q, const char *cachename );
 
+int vine_file_replica_table_count_replicas( struct vine_manager *q, const char *cachename );
+
 
 #endif
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -260,11 +260,14 @@ static void handle_worker_timeout(struct vine_manager *q, struct vine_worker_inf
 	// Look at the files and check if any are endangered temps.
 	char *cachename;
 	struct vine_file_replica *remote_info;
+	//debug(D_VINE, "Handling timeout request"); 
 	HASH_TABLE_ITERATE(w->current_files, cachename, remote_info)
 	{
+	//	debug(D_VINE, "Looking at file %s", cachename); 
 		if(strncmp(cachename, "temp-rnd-", 9) == 0)
 		{
 			int c = vine_file_replica_table_count_replicas(q, cachename);
+	//		debug(D_VINE, "Temp file found with %d replicas", c); 
 			if(c == 1)
 			{
 				debug(D_VINE, "Rejecting timeout request from worker %s (%s). Has unique file %s", w->hostname, w->addrport, cachename); 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -250,7 +250,6 @@ static vine_msg_code_t handle_name(struct vine_manager *q, struct vine_worker_in
 	return VINE_MSG_PROCESSED;
 }
 
-
 /*
 Handle a timeout request from a worker. Check if the worker has any important data before letting it go.
 */
@@ -260,23 +259,24 @@ static void handle_worker_timeout(struct vine_manager *q, struct vine_worker_inf
 	// Look at the files and check if any are endangered temps.
 	char *cachename;
 	struct vine_file_replica *remote_info;
-	//debug(D_VINE, "Handling timeout request"); 
+	// debug(D_VINE, "Handling timeout request");
 	HASH_TABLE_ITERATE(w->current_files, cachename, remote_info)
 	{
-	//	debug(D_VINE, "Looking at file %s", cachename); 
-		if(strncmp(cachename, "temp-rnd-", 9) == 0)
-		{
+		//	debug(D_VINE, "Looking at file %s", cachename);
+		if (strncmp(cachename, "temp-rnd-", 9) == 0) {
 			int c = vine_file_replica_table_count_replicas(q, cachename);
-	//		debug(D_VINE, "Temp file found with %d replicas", c); 
-			if(c == 1)
-			{
-				debug(D_VINE, "Rejecting timeout request from worker %s (%s). Has unique file %s", w->hostname, w->addrport, cachename); 
+			//		debug(D_VINE, "Temp file found with %d replicas", c);
+			if (c == 1) {
+				debug(D_VINE,
+						"Rejecting timeout request from worker %s (%s). Has unique file %s",
+						w->hostname,
+						w->addrport,
+						cachename);
 				return;
 			}
-		} 
-
+		}
 	}
-	debug(D_VINE, "Accepting drain request from worker %s (%s).", w->hostname, w->addrport); 
+	debug(D_VINE, "Accepting drain request from worker %s (%s).", w->hostname, w->addrport);
 	w->draining = 1;
 	return;
 }
@@ -1320,7 +1320,6 @@ static void handle_worker_failure(struct vine_manager *q, struct vine_worker_inf
 	remove_worker(q, w, VINE_WORKER_DISCONNECT_FAILURE);
 	return;
 }
-
 
 /*
 Handle the failure of a task, taking different actions depending on whether

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -276,8 +276,12 @@ static void handle_worker_timeout(struct vine_manager *q, struct vine_worker_inf
 			}
 		}
 	}
-	debug(D_VINE, "Accepting drain request from worker %s (%s).", w->hostname, w->addrport);
-	w->draining = 1;
+
+	if (itable_size(w->current_tasks) == 0) {
+		debug(D_VINE, "Accepting timeout request from worker %s (%s).", w->hostname, w->addrport);
+		shut_down_worker(q, w);
+	}
+
 	return;
 }
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -279,6 +279,7 @@ static void handle_worker_timeout(struct vine_manager *q, struct vine_worker_inf
 
 	if (itable_size(w->current_tasks) == 0) {
 		debug(D_VINE, "Accepting timeout request from worker %s (%s).", w->hostname, w->addrport);
+		q->stats->workers_idled_out++;
 		shut_down_worker(q, w);
 	}
 

--- a/taskvine/src/manager/vine_protocol.h
+++ b/taskvine/src/manager/vine_protocol.h
@@ -13,7 +13,7 @@ worker, and catalog, but should not be visible to the public user API.
 #ifndef VINE_PROTOCOL_H
 #define VINE_PROTOCOL_H
 
-#define VINE_PROTOCOL_VERSION 3
+#define VINE_PROTOCOL_VERSION 4
 
 #define VINE_LINE_MAX 4096       /**< Maximum length of a vine message line. */
 

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1494,14 +1494,15 @@ static void work_for_manager(struct link *manager)
 	// Start serving managers
 	while (!abort_flag) {
 
+		/* Propose a disconnect from the manager, but do not do it until requested */
 		if (time(0) > idle_stoptime) {
 			debug(D_NOTICE,
-					"disconnecting from %s:%d because I did not receive any task in %d seconds (--idle-timeout).\n",
+					"requesting disconnect from %s:%d because I did not receive any task in %d seconds (--idle-timeout).\n",
 					current_manager_address->addr,
 					current_manager_address->port,
 					idle_timeout);
-			send_message(manager, "info idle-disconnecting %lld\n", (long long)idle_timeout);
-			break;
+			send_message(manager, "info idle-disconnect-request %lld\n", (long long)idle_timeout);
+			reset_idle_timer();
 		}
 
 		if (initial_ppid != 0 && getppid() != initial_ppid) {


### PR DESCRIPTION
## Proposed changes

#3531 

This is one implementation where the worker signals the manager it has reached its configured timeout. With this information the manager makes the decision whether or not to release the worker shortly after. 

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
