### PR TITLE
vine: write custom entries to debug and transactions logs

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -2203,6 +2203,7 @@ If you need to change the prefix `vine-run-info` to some other directory, use
     ```
 
 === "C"
+    ```C
     // logs appear at /new/desired/path/%Y-%m-%dT%H:%M:%S/vine-logs
     vine_set_runtime_info_path("/new/desired/path")
     struct taskvine *m = vine_create(0);
@@ -2231,6 +2232,18 @@ To enable debugging at the worker, set the `-d` option:
 ```sh
 $ vine_worker -d all -o worker.debug -M myproject
 ```
+
+Custom APPLICATION messages can be added to the log with the calls:
+
+=== "Python"
+    ```python
+    m.log_debug_app("your custom log message")
+    ```
+
+=== "C"
+    ```
+    vine_log_debug_app("your custom log message")
+    ```
 
 ### Performance Log
 
@@ -2279,6 +2292,19 @@ to produce a visualization of how tasks are packed into workers like this:
 ![](images/plot-txn-workers.png)
 
 - [Transactions Log File Format Details](log-file-formats#transactions-log-format)
+
+
+Custom APPLICATION messages can be added to the log with the calls:
+
+=== "Python"
+    ```python
+    m.log_txn_app("your custom log message")
+    ```
+
+=== "C"
+    ```
+    vine_log_txn_app("your custom log message")
+    ```
 
 ### Task Graph Log
 

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1622,6 +1622,22 @@ class Manager(object):
         f = cvine.vine_declare_chirp(self._taskvine, server, source, ticket_c, env_c, flags)
         return File(f)
 
+    ##
+    # Adds a custom APPLICATION entry to the transactions log.
+    #
+    # @param self   The manager to register this file.
+    # @param server A custom transaction message
+    def log_txn_app(self, entry):
+        cvine.vine_log_txn_app(self._taskvine, entry)
+
+    ##
+    # Adds a custom APPLICATION entry to the debug log.
+    #
+    # @param self   The manager to register this file.
+    # @param server A custom debug message
+    def log_debug_app(self, entry):
+        cvine.vine_log_debug_app(self._taskvine, entry)
+
 
 ##
 # @class ndcctools.taskvine.manager.Factory

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -1267,6 +1267,20 @@ void vine_initialize_categories(struct vine_manager *m, struct rmsummary *max, c
 void vine_set_runtime_info_path(const char *path);
 
 
+/** Adds a custom APPLICATION entry to the debug log.
+@param m     Reference to the current manager object.
+@param entry A custom debug message.
+*/
+void vine_log_debug_app(struct vine_manager *q, const char *entry);
+
+/** Adds a custom APPLICATION entry to the transactions log.
+@param m     Reference to the current manager object.
+@param entry A custom transaction message.
+*/
+void vine_log_txn_app(struct vine_manager *q, const char *entry);
+
+
+
 //@}
 
 #endif

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5857,4 +5857,8 @@ const char *vine_fetch_file(struct vine_manager *m, struct vine_file *f)
 	return 0;
 }
 
+void vine_log_debug_app(struct vine_manager *m, const char *entry) { debug(D_VINE, "APPLICATION %s", entry); }
+
+void vine_log_txn_app(struct vine_manager *m, const char *entry) { vine_txn_log_write_app_entry(m, entry); }
+
 /* vim: set noexpandtab tabstop=8: */

--- a/taskvine/src/manager/vine_txn_log.c
+++ b/taskvine/src/manager/vine_txn_log.c
@@ -55,8 +55,8 @@ void vine_txn_log_write_header(struct vine_manager *q)
 			"# time manager_pid TASK task_id RETRIEVED (SUCCESS|UNKNOWN|INPUT_MISSING|OUTPUT_MISSING|STDOUT_MISSING|SIGNAL|RESOURCE_EXHAUSTION|MAX_RETRIES|MAX_END_TIME|MAX_WALL_TIME|FORSAKEN) {limits_exceeded} {resources_measured}\n");
 	fprintf(q->txn_logfile,
 			"# time manager_pid TASK task_id DONE (SUCCESS|UNKNOWN|INPUT_MISSING|OUTPUT_MISSING|STDOUT_MISSING|SIGNAL|RESOURCE_EXHAUSTION|MAX_RETRIES|MAX_END_TIME|MAX_WALL_TIME|FORSAKEN) exit_code\n");
-	fprintf(q->txn_logfile, "# time manager_pid LIBRARY library_id (WAITING|SENT|STARTED|FAILURE) worker_id");
-	fprintf(q->txn_logfile, "\n");
+	fprintf(q->txn_logfile, "# time manager_pid LIBRARY library_id (WAITING|SENT|STARTED|FAILURE) worker_id\n");
+	fprintf(q->txn_logfile, "# time manager_pid APPLICATION message*\n");
 }
 
 static struct jx *resources_with_io_report(const struct vine_task *t, const struct rmsummary *s)
@@ -376,6 +376,15 @@ void vine_txn_log_write_library_update(
 	buffer_printf(&B, " %s", status);
 	buffer_printf(&B, " %s", w->workerid);
 
+	vine_txn_log_write(q, buffer_tostring(&B));
+	buffer_free(&B);
+}
+
+void vine_txn_log_write_app_entry(struct vine_manager *q, const char *entry)
+{
+	struct buffer B;
+	buffer_init(&B);
+	buffer_printf(&B, "APPLICATION %s", entry);
 	vine_txn_log_write(q, buffer_tostring(&B));
 	buffer_free(&B);
 }

--- a/taskvine/src/manager/vine_txn_log.h
+++ b/taskvine/src/manager/vine_txn_log.h
@@ -30,6 +30,7 @@ void vine_txn_log_write_transfer(struct vine_manager *q, struct vine_worker_info
 void vine_txn_log_write_cache_update(struct vine_manager *q, struct vine_worker_info *w, size_t size_in_bytes, timestamp_t time_in_usecs, timestamp_t start_in_usecs, const char *name );
 void vine_txn_log_write_worker_resources(struct vine_manager *q, struct vine_worker_info *w);
 void vine_txn_log_write_library_update(struct vine_manager *q, struct vine_worker_info *w, int library_id, vine_library_state_t state);
+void vine_txn_log_write_app_entry(struct vine_manager *q, const char *entry);
 
 #endif
 

--- a/taskvine/src/tools/vine_plot_txn_log
+++ b/taskvine/src/tools/vine_plot_txn_log
@@ -19,6 +19,7 @@
 # time manager_pid TASK task_id WAITING_RETRIEVAL worker_id
 # time manager_pid TASK task_id (RETRIEVED|DONE) (SUCCESS|SIGNAL|END_TIME|FORSAKEN|MAX_RETRIES|MAX_WALLTIME|UNKNOWN|RESOURCE_EXHAUSTION) exit_code {limits_exceeded} {resources_measured}
 # time manager_pid LIBRARY task_id (WAITING|SENT|STARTED|FAILURE) worker_id
+# time manager_pid APPLICATION message*
 
 
 from collections import defaultdict
@@ -416,6 +417,8 @@ class ParseTxn:
                 self._parse_library(time, manager_pid, target, event, arg)
             elif subject == "TASK":
                 self._parse_task(time, manager_pid, target, event, arg)
+            elif subject == "APPLICATION":
+                continue
 
         if self.cm:
             # if self.cm still assigned, then END record missing. Here we force


### PR DESCRIPTION
These entries appear as APPLICATION [custom message]

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
