### PR TITLE
Vine: Rename Uses of Environment to Context and Package.

### DIFF
--- a/doc/manuals/taskvine/examples/run_command_in_apptainer.sh
+++ b/doc/manuals/taskvine/examples/run_command_in_apptainer.sh
@@ -2,8 +2,8 @@
 
 # Wrap tasks with an Apptainer container
 
-# get the directory that contains the environment from the location of this script
-env_dir=$(dirname $( cd -- "$( dirname -- "$0" )" > /dev/null 2>&1 && pwd ))
+# get the directory that contains the execution context from the location of this script
+ctx_dir=$(dirname $( cd -- "$( dirname -- "$0" )" > /dev/null 2>&1 && pwd ))
 
 # execute the command line with the container image "image.img"
-exec apptainer exec --home "${VINE_SANDBOX:-${PWD}}" "${env_dir}/image.sif" "$@"
+exec apptainer exec --home "${VINE_SANDBOX:-${PWD}}" "${ctx_dir}/image.sif" "$@"

--- a/doc/manuals/taskvine/examples/vine_example_apptainer_ctx.py
+++ b/doc/manuals/taskvine/examples/vine_example_apptainer_ctx.py
@@ -5,20 +5,19 @@ import ndcctools.taskvine as vine
 import subprocess
 import argparse
 
-
-def env_from_image(manager, image_path, run_script="run_command_in_apptainer.sh"):
+def ctx_from_image(manager, image_path, run_script="run_command_in_apptainer.sh"):
     # construct the mini task. We only need the mini task for its sandbox to
-    # create the environment structure, thus we use the command ":" as no-op.
+    # create the execution context, thus we use the command ":" as no-op.
     mt = vine.Task(":")
 
     runner = m.declare_file(run_script, cache=True)
     image  = m.declare_file(image_path, cache=True)
 
-    mt.add_input(runner, "env_dir/bin/run_in_env")
-    mt.add_input(image,  "env_dir/image.sif")
+    mt.add_input(runner, "ctx/bin/run_in_env")
+    mt.add_input(image,  "ctx/image.sif")
 
-    # the output of the mini task is the environment directory
-    mt.add_output(image,  "env_dir")
+    # the output of the mini task is the execution context directory
+    mt.add_output(image,  "ctx")
 
     # tell the manager that this is a mini task.
     return m.declare_minitask(mt)
@@ -26,8 +25,8 @@ def env_from_image(manager, image_path, run_script="run_command_in_apptainer.sh"
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-            prog="vine_example_apptainer_env.py",
-            description="This example TaskVine program shows how to construct a custom environment to execute Tasks inside an Apptainer container.")
+            prog="vine_example_apptainer_ctx.py",
+            description="This example TaskVine program shows how to construct a custom execution context to run Tasks inside an Apptainer container.")
 
     parser.add_argument('--image', action='store', help='Container image to use. (To get an example image, try: apptainer pull docker://ghcr.io/apptainer/lolcow)', default="lolcow_latest.sif")
     args = parser.parse_args()
@@ -37,13 +36,13 @@ if __name__ == "__main__":
     print(f"listening for workers at port {m.port}")
 
     # tell the manager that this is a mini task.
-    env = env_from_image(m, args.image)
+    ctx = env_from_image(m, args.image)
 
-    # now we define our regular task, and attach the environment to it.
+    # now we define our regular task, and attach the execution context to it.
     t = vine.Task("/bin/echo 'from inside apptainer!'")
     t.set_cores(1)
-    t.add_environment(env)
-
+    t.add_execution_context(ctx)
+    
     m.submit(t)
 
     factory = vine.Factory(manager=m)

--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -812,22 +812,21 @@ like the input to be the result of a query to a database.
     vine_submit(m, my_other_task);
     ```
 
-### Environments
+### Execution Contexts
 
-The execution of a task can be wrapped with specially designed files called
-environments. These environments ensure that the software dependencies for the
+The execution of a task can be wrapped with specially designed packages called execution contexts.
+These ensure that the software dependencies for the
 task are available in the execution site. TaskVine natively supports two types
 of environments: [poncho](../poncho/index.md), which is based on `conda-pack`;
 and [starch](../man_pages/starch.md), a lightweight package useful when the
 manager and workers run the same linux version. Mini tasks can be used to
 create environments not natively supported, as we will show later to construct
-environments for Apptainer (i.e., singularity containers).
+execution contexts for Apptainer (i.e., singularity containers).
 
 #### Poncho
 
-A Poncho environment is a tarball based on `conda-pack`, and is useful to deliver
-complete python environments. For example, to create a python environment with
-`numpy`:
+A Poncho package is a tarball based on `conda-pack`, and is useful to deliver
+a complete python execution context. For example, to create a python package containing `numpy`:
 
 `my_poncho_spec.json`
 ```json
