### PR TITLE
null check resource

### DIFF
--- a/work_queue/src/work_queue_coprocess.c
+++ b/work_queue/src/work_queue_coprocess.c
@@ -310,6 +310,9 @@ void work_queue_coprocess_measure_resources(struct work_queue_coprocess *coproce
 		}
 		struct rmsummary *resources = rmonitor_measure_process(curr_coprocess->pid);
 
+		if(!resources)
+			continue;
+
 		debug(D_WQ, "Measuring resources of coprocess with pid %d\n", curr_coprocess->pid);
 		debug(D_WQ, "cores: %lf, memory: %lf, disk: %lf, gpus: %lf\n", resources->cores, resources->memory + resources->swap_memory, resources->disk, resources->gpus);
 		debug(D_WQ, "Max resources available to coprocess:\ncores: %"PRId64 " memory: %"PRId64 " disk: %"PRId64 " gpus: %"PRId64 "\n", curr_coprocess->coprocess_resources->cores.total, curr_coprocess->coprocess_resources->memory.total, curr_coprocess->coprocess_resources->disk.total, curr_coprocess->coprocess_resources->gpus.total);


### PR DESCRIPTION
## Proposed changes

Null check resource in case coprocess no longer exists

#3583 

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

