### PR TITLE
vine: use a single file for wrappers, buffer for functions

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -182,13 +182,13 @@ class FutureTask(PythonTask):
     def add_future_dep(self, arg):
         self.add_input(arg._task._output_file, str('outfile-' + str(arg._task.id)))
 
-    def submit_finalize(self, manager):
+    def submit_finalize(self):
         func, args, kwargs = self._fn_def
         for arg in args:
             if isinstance(arg, VineFuture):
                 self.add_future_dep(arg)
         args = [{"VineFutureFile": str('outfile-' + str(arg._task.id))} if isinstance(arg, VineFuture) else arg for arg in args]
-        self._add_inputs_outputs(manager, func, args, kwargs)
+        self._add_inputs_outputs(self.manager, func, args, kwargs)
 
     def add_environment(self, f):
         self._envs.append(f)

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -132,7 +132,7 @@ class Manager(object):
             # support for PythonTask serialization:
             self._function_buffers = {}
             for d in ['outputs', 'arguments', 'functions']:
-                pathlib.Path.mkdir(pathlib.Path(self.staging_directory, d), exist_ok=True)
+                pathlib.Path.mkdir(pathlib.Pure(self.staging_directory, d), exist_ok=True)
 
             try:
                 if init_fn:

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1435,6 +1435,18 @@ class Manager(object):
         self.undeclare_file(file)
 
     ##
+    # Remove the manager's local serialized copy of a function used with PythonTask.
+    #
+    # @param self    The manager to register this file
+    # @param fn      The function that the manager should forget.
+    def undeclare_function(self, fn):
+        try:
+            b = self._function_buffers.pop(fn, None)
+            self.remove_file(b)
+        except KeyError:
+            pass
+
+    ##
     # Declare an anonymous file has no initial content, but is created as the
     # output of a task, and may be consumed by other tasks.
     #

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -132,7 +132,7 @@ class Manager(object):
             # support for PythonTask serialization:
             self._function_buffers = {}
             for d in ['outputs', 'arguments', 'functions']:
-                pathlib.Path.mkdir(pathlib.Pure(self.staging_directory, d), exist_ok=True)
+                pathlib.Path.mkdir(pathlib.Path(self.staging_directory, d), exist_ok=True)
 
             try:
                 if init_fn:

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -129,6 +129,7 @@ class Manager(object):
             if name:
                 cvine.vine_set_name(self._taskvine, name)
 
+            # support for PythonTask serialization:
             self._function_buffers = {}
             for d in ['outputs', 'arguments', 'functions']:
                 pathlib.Path.mkdir(pathlib.Path(self.staging_directory, d), exist_ok=True)

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -770,16 +770,11 @@ class PythonTask(Task):
     # @param args	arguments used in function to be executed by task
     # @param kwargs	keyword arguments used in function to be executed by task
     def __init__(self, func, *args, **kwargs):
-        self._pp_run = None
+        self._id = str(uuid.uuid4())
+
         self._output_loaded = False
         self._output = None
-        self._stdout = None
 
-        self._id = str(uuid.uuid4())
-        self._func_file = None
-        self._args_file = None
-        self._wrapper_file = None
-        self._output_file = None
         self._serialize_output = True
 
         self._out_name_file = self._id
@@ -791,6 +786,9 @@ class PythonTask(Task):
 
         # vine File object that will contain the output of this function
         self._output_file = None
+
+        # vine File object with the serialized arguments to the function
+        self._args_file = None
 
         # we delay any PythonTask initialization until the task is submitted to
         # a manager. This is because we don't know the staging directory where
@@ -805,21 +803,18 @@ class PythonTask(Task):
     #
     # @param self 	Reference to the current python task object
     # @param manager Manager to which the task was submitted
-    def submit_finalize(self):
-        super().submit_finalize()
-        self._add_IO_files()
+    def submit_finalize(self, manager):
+        super().submit_finalize(manager)
+        self._add_inputs_outputs(manager, *self._fn_def)
+        self._fn_def = None  # avoid possible memory leak
 
-    # remove any temp files generated
+    # remove any ancillary files generated
     # if __del__ is never called, or called too late (e.g. on interpreter shutdown),
     # then temp files will be deleted in the atexit of the manager staging directory
     def __del__(self):
         try:
-            if self._func_file:
-                self.manager.undeclare_file(self._func_file)
             if self._args_file:
                 self.manager.undeclare_file(self._args_file)
-            if self._wrapper_file:
-                self.manager.undeclare_file(self._wrapper_file)
             super().__del__()
         except TypeError:
             # in case the interpreter is shuting down. staging files will be deleted by manager atexit function.
@@ -918,71 +913,61 @@ class PythonTask(Task):
         command = f"{py_exec} w_{self._id} f_{self._id} a_{self._id} o_{self._id}"
         return command
 
-    def _add_IO_files(self):
-        func, args, kwargs = self._fn_def
-        self._fn_def = None
+    def _add_inputs_outputs(self, manager, func, args, kwargs):
+        self.add_input(self._fn_wrapper(manager, self._serialize_output), f"w_{self._id}")
+        self.add_input(self._fn_buffer(manager, func), f"f_{self._id}")
 