@@ -844,13 +843,13 @@ complete python environments. For example, to create a python environment with
 }
 ```
 
-In the command line, create the poncho environment from the specification:
+From the command line, create the poncho package like this:
 
 ```sh
-poncho_package_create my_poncho_spec.json my_env.tar.gz
+poncho_package_create my_poncho_spec.json my_poncho_pkg.tar.gz
 ```
 
-Attach the environment to the task:
+Attach the package to the task:
 
 === "Python"
     ```python
@@ -860,12 +859,12 @@ Attach the environment to the task:
     s = m.declare_file("my_numpy_script.py", cache=True)
     t.add_input(s, "my_numpy_script.py")
 
-    # declare the environment and its input file
-    poncho_file = m.declare_file("my_env.tar.gz", cache=True)
-    poncho_env = m.declare_poncho(poncho_file, cache=True)
+    # declare the package and its input file
+    poncho_file = m.declare_file("my_poncho_pkg.tar.gz", cache=True)
+    poncho_pkg = m.declare_poncho(poncho_file, cache=True)
 
-    # attach the environment to the task
-    t.add_environment(poncho_env)
+    # attach the package to the task
+    t.add_poncho_package(poncho_pkg)
 
     m.submit(t)
     ```
@@ -878,12 +877,12 @@ Attach the environment to the task:
     struct vine_file *s = vine_declare_file("my_numpy_script.py", VINE_CACHE);
     vine_task_add_input(t, "my_numpy_script.py", 0);
 
-    // declare the environment and its input file
-    struct vine_file *poncho_file = vine_declare_file("my_env.tar.gz", cache=True);
-    struct vine_file *poncho_env  = vine_declare_poncho(poncho_file, cache=True)
+    // declare the package and its input file
+    struct vine_file *poncho_file = vine_declare_file("my_poncho_pkg.tar.gz", cache=True);
+    struct vine_file *poncho_pkg  = vine_declare_poncho(poncho_file, cache=True)
 
-    # attach the environment to the task
-    vine_task_add_environment(poncho_env);
+    # attach the package to the task
+    vine_task_add_poncho_package(t,poncho_pkg);
 
     vine_submit(m, t);
     ```
@@ -892,23 +891,23 @@ Attach the environment to the task:
 
 (to do)
 
-#### Custom Environments
+#### Custom Execution Contents
 
-TaskVine expects environments to expand to a directory, with this minimal
+TaskVine expects execution contents to expand to a directory, with this minimal
 structure:
 
 ```text
-env
+root
 └── bin
     └── run_in_env
 ```
 
 where `run_in_env` is an executable file (usually a shell script) that takes as
 an argument a command line to execute. In the rest of this section we will show
-how to construct an environment that runs its command line inside an Apptainer
+how to construct an execution context that runs its command line inside an Apptainer
 container.
 
-##### Apptainer Custom Environment
+##### Apptainer Execution Context
 
 Our script `run_in_env` script simply calls Apptainer with the desired image, and
 mounts the task's sandbox as the home directory:
@@ -919,30 +918,30 @@ mounts the task's sandbox as the home directory:
 ```
 
 To start, we can manually construct in the command line the needed directory
-structure as follows. Later will be automate these steps with a mini task.
+structure as follows. Later we will automate these steps with a mini task.
 
 ```sh
 # ensure the right execution permissions for the script
 chmod 755 run_command_in_apptainer.sh
 
 # construct the needed directory structure
-mkdir -p my_env/bin
+mkdir -p my_ctx/bin
 
 # copy the apptainer script to the expected run_in_env location
-cp run_command_in_apptainer.sh my_env/bin/run_in_env
+cp run_command_in_apptainer.sh my_ctx/bin/run_in_env
 
