### PR TITLE
Vine: Unlink Intermediate Files Automatically

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -168,7 +168,7 @@ class FutureTask(PythonTask):
             if not self._output_loaded and self._future_resolved:
                 if self.successful():
                     try:
-                        with open(os.path.join(self._tmpdir, self._out_name_file), "rb") as f:
+                        with open(os.path.join(self._tmpdir, "output"), "rb") as f:
                             if self._serialize_output:
                                 self._output = cloudpickle.load(f)
                             else:
@@ -202,7 +202,7 @@ class FutureTask(PythonTask):
         return cvine.vine_task_add_environment(self._task, f._file)
 
     def _create_wrapper(self):
-        with open(os.path.join(self._tmpdir, self._wrapper), "w") as f:
+        with open(os.path.join(self._tmpdir, "wrapper"), "w") as f:
             f.write(
                 textwrap.dedent(
                     f"""

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1381,11 +1381,11 @@ class Manager(object):
     #                end-of-life of the worker. Default is False (file is not cache).
     # @param peer_transfer   Whether the file can be transfered between workers when
     #                peer transfers are enabled (see @ref ndcctools.taskvine.manager.Manager.enable_peer_transfers). Default is True.
-    # @param _unlink_on_rc   Whether to delete the file when its reference count is 0. (Use with care, TaskVine internal only)
+    # @param unlink_when_done   Whether to delete the file when its reference count is 0. (Warning: Only use on files produced by the application, and never on irreplaceable input files.)
     # @return
     # A file object to use in @ref ndcctools.taskvine.task.Task.add_input or @ref ndcctools.taskvine.task.Task.add_output
-    def declare_file(self, path, cache=False, peer_transfer=True, _unlink_on_rc=False):
-        flags = Task._determine_file_flags(cache, peer_transfer, _unlink_on_rc)
+    def declare_file(self, path, cache=False, peer_transfer=True, unlink_when_done=False):
+        flags = Task._determine_file_flags(cache, peer_transfer, unlink_when_done)
         f = cvine.vine_declare_file(self._taskvine, path, flags)
         return File(f)
 

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1381,10 +1381,11 @@ class Manager(object):
     #                end-of-life of the worker. Default is False (file is not cache).
     # @param peer_transfer   Whether the file can be transfered between workers when
     #                peer transfers are enabled (see @ref ndcctools.taskvine.manager.Manager.enable_peer_transfers). Default is True.
+    # @param _unlink_on_rc   Whether to delete the file when its reference count is 0. (Use with care, TaskVine internal only)
     # @return
     # A file object to use in @ref ndcctools.taskvine.task.Task.add_input or @ref ndcctools.taskvine.task.Task.add_output
-    def declare_file(self, path, cache=False, peer_transfer=True):
-        flags = Task._determine_file_flags(cache, peer_transfer)
+    def declare_file(self, path, cache=False, peer_transfer=True, _unlink_on_rc=False):
+        flags = Task._determine_file_flags(cache, peer_transfer, _unlink_on_rc)
         f = cvine.vine_declare_file(self._taskvine, path, flags)
         return File(f)
 

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -142,7 +142,7 @@ class Task(object):
         return flags
 
     @staticmethod
-    def _determine_file_flags(cache=False, peer_transfer=False, _unlink_on_rc=False):
+    def _determine_file_flags(cache=False, peer_transfer=False, unlink_when_done=False):
         flags = cvine.VINE_CACHE_NEVER
         if cache is True or cache == "workflow":
             flags |= cvine.VINE_CACHE
@@ -150,8 +150,8 @@ class Task(object):
             flags |= cvine.VINE_CACHE_ALWAYS
         if not peer_transfer:
             flags |= cvine.VINE_PEER_NOSHARE
-        if _unlink_on_rc:
-            flags |= cvine.VINE_UNLINK_ON_RC0
+        if unlink_when_done:
+            flags |= cvine.VINE_UNLINK_WHEN_DONE
         return flags
 
     ##
@@ -882,7 +882,7 @@ class PythonTask(Task):
         return command
 
     def _add_IO_files(self, manager):
-        f = manager.declare_file(self._tmpdir, _unlink_on_rc=True)
+        f = manager.declare_file(self._tmpdir, unlink_when_done=True)
         self.add_input(f, "input_dir")
 
         f = manager.declare_file(os.path.join(self._tmpdir, "stdout"))

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -61,7 +61,7 @@ typedef enum {
 	VINE_CACHE = 1,        /**< File remains in cache until workflow ends. */
 	VINE_CACHE_ALWAYS = 3, /**< File remains in cache until the worker teminates. **/
 	VINE_PEER_NOSHARE = 4,  /**< Schedule this file to be shared between peers where available. See @ref vine_enable_peer_transfers **/
-	VINE_UNLINK_ON_RC0 = 8  /**< Remove the file from disk at the manager execution site when the reference count of the file is 0. (Use with care, TaskVine internal use only.) */
+	VINE_UNLINK_WHEN_DONE = 8  /**< Whether to delete the file when its reference count is 0. (Warning: Only use on files produced by the application, and never on irreplaceable input files.) */
 } vine_file_flags_t;
 
 /** Select overall scheduling algorithm for matching tasks to workers. */

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -60,7 +60,8 @@ typedef enum {
 	VINE_CACHE_NEVER = 0,  /**< Do not cache file at execution site. (default) */
 	VINE_CACHE = 1,        /**< File remains in cache until workflow ends. */
 	VINE_CACHE_ALWAYS = 3, /**< File remains in cache until the worker teminates. **/
-	VINE_PEER_NOSHARE = 4  /**< Schedule this file to be shared between peers where available. See @ref vine_enable_peer_transfers **/
+	VINE_PEER_NOSHARE = 4,  /**< Schedule this file to be shared between peers where available. See @ref vine_enable_peer_transfers **/
+	VINE_UNLINK_ON_RC0 = 8  /**< Remove the file from disk at the manager execution site when the reference count of the file is 0. (Use with care, TaskVine internal use only.) */
 } vine_file_flags_t;
 
 /** Select overall scheduling algorithm for matching tasks to workers. */

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -13,6 +13,7 @@ See the file COPYING for details.
 #include "path.h"
 #include "stringtools.h"
 #include "unlink_recursive.h"
+#include "timestamp.h"
 #include "xxmalloc.h"
 
 #include <limits.h>
@@ -37,7 +38,11 @@ int vine_file_delete(struct vine_file *f)
 		}
 
 		if (f->type == VINE_FILE && f->flags & VINE_UNLINK_WHEN_DONE) {
+			timestamp_t start_time = timestamp_get();
 			unlink_recursive(f->source);
+			timestamp_t end_time = timestamp_get();
+
+			debug(D_VINE, "vine_file_delete: deleting file on reference count took: %.02lfs", (end_time - start_time)/1000000.0);
 		}
 
 		vine_task_delete(f->mini_task);

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -36,7 +36,7 @@ int vine_file_delete(struct vine_file *f)
 			return 0;
 		}
 
-		if (f->type == VINE_FILE && f->flags & VINE_UNLINK_ON_RC0) {
+		if (f->type == VINE_FILE && f->flags & VINE_UNLINK_WHEN_DONE) {
 			unlink_recursive(f->source);
 		}
 

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -12,6 +12,7 @@ See the file COPYING for details.
 #include "debug.h"
 #include "path.h"
 #include "stringtools.h"
+#include "unlink_recursive.h"
 #include "xxmalloc.h"
 
 #include <limits.h>
@@ -33,6 +34,10 @@ int vine_file_delete(struct vine_file *f)
 		if (f->refcount < 0) {
 			notice(D_VINE, "vine_file_delete: prevented multiple-free of file");
 			return 0;
+		}
+
+		if (f->type == VINE_FILE && f->flags & VINE_UNLINK_ON_RC0) {
+			unlink_recursive(f->source);
 		}
 
 		vine_task_delete(f->mini_task);

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -12,8 +12,8 @@ See the file COPYING for details.
 #include "debug.h"
 #include "path.h"
 #include "stringtools.h"
-#include "unlink_recursive.h"
 #include "timestamp.h"
+#include "unlink_recursive.h"
 #include "xxmalloc.h"
 
 #include <limits.h>
@@ -42,7 +42,9 @@ int vine_file_delete(struct vine_file *f)
 			unlink_recursive(f->source);
 			timestamp_t end_time = timestamp_get();
 
-			debug(D_VINE, "vine_file_delete: deleting file on reference count took: %.02lfs", (end_time - start_time)/1000000.0);
+			debug(D_VINE,
+					"vine_file_delete: deleting file on reference count took: %.02lfs",
+					(end_time - start_time) / 1000000.0);
 		}
 
 		vine_task_delete(f->mini_task);


### PR DESCRIPTION
## Proposed changes

Adds the VINE_UNLINK_ON_RC0 flag to delete files from disk when the reference count goes to 0.
Intended only for internal taskvine usage.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