-        name = os.path.join(self.manager.staging_directory, "functions", self._id)
-        with open(name, "wb") as wf:
-            cloudpickle.dump(func, wf)
-        self._func_file = self.manager.declare_file(name, unlink_when_done=True)
-        self.add_input(self._func_file, f"f_{self._id}")
-
-        name = os.path.join(self.manager.staging_directory, "arguments", self._id)
+        name = os.path.join(manager.staging_directory, "arguments", self._id)
         with open(name, "wb") as wf:
             cloudpickle.dump([args, kwargs], wf)
-        self._args_file = self.manager.declare_file(name, unlink_when_done=True)
-        self.add_input(self._args_file, f"a_{self._id}")
-
-        name = os.path.join(self.manager.staging_directory, "functions", f"w_{self._id}")
-        self._create_wrapper(name)
-        self._wrapper_file = self.manager.declare_file(name, unlink_when_done=True)
-        self.add_input(self._wrapper_file, f"w_{self._id}")
+        f = manager.declare_file(name, unlink_when_done=True)
+        self.add_input(f, f"a_{self._id}")
 
         if self._tmp_output_enabled:
             self._output_file = self.manager.declare_temp()
         else:
-            name = os.path.join(self.manager.staging_directory, "outputs", self._out_name_file)
-            self._output_file = self.manager.declare_file(name, cache=self._cache_output, unlink_when_done=True)
+            name = os.path.join(manager.staging_directory, "outputs", self._id)
+            self._output_file = manager.declare_file(name, cache=self._cache_output, unlink_when_done=False)
         self.add_output(self._output_file, f"o_{self._id}")
 
-    ##
-    # creates the wrapper script which will execute the function. pickles output.
-    def _create_wrapper(self, filename):
-        with open(filename, "w") as f:
-            f.write(
-                textwrap.dedent(
-                    f"""
-                try:
-                    import sys
-                    import cloudpickle
-                except ImportError as e:
-                    print("Could not execute PythonTask function because a module was not available at the worker.")
-                    raise
+    def _fn_wrapper(self, manager, serialize):
+        base = f"py_wrapper_{int(bool(serialize))}"
+        if base not in manager._function_buffers:
+            name = os.path.join(manager.staging_directory, base)
+            with open(name, "w") as f:
+                f.write(textwrap.dedent(f"""
+                                        import sys
+                                        import cloudpickle
+                                        fn, args, out = sys.argv[1:]
 
-                (fn, args, out) = sys.argv[1], sys.argv[2], sys.argv[3]
-                with open (fn , 'rb') as f:
-                    exec_function = cloudpickle.load(f)
-                with open(args, 'rb') as f:
-                    args, kwargs = cloudpickle.load(f)
+                                        with open(fn, "rb") as f:
+                                            exec_function = cloudpickle.load(f)
+                                        with open(args, "rb") as f:
+                                            args, kwargs = cloudpickle.load(f)
 
-                status = 0
-                try:
-                    exec_out = exec_function(*args, **kwargs)
-                except Exception as e:
-                    exec_out = e
-                    status = 1
+                                        error = 0
+                                        try:
+                                            exec_out = exec_function(*args, **kwargs)
+                                        except Exception as e:
+                                            exec_out = e
+                                            error = e
+                                        finally:
+                                            with open(out, "wb") as f:
+                                                if {serialize}:
+                                                    cloudpickle.dump(exec_out, f)
+                                                else:
+                                                    f.write(exec_out)
+                                            if error:
+                                                raise error
+                                        """))
+                manager._function_buffers[base] = manager.declare_file(name, cache=True)
+        return manager._function_buffers[base]
 
-                with open(out, 'wb') as f:
-                    if {self._serialize_output}:
-                        cloudpickle.dump(exec_out, f)
-                    else:
-                        f.write(exec_out)
-
-                sys.exit(status)
-                """
-                )
-            )
+    def _fn_buffer(self, manager, fn):
+        if fn not in manager._function_buffers:
+            load = cloudpickle.dumps(fn)
+            manager._function_buffers[fn] = manager.declare_buffer(load, cache=True)
+        return manager._function_buffers[fn]
 
 
 class PythonTaskNoResult(Exception):

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -803,9 +803,9 @@ class PythonTask(Task):
     #
     # @param self 	Reference to the current python task object
     # @param manager Manager to which the task was submitted
-    def submit_finalize(self, manager):
-        super().submit_finalize(manager)
-        self._add_inputs_outputs(manager, *self._fn_def)
+    def submit_finalize(self):
+        super().submit_finalize()
+        self._add_inputs_outputs(self.manager, *self._fn_def)
         self._fn_def = None  # avoid possible memory leak
 
     # remove any ancillary files generated
@@ -1006,7 +1006,6 @@ class FunctionCall(Task):
     # execution.
     #
     # @param self 	Reference to the current python task object
-    # @param manager Manager to which the task was submitted
     def submit_finalize(self):
         super().submit_finalize()
         self._input_buffer = self.manager.declare_buffer(cloudpickle.dumps(self._event), cache=False, peer_transfer=True)


### PR DESCRIPTION
Previously TaskVine would generate wrapper and function file per task, even when the wrapper was the same for all the PythonTask, and the function was used by other tasks.

This pr makes it so that wrappers and functions are serialized once. Further, functions are not written to disc but kept as a declare_buffer.

## Proposed changes

Please describe your changes (e.g., what problems they attempt to solve, what results are expected, etc.) Additional motivation and context are welcome.
Please also mention relevant issues and pull requests as appropriate.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
