### PR TITLE
Factory: Handling of Scratch Dir for HTCondor

### DIFF
--- a/batch_job/src/vine_factory.c
+++ b/batch_job/src/vine_factory.c
@@ -127,6 +127,9 @@ struct jx *batch_env = NULL;
 //Features to pass along as worker arguments
 struct hash_table *features_table = NULL;
 
+// Disable the check for invalid use of AFS with HTCondor.
+static int disable_afs_check = 0;
+
 /*
 In a signal handler, only a limited number of functions are safe to
 invoke, so we construct a string and emit it with a low-level write.
@@ -1170,6 +1173,7 @@ static void show_help(const char *cmd)
 	printf("\nOptions specific to batch systems:\n");
 	printf(" %-30s Generic batch system options.\n", "-B,--batch-options=<options>");
 	printf(" %-30s Specify Amazon config file.\n", "--amazon-config");
+	printf(" %-30s Disable check for use of AFS with HTCondor.\n", "--disable-afs-check");
 	printf(" %-30s Set requirements for the workers as Condor jobs.\n", "--condor-requirements");
 
 }
@@ -1203,6 +1207,7 @@ enum{   LONG_OPT_CORES = 255,
 		LONG_OPT_USE_SSL,
 		LONG_OPT_FACTORY_NAME,
 		LONG_OPT_DEBUG_WORKERS,
+		LONG_OPT_DISABLE_AFS_CHECK,
 };
 
 static const struct option long_options[] = {
@@ -1219,6 +1224,7 @@ static const struct option long_options[] = {
 	{"debug-file", required_argument, 0, 'o'},
 	{"debug-file-size", required_argument, 0, 'O'},
 	{"debug-workers", no_argument, 0, LONG_OPT_DEBUG_WORKERS },
+	{"disable-afs-check", no_argument, 0, LONG_OPT_DISABLE_AFS_CHECK },
 	{"disk",   required_argument,  0,  LONG_OPT_DISK},
 	{"env", required_argument, 0, LONG_OPT_ENVIRONMENT_VARIABLE},
 	{"extra-options", required_argument, 0, 'E'},
@@ -1434,6 +1440,9 @@ int main(int argc, char *argv[])
 			case LONG_OPT_FACTORY_NAME:
 				factory_name = xxstrdup(optarg);
 				break;
+			case LONG_OPT_DISABLE_AFS_CHECK:
+				disable_afs_check = 1;
+				break;
 			default:
 				show_help(argv[0]);
 				return EXIT_FAILURE;
@@ -1512,14 +1521,22 @@ int main(int argc, char *argv[])
 	/*
 	Careful here: most of the supported batch systems expect
 	that jobs are submitting from a single shared filesystem.
-	Changing to /tmp only works in the case of Condor.
+	In general, we will put log files into a subdir of the
+	current working directory, with a unique name to separate
+	factory instances.
+
+	However, HTCondor has two constraints:
+	1 - Recent versions of HTCondor insist upon the user log
+	being written to a file under $HOME, for reasons unknown.
+	It will emit errors at submit time if this happens.
+
+	2 - Condor cannot easily deal with files submitted from
+	an AFS home directory, without making things world writeable.
+	We will complain about that here.
 	*/
