### PR TITLE
vine: force gc on undeclare

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -44,6 +44,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import gc
 
 
 ##
@@ -1422,6 +1423,9 @@ class Manager(object):
     # @param self    The manager to register this file
     # @param file    The file object
     def undeclare_file(self, file):
+        # Force outstanding references to the file (or tasks that use the file) to be collected.
+        # This to make unlink_when_done work when we expect it (or to some approximation)
+        gc.collect()
         cvine.vine_undeclare_file(self._taskvine, file._file)
 
     # Deprecated, for backwards compatibility.

--- a/taskvine/test/TR_vine_python_unlink_when_done.sh
+++ b/taskvine/test/TR_vine_python_unlink_when_done.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -e
+
+. ../../dttools/test/test_runner_common.sh
+
+import_config_val CCTOOLS_PYTHON_TEST_EXEC
+import_config_val CCTOOLS_PYTHON_TEST_DIR
+
+export PYTHONPATH=$(pwd)/../../test_support/python_modules/${CCTOOLS_PYTHON_TEST_DIR}:$PYTHONPATH
+export PATH=$(dirname "${CCTOOLS_PYTHON_TEST_EXEC}"):$PATH
+
+STATUS_FILE=vine.status
+PORT_FILE=vine.port
+
+check_needed()
+{
+	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import cloudpickle"  || return 1
+
+	return 0
+}
+
+prepare()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+
+	return 0
+}
+
+run()
+{
+	${CCTOOLS_PYTHON_TEST_EXEC} vine_python_unlink_when_done.py
+	echo $? > $STATUS_FILE
+
+	# retrieve taskvine exit status
+	status=$(cat $STATUS_FILE)
+	if [ $status -ne 0 ]
+	then
+		exit 1
+	fi
+
+	exit 0
+}
+
+clean()
+{
+	rm -rf vine-run-info
+	exit 0
+}
+
+dispatch "$@"

--- a/taskvine/test/vine_python_unlink_when_done.py
+++ b/taskvine/test/vine_python_unlink_when_done.py
@@ -1,0 +1,63 @@
+#! /usr/bin/env python
+
+import ndcctools.taskvine as vine
+import os.path as path
+import weakref
+import gc
+import sys
+
+filename = "hello.txt"
+
+def create_file():
+    with open(filename, "w") as f:
+        f.write("hello")
+
+m = vine.DaskVine(port=[9123, 9129])
+
+print("testing without submitting task")
+create_file()
+assert path.exists(filename)
+f = m.declare_file("hello.txt", unlink_when_done=True)
+m.remove_file(f)
+assert not path.exists(filename)
+
+class FakeTask(vine.PythonTask):
+    def __init__(self, filename):
+        super().__init__(lambda x: x)
+        self._filename = filename
+        self._cleanup = None
+
+    def submit_finalize(self, manager):
+        self._input = m.declare_file(self._filename, unlink_when_done=True)
+        self.add_input(self._input, "input")
+
+        def cleanup():
+            manager.remove_file(self._input)
+        self._cleanup = cleanup
+        super().submit_finalize(manager)
+
+    def __del__(self):
+        self._cleanup()
+        super().__del__()
+
+
+print("test unlink_when_done deleting task")
+create_file()
+assert path.exists(filename)
+
+o = m.declare_temp()
+
+m.log_debug_app("declaring task")
+t = FakeTask(filename)
+
+t.add_output(o, "output")
+
+id = m.submit(t)
+m.cancel_by_task_id(id)
+
+t = m.wait(5)
+
+assert path.exists(filename)
+t = None
+m.remove_file(o)
+assert not path.exists(filename)


### PR DESCRIPTION
Force outstanding references to the file (or tasks that use the file) to be collected. This to make unlink_when_done work when we expect it (or to some approximation).

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
