### PR TITLE
Vine: Truncate Watched Files on Submit

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4374,6 +4374,9 @@ int vine_submit(struct vine_manager *q, struct vine_task *t)
 	/* If the task produces temporary files, create recovery tasks for those. */
 	vine_manager_create_recovery_tasks(q, t);
 
+	/* If the task produces watched output files, truncate them. */
+	vine_task_truncate_watched_outputs(t);
+	
 	/* Add reference to task when adding it to primary table. */
 	itable_insert(q->tasks, t->task_id, vine_task_clone(t));
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4376,7 +4376,7 @@ int vine_submit(struct vine_manager *q, struct vine_task *t)
 
 	/* If the task produces watched output files, truncate them. */
 	vine_task_truncate_watched_outputs(t);
-	
+
 	/* Add reference to task when adding it to primary table. */
 	itable_insert(q->tasks, t->task_id, vine_task_clone(t));
 

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -462,8 +462,8 @@ void vine_task_truncate_watched_outputs(struct vine_task *t)
 	LIST_ITERATE(t->output_mounts, m)
 	{
 		if (m->file->type == VINE_FILE && m->flags & VINE_WATCH) {
-			debug(D_VINE,"truncating watched output file %s\n",m->file->source);
-			truncate(m->file->source,0);
+			debug(D_VINE, "truncating watched output file %s\n", m->file->source);
+			truncate(m->file->source, 0);
 		}
 	}
 }

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -452,6 +452,22 @@ void vine_task_check_consistency(struct vine_task *t)
 	hash_table_delete(table);
 }
 
+/* Truncate any output files with the WATCH flag, to avoid confusion with prior runs. */
+/* We use truncate instead of unlink, so that "tail -f logfile" has the desired result. */
+
+void vine_task_truncate_watched_outputs(struct vine_task *t)
+{
+	struct vine_mount *m;
+
+	LIST_ITERATE(t->output_mounts, m)
+	{
+		if (m->file->type == VINE_FILE && m->flags & VINE_WATCH) {
+			debug(D_VINE,"truncating watched output file %s\n",m->file->source);
+			truncate(m->file->source,0);
+		}
+	}
+}
+
 int vine_task_add_input(struct vine_task *t, struct vine_file *f, const char *remote_name, vine_mount_flags_t flags)
 {
 	if (!t || !f || !f->source || !remote_name) {

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -132,7 +132,11 @@ void vine_task_clean( struct vine_task *t );
 int  vine_task_set_result(struct vine_task *t, vine_result_t new_result);
 void vine_task_set_resources(struct vine_task *t, const struct rmsummary *rm);
 
+/* Check for inconsistencies like duplicate input and output files. */
 void vine_task_check_consistency( struct vine_task *t );
+
+/* If the task produces watched output files, truncate them. */
+void vine_task_truncate_watched_outputs(struct vine_task *t);
 
 const char *vine_task_state_to_string( vine_task_state_t task_state );
 


### PR DESCRIPTION
## Proposed changes

Truncate watched files at submit time, to avoid confusion when a workflow is restarted, and the user is doing a `tail -f log file`.

Arguably, we could also do an `unlink_recursive` on all output files, but I'm not so eager to take a destructive action that could be triggered accidentally.

Addressed #3051 

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