-# copy the desired image to the environment's directory
-cp path/to/my_image.img my_env/image.img
+# copy the desired image into the package
+cp path/to/my_image.img my_ctx/image.img
 ```
 
-Now we are ready to declare the environment from its local directory "my_env":
+Now we are ready to declare the execution context from its local directory "my_ctx":
 
 === "Python"
     ```python
     t = Task("/bin/echo from inside apptainer!")
 
-    env = m.declare_file("my_env", cache=True)
-    t.add_environment(env)
+    ctx = m.declare_file("my_ctx", cache=True)
+    t.add_execution_context(ctx)
 
     m.submit(t)
     ```
@@ -951,19 +950,19 @@ Now we are ready to declare the environment from its local directory "my_env":
     ```C
     struct vine_task *t = vine_task_create("/bin/echo from inside apptainer!");
 
-    struct vine_file *env = vine_declare_file(m, "my_env", VINE_CACHE);
-    vine_task_add_environment(env);
+    struct vine_file *ctx = vine_declare_file(m, "my_ctx", VINE_CACHE);
+    vine_task_add_execution_context(ctx);
 
     vine_submit(t);
     ```
 
 
-##### Apptainer Custom Environment with a Mini Task
+##### Apptainer Execution Cpntext From a Mini Task
 
 In the previous section we manually built the directory structure needed for
-the environment. This is not very flexible, as we need to create one such
+the execution context. This is not very flexible, as we need to create one such
 directory per container image that we would like to use. Instead, we can use a
-mini task to construct the environment structure directly on the workers.
+mini task to construct the execution context directly on the workers.
 
 
 === "Python"
@@ -975,20 +974,20 @@ mini task to construct the environment structure directly on the workers.
     runner = m.declare_file("run_command_in_apptainer.sh", cache=True)
     image  = m.declare_file("path/to/my_image.img", cache=True)
 
-    mt.add_input(runner, "env_dir/bin/run_in_env")
-    mt.add_input(image,  "env_dir/image.img")
+    mt.add_input(runner, "ctx/bin/run_in_env")
+    mt.add_input(image,  "ctx/image.img")
 
     # the mini task will extract the environment directory
-    env = m.declare_mini_task(mt,"env_dir")
+    ctx = m.declare_mini_task(mt,"ctx")
 
     # now we define our regular task, and attach the environment to it.
     t = Task("/bin/echo from inside apptainer!")
-    t.add_environment(env)
+    t.add_execution_context(ctx)
 
     m.submit(t)
     ```
 
-You can see the complete example [here](examples/vine_example_apptainer_env.py).
+You can see the complete example [here](examples/vine_example_apptainer_ctx.py).
 
 ### Watching Output Files
 

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -367,7 +367,7 @@ class Task(object):
     # @param f A file containing an unpacked Starch package.
     def add_starch_package(self, file):
         return cvine.vine_task_add_starch_package(self._task, file._file)
-    
+
     ##
     # Add a Poncho package as an execution context.
     # The file given must refer to a (unpacked) PONCHO package,
@@ -378,7 +378,8 @@ class Task(object):
     def add_poncho_package(self, file):
         return cvine.vine_task_add_poncho_package(self._task, file._file)
 
-    ## Adds an execution context to the task.
+    ##
+    # Adds an execution context to the task.
     # The context file given must expand to a directory containing
     # (at a minimum) a file
     # named bin/run_in_env that will perform any desired setup

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -359,13 +359,42 @@ class Task(object):
         return cvine.vine_task_set_snapshot_file(self._task, filename)
 
     ##
