### PR TITLE
Vine: Memory Leak Supplement

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -974,21 +974,22 @@ class FunctionCall(Task):
         self._event["fn_args"] = args
         self.set_time_max(900)     # maximum run time for function calls is 900s by default.
         self.needs_library(library_name)
-        self.output_buffer = None
+        self._input_buffer = None
+        self._output_buffer = None
 
     ##
     # Finalizes the task definition once the manager that will execute is run.
     # This function is run by the manager before registering the task for
     # execution.
-    #
+    # 
     # @param self 	Reference to the current python task object
     # @param manager Manager to which the task was submitted
     def submit_finalize(self, manager):
         super().submit_finalize(manager)
-        f = manager.declare_buffer(cloudpickle.dumps(self._event))
-        self.add_input(f, "infile")
-        self.output_buffer = manager.declare_buffer(cache=False, peer_transfer=False)
-        self.add_output(self.output_buffer, "outfile")
+        self._input_buffer = manager.declare_buffer(buffer=cloudpickle.dumps(self._event), cache=False, peer_transfer=True)
+        self.add_input(self._input_buffer, "infile")
+        self._output_buffer = manager.declare_buffer(buffer=None, cache=False, peer_transfer=False)
+        self.add_output(self._output_buffer, "outfile")
 
     ##
     # Specify function arguments. Accepts arrays and dictionaries. This
@@ -1014,7 +1015,9 @@ class FunctionCall(Task):
 
     @property
     def output(self):
-        output = cloudpickle.loads(self.output_buffer.contents())
+        output = cloudpickle.loads(self._output_buffer.contents())
+        self._manager.remove_file(self._input_buffer)
+        self._manager.remove_file(self._output_buffer)
         if output['Success']:
             return output['Result']
         else:


### PR DESCRIPTION
## Proposed changes

This PR is a supplement of #3592.

The memory leak issue of FunctionCall tasks manifests on two sites: 

- Python maintains references to task objects, failing to timely delete them.
- The manager's declared input and output buffers were not properly disposed of immediately after output retrieval.

While #3592 resolved the first issue, this PR remedies the second.

Comparison of consumed memory before and after changes in this PR with an example executed on 100 tasks:

![Screenshot from 2024-01-09 11-53-05](https://github.com/cooperative-computing-lab/cctools/assets/142265839/6ce92209-d934-442e-8dab-c7ffc8078083)


![Screenshot from 2024-01-09 11-51-30](https://github.com/cooperative-computing-lab/cctools/assets/142265839/64d2e84b-8557-4dff-969c-13c08bb32c2f)


## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
