### PR TITLE
vine: remove_file to undeclare_file

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1221,7 +1221,7 @@ the application indicates that they will not be needed anymore:
     # taskvine workflow. Further, when not task refers to the file, the file
     # will be removed from the manager's disk because of unlink_when_done=True
     # at its declaration.
-    m.remove_file(partial_result)
+    m.undeclare_file(partial_result)
     ```
 
 === "C"
@@ -1240,7 +1240,7 @@ the application indicates that they will not be needed anymore:
     # will remove the file from the taskvine workflow. Further, when not task
     # refers to the file, the file will be removed from the manager's disk
     # because of VINE_UNLINK_WHEN_DONE at its declaration.
-    vine_remove_file(partial_result);
+    vine_undeclare_file(partial_result);
     ```
 
 !!! warning

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1417,8 +1417,8 @@ class Manager(object):
     #
     # @param self    The manager to register this file
     # @param file    The file object
-    def remove_file(self, file):
-        cvine.vine_remove_file(self._taskvine, file._file)
+    def undeclare_file(self, file):
+        cvine.vine_undeclare_file(self._taskvine, file._file)
 
     ##
     # Declare an anonymous file has no initial content, but is created as the

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -1024,9 +1024,9 @@ class FunctionCall(Task):
     @property
     def output(self):
         output = cloudpickle.loads(self._output_buffer.contents())
-        self._manager.remove_file(self._input_buffer)
+        self._manager.undeclare_file(self._input_buffer)
         self._input_buffer = None
-        self._manager.remove_file(self._output_buffer)
+        self._manager.undeclare_file(self._output_buffer)
         self._output_buffer = None
 
         if output['Success']:
@@ -1039,10 +1039,10 @@ class FunctionCall(Task):
     def __del__(self):
         try:
             if self._input_buffer:
-                self._manager.remove_file(self._input_buffer)
+                self._manager.undeclare_file(self._input_buffer)
                 self._input_buffer = None
             if self._output_buffer:
-                self._manager.remove_file(self._output_buffer)
+                self._manager.undeclare_file(self._output_buffer)
                 self._output_buffer = None
             super().__del__()
         except TypeError:

--- a/taskvine/src/examples/vine_example_fixed_location.py
+++ b/taskvine/src/examples/vine_example_fixed_location.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
 
     # we are done with the unsorted lists and we remove them from the cluster
     for f in temporary_unsorted_lists.values():
-        m.remove_file(f)
+        m.undeclare_file(f)
 
     merge_outputs = []
     for tids in tasks_of_worker.values():
@@ -101,7 +101,7 @@ if __name__ == "__main__":
 
     # we are done with the sorted lists and we remove them from the cluster
     for f in temporary_sorted_lists.values():
-        m.remove_file(f)
+        m.undeclare_file(f)
 
     # create final merge, and run it at whatever worker has the most inputs
     out_file = m.declare_file("final_output.txt")
@@ -128,7 +128,7 @@ if __name__ == "__main__":
 
     # we are done with the merged lists and we remove them from the cluster
     for f in merge_outputs:
-        m.remove_file(f)
+        m.undeclare_file(f)
 
 
 # vim: set sts=4 sw=4 ts=4 expandtab ft=python:

--- a/taskvine/src/examples/vine_example_mosaic.py
+++ b/taskvine/src/examples/vine_example_mosaic.py
@@ -158,6 +158,6 @@ if __name__ == "__main__":
     # in this small example this is not strictly necessary, as these files are
     # deleted from workers once the manager terminates.
     for f in convert_temporary_outputs.values():
-        m.remove_file(f)
+        m.undeclare_file(f)
 
 # vim: set sts=4 sw=4 ts=4 expandtab ft=python:

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -778,7 +778,7 @@ Completed tasks waiting for retrieval are not affected.
 @param m A manager object
 @param f Any file object.
 */
-void vine_remove_file(struct vine_manager *m, struct vine_file *f );
+void vine_undeclare_file(struct vine_manager *m, struct vine_file *f );
 
 //@}
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5698,7 +5698,7 @@ int vine_set_task_id_min(struct vine_manager *q, int minid)
 Request to remove a file
 Decrement the reference count and delete if zero.
 */
-void vine_remove_file(struct vine_manager *m, struct vine_file *f)
+void vine_undeclare_file(struct vine_manager *m, struct vine_file *f)
 {
 	if (!f) {
 		return;

--- a/taskvine/test/vine_python_temp_files.py
+++ b/taskvine/test/vine_python_temp_files.py
@@ -50,7 +50,7 @@ while not m.empty():
         sys.exit(1)
 
 # we now can remove the temp file from the worker
-m.remove_file(t_a.output_file)
+m.undeclare_file(t_a.output_file)
 
 print(f"final output: {t_b.output}")
 


### PR DESCRIPTION
Rename remove_file to undeclare_file.

This better reflects the fact that we want the opposite of what declare_file does, and that remove_file does not actually remove the file from disk.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
