### PR TITLE
Vine: Report UUID and Catalog Properties

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -523,8 +523,9 @@ class Manager(object):
     # @param catalogs   The catalog servers given as a comma delimited list of hostnames or hostname:port
     def set_catalog_servers(self, catalogs):
         return cvine.vine_set_catalog_servers(self._taskvine, catalogs)
-    
-    ## Add a global property to the manager which will be included in periodic
+
+    ##
+    # Add a global property to the manager which will be included in periodic
     # reports to the catalog server and other telemetry destinations.
     # This is helpful for distinguishing higher level information about the entire run,
     # such as the name of the framework being used, or the logical name of the dataset

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -524,16 +524,16 @@ class Manager(object):
     def set_catalog_servers(self, catalogs):
         return cvine.vine_set_catalog_servers(self._taskvine, catalogs)
     
-    ##
-    # Add a property to the periodic report made to the catalog server.
+    ## Add a global property to the manager which will be included in periodic
+    # reports to the catalog server and other telemetry destinations.
     # This is helpful for distinguishing higher level information about the entire run,
     # such as the name of the framework being used, or the logical name of the dataset
     # being processed.
     # @param m A manager object
     # @param name The name of the property.
     # @param value The value of the property.
-    def set_catalog_property(self, name, value):
-        cvine.vine_set_catalog_property(self._taskvine, name, value)
+    def set_property(self, name, value):
+        cvine.vine_set_property(self._taskvine, name, value)
 
     ##
     # Specify a directory to write logs and staging files.

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -524,6 +524,18 @@ class Manager(object):
     def set_catalog_servers(self, catalogs):
         return cvine.vine_set_catalog_servers(self._taskvine, catalogs)
 
+
+    ##
+    # Add a property to the periodic report made to the catalog server.
+    # This is helpful for distinguishing higher level information about the entire run,
+    # such as the name of the framework being used, or the logical name of the dataset
+    # being processed.
+    # @param m A manager object
+    # @param name The name of the property.
+    # @param value The value of the property.
+    def set_catalog_property(self, name, value):
+        cvine.vine_set_catalog_property(self._taskvine, name, value)
+                
     ##
     # Specify a directory to write logs and staging files.
     #

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -523,8 +523,7 @@ class Manager(object):
     # @param catalogs   The catalog servers given as a comma delimited list of hostnames or hostname:port
     def set_catalog_servers(self, catalogs):
         return cvine.vine_set_catalog_servers(self._taskvine, catalogs)
-
-
+    
     ##
     # Add a property to the periodic report made to the catalog server.
     # This is helpful for distinguishing higher level information about the entire run,
@@ -535,7 +534,7 @@ class Manager(object):
     # @param value The value of the property.
     def set_catalog_property(self, name, value):
         cvine.vine_set_catalog_property(self._taskvine, name, value)
-                
+
     ##
     # Specify a directory to write logs and staging files.
     #

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -1098,7 +1098,8 @@ void vine_set_catalog_servers(struct vine_manager *m, const char *hosts);
 
 /** Add a property to the periodic report made to the catalog server.
 This is helpful for distinguishing higher level information about the entire run,
-such as the name of the dataset being processed.
+such as the name of the framework being used, or the logical name of the dataset
+being processed.
 @param m A manager object
 @param name The name of the property.
 @param value The value of the property.

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -1096,6 +1096,16 @@ void vine_set_tasks_left_count(struct vine_manager *m, int ntasks);
 */
 void vine_set_catalog_servers(struct vine_manager *m, const char *hosts);
 
+/** Add a property to the periodic report made to the catalog server.
+This is helpful for distinguishing higher level information about the entire run,
+such as the name of the dataset being processed.
+@param m A manager object
+@param name The name of the property.
+@param value The value of the property.
+*/
+
+void vine_set_catalog_property( struct vine_manager *m, const char *name, const char *value );
+	
 /** Cancel a submitted task using its task id.
 The cancelled task will be returned in the normal way via @ref vine_wait with a result of VINE_RESULT_CANCELLED.
 @param m A manager object

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -1096,7 +1096,8 @@ void vine_set_tasks_left_count(struct vine_manager *m, int ntasks);
 */
 void vine_set_catalog_servers(struct vine_manager *m, const char *hosts);
 
-/** Add a property to the periodic report made to the catalog server.
+/** Add a global property to the manager which will be included in periodic
+reports to the catalog server and other telemetry destinations.
 This is helpful for distinguishing higher level information about the entire run,
 such as the name of the framework being used, or the logical name of the dataset
 being processed.
@@ -1105,7 +1106,7 @@ being processed.
 @param value The value of the property.
 */
 
-void vine_set_catalog_property( struct vine_manager *m, const char *name, const char *value );
+void vine_set_property( struct vine_manager *m, const char *name, const char *value );
 	
 /** Cancel a submitted task using its task id.
 The cancelled task will be returned in the normal way via @ref vine_wait with a result of VINE_RESULT_CANCELLED.

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3969,7 +3969,7 @@ void vine_set_catalog_servers(struct vine_manager *q, const char *hosts)
 	}
 }
 
-void vine_set_catalog_property(struct vine_manager *m, const char *name, const char *value)
+void vine_set_property(struct vine_manager *m, const char *name, const char *value)
 {
 	char *oldvalue = hash_table_remove(m->properties, name);
 	if (oldvalue)

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2016,7 +2016,8 @@ static struct jx *manager_to_jx(struct vine_manager *q)
 	jx_insert_integer(j, "port", vine_port(q));
 	jx_insert_integer(j, "priority", q->priority);
 	jx_insert_string(j, "manager_preferred_connection", q->manager_preferred_connection);
-
+	jx_insert_string(j, "uuid", q->manager_uuid );
+	
 	int use_ssl = 0;
 #ifdef HAS_OPENSSL
 	if (q->ssl_enabled) {
@@ -3691,6 +3692,15 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 
 	getcwd(q->workingdir, PATH_MAX);
 
+	/*
+	Do it the long way around here so that m->manager_uuid
+	is a plain string pointer and we don't end up polluting
+	taskvine.h with dttools/uuid.h
+	*/
+	cctools_uuid_t local_uuid;
+	cctools_uuid_create(&local_uuid);
+	q->manager_uuid = strdup(local_uuid.str);
+		
 	q->next_task_id = 1;
 	q->fixed_location_in_queue = 0;
 
