### PR TITLE
Vine: Finalize Task When Creating Mini-Task

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1487,6 +1487,11 @@ class Manager(object):
     #                peer transfers are enabled (see @ref ndcctools.taskvine.manager.Manager.enable_peer_transfers). Default is True.
     # @return A file object to use in @ref ndcctools.taskvine.task.Task.add_input
     def declare_minitask(self, minitask, name="minitask", cache=False, peer_transfer=True):
+
+        # Attaching a task as a mini-task is like submitting it, so we must finalize the details.
+        minitask.submit_finalize(self)
+
+        # Then proceed to attach the task to the mini-task file object.
         flags = Task._determine_file_flags(cache, peer_transfer)
         f = cvine.vine_declare_mini_task(self._taskvine, minitask._task, name, flags)
 


### PR DESCRIPTION


## Proposed changes

Fix issue: #3573. task.submit_finalize(m) must be called when declaring a minitask, because that is equivalent to "submitting" the task for execution.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