+
 	if(!scratch_dir) {
-		const char *scratch_parent_dir = ".";
-		if(batch_queue_type==BATCH_QUEUE_TYPE_CONDOR) {
-			scratch_parent_dir = system_tmp_dir(NULL);
-		}
-		scratch_dir = string_format("%s/vine-factory-%d", scratch_parent_dir, getuid());
+		scratch_dir = string_format("vine-factory-%d",getuid());
 	}
 
 	if(!create_dir(scratch_dir,0777)) {
@@ -1527,6 +1544,21 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+	if(batch_queue_type==BATCH_QUEUE_TYPE_CONDOR && !disable_afs_check) {
+		char *absolute_scratch_dir = realpath(scratch_dir,0);
+		if(!absolute_scratch_dir) {
+			fprintf(stderr,"vine_factory: couldn't get full path of %s: %s\n",scratch_dir,strerror(errno));
+			return 1;
+		}
+
+		if(!strncmp(absolute_scratch_dir,"/afs",4)) {
+			fprintf(stderr,"vine_factory: The scratch directory is '%s'\n", absolute_scratch_dir);
+			fprintf(stderr,"This won't work because Condor is not able to write to files in AFS.\n");
+			fprintf(stderr,"Please use --scratch-dir to choose a different scratch directory.\n");
+			return 1;
+		}
+	}
+		
 	const char *item = NULL;
 	list_first_item(wrapper_inputs);
 	while((item = list_next_item(wrapper_inputs))) {

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -129,6 +129,10 @@ struct hash_table *features_table = NULL;
 
 //0 means the container image does not container work_queue_worker binary
 int k8s_worker_image = 0;
+
+// Disable the check for invalid use of AFS with HTCondor.
+static int disable_afs_check = 0;
+
 /*
 In a signal handler, only a limited number of functions are safe to
 invoke, so we construct a string and emit it with a low-level write.
@@ -1179,6 +1183,7 @@ static void show_help(const char *cmd)
 
 	printf("\nOptions specific to batch systems:\n");
 	printf(" %-30s Generic batch system options.\n", "-B,--batch-options=<options>");
+	printf(" %-30s Disable check for use of AFS with HTCondor.\n", "--disable-afs-check");
 	printf(" %-30s Specify Amazon config file.\n", "--amazon-config");
 	printf(" %-30s Set requirements for the workers as Condor jobs.\n", "--condor-requirements");
 	printf(" %-30s Host name of mesos manager node..\n", "--mesos-master");
@@ -1216,7 +1221,8 @@ enum{   LONG_OPT_CORES = 255,
 		LONG_OPT_PARENT_DEATH,
 		LONG_OPT_PONCHO_ENV,
 		LONG_OPT_USE_SSL,
-		LONG_OPT_FACTORY_NAME
+		LONG_OPT_FACTORY_NAME,
+		LONG_OPT_DISABLE_AFS_CHECK,
 	};
 
 static const struct option long_options[] = {
@@ -1232,6 +1238,7 @@ static const struct option long_options[] = {
 	{"debug", required_argument, 0, 'd'},
 	{"debug-file", required_argument, 0, 'o'},
 	{"debug-file-size", required_argument, 0, 'O'},
+	{"disable-afs-check", no_argument, 0, LONG_OPT_DISABLE_AFS_CHECK },
 	{"disk",   required_argument,  0,  LONG_OPT_DISK},
 	{"env", required_argument, 0, LONG_OPT_ENVIRONMENT_VARIABLE},
 	{"extra-options", required_argument, 0, 'E'},
@@ -1479,6 +1486,9 @@ int main(int argc, char *argv[])
 			case LONG_OPT_FACTORY_NAME:
 				factory_name = xxstrdup(optarg);
 				break;
+			case LONG_OPT_DISABLE_AFS_CHECK:
+				disable_afs_check = 1;
+				break;
 			default:
 				show_help(argv[0]);
 				return EXIT_FAILURE;
@@ -1562,14 +1572,22 @@ int main(int argc, char *argv[])
 	/*
 	Careful here: most of the supported batch systems expect
 	that jobs are submitting from a single shared filesystem.
-	Changing to /tmp only works in the case of Condor.
+	In general, we will put log files into a subdir of the
+	current working directory, with a unique name to separate
+	factory instances.
+
+	However, HTCondor has two constraints:
+	1 - Recent versions of HTCondor insist upon the user log
+	being written to a file under $HOME, for reasons unknown.
+	It will emit errors at submit time if this happens.
+
+	2 - Condor cannot easily deal with files submitted from
+	an AFS home directory, without making things world writeable.
+	We will complain about that here.
 	*/
+
 	if(!scratch_dir) {
-		const char *scratch_parent_dir = ".";
-		if(batch_queue_type==BATCH_QUEUE_TYPE_CONDOR) {
-			scratch_parent_dir = system_tmp_dir(NULL);
-		}
-		scratch_dir = string_format("%s/wq-factory-%d", scratch_parent_dir, getuid());
+		scratch_dir = string_format("wq-factory-%d",getuid());
 	}
 
 	if(!create_dir(scratch_dir,0777)) {
@@ -1577,7 +1595,21 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+	if(batch_queue_type==BATCH_QUEUE_TYPE_CONDOR && !disable_afs_check) {
+		char *absolute_scratch_dir = realpath(scratch_dir,0);
+		if(!absolute_scratch_dir) {
+			fprintf(stderr,"work_queue_factory: couldn't get full path of %s: %s\n",scratch_dir,strerror(errno));
+			return 1;
+		}
 
+		if(!strncmp(absolute_scratch_dir,"/afs",4)) {
+			fprintf(stderr,"work_queue_factory: The scratch directory is '%s'\n", absolute_scratch_dir);
+			fprintf(stderr,"This won't work because Condor is not able to write to files in AFS.\n");
+			fprintf(stderr,"Please use --scratch-dir to choose a different scratch directory.\n");
+			return 1;
+		}
+	}
+		
 	const char *item = NULL;
 	list_first_item(wrapper_inputs);
 	while((item = list_next_item(wrapper_inputs))) {


### PR DESCRIPTION
## Proposed changes

Previously, the Work Queue and Vine factories special-cased HTCondor and required it to use /tmp for the scratch dir.  This was because (at Notre Dame), AFS was used for home directories, but HTCondor did not play well with AFS.

Today, HTCondor requires the use of the home directory for the user-log.  And also very few users of AFS remain.

So, this changes the factories to have the same default behavior for all batch systems -- use the current working directory for the scratch dir.  If that happens to be AFS, the factory gives an error.  If that happens to be not-home, (certain versions of) HTCondor gives an error.  The user can override with `--scratch-dir`

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
