### PR TITLE
vine: avoid capturing variables in closurs with submit_finalize

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -183,19 +183,18 @@ class FutureTask(PythonTask):
     def add_future_dep(self, arg):
         self.add_input(arg._task._output_file, str('outfile-' + str(arg._task.id)))
 
-    def submit_finalize(self, manager):
-        self._manager = manager
+    def submit_finalize(self):
         func, args, kwargs = self._fn_def
         for arg in args:
             if isinstance(arg, VineFuture):
                 self.add_future_dep(arg)
         args = [{"VineFutureFile": str('outfile-' + str(arg._task.id))} if isinstance(arg, VineFuture) else arg for arg in args]
         self._fn_def = (func, args, kwargs)
-        self._tmpdir = tempfile.mkdtemp(dir=manager.staging_directory)
+        self._tmpdir = tempfile.mkdtemp(dir=self.manager.staging_directory)
         self._serialize_python_function(*self._fn_def)
         self._fn_def = None  # avoid possible memory leak
         self._create_wrapper()
-        self._add_IO_files(manager)
+        self._add_IO_files()
 
     def add_environment(self, f):
         self._envs.append(f)

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -834,7 +834,8 @@ class Manager(object):
     # @param self   Reference to the current manager object.
     # @param task   A task description created from @ref ndcctools.taskvine.task.Task.
     def submit(self, task):
-        task.submit_finalize(self)
+        task.manager = self
+        task.submit_finalize()
         task_id = cvine.vine_submit(self._taskvine, task._task)
         if task_id == 0:
             raise ValueError("invalid task description")
@@ -1516,7 +1517,8 @@ class Manager(object):
     def declare_minitask(self, minitask, source, cache=False, peer_transfer=True):
 
         # Attaching a task as a mini-task is like submitting it, so we must finalize the details.
-        minitask.submit_finalize(self)
+        minitask.manager = self
+        minitask.submit_finalize()
 
         # Then proceed to attach the task to the mini-task file object.
         flags = Task._determine_file_flags(cache, peer_transfer)

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -37,7 +37,7 @@ class Task(object):
     def __init__(self, command, **task_info):
         self._task = None
 
-        self._manager = None  # set by submit_finalize
+        self._manager = None  # set when task is submitted
 
         if isinstance(command, dict):
             raise TypeError(f"{command} is not a str. Did you mean **{command}?")
@@ -114,10 +114,10 @@ class Task(object):
             if not self._task:
                 return
             if self._manager_will_free:
-                # e.g., for a minitask that won't be in self._manager._task_table
+                # e.g., for a minitask that won't be in self.manager._task_table
                 # otherwise the task gets a double-free
                 return
-            if self._manager and self.id in self._manager._task_table:
+            if self.manager and self.id in self.manager._task_table:
                 # interpreter is shutting down. Don't delete task here so that manager
                 # does not get memory errors
                 return
@@ -161,8 +161,15 @@ class Task(object):
     # execution.
     #
     # @param self 	Reference to the current python task object
-    # @param manager Manager to which the task was submitted
-    def submit_finalize(self, manager):
+    def submit_finalize(self):
+        pass
+
+    @property
+    def manager(self):
+        return self._manager
+
+    @manager.setter
+    def manager(self, manager):
         self._manager = manager
 
     ##
@@ -800,13 +807,13 @@ class PythonTask(Task):
     #
     # @param self 	Reference to the current python task object
     # @param manager Manager to which the task was submitted
-    def submit_finalize(self, manager):
-        super().submit_finalize(manager)
-        self._tmpdir = tempfile.mkdtemp(dir=manager.staging_directory)
+    def submit_finalize(self):
+        super().submit_finalize()
+        self._tmpdir = tempfile.mkdtemp(dir=self.manager.staging_directory)
         self._serialize_python_function(*self._fn_def)
         self._fn_def = None  # avoid possible memory leak
         self._create_wrapper()
-        self._add_IO_files(manager)
+        self._add_IO_files()
 
     # remove any temp files generated
     # if __del__ is never called, or called too late (e.g. on interpreter shutdown),
@@ -929,20 +936,20 @@ class PythonTask(Task):
         command = f"{py_exec} {self._wrapper} {self._func_file} {self._args_file} {self._id} > {self._stdout_file} 2>&1"
         return command
 
-    def _add_IO_files(self, manager):
+    def _add_IO_files(self):
         def source(name):
             return os.path.join(self._tmpdir, name)
         for name in [self._wrapper, self._func_file, self._args_file]:
-            f = manager.declare_file(source(name))
+            f = self.manager.declare_file(source(name))
             self.add_input(f, name)
 
-        f = manager.declare_file(source(self._stdout_file))
+        f = self.manager.declare_file(source(self._stdout_file))
         self.add_output(f, self._stdout_file)
 
         if self._tmp_output_enabled:
-            self._output_file = manager.declare_temp()
+            self._output_file = self.manager.declare_temp()
         else:
-            self._output_file = manager.declare_file(source(self._out_name_file), cache=self._cache_output)
+            self._output_file = self.manager.declare_file(source(self._out_name_file), cache=self._cache_output)
         self.add_output(self._output_file, self._id)
 
     ##