-    # Adds an execution environment to the task. The environment file specified
-    # is expected to expand to a directory with a bin/run_in_env file that will wrap
-    # the task command (e.g. a poncho or a starch file, or any other vine mini_task
-    # that creates such a wrapper). If specified multiple times,
-    # environments are nested in the order given (i.e. first added is the first applied).
-    # @param self Reference to the current task object.
-    # @param f The environment file.
+    # Add a Starch package as an execution context.
+    # The file given must refer to a (unpacked) package
+    # containing libraries captured by the <tt>starch</tt> command.
+    # The task will execute using this package as its environment.
+    # @param t A task object.
+    # @param f A file containing an unpacked Starch package.
+    def add_starch_package(self, file):
+        return cvine.vine_task_add_starch_package(self._task, file._file)
+    
+    ##
+    # Add a Poncho package as an execution context.
+    # The file given must refer to a (unpacked) PONCHO package,
+    # containing a set of Python modules needed by the task.
+    # The task will execute using this package as its Python environment.
+    # @param t A task object.
+    # @param f A file containing an unpacked Poncho package.
+    def add_poncho_package(self, file):
+        return cvine.vine_task_add_poncho_package(self._task, file._file)
+
+    ## Adds an execution context to the task.
+    # The context file given must expand to a directory containing
+    # (at a minimum) a file
+    # named bin/run_in_env that will perform any desired setup
+    # (e.g. setting PATH, LD_LIBRARY_PATH, PYTHONPATH), execute the given command,
+    # and then perform any desired cleanup.  The context directory
+    # may also include any support files or libraries needed by the task.
+    # If specified multiple times, execution contexts are
+    # nested in the order given (i.e. first added is the first applied).
+    # @see add_poncho_package
+    # @see add_starch_package
+    # @param t A task object.
+    # @param f The execution context file.
+    def add_execution_context(self, f):
+        return cvine.vine_task_add_execution_context(self._task, f._file)
+
+    # Deprecated, for backwards compatibility.
     def add_environment(self, f):
         return cvine.vine_task_add_environment(self._task, f._file)
 

--- a/taskvine/src/examples/vine_example_chirp.py
+++ b/taskvine/src/examples/vine_example_chirp.py
@@ -3,7 +3,7 @@
 # This example shows how to declare an chirp file
 # so that it can be cached at the workers.
 # It assumes that chirp is installed where workers are executed. If this is
-# not the case, a starch recipe to construct this environment is also given.
+# not the case, a starch recipe to construct this package is also given.
 #
 
 import ndcctools.taskvine as vine
@@ -21,19 +21,19 @@ def count_lines(chirp_file):
     return lines
 
 
-# construct a starch environment to execute the tasks. Only needed if the chirp
+# construct a starch package to execute the tasks. Only needed if the chirp
 # executables are not available where the workers execute
-def create_env(env_name):
+def create_package(package_name):
     import subprocess
-    # add the executables chirp, chirp_get, and chirp_put to the env_name starch file.
+    # add the executables chirp, chirp_get, and chirp_put to the package_name starch file.
     # these executables are assumed to be in the current $PATH.
     # by default, the starch file will execute the chirp command.
 
-    if os.path.exists(env_name):
-        print(f"reusing existing {env_name} starch file...")
+    if os.path.exists(package_name):
+        print(f"reusing existing {package_name} starch file...")
     else:
-        print(f"creating {env_name} starch file...")
-        subprocess.run(["starch", "-x", "chirp_get", "-x", "chirp_put", "-x", "chirp", "-c", "chirp", env_name], check=True)
+        print(f"creating {package_name} starch file...")
+        subprocess.run(["starch", "-x", "chirp_get", "-x", "chirp_put", "-x", "chirp", "-c", "chirp", package_name], check=True)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -43,17 +43,17 @@ if __name__ == "__main__":
     parser.add_argument('chirp_server', action='store', help='the chirp server where the file is located')
     parser.add_argument('filename', action='store', help='the name of the file')
     parser.add_argument('--ticket', action='store', help='optional server authentication ticket', default=None)
-    parser.add_argument('--create-env', action='store_true', help='whether to create mini environment to ensure chirp is available at the worker.', default=False)
+    parser.add_argument('--create-package', action='store_true', help='whether to create starch package to ensure chirp is available at the worker.', default=False)
 
     args = parser.parse_args()
 
-    # create the chirp environment if needed. This just creates the environment
+    # create the chirp package if needed. This just creates the package
     # in a local file, but does not registers it with a manager. The
-    # environment created comes from a starch file.
-    env_filename = None
-    if args.create_env:
-        env_filename = "chirp_client.sfx"
-        create_env(env_filename)
+    # package created comes from a starch file.
+    package_filename = None
+    if args.create_package:
+        package_filename = "chirp_client.sfx"
+        create_package(package_filename)
 
     # create the manager to now listen to connections, and register files and
     # tasks.
@@ -61,18 +61,18 @@ if __name__ == "__main__":
     print(f"logs in {m.logging_directory}")
     print(f"listening on port {m.port}")
 
-    # declare ticket and env file if needed. These vine files that can
+    # declare ticket and package file if needed. These vine files that can
     # be used as input to tasks.
     ticket = None
     if args.ticket:
         ticket = m.declare_file(args.ticket, cache=True)
 
