### PR TITLE
Vine: Remove File Focused on Deleting Replicas

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1426,7 +1426,7 @@ class Manager(object):
 
     # Deprecated, for backwards compatibility.
     def remove_file(self, file):
-        undeclare_file(self,file)
+        self.undeclare_file(self, file)
 
     ##
     # Declare an anonymous file has no initial content, but is created as the

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5736,7 +5736,7 @@ void vine_remove_file(struct vine_manager *m, struct vine_file *f)
 	delete all of the replicas present at remote workers.
 	*/
 
-	if((m->file->flags&VINE_CACHE_ALWAYS)!=VINE_CACHE_ALWAYS {
+	if((f->flags&VINE_CACHE_ALWAYS)!=VINE_CACHE_ALWAYS) {
 		char *key;
 		struct vine_worker_info *w;
 		HASH_TABLE_ITERATE(m->worker_table, key, w)

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5723,7 +5723,7 @@ void vine_remove_file(struct vine_manager *m, struct vine_file *f)
 	file object itself, which may have further cleanup
 	side effects.
 	*/
-	
+
 	if (!m) {
 		vine_file_delete(f);
 		return;
@@ -5739,7 +5739,8 @@ void vine_remove_file(struct vine_manager *m, struct vine_file *f)
 	if((m->file->flags&VINE_CACHE_ALWAYS)!=VINE_CACHE_ALWAYS {
 		char *key;
 		struct vine_worker_info *w;
-		HASH_TABLE_ITERATE(m->worker_table, key, w) {
+		HASH_TABLE_ITERATE(m->worker_table, key, w)
+		{
 			if (vine_file_replica_table_lookup(w, filename)) {
 				delete_worker_file(m, w, filename, 0, 0);
 			}

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5736,7 +5736,7 @@ void vine_remove_file(struct vine_manager *m, struct vine_file *f)
 	delete all of the replicas present at remote workers.
 	*/
 
-	if((f->flags&VINE_CACHE_ALWAYS)!=VINE_CACHE_ALWAYS) {
+	if ((f->flags & VINE_CACHE_ALWAYS) != VINE_CACHE_ALWAYS) {
 		char *key;
 		struct vine_worker_info *w;
 		HASH_TABLE_ITERATE(m->worker_table, key, w)
@@ -5746,9 +5746,9 @@ void vine_remove_file(struct vine_manager *m, struct vine_file *f)
 			}
 		}
 	}
-		
+
 	/* Remove the object from our table and delete a reference. */
-	
+
 	if (hash_table_lookup(m->file_table, f->cached_name)) {
 		hash_table_remove(m->file_table, f->cached_name);
 		vine_file_delete(f);


### PR DESCRIPTION
## Proposed changes

The operation of vine_remove_file is now limited to just the file itself: it is removed from the file table, deleted from all workers.
But we don't iterate over all tasks.  (esp since there will often be a unique file per task). It is the caller's job to ensure that a file is only removed when all uses are complete.
 
## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