@@ -1019,12 +1026,11 @@ class FunctionCall(Task):
     # execution.
     #
     # @param self 	Reference to the current python task object
-    # @param manager Manager to which the task was submitted
-    def submit_finalize(self, manager):
-        super().submit_finalize(manager)
-        self._input_buffer = manager.declare_buffer(buffer=cloudpickle.dumps(self._event), cache=False, peer_transfer=True)
+    def submit_finalize(self):
+        super().submit_finalize()
+        self._input_buffer = self.manager.declare_buffer(buffer=cloudpickle.dumps(self._event), cache=False, peer_transfer=True)
         self.add_input(self._input_buffer, "infile")
-        self._output_buffer = manager.declare_buffer(buffer=None, cache=False, peer_transfer=False)
+        self._output_buffer = self.manager.declare_buffer(buffer=None, cache=False, peer_transfer=False)
         self.add_output(self._output_buffer, "outfile")
 
     ##
@@ -1054,9 +1060,9 @@ class FunctionCall(Task):
     @property
     def output(self):
         output = cloudpickle.loads(self._output_buffer.contents())
-        self._manager.undeclare_file(self._input_buffer)
+        self.manager.undeclare_file(self._input_buffer)
         self._input_buffer = None
-        self._manager.undeclare_file(self._output_buffer)
+        self.manager.undeclare_file(self._output_buffer)
         self._output_buffer = None
 
         if output['Success']:
@@ -1069,10 +1075,10 @@ class FunctionCall(Task):
     def __del__(self):
         try:
             if self._input_buffer:
-                self._manager.undeclare_file(self._input_buffer)
+                self.manager.undeclare_file(self._input_buffer)
                 self._input_buffer = None
             if self._output_buffer:
-                self._manager.undeclare_file(self._output_buffer)
+                self.manager.undeclare_file(self._output_buffer)
                 self._output_buffer = None
             super().__del__()
         except TypeError:

--- a/taskvine/test/TR_vine_python_unlink_when_done.sh
+++ b/taskvine/test/TR_vine_python_unlink_when_done.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -e
+
+. ../../dttools/test/test_runner_common.sh
+
+import_config_val CCTOOLS_PYTHON_TEST_EXEC
+import_config_val CCTOOLS_PYTHON_TEST_DIR
+
+export PYTHONPATH=$(pwd)/../../test_support/python_modules/${CCTOOLS_PYTHON_TEST_DIR}:$PYTHONPATH
+export PATH=$(dirname "${CCTOOLS_PYTHON_TEST_EXEC}"):$PATH
+
+STATUS_FILE=vine.status
+PORT_FILE=vine.port
+
+check_needed()
+{
+	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import cloudpickle"  || return 1
+
+	return 0
+}
+
+prepare()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+
+	return 0
+}
+
+run()
+{
+	${CCTOOLS_PYTHON_TEST_EXEC} vine_python_unlink_when_done.py
+	echo $? > $STATUS_FILE
+
+	# retrieve taskvine exit status
+	status=$(cat $STATUS_FILE)
+	if [ $status -ne 0 ]
+	then
+		exit 1
+	fi
+
+	exit 0
+}
+
+clean()
+{
+	rm -rf vine-run-info
+	exit 0
+}
+
+dispatch "$@"

--- a/taskvine/test/vine_python_unlink_when_done.py
+++ b/taskvine/test/vine_python_unlink_when_done.py
@@ -1,0 +1,62 @@
+#! /usr/bin/env python
+
+import ndcctools.taskvine as vine
+import os.path as path
+
+filename = "hello.txt"
+
+
+def create_file():
+    with open(filename, "w") as f:
+        f.write("hello")
+
+
+m = vine.DaskVine(port=[9123, 9129])
+
+print("testing without submitting task")
+create_file()
+assert path.exists(filename)
+f = m.declare_file("hello.txt", unlink_when_done=True)
+m.remove_file(f)
+assert not path.exists(filename)
+
+
+class FakeTask(vine.PythonTask):
+    def __init__(self, filename):
+        super().__init__(lambda x: x)
+        self._filename = filename
+        self._cleanup = None
+
+    def submit_finalize(self):
+        self._input = m.declare_file(self._filename, unlink_when_done=True)
+        self.add_input(self._input, "input")
+        super().submit_finalize()
+
+    def __del__(self):
+        self._manager.remove_file(self._input)
+        super().__del__()
+
+
+print("test unlink_when_done deleting task")
+create_file()
+assert path.exists(filename)
+
+o = m.declare_temp()
+
+m.log_debug_app("declaring task")
+t = FakeTask(filename)
+
+t.add_output(o, "output")
+
+id = m.submit(t)
+m.cancel_by_task_id(id)
+
+t = m.wait(5)
+
+assert path.exists(filename)
+t = None
+m.remove_file(o)
+m.log_debug_app(f"was hello.txt deleted? {not path.exists(filename)}")
+
+assert not path.exists(filename)
+


### PR DESCRIPTION
This avoids the creating of a cell object that increases the reference count to the task object, making the garbage collection (and therefore unlink_when_done) a little more predictable.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