-    env = None
-    if env_filename:
-        env = m.declare_starch(env_filename, cache=True)
+    package = None
+    if package_filename:
+        package = m.declare_starch(package_filename, cache=True)
 
     # declaring the file as coming from chirp server
-    chirp_file = m.declare_chirp(args.chirp_server, args.filename, ticket=ticket, env=env, cache=True)
+    chirp_file = m.declare_chirp(args.chirp_server, args.filename, ticket=ticket, env=package, cache=True)
 
     # create a task from the python function count_lines. The function will
     # operate on the file "mychirp.file", with is the name that the input file

--- a/taskvine/src/examples/vine_example_mosaic.py
+++ b/taskvine/src/examples/vine_example_mosaic.py
@@ -12,29 +12,29 @@
 # on remote machines.  To make the tasks portable, the program "/usr/bin/convert"
 # is packaged up into a self-contained archive "convert.sfx" which contains
 # the executable and all of its dynamic dependencies.  This allows the
-# use of arbitrary workers without regard to their software environment.
+# use of arbitrary workers without regard to their software context.
 
 import ndcctools.taskvine as vine
 import argparse
 import os
 import sys
 
-# construct a starch environment that ensures convert and montage are available
+# construct a starch package that ensures convert and montage are available
 # when the task executes at the worker.
-def create_env(env_name, convert="convert", montage="montage"):
+def create_package(package_name, convert="convert", montage="montage"):
     import subprocess
-    # add the executables convert, and montage to the env_name starch file.
+    # add the executables convert, and montage to the package_name starch file.
     # these executables are assumed to be in the current $PATH if a full path was not specified.
     # by default, the starch file will execute the convert command.
 
-    if os.path.exists(env_name):
-        print(f"reusing existing {env_name} starch file...")
+    if os.path.exists(package_name):
+        print(f"reusing existing {package_name} starch file...")
     else:
         try:
-            print(f"creating {env_name} starch file...")
-            subprocess.run(["starch", "-x", "convert", "-x", "montage", "-c", "montage", env_name], check=True)
+            print(f"creating {package_name} starch file...")
+            subprocess.run(["starch", "-x", "convert", "-x", "montage", "-c", "montage", package_name], check=True)
         except subprocess.CalledProcessError:
-            print("could not create environment.")
+            print("could not create package.")
             print("check that starch is in $PATH, and check that ImageMagick executables are in $PATH,")
             print("or provide their location at the command line.")
 
@@ -45,7 +45,7 @@ def process_result(t):
         if t.successful():
             print(f"task {t.id} done: {t.command}")
         elif t.completed():
-            print(f"task {t.id} completed with an executin error, exit code {t.exit_code}")
+            print(f"task {t.id} completed with an execution error, exit code {t.exit_code}")
         else:
             print(f"task {t.id} failed with status {t.result}")
 
@@ -53,22 +53,22 @@ def process_result(t):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
             prog="vine_example_mosaic.py",
-            description="This example TaskVine program produces a mosaic of images, each one transformed with a different amount of swirl. Each task consumes remote data accessed via url, cached and shared among all tasks on that machine. Also each task is executed in a mini environment that ensures that the required executables and libraries are available at the worker.")
+            description="This example TaskVine program produces a mosaic of images, each one transformed with a different amount of swirl. Each task consumes remote data accessed via url, cached and shared among all tasks on that machine. Also each task is executed in a starch package that ensures that the required executables and libraries are available at the worker.")
 
     parser.add_argument('--convert', action='store', help='path to the convert ImageMagick executable.', default="convert")
     parser.add_argument('--montage', action='store', help='path to the montage ImageMagick executable.', default="montage")
     args = parser.parse_args()
 
-    env_filename = "convert_montage.sfx"
-    create_env(env_filename)
+    package_filename = "convert_montage.sfx"
+    create_package(package_filename)
 
     m = vine.Manager()
     print(f"listening on port {m.port}")
 
-    # declare the environment just created as a starch file.
-    # when this env is associated with a task, it will be expanded and wrap its
+    # declare the package just created as a starch file.
+    # when this package is associated with a task, it will be expanded and wrap its
     # command.
-    env = m.declare_starch(env_filename)
+    package = m.declare_starch(package_filename)
 
     # source image to which all the operations will be applied
     image_file = m.declare_url("https://upload.wikimedia.org/wikipedia/commons/7/74/A-Cat.jpg", cache=True)
