### PR TITLE
Vine: temp file replication

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -228,7 +228,10 @@ for the duration of a workflow, and are deleted when no longer needed.
 This accelerates a workflow by avoiding the step of returning the
 data to the manager.
 If a temporary file is unexpectedly lost due to the crash or failure
-of a worker, then the task that created it will be re-executed.
+of a worker, then the task that created it will be re-executed. Temp files
+may also be replicated across workers to a degree set by the `vine_tune` parameter
+`temp-replica-count'. Temp file replicas are useful if significant work
+is required to re-execute the task that created it. 
 The contents of a temporary file can be obtained with `fetch_file`
 
 If it is necessary to unpack a file before it is used,
@@ -2446,6 +2449,7 @@ change.
 | hungry-minimum-factor   | Queue is hungry if number of waiting tasks is less than hungry-minumum-factor x (number of workers) | 2 |
 | ramp-down-heuristic     | If set to 1 and there are more workers than tasks waiting, then tasks are allocated all the free resources of a worker large enough to run them. If monitoring watchdog is not enabled, then this heuristic has no effect. | 0 |
 | immediate-recovery    | If set to 1, create recovery tasks for temporary files as soon as their worker disconnects. Otherwise, create recovery tasks only if the temporary files are used as input when trying to dispatch another task. | 0 |
+| temp-replica-count    | Number of temp file replicas created across workers | 0 |
 | monitor-interval        | Maximum number of seconds between resource monitor measurements. If less than 1, use default. | 5 |
 | resource-submit-multiplier | Assume that workers have `resource x resources-submit-multiplier` available.<br> This overcommits resources at the worker, causing tasks to be sent to workers that cannot be immediately executed.<br>The extra tasks wait at the worker until resources become available. | 1 |
 | wait-for-workers        | Do not schedule any tasks until `wait-for-workers` are connected. | 0 |

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -1208,6 +1208,7 @@ void vine_set_manager_preferred_connection(struct vine_manager *m, const char *p
  - "wait_retrieve_many" Parameter to alter how vine_wait works. If set to 0, vine_wait breaks out of the while loop whenever a task changes to VINE_TASK_DONE (wait_retrieve_one mode). If set to 1, vine_wait does not break, but continues recieving and dispatching tasks. This occurs until no task is sent or recieved, at which case it breaks out of the while loop (wait_retrieve_many mode). (default=0)
  - "monitor-interval" Parameter to change how frequently the resource monitor records resource consumption of a task in a times series, if this feature is enabled. See @ref vine_enable_monitoring.
  - "update_interval"  Seconds between updates to the catalog. (default=60)
+ - "temp-replica-count" Degree of replication across workers for remote temp files (default=0)
  - "resource_management_interval" Seconds between measurement of manager local resources. (default=30)
  - "max_task_stdout_storage" Maximum size of standard output from task.  (If larger, send to a separate file.) (default=1*GIGABYTE)
  - "max_new_workers" Maximum number of workers to add in a single cycle before dealing with other matters. (default=10)

--- a/taskvine/src/manager/vine_current_transfers.c
+++ b/taskvine/src/manager/vine_current_transfers.c
@@ -70,6 +70,20 @@ int vine_current_transfers_source_in_use(struct vine_manager *q, const char *sou
 	return c;
 }
 
+// count the number of ongoing transfers to a specific worker
+int vine_current_transfers_dest_in_use(struct vine_manager *q, struct vine_worker_info *w)
+{
+	char *id;
+	struct vine_transfer_pair *t;
+	int c = 0;
+	HASH_TABLE_ITERATE(q->current_transfer_table, id, t)
+	{
+		if (t->to == w)
+			c++;
+	}
+	return c;
+}
+
 int vine_current_transfers_worker_in_use(struct vine_manager *q, const char *peer_addr)
 {
 	char *id;

--- a/taskvine/src/manager/vine_current_transfers.h
+++ b/taskvine/src/manager/vine_current_transfers.h
@@ -16,6 +16,8 @@ int vine_current_transfers_remove(struct vine_manager *q, const char *id);
 
 int vine_current_transfers_source_in_use(struct vine_manager *q,const char *source);
 
+int vine_current_transfers_dest_in_use(struct vine_manager *q,struct vine_worker_info *w);
+
 int vine_current_transfers_worker_in_use(struct vine_manager *q,const char *peer_addr);
 
 int vine_current_transfers_wipe_worker(struct vine_manager *q, struct vine_worker_info *w);

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -79,17 +79,11 @@ struct vine_worker_info **vine_file_replica_table_find_replication_targets(
 		if (!peer->transfer_port_active)
 			continue;
 
-		if (!(remote_info = hash_table_lookup(peer->current_files, cachename)) &&
-				(strcmp(w->hostname, peer->hostname))) {
-			debug(D_VINE, "found replication target : %s", peer->transfer_addr);
-			workers[found] = peer;
-			found++;
-		}
 		char *peer_addr = string_format("worker://%s:%d", peer->transfer_addr, peer->transfer_port);
 		if (!(remote_info = hash_table_lookup(peer->current_files, cachename)) &&
 				(strcmp(w->hostname, peer->hostname))) {
-			if (vine_current_transfers_worker_in_use(q, peer_addr) < q->worker_source_max_transfers) {
-				debug(D_VINE, "found replication target : %s", peer->transfer_addr);
+			if ((vine_current_transfers_worker_in_use(q, peer_addr) < q->worker_source_max_transfers) && (vine_current_transfers_dest_in_use(q, peer) < q->worker_source_max_transfers)) {
+				debug(D_VINE, "found replication target : %s, current load %d", peer->transfer_addr, vine_current_transfers_dest_in_use(q, peer));
 				workers[found] = peer;
 				found++;
 			}

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -60,25 +60,28 @@ struct vine_worker_info *vine_file_replica_table_find_worker(struct vine_manager
 	return 0;
 }
 
-struct vine_worker_info **vine_file_replica_table_find_replication_targets(struct vine_manager *q, struct vine_worker_info *w, const char *cachename, int *count)
+struct vine_worker_info **vine_file_replica_table_find_replication_targets(
+		struct vine_manager *q, struct vine_worker_info *w, const char *cachename, int *count)
 {
 	char *id;
 	struct vine_worker_info *peer;
 	struct vine_file_replica *remote_info;
-	
+
 	int found = 0;
-	struct vine_worker_info **workers = malloc(sizeof(struct vine_worker_info)*(q->temp_replica_count));
+	struct vine_worker_info **workers = malloc(sizeof(struct vine_worker_info) * (q->temp_replica_count));
 
 	HASH_TABLE_ITERATE(q->worker_table, id, peer)
 	{
-		if (found == q->temp_replica_count) break;
+		if (found == q->temp_replica_count)
+			break;
 		if (!peer->transfer_port_active)
 			continue;
 
 		// generate a peer address stub as it would appear in the transfer table
 		char *peer_addr = string_format("worker://%s:%d", peer->transfer_addr, peer->transfer_port);
-		if (!(remote_info = hash_table_lookup(peer->current_files, cachename)) && (strcmp(w->hostname, peer->hostname))) {
-			debug(D_VINE, "found replication target : %s", peer_addr); 
+		if (!(remote_info = hash_table_lookup(peer->current_files, cachename)) &&
+				(strcmp(w->hostname, peer->hostname))) {
+			debug(D_VINE, "found replication target : %s", peer_addr);
 			workers[found] = peer;
 			found++;
 		}

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -85,6 +85,16 @@ struct vine_worker_info **vine_file_replica_table_find_replication_targets(
 			workers[found] = peer;
 			found++;
 		}
+		char *peer_addr = string_format("worker://%s:%d", peer->transfer_addr, peer->transfer_port);
+		if (!(remote_info = hash_table_lookup(peer->current_files, cachename)) &&
+				(strcmp(w->hostname, peer->hostname))) {
+			if (vine_current_transfers_worker_in_use(q, peer_addr) < q->worker_source_max_transfers) {
+				debug(D_VINE, "found replication target : %s", peer->transfer_addr);
+				workers[found] = peer;
+				found++;
+			}
+		}
+		free(peer_addr);
 	}
 	*count = found;
 	return workers;

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -82,8 +82,13 @@ struct vine_worker_info **vine_file_replica_table_find_replication_targets(
 		char *peer_addr = string_format("worker://%s:%d", peer->transfer_addr, peer->transfer_port);
 		if (!(remote_info = hash_table_lookup(peer->current_files, cachename)) &&
 				(strcmp(w->hostname, peer->hostname))) {
-			if ((vine_current_transfers_worker_in_use(q, peer_addr) < q->worker_source_max_transfers) && (vine_current_transfers_dest_in_use(q, peer) < q->worker_source_max_transfers)) {
-				debug(D_VINE, "found replication target : %s, current load %d", peer->transfer_addr, vine_current_transfers_dest_in_use(q, peer));
+			if ((vine_current_transfers_worker_in_use(q, peer_addr) < q->worker_source_max_transfers) &&
+					(vine_current_transfers_dest_in_use(q, peer) <
+							q->worker_source_max_transfers)) {
+				debug(D_VINE,
+						"found replication target : %s, current load %d",
+						peer->transfer_addr,
+						vine_current_transfers_dest_in_use(q, peer));
 				workers[found] = peer;
 				found++;
 			}

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -72,10 +72,14 @@ struct vine_worker_info **vine_file_replica_table_find_replication_targets(
 	int found = 0;
 	struct vine_worker_info **workers = malloc(sizeof(struct vine_worker_info) * (q->temp_replica_count));
 
+	// some random distribution
+	int skip_workers = (rand() % hash_table_size(q->worker_table)) + 1;
 	HASH_TABLE_ITERATE(q->worker_table, id, peer)
 	{
 		if (found == q->temp_replica_count)
 			break;
+		if (skip_workers--)
+			continue;
 		if (!peer->transfer_port_active)
 			continue;
 
@@ -85,10 +89,7 @@ struct vine_worker_info **vine_file_replica_table_find_replication_targets(
 			if ((vine_current_transfers_worker_in_use(q, peer_addr) < q->worker_source_max_transfers) &&
 					(vine_current_transfers_dest_in_use(q, peer) <
 							q->worker_source_max_transfers)) {
-				debug(D_VINE,
-						"found replication target : %s, current load %d",
-						peer->transfer_addr,
-						vine_current_transfers_dest_in_use(q, peer));
+				debug(D_VINE, "found replication target : %s", peer->transfer_addr);
 				workers[found] = peer;
 				found++;
 			}

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -60,6 +60,8 @@ struct vine_worker_info *vine_file_replica_table_find_worker(struct vine_manager
 	return 0;
 }
 
+// return a set of up to q->temp_replica_count workers that do not have the file cachename
+// and are not on the same host as worker w.
 struct vine_worker_info **vine_file_replica_table_find_replication_targets(
 		struct vine_manager *q, struct vine_worker_info *w, const char *cachename, int *count)
 {
@@ -77,15 +79,12 @@ struct vine_worker_info **vine_file_replica_table_find_replication_targets(
 		if (!peer->transfer_port_active)
 			continue;
 
-		// generate a peer address stub as it would appear in the transfer table
-		char *peer_addr = string_format("worker://%s:%d", peer->transfer_addr, peer->transfer_port);
 		if (!(remote_info = hash_table_lookup(peer->current_files, cachename)) &&
 				(strcmp(w->hostname, peer->hostname))) {
-			debug(D_VINE, "found replication target : %s", peer_addr);
+			debug(D_VINE, "found replication target : %s", peer->transfer_addr);
 			workers[found] = peer;
 			found++;
 		}
-		free(peer_addr);
 	}
 	*count = found;
 	return workers;

--- a/taskvine/src/manager/vine_file_replica_table.h
+++ b/taskvine/src/manager/vine_file_replica_table.h
@@ -25,6 +25,8 @@ struct vine_file_replica *vine_file_replica_table_lookup(struct vine_worker_info
 
 struct vine_worker_info *vine_file_replica_table_find_worker(struct vine_manager *q, const char *cachename);
 
+struct vine_worker_info **vine_file_replica_table_find_replication_targets(struct vine_manager *q, struct vine_worker_info *w, const char *cachename, int *count);
+
 int vine_file_replica_table_exists_somewhere( struct vine_manager *q, const char *cachename );
 
 int vine_file_replica_table_count_replicas( struct vine_manager *q, const char *cachename );

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -348,17 +348,13 @@ static void replicate_temp(struct vine_manager *q, struct vine_worker_info *w, c
 	int found = q->temp_replica_count;
 	struct vine_worker_info **workers;
 	workers = vine_file_replica_table_find_replication_targets(q, w, cachename, &found);
-	
+
 	debug(D_VINE, "Found %d available workers to replicate %s", found, cachename);
 
-	for(int i=0; i<found; i++)
-	{
+	for (int i = 0; i < found; i++) {
 		struct vine_worker_info *peer = workers[i];
-		char *worker_source = string_format("worker://%s:%d/%s",
-						w->transfer_addr,
-						w->transfer_port,
-						cachename);
-		
+		char *worker_source = string_format("worker://%s:%d/%s", w->transfer_addr, w->transfer_port, cachename);
+
 		char *transfer_id = vine_current_transfers_add(q, w, worker_source);
 		vine_manager_send(q,
 				peer,
@@ -369,12 +365,10 @@ static void replicate_temp(struct vine_manager *q, struct vine_worker_info *w, c
 				0777,
 				transfer_id);
 
-		
 		free(worker_source);
 		free(transfer_id);
-
 	}
-	free(workers);	
+	free(workers);
 }
 
 /*
@@ -394,7 +388,6 @@ static int handle_cache_update(struct vine_manager *q, struct vine_worker_info *
 	if (sscanf(line, "cache-update %s %lld %lld %lld %s", cachename, &size, &transfer_time, &start_time, id) == 5) {
 		struct vine_file_replica *remote_info = vine_file_replica_table_lookup(w, cachename);
 
-		
 		if (!remote_info) {
 			/*
 			If an unsolicited cache-update arrives, there are several possibilities:
@@ -416,7 +409,7 @@ static int handle_cache_update(struct vine_manager *q, struct vine_worker_info *
 
 		vine_txn_log_write_cache_update(q, w, size, transfer_time, start_time, cachename);
 		debug(D_VINE, "Received cache update id %c", *id);
-		
+
 		if (strncmp(cachename, "temp-rnd-", 9) == 0 && *id == 'X') {
 			debug(D_VINE, "Received temp to potentially replicate");
 			replicate_temp(q, w, cachename, size);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -362,6 +362,7 @@ static void replicate_temp_file(
 	for (int i = 0; i < found; i++) {
 		struct vine_worker_info *peer = workers[i];
 		char *worker_source = string_format("worker://%s:%d/%s", w->transfer_addr, w->transfer_port, cachename);
+		char *worker_addr = string_format("worker://%s:%d", w->transfer_addr, w->transfer_port);
 
 		char *transfer_id = vine_current_transfers_add(q, w, worker_source);
 		vine_manager_send(q,
@@ -374,6 +375,7 @@ static void replicate_temp_file(
 				transfer_id);
 
 		free(worker_source);
+		free(worker_addr);
 		free(transfer_id);
 	}
 	free(workers);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -343,6 +343,40 @@ static vine_msg_code_t handle_info(struct vine_manager *q, struct vine_worker_in
 	return VINE_MSG_PROCESSED;
 }
 
+static void replicate_temp(struct vine_manager *q, struct vine_worker_info *w, const char *cachename, long long size)
+{
+	int found = q->temp_replica_count;
+	struct vine_worker_info **workers;
+	workers = vine_file_replica_table_find_replication_targets(q, w, cachename, &found);
+	
+	debug(D_VINE, "Found %d available workers to replicate %s", found, cachename);
+
+	for(int i=0; i<found; i++)
+	{
+		struct vine_worker_info *peer = workers[i];
+		char *worker_source = string_format("worker://%s:%d/%s",
+						w->transfer_addr,
+						w->transfer_port,
+						cachename);
+		
+		char *transfer_id = vine_current_transfers_add(q, w, worker_source);
+		vine_manager_send(q,
+				peer,
+				"puturl_now %s %s %lld %o %s\n",
+				worker_source,
+				cachename,
+				size,
+				0777,
+				transfer_id);
+
+		
+		free(worker_source);
+		free(transfer_id);
+
+	}
+	free(workers);	
+}
+
 /*
 A cache-update message coming from the worker means that a requested
 remote transfer or command was successful, and know we know the size
@@ -360,6 +394,7 @@ static int handle_cache_update(struct vine_manager *q, struct vine_worker_info *
 	if (sscanf(line, "cache-update %s %lld %lld %lld %s", cachename, &size, &transfer_time, &start_time, id) == 5) {
 		struct vine_file_replica *remote_info = vine_file_replica_table_lookup(w, cachename);
 
+		
 		if (!remote_info) {
 			/*
 			If an unsolicited cache-update arrives, there are several possibilities:
@@ -380,6 +415,12 @@ static int handle_cache_update(struct vine_manager *q, struct vine_worker_info *
 		vine_current_transfers_remove(q, id);
 
 		vine_txn_log_write_cache_update(q, w, size, transfer_time, start_time, cachename);
+		debug(D_VINE, "Received cache update id %c", *id);
+		
+		if (strncmp(cachename, "temp-rnd-", 9) == 0 && *id == 'X') {
+			debug(D_VINE, "Received temp to potentially replicate");
+			replicate_temp(q, w, cachename, size);
+		}
 	}
 
 	return VINE_MSG_PROCESSED;
@@ -3697,6 +3738,8 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 	q->worker_source_max_transfers = VINE_WORKER_SOURCE_MAX_TRANSFERS;
 	q->perf_log_interval = VINE_PERF_LOG_INTERVAL;
 
+	q->temp_replica_count = 1;
+
 	q->resource_submit_multiplier = 1.0;
 
 	q->minimum_transfer_timeout = 60;
@@ -5167,6 +5210,9 @@ int vine_tune(struct vine_manager *q, const char *name, double value)
 
 	} else if (!strcmp(name, "worker-source-max-transfers")) {
 		q->worker_source_max_transfers = MAX(1, (int)value);
+
+	} else if (!strcmp(name, "temp-replica-count")) {
+		q->temp_replica_count = MAX(1, (int)value);
 
 	} else if (!strcmp(name, "perf-log-interval")) {
 		q->perf_log_interval = MAX(1, (int)value);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3740,7 +3740,7 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 	q->worker_source_max_transfers = VINE_WORKER_SOURCE_MAX_TRANSFERS;
 	q->perf_log_interval = VINE_PERF_LOG_INTERVAL;
 
-	q->temp_replica_count = 1;
+	q->temp_replica_count = 0;
 
 	q->resource_submit_multiplier = 1.0;
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5214,7 +5214,7 @@ int vine_tune(struct vine_manager *q, const char *name, double value)
 		q->worker_source_max_transfers = MAX(1, (int)value);
 
 	} else if (!strcmp(name, "temp-replica-count")) {
-		q->temp_replica_count = MAX(1, (int)value);
+		q->temp_replica_count = MAX(0, (int)value);
 
 	} else if (!strcmp(name, "perf-log-interval")) {
 		q->perf_log_interval = MAX(1, (int)value);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -364,7 +364,7 @@ static void replicate_temp_file(
 		char *worker_source = string_format("worker://%s:%d/%s", w->transfer_addr, w->transfer_port, cachename);
 		char *worker_addr = string_format("worker://%s:%d", w->transfer_addr, w->transfer_port);
 
-		char *transfer_id = vine_current_transfers_add(q, w, worker_source);
+		char *transfer_id = vine_current_transfers_add(q, peer, worker_source);
 		vine_manager_send(q,
 				peer,
 				"puturl_now %s %s %lld %o %s\n",

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -362,21 +362,8 @@ static void replicate_temp_file(
 	for (int i = 0; i < found; i++) {
 		struct vine_worker_info *peer = workers[i];
 		char *worker_source = string_format("worker://%s:%d/%s", w->transfer_addr, w->transfer_port, cachename);
-		char *worker_addr = string_format("worker://%s:%d", w->transfer_addr, w->transfer_port);
-
-		char *transfer_id = vine_current_transfers_add(q, peer, worker_source);
-		vine_manager_send(q,
-				peer,
-				"puturl_now %s %s %lld %o %s\n",
-				worker_source,
-				cachename,
-				size,
-				0777,
-				transfer_id);
-
+		vine_manager_put_url_now(q, peer, worker_source, cachename, size); 
 		free(worker_source);
-		free(worker_addr);
-		free(transfer_id);
 	}
 	free(workers);
 }

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -362,7 +362,7 @@ static void replicate_temp_file(
 	for (int i = 0; i < found; i++) {
 		struct vine_worker_info *peer = workers[i];
 		char *worker_source = string_format("worker://%s:%d/%s", w->transfer_addr, w->transfer_port, cachename);
-		vine_manager_put_url_now(q, peer, worker_source, cachename, size); 
+		vine_manager_put_url_now(q, peer, worker_source, cachename, size);
 		free(worker_source);
 	}
 	free(workers);

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -167,6 +167,7 @@ struct vine_manager {
 	/* Peer Transfer Configuration */
 	int peer_transfers_enabled;
 	int file_source_max_transfers;
+	int temp_replica_count;
 	int worker_source_max_transfers;
 	/* Various performance knobs that can be tuned. */
 

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -211,6 +211,36 @@ may be an estimate at this point and will be updated by return
 message once the object is actually loaded into the cache.
 */
 
+vine_result_code_t vine_manager_put_url_now(
+		struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct vine_file *f)
+{
+	char source_encoded[VINE_LINE_MAX];
+	char cached_name_encoded[VINE_LINE_MAX];
+
+	url_encode(f->source, source_encoded, sizeof(source_encoded));
+	url_encode(f->cached_name, cached_name_encoded, sizeof(cached_name_encoded));
+
+	char *transfer_id = vine_current_transfers_add(q, w, f->source);
+	vine_manager_send(q,
+			w,
+			"puturl_now %s %s %lld %o %s\n",
+			source_encoded,
+			cached_name_encoded,
+			(long long)f->size,
+			0777,
+			transfer_id);
+
+	free(transfer_id);
+	return VINE_SUCCESS;
+}
+
+/*
+Send a url to generate a cached file,
+if it has not already been cached there.  Note that the length
+may be an estimate at this point and will be updated by return
+message once the object is actually loaded into the cache.
+*/
+
 static vine_result_code_t vine_manager_put_url(
 		struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct vine_file *f)
 {

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -221,7 +221,7 @@ vine_result_code_t vine_manager_put_url_now(
 	url_encode(f->cached_name, cached_name_encoded, sizeof(cached_name_encoded));
 
 	char *transfer_id = vine_current_transfers_add(q, w, f->source);
-	vine_manager_send(q,
+	int result = vine_manager_send(q,
 			w,
 			"puturl_now %s %s %lld %o %s\n",
 			source_encoded,
@@ -231,7 +231,7 @@ vine_result_code_t vine_manager_put_url_now(
 			transfer_id);
 
 	free(transfer_id);
-	return VINE_SUCCESS;
+	return result;
 }
 
 /*

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -212,21 +212,21 @@ message once the object is actually loaded into the cache.
 */
 
 vine_result_code_t vine_manager_put_url_now(
-		struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct vine_file *f)
+		struct vine_manager *q, struct vine_worker_info *w, const char *source, const char *cachename, long long size)
 {
 	char source_encoded[VINE_LINE_MAX];
 	char cached_name_encoded[VINE_LINE_MAX];
 
-	url_encode(f->source, source_encoded, sizeof(source_encoded));
-	url_encode(f->cached_name, cached_name_encoded, sizeof(cached_name_encoded));
+	url_encode(source, source_encoded, sizeof(source_encoded));
+	url_encode(cachename, cached_name_encoded, sizeof(cached_name_encoded));
 
-	char *transfer_id = vine_current_transfers_add(q, w, f->source);
+	char *transfer_id = vine_current_transfers_add(q, w, cachename);
 	int result = vine_manager_send(q,
 			w,
 			"puturl_now %s %s %lld %o %s\n",
 			source_encoded,
 			cached_name_encoded,
-			(long long)f->size,
+			size,
 			0777,
 			transfer_id);
 

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -211,8 +211,8 @@ may be an estimate at this point and will be updated by return
 message once the object is actually loaded into the cache.
 */
 
-vine_result_code_t vine_manager_put_url_now(
-		struct vine_manager *q, struct vine_worker_info *w, const char *source, const char *cachename, long long size)
+vine_result_code_t vine_manager_put_url_now(struct vine_manager *q, struct vine_worker_info *w, const char *source,
+		const char *cachename, long long size)
 {
 	char source_encoded[VINE_LINE_MAX];
 	char cached_name_encoded[VINE_LINE_MAX];

--- a/taskvine/src/manager/vine_manager_put.h
+++ b/taskvine/src/manager/vine_manager_put.h
@@ -18,6 +18,7 @@ This module is private to the manager and should not be invoked by the end user.
 
 vine_result_code_t vine_manager_put_input_files( struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t );
 vine_result_code_t vine_manager_put_task( struct vine_manager *m, struct vine_worker_info *w, struct vine_task *t, const char *command_line, struct rmsummary *limits, struct vine_file *target );
+vine_result_code_t vine_manager_put_url_now( struct vine_manager *q, struct vine_worker_info *w, const char *source, const char *cachename, long long size );
 
 #endif
 

--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -243,11 +243,12 @@ Queue a remote file transfer to produce a file.
 This entry will be materialized later in vine_cache_ensure.
 */
 
-int vine_cache_queue_transfer(struct vine_cache *c, const char *source, const char *cachename, int64_t size, int mode, int flags)
+int vine_cache_queue_transfer(
+		struct vine_cache *c, const char *source, const char *cachename, int64_t size, int mode, int flags)
 {
 	struct vine_cache_file *f = vine_cache_file_create(VINE_CACHE_TRANSFER, source, size, mode, 0);
 	hash_table_insert(c->table, cachename, f);
-	if(flags==VINE_CACHE_NOW)
+	if (flags == VINE_CACHE_NOW)
 		vine_cache_ensure(c, cachename);
 	return 1;
 }

--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -251,6 +251,18 @@ int vine_cache_queue_transfer(struct vine_cache *c, const char *source, const ch
 }
 
 /*
+Perform a remote file transfer to produce a file.
+*/
+
+int vine_cache_transfer_now(struct vine_cache *c, const char *source, const char *cachename, int64_t size, int mode)
+{
+	struct vine_cache_file *f = vine_cache_file_create(VINE_CACHE_TRANSFER, source, size, mode, 0);
+	hash_table_insert(c->table, cachename, f);
+	vine_cache_ensure(c, cachename);
+	return 1;
+}
+
+/*
 Queue a mini-task to produce a file.
 This entry will be materialized later in vine_cache_ensure.
 */

--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -248,7 +248,7 @@ int vine_cache_queue_transfer(
 {
 	struct vine_cache_file *f = vine_cache_file_create(VINE_CACHE_TRANSFER, source, size, mode, 0);
 	hash_table_insert(c->table, cachename, f);
-	if (flags == VINE_CACHE_NOW)
+	if (flags & VINE_CACHE_FLAGS_NOW)
 		vine_cache_ensure(c, cachename);
 	return 1;
 }

--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -243,22 +243,12 @@ Queue a remote file transfer to produce a file.
 This entry will be materialized later in vine_cache_ensure.
 */
 
-int vine_cache_queue_transfer(struct vine_cache *c, const char *source, const char *cachename, int64_t size, int mode)
+int vine_cache_queue_transfer(struct vine_cache *c, const char *source, const char *cachename, int64_t size, int mode, int flags)
 {
 	struct vine_cache_file *f = vine_cache_file_create(VINE_CACHE_TRANSFER, source, size, mode, 0);
 	hash_table_insert(c->table, cachename, f);
-	return 1;
-}
-
-/*
-Perform a remote file transfer to produce a file.
-*/
-
-int vine_cache_transfer_now(struct vine_cache *c, const char *source, const char *cachename, int64_t size, int mode)
-{
-	struct vine_cache_file *f = vine_cache_file_create(VINE_CACHE_TRANSFER, source, size, mode, 0);
-	hash_table_insert(c->table, cachename, f);
-	vine_cache_ensure(c, cachename);
+	if(flags==VINE_CACHE_NOW)
+		vine_cache_ensure(c, cachename);
 	return 1;
 }
 

--- a/taskvine/src/worker/vine_cache.h
+++ b/taskvine/src/worker/vine_cache.h
@@ -31,9 +31,9 @@ typedef enum {
 } vine_cache_type_t;
 
 typedef enum {
-	VINE_CACHE_ON_TASK,
-	VINE_CACHE_NOW
-} vine_cache_ensure_when_t;
+	VINE_CACHE_FLAGS_ON_TASK = 1,
+	VINE_CACHE_FLAGS_NOW = 2,
+} vine_cache_flags_t;
 
 typedef enum {
 	VINE_CACHE_STATUS_NOT_PRESENT,

--- a/taskvine/src/worker/vine_cache.h
+++ b/taskvine/src/worker/vine_cache.h
@@ -47,6 +47,8 @@ char *vine_cache_full_path( struct vine_cache *c, const char *cachename );
 int vine_cache_addfile( struct vine_cache *c, int64_t size, int mode, const char *cachename );
 int vine_cache_queue_transfer( struct vine_cache *c, const char *source, const char *cachename, int64_t size, int mode );
 int vine_cache_queue_mini_task( struct vine_cache *c, struct vine_task *minitask, const char *source, const char *cachename, int64_t size, int mode );
+int vine_cache_transfer_now( struct vine_cache *c, const char *source, const char *cachename, int64_t size, int mode );
+int vine_cache_queue_command( struct vine_cache *c, struct vine_task *minitask, const char *cachename, int64_t size, int mode );
 vine_cache_status_t vine_cache_ensure( struct vine_cache *c, const char *cachename);
 int vine_cache_remove( struct vine_cache *c, const char *cachename, struct link *manager );
 int vine_cache_contains( struct vine_cache *c, const char *cachename );

--- a/taskvine/src/worker/vine_cache.h
+++ b/taskvine/src/worker/vine_cache.h
@@ -31,6 +31,11 @@ typedef enum {
 } vine_cache_type_t;
 
 typedef enum {
+	VINE_CACHE_ON_TASK,
+	VINE_CACHE_NOW
+} vine_cache_ensure_when_t;
+
+typedef enum {
 	VINE_CACHE_STATUS_NOT_PRESENT,
 	VINE_CACHE_STATUS_PROCESSING,
 	VINE_CACHE_STATUS_READY,
@@ -45,9 +50,8 @@ void vine_cache_scan( struct vine_cache *c, struct link *manager );
 char *vine_cache_full_path( struct vine_cache *c, const char *cachename );
 
 int vine_cache_addfile( struct vine_cache *c, int64_t size, int mode, const char *cachename );
-int vine_cache_queue_transfer( struct vine_cache *c, const char *source, const char *cachename, int64_t size, int mode );
+int vine_cache_queue_transfer( struct vine_cache *c, const char *source, const char *cachename, int64_t size, int mode, int flags );
 int vine_cache_queue_mini_task( struct vine_cache *c, struct vine_task *minitask, const char *source, const char *cachename, int64_t size, int mode );
-int vine_cache_transfer_now( struct vine_cache *c, const char *source, const char *cachename, int64_t size, int mode );
 int vine_cache_queue_command( struct vine_cache *c, struct vine_task *minitask, const char *cachename, int64_t size, int mode );
 vine_cache_status_t vine_cache_ensure( struct vine_cache *c, const char *cachename);
 int vine_cache_remove( struct vine_cache *c, const char *cachename, struct link *manager );

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -809,7 +809,7 @@ Accept a url specification and queue it for later transfer.
 
 static int do_put_url(const char *cache_name, int64_t size, int mode, const char *source)
 {
-	return vine_cache_queue_transfer(cache_manager, source, cache_name, size, mode, VINE_CACHE_ON_TASK);
+	return vine_cache_queue_transfer(cache_manager, source, cache_name, size, mode, VINE_CACHE_FLAGS_ON_TASK);
 }
 
 /*
@@ -818,7 +818,7 @@ Accept a url specification and transfer immediately.
 
 static int do_put_url_now(const char *cache_name, int64_t size, int mode, const char *source)
 {
-	return vine_cache_queue_transfer(cache_manager, source, cache_name, size, mode, VINE_CACHE_NOW);
+	return vine_cache_queue_transfer(cache_manager, source, cache_name, size, mode, VINE_CACHE_FLAGS_NOW);
 }
 
 /*

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -813,6 +813,15 @@ static int do_put_url(const char *cache_name, int64_t size, int mode, const char
 }
 
 /*
+Accept a url specification and transfer immediately.
+*/
+
+static int do_put_url_now(const char *cache_name, int64_t size, int mode, const char *source)
+{
+	return vine_cache_transfer_now(cache_manager, source, cache_name, size, mode);
+}
+
+/*
 Accept a mini_task that is executed on demand.
 We will then extract the file "source" from the sandbox in order to produce "cache_name".
 */
@@ -1089,6 +1098,19 @@ static int handle_manager(struct link *manager)
 			url_decode(filename_encoded, filename, sizeof(filename));
 			url_decode(source_encoded, source, sizeof(source));
 			r = do_put_url(filename, length, mode, source);
+			reset_idle_timer();
+			hash_table_insert(current_transfers, strdup(filename), strdup(transfer_id));
+			debug(D_VINE, "Insert ID-File pair into transfer table : %s :: %s", filename, transfer_id);
+		} else if (sscanf(line,
+					   "puturl_now %s %s %" SCNd64 " %o %s",
+					   source_encoded,
+					   filename_encoded,
+					   &length,
+					   &mode,
+					   transfer_id) == 5) {
+			url_decode(filename_encoded, filename, sizeof(filename));
+			url_decode(source_encoded, source, sizeof(source));
+			r = do_put_url_now(filename, length, mode, source);
 			reset_idle_timer();
 			hash_table_insert(current_transfers, strdup(filename), strdup(transfer_id));
 			debug(D_VINE, "Insert ID-File pair into transfer table : %s :: %s", filename, transfer_id);

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -809,7 +809,7 @@ Accept a url specification and queue it for later transfer.
 
 static int do_put_url(const char *cache_name, int64_t size, int mode, const char *source)
 {
-	return vine_cache_queue_transfer(cache_manager, source, cache_name, size, mode);
+	return vine_cache_queue_transfer(cache_manager, source, cache_name, size, mode, VINE_CACHE_ON_TASK);
 }
 
 /*
@@ -818,7 +818,7 @@ Accept a url specification and transfer immediately.
 
 static int do_put_url_now(const char *cache_name, int64_t size, int mode, const char *source)
 {
-	return vine_cache_transfer_now(cache_manager, source, cache_name, size, mode);
+	return vine_cache_queue_transfer(cache_manager, source, cache_name, size, mode, VINE_CACHE_NOW);
 }
 
 /*

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1100,7 +1100,6 @@ static int handle_manager(struct link *manager)
 			r = do_put_url(filename, length, mode, source);
 			reset_idle_timer();
 			hash_table_insert(current_transfers, strdup(filename), strdup(transfer_id));
-			debug(D_VINE, "Insert ID-File pair into transfer table : %s :: %s", filename, transfer_id);
 		} else if (sscanf(line,
 					   "puturl_now %s %s %" SCNd64 " %o %s",
 					   source_encoded,
@@ -1113,7 +1112,6 @@ static int handle_manager(struct link *manager)
 			r = do_put_url_now(filename, length, mode, source);
 			reset_idle_timer();
 			hash_table_insert(current_transfers, strdup(filename), strdup(transfer_id));
-			debug(D_VINE, "Insert ID-File pair into transfer table : %s :: %s", filename, transfer_id);
 		} else if (sscanf(line,
 					   "mini_task %s %s %" SCNd64 " %o",
 					   source_encoded,


### PR DESCRIPTION
## Proposed changes
Related to #3563 

At the moment, upon a cache update, the manager will check if a temp file was created.

If that is the case, the manager will look for up to q->temp_replica_count workers to replicate the file to.

It uses the new message, `puturl_now,` to tell a worker to bring a remote file to the cache without the need to run a task


## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.


