### PR TITLE
vine: free file resources if manager is gc'ed.

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5704,6 +5704,13 @@ void vine_remove_file(struct vine_manager *m, struct vine_file *f)
 		return;
 	}
 
+	if (!m) {
+		/* if manager has been already gc'ed (e.g. by python exiting), we stil want to
+		 * free any external resources the file has */
+		vine_file_delete(f);
+		return;
+	}
+
 	const char *filename = f->cached_name;
 
 	char *key;


### PR DESCRIPTION
## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