@@ -85,14 +85,14 @@ if __name__ == "__main__":
     # from 0 to 360, by steps of 10 degrees
     for angle in range(0, 360, 10):
         # the command the task will execute. The convert executable will be
-        # provided by the starch environment.
+        # provided by the starch package.
         # note that all tasks will produce as a result a file named output.jpg
         # in their respective sandboxes. It is this file that will be declared
         # as temporary file.
         command = f"convert -swirl {angle} cat.jpg output.jpg"
 
         t = vine.Task(command)
-        t.add_environment(env)
+        t.add_starch_package(package)
 
         # add the main source image
         t.add_input(image_file,"cat.jpg")
@@ -127,9 +127,9 @@ if __name__ == "__main__":
 
     # create a tasks that combines the results of all the convert tasks.
     # each convert temporary output will be mapped to an {angle}.cat.jpg file.
-    # the montage executable will be provided by the starch environment
+    # the montage executable will be provided by the starch package
     t = vine.Task("montage `ls *.cat.jpg | sort -n` -tile 6x6 -geometry 128x128+0+0 output_of_montage.jpg")
-    t.add_environment(env)
+    t.add_starch_package(package)
 
     for (angle, f) in convert_temporary_outputs.items():
         convert_output = f"{angle}.cat.jpg"

--- a/taskvine/src/examples/vine_example_poncho.c
+++ b/taskvine/src/examples/vine_example_poncho.c
@@ -25,13 +25,13 @@ int main(int argc, char *argv[])
 
 	struct vine_file *script = vine_declare_file(m, "script_example_for_poncho.py", VINE_CACHE);
 
