### PR TITLE
Unlink when done (C and python bindings)

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1226,7 +1226,7 @@ the application indicates that they will not be needed anymore:
 
 === "C"
     ```C
-    struct vine_file *intemerdiate = vine_declare_file(m, "my_partial_result", VINE_UNLINK_WHEN_DONE);
+    struct vine_file *partial_result = vine_declare_file(m, "my_partial_result", VINE_UNLINK_WHEN_DONE);
 
     struct vine_task *t1 = vine_task_create(...);
     vine_task_add_output(partial_result, "my_partial_result", /* any desired mount flags */ 0);
@@ -1240,7 +1240,7 @@ the application indicates that they will not be needed anymore:
     # will remove the file from the taskvine workflow. Further, when not task
     # refers to the file, the file will be removed from the manager's disk
     # because of VINE_UNLINK_WHEN_DONE at its declaration.
-    vine_remove_file(intermediate);
+    vine_remove_file(partial_result);
     ```
 
 !!! warning

--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1201,39 +1201,39 @@ warranted:
 
 ### Automatic Garbage Collection on Disk
 
-For workflows that generate intermediate files, TaskVine can automatically
-delete them from disk when the application indicates that they will not be
-needed anymore:
+For workflows that generate partial results that are not needed once a final
+result has been computed, TaskVine can automatically delete them from disk when
+the application indicates that they will not be needed anymore:
 
 === "Python"
     ```python
-    intemerdiate = m.declare_file("intermediate_file", unlink_when_done=True)
+    partial_result = m.declare_file("my_partial_result", unlink_when_done=True)
 
     t1 = Task(...)
-    t1.add_output(intermediate, "my_file")
+    t1.add_output(partial_result, "my_partial_result")
     ...
 
     t2 = Task(...)
-    t2.add_input(intermediate, "my_file")
+    t2.add_input(partial_result, "my_partial_result")
     ...
 
     # once t2 is done, the following call will remove the file from the
     # taskvine workflow. Further, when not task refers to the file, the file
     # will be removed from the manager's disk because of unlink_when_done=True
     # at its declaration.
-    m.remove_file(intermediate)
+    m.remove_file(partial_result)
     ```
 
 === "C"
     ```C
-    struct vine_file *intemerdiate = vine_declare_file(m, "intermediate_file", VINE_UNLINK_WHEN_DONE);
+    struct vine_file *intemerdiate = vine_declare_file(m, "my_partial_result", VINE_UNLINK_WHEN_DONE);
 
     struct vine_task *t1 = vine_task_create(...);
-    vine_task_add_output(intermediate, "my_file", /* any desired mount flags */ 0);
+    vine_task_add_output(partial_result, "my_partial_result", /* any desired mount flags */ 0);
     ...
 
     struct vine_task *t2 = vine_task_create(...);
-    vine_task_add_input(intermediate, "my_file", /* any desired mount flags */ 0);
+    vine_task_add_input(partial_result, "my_partial_result", /* any desired mount flags */ 0);
     ...
 
     # once t2 is done and deleted with `vine_task_delete`, the following call

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1393,10 +1393,11 @@ class Manager(object):
     #                end-of-life of the worker. Default is False (file is not cache).
     # @param peer_transfer   Whether the file can be transfered between workers when
     #                peer transfers are enabled (see @ref ndcctools.taskvine.manager.Manager.enable_peer_transfers). Default is True.
+    # @param unlink_when_done   Whether to delete the file when its reference count is 0. (Warning: Only use on files produced by the application, and never on irreplaceable input files.)
     # @return
     # A file object to use in @ref ndcctools.taskvine.task.Task.add_input or @ref ndcctools.taskvine.task.Task.add_output
-    def declare_file(self, path, cache=False, peer_transfer=True):
-        flags = Task._determine_file_flags(cache, peer_transfer)
+    def declare_file(self, path, cache=False, peer_transfer=True, unlink_when_done=False):
+        flags = Task._determine_file_flags(cache, peer_transfer, unlink_when_done)
         f = cvine.vine_declare_file(self._taskvine, path, flags)
         return File(f)
 

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -143,7 +143,7 @@ class Task(object):
         return flags
 
     @staticmethod
-    def _determine_file_flags(cache=False, peer_transfer=False):
+    def _determine_file_flags(cache=False, peer_transfer=False, unlink_when_done=False):
         flags = cvine.VINE_CACHE_NEVER
         if cache is True or cache == "workflow":
             flags |= cvine.VINE_CACHE
@@ -151,6 +151,8 @@ class Task(object):
             flags |= cvine.VINE_CACHE_ALWAYS
         if not peer_transfer:
             flags |= cvine.VINE_PEER_NOSHARE
+        if unlink_when_done:
+            flags |= cvine.VINE_UNLINK_WHEN_DONE
         return flags
 
     ##

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -60,7 +60,8 @@ typedef enum {
 	VINE_CACHE_NEVER = 0,  /**< Do not cache file at execution site. (default) */
 	VINE_CACHE = 1,        /**< File remains in cache until workflow ends. */
 	VINE_CACHE_ALWAYS = 3, /**< File remains in cache until the worker teminates. **/
-	VINE_PEER_NOSHARE = 4  /**< Schedule this file to be shared between peers where available. See @ref vine_enable_peer_transfers **/
+	VINE_PEER_NOSHARE = 4,  /**< Schedule this file to be shared between peers where available. See @ref vine_enable_peer_transfers **/
+	VINE_UNLINK_WHEN_DONE = 8  /**< Whether to delete the file when its reference count is 0. (Warning: Only use on files produced by the application, and never on irreplaceable input files.) */
 } vine_file_flags_t;
 
 /** Select overall scheduling algorithm for matching tasks to workers. */


### PR DESCRIPTION
## Proposed changes

Adds the declare_file VINE_UNLINK_WHEN_DONE  (unlink_when_done=True in python) to unlink a file at the manager's disk when the file refcount goes to 0.

This pr only implements the mechanism, but it has not been integrated to other parts of the code (e.g., PythonTask).

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
