### PR TITLE
vine: when copying mounts, do not clone input file twice.

### DIFF
--- a/taskvine/src/manager/vine_mount.c
+++ b/taskvine/src/manager/vine_mount.c
@@ -26,7 +26,7 @@ struct vine_mount *vine_mount_create(
 		m->remote_name = 0;
 	}
 	m->flags = flags;
-	m->substitute = substitute;
+	m->substitute = vine_file_clone(substitute);
 
 	return m;
 }
@@ -44,5 +44,5 @@ struct vine_mount *vine_mount_copy(struct vine_mount *m)
 {
 	if (!m)
 		return 0;
-	return vine_mount_create(vine_file_clone(m->file), m->remote_name, m->flags, vine_file_clone(m->substitute));
+	return vine_mount_create(m->file, m->remote_name, m->flags, m->substitute);
 }


### PR DESCRIPTION
## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
