### PR TITLE
dask+vine: set custom name to file outputs

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -212,7 +212,7 @@ class DaskVine(Manager):
 
 
 class DaskVineFile:
-    def __init__(self, file, key, staging_dir):
+    def __init__(self, file, key):
         self._file = file
         self._loaded = False
         self._load = None
@@ -300,6 +300,8 @@ class PythonTaskDask(PythonTask):
             self.set_category(category)
         if lazy_transfers:
             self.enable_temp_output()
+        else:
+            self.set_output_name(f"{m.staging_directory}/{uuid4()}.p")
         if environment:
             self.add_environment(environment)
         if extra_files:
@@ -324,6 +326,10 @@ class PythonTaskDask(PythonTask):
     def decrement_retry(self):
         self._retries_left -= 1
         return self._retries_left
+
+    def set_output_name(self, filename):
+        self._out_name_file = filename
+
 
 
 def execute_graph_vertex(sexpr, args, keys_of_files):

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -743,8 +743,9 @@ class PythonTask(Task):
         self._out_name_file = f"out_{self._id}.p"
         self._stdout_file = f"stdout_{self._id}.p"
         self._wrapper = f"pytask_wrapper_{self._id}.py"
-        self._command = self._python_function_command()
         self._serialize_output = True
+
+        self._command = self._python_function_command()
 
         self._tmp_output_enabled = False
         self._cache_output = False
@@ -816,6 +817,7 @@ class PythonTask(Task):
     # @param self 	Reference to the current python task object
     def enable_temp_output(self):
         self._tmp_output_enabled = True
+
     def disable_temp_output(self):
         self._tmp_output_enabled = False
 
@@ -890,7 +892,7 @@ class PythonTask(Task):
         else:
             py_exec = f"python{sys.version_info[0]}"
 
-        command = f"{py_exec} {self._wrapper} {self._func_file} {self._args_file} {self._out_name_file} > {self._stdout_file} 2>&1"
+        command = f"{py_exec} {self._wrapper} {self._func_file} {self._args_file} {self._id} > {self._stdout_file} 2>&1"
         return command
 
     def _add_IO_files(self, manager):
@@ -907,7 +909,7 @@ class PythonTask(Task):
             self._output_file = manager.declare_temp()
         else:
             self._output_file = manager.declare_file(source(self._out_name_file), cache=self._cache_output)
-        self.add_output(self._output_file, self._out_name_file)
+        self.add_output(self._output_file, self._id)
 
     ##
     # creates the wrapper script which will execute the function. pickles output.


### PR DESCRIPTION
Fix for #3606. When outputs are not vine temp files, a name outside the task staging directory (but inside the manager staging directory) is set. This allows for the task to be garbaged collected without deleting its output.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
