### PR TITLE
TaskVine: Fix bug in function call scheduling

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3109,7 +3109,8 @@ static struct vine_task *find_library_on_worker_for_task(struct vine_worker_info
 /* Check if this worker can run the function task.
  * @return 1 if it can, 0 otherwise.
  */
-static int check_worker_can_run_function_task(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
+int vine_manager_check_worker_can_run_function_task(
+		struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
 {
 	struct vine_task *library = find_library_on_worker_for_task(w, t->needs_library);
 	if (!library) {
@@ -3170,12 +3171,6 @@ static int send_one_task(struct vine_manager *q)
 		if (q->peer_transfers_enabled) {
 			if (!vine_manager_transfer_capacity_available(q, w, t))
 				continue;
-		}
-
-		// If this is a function task, check if the worker can run it.
-		// May require the manager to send a library to the worker first.
-		if (t->needs_library && !check_worker_can_run_function_task(q, w, t)) {
-			continue;
 		}
 
 		// Otherwise, remove it from the ready list and start it:

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -246,6 +246,8 @@ struct rmsummary *vine_manager_choose_resources_for_task( struct vine_manager *q
 
 int64_t overcommitted_resource_total(struct vine_manager *q, int64_t total);
 
+/* Internal: Enable checking and sending library tasks as necessary. Needed for @vine_schedule.c to check if a worker is compatible to a function task. */
+int vine_manager_check_worker_can_run_function_task(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t);
 
 /* The expected format of files created by the resource monitor.*/
 #define RESOURCE_MONITOR_TASK_LOCAL_NAME "vine-task-%d"

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -163,6 +163,12 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 	}
 	rmsummary_delete(l);
 
+	/* If this is a function task, check if the worker can run it.
+	 * May require the manager to send a library to the worker first. */
+	if (t->needs_library && !vine_manager_check_worker_can_run_function_task(q, w, t)) {
+		return 0;
+	}
+
 	// if worker's end time has not been received
 	if (w->end_time < 0) {
 		return 0;


### PR DESCRIPTION
## Proposed changes

The current implementation of scheduling function calls is buggy, as for a given task T1, it looks for a candidate worker W in the regular way as other tasks. It then checks W to see if W has the capacity to run T1. The problem is when the second check fails, the main loop in `send_one_task` rotates to the next task T2, T3, T4, etc., until W is available to run a function call again, instead of finding the next worker to run T1.

The fix moves the checking code inside `check_worker_against_task` in `vine_schedule.c`, effectively merging two checks into one. So all workers are checked for a task first before we loop through the task list.

## Post-change actions

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
