### PR TITLE
daskvine: add argument to set env variables

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -2532,8 +2532,9 @@ The `compute` call above may receive the following keyword arguments:
 | Keyword | Description |
 |------------ |---------|
 | environment | A TaskVine file that provides an [environment](#environments) to execute each task. |
-| extra_files | A dictionary of {taskvine.File: "remote_name"} of input files to attach to each task.|
-| lazy_transfer | Whether to bring each result back from the workers (False, default), or keep transient results at workers (True) |
+| env\_vars   | A dictionary of VAR=VALUE environment variables to set per task. A value should be either a string, or a function that accepts as arguments the manager and task, and that returns a string. |
+| extra\_files | A dictionary of {taskvine.File: "remote_name"} of input files to attach to each task.|
+| lazy\_transfer | Whether to bring each result back from the workers (False, default), or keep transient results at workers (True) |
 | resources   | A dictionary to specify [maximum resources](#task-resources), e.g. `{"cores": 1, "memory": 2000"}` |
 | resources\_mode | [Automatic resource management](#automatic-resource-management) to use, e.g., "fixed", "max", or "max throughput"| 
 


### PR DESCRIPTION
## Proposed changes

Adds the `env_vars` parameter to `DaskVine.get` to set environment variables per task. Values of variables should be either strings, or functions that return strings and that take as arguments the current manager and current task.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
