### PR TITLE
vine: file remove before delete

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5713,8 +5713,8 @@ void vine_remove_file(struct vine_manager *m, struct vine_file *f)
 		/* the rest of the references, if any, will be deleted as the tasks
 		 * that reference the file are deleted. */
 
-		vine_file_delete(f);
 		hash_table_remove(m->file_table, f->cached_name);
+		vine_file_delete(f);
 	}
 }
 


### PR DESCRIPTION
 vine: remove file before table before freeing structure
 We where using f->cache_name after the f structure had been freed.
It led to a segfault when a file was declared and removed immediately.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