-	struct vine_file *poncho_tarball = vine_declare_file(m, "package.tar.gz", VINE_CACHE);
-	struct vine_file *poncho_env = vine_declare_poncho(m, poncho_tarball, VINE_CACHE);
+	struct vine_file *tarball = vine_declare_file(m, "package.tar.gz", VINE_CACHE);
+	struct vine_file *package = vine_declare_poncho(m, tarball, VINE_CACHE);
 
 	for(i=0;i<5;i++) {
 
 		struct vine_task *task = vine_task_create("python my_script.py");
-		vine_task_add_environment(task, poncho_env);
+		vine_task_add_poncho_package(task, package);
 
 		vine_task_add_input(task, script, "my_script.py", 0);
 

--- a/taskvine/src/examples/vine_example_poncho_in_python.py
+++ b/taskvine/src/examples/vine_example_poncho_in_python.py
@@ -55,13 +55,13 @@ def main():
     if args.disable_peer_transfers:
         q.disable_peer_transfers()
 
-    env_spec = {"conda": {"channels": ["conda-forge"],"packages": ["python","pip","conda","conda-pack","cloudpickle","xrootd"]},"pip": ["matplotlib"]}
-    env_tarball = package_create.dict_to_env(env_spec, cache=True)
-    env_file = q.declare_poncho(env_tarball, cache=True)
+    spec = {"conda": {"channels": ["conda-forge"],"packages": ["python","pip","conda","conda-pack","cloudpickle","xrootd"]},"pip": ["matplotlib"]}
+    tarball = package_create.dict_to_env(spec, cache=True)
+    package = q.declare_poncho(tarball, cache=True)
 
     for i in range(1, 16):
         p_task = vine.PythonTask(divide, 1, i**2)
-        p_task.add_environment(env_file)
+        p_task.add_poncho_package(package);
 
         q.submit(p_task)
 

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -571,18 +571,45 @@ For more information, consult the manual of the resource_monitor.
 
 int vine_task_set_snapshot_file(struct vine_task *t, struct vine_file *monitor_snapshot_file);
 
-
-/** Adds an execution environment to the task. The environment file specified
-is expected to expand to a directory with a bin/run_in_env file that will
-wrap the task command (e.g. a poncho, starch file, or any other vine mini_task
-that creates such a wrapper). If specified multiple times, environments are
-nested in the order given (i.e. first added is the first applied).
+/** Add a Starch package as an execution context.
+The file given must refer to a (unpacked) package
+containing libraries captured by the <tt>starch</tt> command.
+The task will execute using this package as its environment.
 @param t A task object.
-@param f The environment file.
+@param f A file containing an unpacked Starch package.
 */
 
-int vine_task_add_environment(struct vine_task *t, struct vine_file *f);
+int vine_task_add_starch_package(struct vine_task *t, struct vine_file *f);
 
+/** Add a Poncho package as an execution context.
+The file given must refer to a (unpacked) PONCHO package,
+containing a set of Python modules needed by the task.
+The task will execute using this package as its Python environment.
+@param t A task object.
+@param f A file containing an unpacked Poncho package.
+*/
+
+int vine_task_add_poncho_package(struct vine_task *t, struct vine_file *f);
+
+/** Adds an execution context to the task.
+The context file given must expand to a directory containing
+(at a minimum) a file
+named bin/run_in_env that will perform any desired setup
+(e.g. setting PATH, LD_LIBRARY_PATH, PYTHONPATH), execute the given command,
+and then perform any desired cleanup.  The context directory
+may also include any support files or libraries needed by the task.
+If specified multiple times, execution contexts are
+nested in the order given (i.e. first added is the first applied).
+@see vine_task_add_starch_package
+@see vine_task_add_poncho_package
+@param t A task object.
+@param f The execution context file.
+*/
+
+int vine_task_add_execution_context(struct vine_task *t, struct vine_file *f);
+
+/* Deprecated alias for vine_task_add_execution_context. */
+int vine_task_add_environment(struct vine_task *t, struct vine_file *f);
 
 //@}
 

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -581,19 +581,19 @@ int vine_task_add_input_mini_task(
 	return r;
 }
 
-int vine_task_add_poncho_package(struct vine_task *t, struct vine_file *f )
+int vine_task_add_poncho_package(struct vine_task *t, struct vine_file *f)
 {
-	return vine_task_add_execution_context(t,f);
+	return vine_task_add_execution_context(t, f);
 }
 
-int vine_task_add_starch_package(struct vine_task *t, struct vine_file *f )
+int vine_task_add_starch_package(struct vine_task *t, struct vine_file *f)
 {
-	return vine_task_add_execution_context(t,f);
+	return vine_task_add_execution_context(t, f);
 }
 
-int vine_task_add_environment(struct vine_task *t, struct vine_file *f )
+int vine_task_add_environment(struct vine_task *t, struct vine_file *f)
 {
-	return vine_task_add_execution_context(t,f);
+	return vine_task_add_execution_context(t, f);
 }
 
 int vine_task_add_execution_context(struct vine_task *t, struct vine_file *context_file)

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -581,15 +581,30 @@ int vine_task_add_input_mini_task(
 	return r;
 }
 
-int vine_task_add_environment(struct vine_task *t, struct vine_file *environment_file)
+int vine_task_add_poncho_package(struct vine_task *t, struct vine_file *f )
 {
-	if (!environment_file) {
-		debug(D_NOTICE | D_VINE, "%s: environment_file cannot be null", __func__);
+	return vine_task_add_execution_context(t,f);
+}
+
+int vine_task_add_starch_package(struct vine_task *t, struct vine_file *f )
+{
+	return vine_task_add_execution_context(t,f);
+}
+
+int vine_task_add_environment(struct vine_task *t, struct vine_file *f )
+{
+	return vine_task_add_execution_context(t,f);
+}
+
+int vine_task_add_execution_context(struct vine_task *t, struct vine_file *context_file)
+{
+	if (!context_file) {
+		debug(D_NOTICE | D_VINE, "%s: context_file cannot be null", __func__);
 		return 0;
 	}
 
-	char *env_name = string_format("__vine_env_%s", environment_file->cached_name);
-	vine_task_add_input(t, environment_file, env_name, VINE_MOUNT_SYMLINK);
+	char *env_name = string_format("__vine_env_%s", context_file->cached_name);
+	vine_task_add_input(t, context_file, env_name, VINE_MOUNT_SYMLINK);
 
 	char *new_cmd = string_format("%s/bin/run_in_env %s", env_name, t->command_line);
 	vine_task_set_command(t, new_cmd);


### PR DESCRIPTION
## Proposed changes

`vine_task_add_environment` is confusingly similar to `vine_task_add_env_var`.  Change to:
- `vine_task_add_execution_context` for the general case
- `vine_task_add_poncho_package` for Poncho
- `vine_task_add_starch_package` for Starch.
- 
## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
