### PR TITLE
Vine: add cpu time to txn stats

### DIFF
--- a/taskvine/src/tools/vine_plot_txn_log
+++ b/taskvine/src/tools/vine_plot_txn_log
@@ -822,8 +822,14 @@ class TxnStats(TxnPlot):
         print(f"Bytes created: {minitasks_size}")    
         print(f"Number of temps: {num_temps}")
         print(f"Bytes created: {temps_size}")
+        times = []
+        for l in manager.worker_lifetime.values():
+            times.append(l["DISCONNECTION"] - l["CONNECTION"])
+        cpu_time = sum(times)
+        print(f"Worker CPU Time (h): {round(cpu_time/60/60, 2)}")
         print("-----------------------------------------")
         print()
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes
Quick addition to sum the worker running time. It will be an interesting statistic when considering ramp-down performance. I may add a running time vs idle time as well. 

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.