@@ -4020,7 +4030,8 @@ void vine_delete(struct vine_manager *q)
 
 	free(q->name);
 	free(q->manager_preferred_connection);
-
+	free(q->manager_uuid);
+	
 	free(q->poll_table);
 	free(q->ssl_cert);
 	free(q->ssl_key);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2016,7 +2016,7 @@ static struct jx *manager_to_jx(struct vine_manager *q)
 	jx_insert_integer(j, "port", vine_port(q));
 	jx_insert_integer(j, "priority", q->priority);
 	jx_insert_string(j, "manager_preferred_connection", q->manager_preferred_connection);
-	jx_insert_string(j, "uuid", q->manager_uuid);
+	jx_insert_string(j, "taskvine_uuid", q->uuid);
 
 	char *name, *key;
 	HASH_TABLE_ITERATE(q->properties, name, key) { jx_insert_string(j, name, key); }
@@ -3701,13 +3701,13 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 	q->properties = hash_table_create(3, 0);
 
 	/*
-	Do it the long way around here so that m->manager_uuid
+	Do it the long way around here so that m->uuid
 	is a plain string pointer and we don't end up polluting
 	taskvine.h with dttools/uuid.h
 	*/
 	cctools_uuid_t local_uuid;
 	cctools_uuid_create(&local_uuid);
-	q->manager_uuid = strdup(local_uuid.str);
+	q->uuid = strdup(local_uuid.str);
 
 	q->next_task_id = 1;
 	q->fixed_location_in_queue = 0;
@@ -4047,7 +4047,7 @@ void vine_delete(struct vine_manager *q)
 
 	free(q->name);
 	free(q->manager_preferred_connection);
-	free(q->manager_uuid);
+	free(q->uuid);
 
 	hash_table_clear(q->properties, (void *)free);
 	hash_table_delete(q->properties);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2141,6 +2141,9 @@ static struct jx *manager_lean_to_jx(struct vine_manager *q)
 	jx_insert_string(j, "type", "vine_manager");
 	jx_insert_integer(j, "port", vine_port(q));
 
+	char *name, *key;
+	HASH_TABLE_ITERATE(q->properties, name, key) { jx_insert_string(j, name, key); }
+
 	int use_ssl = 0;
 #ifdef HAS_OPENSSL
 	if (q->ssl_enabled) {
@@ -4045,6 +4048,9 @@ void vine_delete(struct vine_manager *q)
 	free(q->name);
 	free(q->manager_preferred_connection);
 	free(q->manager_uuid);
+
+	hash_table_clear(q->properties, (void *)free);
+	hash_table_delete(q->properties);
 
 	free(q->poll_table);
 	free(q->ssl_cert);

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -84,7 +84,8 @@ struct vine_manager {
 	char *catalog_hosts; /* List of catalogs to which this manager reports. */
 	char *manager_preferred_connection; /* Recommended method for connecting to this manager.  @ref vine_set_manager_preferred_connection */
 	char  workingdir[PATH_MAX];         /* Current working dir, for reporting to the catalog server. */
-
+	char *manager_uuid;        /* Unique identifier of manager when reported to catalog. */
+	
 	struct link *manager_link;       /* Listening TCP connection for accepting new workers. */
 	struct link_info *poll_table;    /* Table for polling on all connected workers. */
 	int poll_table_size;             /* Number of entries in poll_table. */

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -85,7 +85,8 @@ struct vine_manager {
 	char *manager_preferred_connection; /* Recommended method for connecting to this manager.  @ref vine_set_manager_preferred_connection */
 	char  workingdir[PATH_MAX];         /* Current working dir, for reporting to the catalog server. */
 	char *manager_uuid;        /* Unique identifier of manager when reported to catalog. */
-	
+	struct hash_table *properties;   /* Set of additional properties to report to catalog server. */
+
 	struct link *manager_link;       /* Listening TCP connection for accepting new workers. */
 	struct link_info *poll_table;    /* Table for polling on all connected workers. */
 	int poll_table_size;             /* Number of entries in poll_table. */

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -84,7 +84,7 @@ struct vine_manager {
 	char *catalog_hosts; /* List of catalogs to which this manager reports. */
 	char *manager_preferred_connection; /* Recommended method for connecting to this manager.  @ref vine_set_manager_preferred_connection */
 	char  workingdir[PATH_MAX];         /* Current working dir, for reporting to the catalog server. */
-	char *manager_uuid;        /* Unique identifier of manager when reported to catalog. */
+	char *uuid;          /* Unique identifier of manager when reported to catalog. */
 	struct hash_table *properties;   /* Set of additional properties to report to catalog server. */
 
 	struct link *manager_link;       /* Listening TCP connection for accepting new workers. */


### PR DESCRIPTION
## Proposed changes

- Manager generates internal uuid and sends to the catalog.
- User can add properties with m.set_catalog_property. 

Intended use is recording connection to frameworks such as Dask, Parsl, etc. per #2642

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
