### PR TITLE
TaskVine: Fix problem where function calls print to stdout of the vine_worker process

### DIFF
--- a/poncho/src/poncho/library_network_code.py
+++ b/poncho/src/poncho/library_network_code.py
@@ -129,7 +129,6 @@ def library_network_code():
                     # output of execution should be dumped to outfile.
                     with open('outfile', 'wb') as f:
                         cloudpickle.dump(globals()[function_name](event), f)
-                    os.fsync(stdout_capture_fd)
                     os.close(stdout_capture_fd)
                     os._exit(0)
                 elif p < 0:

--- a/taskvine/src/manager/vine_protocol.h
+++ b/taskvine/src/manager/vine_protocol.h
@@ -13,7 +13,7 @@ worker, and catalog, but should not be visible to the public user API.
 #ifndef VINE_PROTOCOL_H
 #define VINE_PROTOCOL_H
 
-#define VINE_PROTOCOL_VERSION 5
+#define VINE_PROTOCOL_VERSION 6
 
 #define VINE_LINE_MAX 4096       /**< Maximum length of a vine message line. */
 

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -285,8 +285,8 @@ int vine_process_execute(struct vine_process *p)
 	int input_fd = -1;
 	int output_fd = -1;
 	int error_fd = -1;
-	int in_pipe_fd = -1;	// only for library task, fd to send functions to library
-	int out_pipe_fd = -1;	// only for library task, fd to receive results from library
+	int in_pipe_fd = -1;  // only for library task, fd to send functions to library
+	int out_pipe_fd = -1; // only for library task, fd to receive results from library
 
 	/* Setting up input, output, and stderr for various task types. */
 	if (p->type == VINE_PROCESS_TYPE_LIBRARY) {

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -239,7 +239,8 @@ int vine_process_execute_and_wait(struct vine_process *p)
 
 int vine_process_invoke_function(struct vine_process *p)
 {
-	char *buffer = string_format("%d %s %s %s", p->task->task_id, p->task->command_line, p->sandbox, p->output_file_name);
+	char *buffer = string_format(
+			"%d %s %s %s", p->task->task_id, p->task->command_line, p->sandbox, p->output_file_name);
 	ssize_t result = link_printf(p->library_process->library_write_link,
 			time(0) + options->active_timeout,
 			"%ld\n%s",

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -239,7 +239,7 @@ int vine_process_execute_and_wait(struct vine_process *p)
 
 int vine_process_invoke_function(struct vine_process *p)
 {
-	char *buffer = string_format("%d %s %s", p->task->task_id, p->task->command_line, p->sandbox);
+	char *buffer = string_format("%d %s %s %s", p->task->task_id, p->task->command_line, p->sandbox, p->output_file_name);
 	ssize_t result = link_printf(p->library_process->library_write_link,
 			time(0) + options->active_timeout,
 			"%ld\n%s",

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -285,35 +285,28 @@ int vine_process_execute(struct vine_process *p)
 	int input_fd = -1;
 	int output_fd = -1;
 	int error_fd = -1;
+	int in_pipe_fd = -1;	// only for library task, fd to send functions to library
+	int out_pipe_fd = -1;	// only for library task, fd to receive results from library
 
 	/* Setting up input, output, and stderr for various task types. */
 	if (p->type == VINE_PROCESS_TYPE_LIBRARY) {
 		/* If starting a library, create the pipes for parent-child communication. */
-
 		if (pipe(pipe_in) < 0)
 			fatal("couldn't create library pipes: %s\n", strerror(errno));
 		if (pipe(pipe_out) < 0)
 			fatal("couldn't create library pipes: %s\n", strerror(errno));
-
-		input_fd = pipe_in[0];
-		output_fd = pipe_out[1];
-
-		/* Standard error of library goes to output file name for return to manager. */
-		error_fd = open(p->output_file_name, O_WRONLY | O_TRUNC | O_CREAT, 0777);
-		if (output_fd == -1) {
-			debug(D_VINE, "Could not open worker stdout: %s", strerror(errno));
-			return 0;
-		}
-	} else {
-		/* For other task types, read input from null and send output to assigned file. */
-		input_fd = open("/dev/null", O_RDONLY);
-		output_fd = open(p->output_file_name, O_WRONLY | O_TRUNC | O_CREAT, 0777);
-		if (output_fd < 0) {
-			debug(D_VINE, "Could not open worker stdout: %s", strerror(errno));
-			return 0;
-		}
-		error_fd = output_fd;
+		in_pipe_fd = pipe_in[0];
+		out_pipe_fd = pipe_out[1];
 	}
+
+	/* Read input from null and send output to assigned file. */
+	input_fd = open("/dev/null", O_RDONLY);
+	output_fd = open(p->output_file_name, O_WRONLY | O_TRUNC | O_CREAT, 0777);
+	if (output_fd < 0) {
+		debug(D_VINE, "Could not open worker stdout: %s", strerror(errno));
+		return 0;
+	}
+	error_fd = output_fd;
 
 	/* Start the performance clock just prior to forking the task. */
 	p->execution_start = timestamp_get();
@@ -336,15 +329,10 @@ int vine_process_execute(struct vine_process *p)
 			/* Close the ends of the pipes that the parent process won't use. */
 			close(pipe_in[0]);
 			close(pipe_out[1]);
-
-			/* Close the error stream that the parent won't use. */
-			close(error_fd);
-		} else {
-			/* For any other task type, drop the fds unused by the parent. */
-			close(input_fd);
-			close(output_fd);
-			close(error_fd);
 		}
+		/* Drop the fds unused by the parent, error_fd is output_fd so close once. */
+		close(input_fd);
+		close(output_fd);
 
 		return 1;
 
@@ -367,31 +355,22 @@ int vine_process_execute(struct vine_process *p)
 			printf("The sandbox dir is %s", p->sandbox);
 			fatal("could not change directory into %s: %s", p->sandbox, strerror(errno));
 		}
-		/* For process types other than library, set up file desciptors.
-		 * The library will use the input_fd and output_fd to talk to the manager instead. */
-		if (p->type != VINE_PROCESS_TYPE_LIBRARY) {
-			int result = dup2(input_fd, STDIN_FILENO);
-			if (result < 0)
-				fatal("could not dup input to stdin: %s", strerror(errno));
+		int result = dup2(input_fd, STDIN_FILENO);
+		if (result < 0)
+			fatal("could not dup input to stdin: %s", strerror(errno));
 
-			result = dup2(output_fd, STDOUT_FILENO);
-			if (result < 0)
-				fatal("could not dup output to stdout: %s", strerror(errno));
+		result = dup2(output_fd, STDOUT_FILENO);
+		if (result < 0)
+			fatal("could not dup output to stdout: %s", strerror(errno));
 
-			result = dup2(error_fd, STDERR_FILENO);
-			if (result < 0)
-				fatal("could not dup error to stderr: %s", strerror(errno));
+		result = dup2(error_fd, STDERR_FILENO);
+		if (result < 0)
+			fatal("could not dup error to stderr: %s", strerror(errno));
 
-			/* Close redundant file descriptors.
-			 * Note that output_fd is the same as error_fd so it's only closed once. */
-			close(input_fd);
-			close(output_fd); // no need to close error_fd.
-		} else {
-			int result = dup2(error_fd, STDERR_FILENO);
-			if (result < 0)
-				fatal("could not dup error to stderr: %s", strerror(errno));
-			close(error_fd);
-		}
+		/* Close redundant file descriptors after dup()'ing.
+		 * Note that output_fd is the same as error_fd so it's only closed once. */
+		close(input_fd);
+		close(output_fd); // no need to close error_fd.
 
 		/* For a library task, close the unused sides of the pipes. */
 		if (p->type == VINE_PROCESS_TYPE_LIBRARY) {
@@ -416,8 +395,8 @@ int vine_process_execute(struct vine_process *p)
 		} else {
 			char *final_command = string_format("%s --input-fd %d --output-fd %d --worker-pid %d",
 					p->task->command_line,
-					input_fd,
-					output_fd,
+					in_pipe_fd,
+					out_pipe_fd,
 					getppid());
 			execl("/bin/sh", "sh", "-c", final_command, (char *)0);
 		}


### PR DESCRIPTION
## Proposed changes

Before, if a function call prints anything to stdout, then it is routed to the vine_worker process' stdout. This fixes that and makes the library task have the same stdin/out/err setup as the standard task.

## Post-change actions

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
