### PR TITLE
Vine: Rework Empty Dir Handling

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1440,21 +1440,6 @@ class Manager(object):
         return File(f)
 
     ##
-    # Create a file object representing an empty directory.
-    # This is very occasionally needed for applications that expect
-    # certain directories to exist in the working directory, prior to producing output.
-    # This function does not transfer any data to the task, but just creates
-    # a directory in its working sandbox.  If you want to transfer an entire
-    # directory worth of data to a task, use @ref ndcctools.taskvine.manager.Manager.declare_file and give a
-    # directory name. output of a task, and may be consumed by other tasks.
-    #
-    # @param self    The manager to register this file
-    # @return A file object to use in @ref ndcctools.taskvine.task.Task.add_input or @ref ndcctools.taskvine.task.Task.add_output
-    def declare_empty_dir(self):
-        f = cvine.vine_declare_empty_dir(self._taskvine)
-        return File(f)
-
-    ##
     # Declare a file obtained from a remote URL.
     #
     # @param self    The manager to register this file

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -47,7 +47,8 @@ typedef enum {
 	VINE_FAILURE_ONLY = 4,    /**< Only return this output file if the task failed.  (Useful for returning large log files.) */
 	VINE_SUCCESS_ONLY = 8,    /**< Only return this output file if the task succeeded. */
 	VINE_RETRACT_ON_RESET = 16,  /**< Remove this file from the mount lists if the task is reset. (TaskVine internal use only.) */
-	VINE_MOUNT_SYMLINK = 32   /**< Permit this directory to be mounted via symlink instead of hardlink. */
+	VINE_MOUNT_SYMLINK = 32,   /**< Permit this directory to be mounted via symlink instead of hardlink. */
+	VINE_MOUNT_MKDIR = 64     /**< Create this empty output directory in the task sandbox prior to execution. */
 } vine_mount_flags_t;
 
 /** Control caching and sharing behavior of file objects.

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -716,19 +716,6 @@ workers when peer transfers are enabled (@ref vine_enable_peer_transfers).
 struct vine_file * vine_declare_buffer( struct vine_manager *m, const char *buffer, size_t size, vine_file_flags_t flags );
 
 
-/** Create a file object representing an empty directory.
-This is very occasionally needed for applications that expect
-certain directories to exist in the working directory, prior to producing output.
-This function does not transfer any data to the task, but just creates
-a directory in its working sandbox.  If you want to transfer an entire
-directory worth of data to a task, use @ref vine_declare_file and give a
-directory name.
-@param m A manager object
-@return A file object to use in @ref vine_task_add_input, and @ref vine_task_add_output
-*/
-struct vine_file * vine_declare_empty_dir( struct vine_manager *m );
-
-
 /** Create a file object produced from a mini-task
 Attaches a task definition to produce an input file by running a Unix command.
 This mini-task will be run on demand in order to produce the desired input file.

--- a/taskvine/src/manager/vine_cached_name.c
+++ b/taskvine/src/manager/vine_cached_name.c
@@ -60,8 +60,6 @@ is consistent and avoids conflicts adequately. For directories, which are a subs
 it is important that the directory is hashed from its contents. This can be done by using a variation of a merkle tree.
 That is, each hash of a directory is a hash of the hashes of the files with the directory. This can be done recursively.
 
-VINE_EMPTY_DIR - Are there cases where an empty directory needs to be unique?
-
 VINE_URL - With files possibly hosted on remote machines, We generally dont have access to the contents unless one
 transfers the entire file to the site of the manager which is somewhat antithetical to the use case for VINE_URLs. Here,
 our general strategy is to only retrieve the header of the file from the server. With the information in the header,
@@ -312,9 +310,6 @@ char *vine_random_name(const struct vine_file *f, ssize_t *totalsize)
 	case VINE_FILE:
 		name = string_format("file-rnd-%s", random);
 		break;
-	case VINE_EMPTY_DIR:
-		name = string_format("empty");
-		break;
 	case VINE_MINI_TASK:
 		name = string_format("task-rnd-%s", random);
 		break;
@@ -356,10 +351,6 @@ char *vine_cached_name(const struct vine_file *f, ssize_t *totalsize)
 			/* A pending file gets a random name. */
 			name = vine_random_name(f, totalsize);
 		}
-		break;
-	case VINE_EMPTY_DIR:
-		/* All empty dirs have the same content! */
-		name = string_format("empty");
 		break;
 	case VINE_MINI_TASK:
 		/* A mini task is idenfied by the task properties. */

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -174,8 +174,6 @@ struct vine_file *vine_file_buffer(const char *data, size_t size, vine_file_flag
 	return vine_file_create("buffer", 0, data, size, VINE_BUFFER, 0, flags);
 }
 
-struct vine_file *vine_file_empty_dir() { return vine_file_create("unnamed", 0, 0, 0, VINE_EMPTY_DIR, 0, 0); }
-
 struct vine_file *vine_file_mini_task(struct vine_task *t, const char *name, vine_file_flags_t flags)
 {
 	flags |= VINE_PEER_NOSHARE; // we don't know how to share mini tasks yet.

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -60,7 +60,6 @@ struct vine_file *vine_file_local( const char *source, vine_file_flags_t flags )
 struct vine_file *vine_file_url( const char *source, vine_file_flags_t flags );
 struct vine_file *vine_file_temp();
 struct vine_file *vine_file_buffer( const char *buffer, size_t size, vine_file_flags_t flags );
-struct vine_file *vine_file_empty_dir( );
 struct vine_file *vine_file_mini_task( struct vine_task *t, const char *name, vine_file_flags_t flags );
 struct vine_file *vine_file_untar( struct vine_file *f, vine_file_flags_t flags );
 struct vine_file *vine_file_poncho( struct vine_file *f, vine_file_flags_t flags );

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -32,7 +32,6 @@ typedef enum {
 	VINE_TEMP,		    /**< A temporary file created as an output of a task. */
 	VINE_BUFFER,                /**< A file obtained from data in the manager's memory space. */
 	VINE_MINI_TASK,             /**< A file obtained by executing a Unix command line. */
-	VINE_EMPTY_DIR,              /**< An empty directory to create in the task sandbox. */
 } vine_file_t;
 
 struct vine_file {

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5892,10 +5892,6 @@ const char *vine_fetch_file(struct vine_manager *m, struct vine_file *f)
 			return f->data;
 		}
 		break;
-	case VINE_EMPTY_DIR:
-		/* Never anything to get. */
-		return 0;
-		break;
 	}
 
 	return 0;

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5813,12 +5813,6 @@ struct vine_file *vine_declare_buffer(struct vine_manager *m, const char *buffer
 	return vine_manager_declare_file(m, f);
 }
 
-struct vine_file *vine_declare_empty_dir(struct vine_manager *m)
-{
-	struct vine_file *f = vine_file_empty_dir();
-	return vine_manager_declare_file(m, f);
-}
-
 struct vine_file *vine_declare_mini_task(
 		struct vine_manager *m, struct vine_task *t, const char *name, vine_file_flags_t flags)
 {

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -315,12 +315,6 @@ static vine_result_code_t vine_manager_put_input_file(struct vine_manager *q, st
 		result = vine_manager_put_url(q, w, t, f);
 		break;
 
-	case VINE_EMPTY_DIR:
-		debug(D_VINE, "%s (%s) will create directory %s", w->hostname, w->addrport, m->remote_name);
-		// Do nothing.  Empty directories are handled by the task specification, while recursive directories are
-		// implemented as VINE_FILEs
-		break;
-
 	case VINE_TEMP:
 		debug(D_VINE, "%s (%s) will use temp file %s", w->hostname, w->addrport, f->source);
 		// Do nothing.  Temporary files are created and used in place.
@@ -453,7 +447,6 @@ static vine_result_code_t vine_manager_put_input_file_if_needed(struct vine_mana
 		switch (file_to_send->type) {
 		case VINE_URL:
 		case VINE_TEMP:
-		case VINE_EMPTY_DIR:
 			break;
 		case VINE_FILE:
 		case VINE_MINI_TASK:
@@ -563,18 +556,14 @@ vine_result_code_t vine_manager_put_task(struct vine_manager *q, struct vine_wor
 		struct vine_mount *m;
 		LIST_ITERATE(t->input_mounts, m)
 		{
-			if (m->file->type == VINE_EMPTY_DIR) {
-				vine_manager_send(q, w, "dir %s\n", m->remote_name);
-			} else {
-				char remote_name_encoded[PATH_MAX];
-				url_encode(m->remote_name, remote_name_encoded, PATH_MAX);
-				vine_manager_send(q,
-						w,
-						"infile %s %s %d\n",
-						m->file->cached_name,
-						remote_name_encoded,
-						m->flags);
-			}
+			char remote_name_encoded[PATH_MAX];
+			url_encode(m->remote_name, remote_name_encoded, PATH_MAX);
+			vine_manager_send(q,
+					w,
+					"infile %s %s %d\n",
+					m->file->cached_name,
+					remote_name_encoded,
+					m->flags);
 		}
 	}
 

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -558,12 +558,8 @@ vine_result_code_t vine_manager_put_task(struct vine_manager *q, struct vine_wor
 		{
 			char remote_name_encoded[PATH_MAX];
 			url_encode(m->remote_name, remote_name_encoded, PATH_MAX);
-			vine_manager_send(q,
-					w,
-					"infile %s %s %d\n",
-					m->file->cached_name,
-					remote_name_encoded,
-					m->flags);
+			vine_manager_send(
+					q, w, "infile %s %s %d\n", m->file->cached_name, remote_name_encoded, m->flags);
 		}
 	}
 

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -515,7 +515,6 @@ int vine_task_add_output(struct vine_task *t, struct vine_file *f, const char *r
 		break;
 	case VINE_URL:
 	case VINE_MINI_TASK:
-	case VINE_EMPTY_DIR:
 		debug(D_NOTICE | D_VINE, "%s: unsupported output file type", __func__);
 		return 0;
 	}
@@ -550,14 +549,6 @@ int vine_task_add_input_url(
 {
 	struct vine_file *f = vine_file_url(file_url, 0);
 	int r = vine_task_add_input(t, f, remote_name, flags);
-	vine_file_delete(f); /* symmetric create/delete needed for reference counting. */
-	return r;
-}
-
-int vine_task_add_empty_dir(struct vine_task *t, const char *remote_name)
-{
-	struct vine_file *f = vine_file_empty_dir();
-	int r = vine_task_add_input(t, f, remote_name, 0);
 	vine_file_delete(f); /* symmetric create/delete needed for reference counting. */
 	return r;
 }

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -151,6 +151,5 @@ int vine_task_add_output_file(struct vine_task *t, const char *local_name, const
 int vine_task_add_input_url(struct vine_task *t, const char *url, const char *remote_name, vine_mount_flags_t flags);
 int vine_task_add_input_mini_task(struct vine_task *t, struct vine_task *mini_task, const char *remote_name, vine_mount_flags_t flags);
 int vine_task_add_input_buffer(struct vine_task *t, const char *data, int length, const char *remote_name, vine_mount_flags_t flags);
-int vine_task_add_empty_dir( struct vine_task *t, const char *remote_name );
 
 #endif

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -37,21 +37,21 @@ vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cach
 	struct vine_task *t = p->task;
 	vine_cache_status_t cache_status = VINE_CACHE_STATUS_READY;
 
-	if (t->input_mounts) {
-		struct vine_mount *m;
-		LIST_ITERATE(t->input_mounts, m)
-		{
-			cache_status = vine_cache_ensure(cache, m->file->cached_name);
-			if (cache_status == VINE_CACHE_STATUS_PROCESSING)
-				processing = 1;
-			if (cache_status == VINE_CACHE_STATUS_FAILED)
-				break;
-		}
+	struct vine_mount *m;
+	LIST_ITERATE(t->input_mounts, m)
+	{
+		cache_status = vine_cache_ensure(cache, m->file->cached_name);
+		if (cache_status == VINE_CACHE_STATUS_PROCESSING)
+			processing = 1;
+		if (cache_status == VINE_CACHE_STATUS_FAILED)
+			break;
 	}
+
 	if (cache_status == VINE_CACHE_STATUS_FAILED)
 		return VINE_CACHE_STATUS_FAILED;
 	if (processing)
 		return VINE_CACHE_STATUS_PROCESSING;
+
 	return VINE_CACHE_STATUS_READY;
 }
 

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -68,39 +68,30 @@ static int stage_input_file(struct vine_process *p, struct vine_mount *m, struct
 
 	int result = 0;
 
-	if (f->type == VINE_EMPTY_DIR) {
-		/* Special case: empty directories are not cached objects, just create in sandbox */
-		result = create_dir(sandbox_path, 0700);
-		if (!result)
-			debug(D_VINE, "couldn't create directory %s: %s", sandbox_path, strerror(errno));
-
-	} else {
-		/* All other types, link the cached object into the sandbox */
-		vine_cache_status_t status;
-		status = vine_cache_ensure(cache, f->cached_name);
-		if (status == VINE_CACHE_STATUS_READY) {
-			create_dir_parents(sandbox_path, 0777);
-			debug(D_VINE, "input: link %s -> %s", cache_path, sandbox_path);
-			if (m->flags & VINE_MOUNT_SYMLINK) {
-				/* If the user has requested a symlink, just do that b/c it is faster for large dirs. */
-				result = symlink(cache_path, sandbox_path);
-				/* Change sense of Unix result to true/false. */
-				result = !result;
-			} else {
-				/* Otherwise recursively hard-link the object into the sandbox. */
-				result = file_link_recursive(cache_path, sandbox_path, 1);
-			}
-
-			if (!result)
-				debug(D_VINE,
-						"couldn't link %s into sandbox as %s: %s",
-						cache_path,
-						sandbox_path,
-						strerror(errno));
+	vine_cache_status_t status;
+	status = vine_cache_ensure(cache, f->cached_name);
+	if (status == VINE_CACHE_STATUS_READY) {
+		create_dir_parents(sandbox_path, 0777);
+		debug(D_VINE, "input: link %s -> %s", cache_path, sandbox_path);
+		if (m->flags & VINE_MOUNT_SYMLINK) {
+			/* If the user has requested a symlink, just do that b/c it is faster for large dirs. */
+			result = symlink(cache_path, sandbox_path);
+			/* Change sense of Unix result to true/false. */
+			result = !result;
 		} else {
-			debug(D_VINE, "input: %s is not ready in the cache!", f->cached_name);
-			result = 0;
+			/* Otherwise recursively hard-link the object into the sandbox. */
+			result = file_link_recursive(cache_path, sandbox_path, 1);
 		}
+
+		if (!result)
+			debug(D_VINE,
+					"couldn't link %s into sandbox as %s: %s",
+					cache_path,
+					sandbox_path,
+					strerror(errno));
+	} else {
+		debug(D_VINE, "input: %s is not ready in the cache!", f->cached_name);
+		result = 0;
 	}
 
 	free(cache_path);
@@ -182,7 +173,7 @@ static int stage_output_file(struct vine_process *p, struct vine_mount *m, struc
 				path_disk_size_info_delete_state(state);
 			} else {
 				vine_cache_addfile(cache, info.st_size, info.st_mode, f->cached_name);
-				vine_worker_send_cache_update(manager, f->cached_name, info.st_size, 0, 0);
+				vine_worker_send_cache_update(manager, f->cached_name, info.st_mode, 0, 0);
 			}
 		} else {
 			// This seems implausible given that the rename/copy succeded, but we still have to check...

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -102,13 +102,13 @@ static int stage_input_file(struct vine_process *p, struct vine_mount *m, struct
 
 /* Create an empty output directory when requested by VINE_MOUNT_MKDIR */
 
-static int create_empty_output_dir( struct vine_process *p, struct vine_mount *m )
+static int create_empty_output_dir(struct vine_process *p, struct vine_mount *m)
 {
 	char *sandbox_path = vine_sandbox_full_path(p, m->remote_name);
 
-	int result = mkdir(sandbox_path,0755);
-	if(result!=0) {
-		debug(D_VINE,"sandbox: couldn't mkdir %s: %s",sandbox_path,strerror(errno));
+	int result = mkdir(sandbox_path, 0755);
+	if (result != 0) {
+		debug(D_VINE, "sandbox: couldn't mkdir %s: %s", sandbox_path, strerror(errno));
 		free(sandbox_path);
 		return 0;
 	} else {
@@ -139,12 +139,13 @@ int vine_sandbox_stagein(struct vine_process *p, struct vine_cache *cache)
 	}
 
 	/* If any of the output mounts have the MKDIR flag, then create those empty dirs. */
-	
+
 	LIST_ITERATE(t->output_mounts, m)
 	{
-		if(m->flags & VINE_MOUNT_MKDIR) {
-			result = create_empty_output_dir(p,m);
-			if(!result) break;
+		if (m->flags & VINE_MOUNT_MKDIR) {
+			result = create_empty_output_dir(p, m);
+			if (!result)
+				break;
 		}
 	}
 

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -694,7 +694,6 @@ and deposit it into the waiting list.
 static struct vine_task *do_task_body(struct link *manager, int task_id, time_t stoptime)
 {
 	char line[VINE_LINE_MAX];
-	char filename[VINE_LINE_MAX];
 	char localname[VINE_LINE_MAX];
 	char taskname[VINE_LINE_MAX];
 	char taskname_encoded[VINE_LINE_MAX];
@@ -734,8 +733,6 @@ static struct vine_task *do_task_body(struct link *manager, int task_id, time_t 
 			url_decode(taskname_encoded, taskname, VINE_LINE_MAX);
 			vine_hack_do_not_compute_cached_name = 1;
 			vine_task_add_output_file(task, localname, taskname, flags);
-		} else if (sscanf(line, "dir %s", filename)) {
-			vine_task_add_empty_dir(task, filename);
 		} else if (sscanf(line, "cores %" PRId64, &n)) {
 			vine_task_set_cores(task, n);
 		} else if (sscanf(line, "memory %" PRId64, &n)) {


### PR DESCRIPTION
## Proposed changes

`vine_declare_empty_dir` was always a bit of an oddity because it mixed up the handling of input and output.  It was a carry over from WQ to handle a special case of long ago.  This PR removes the concept of an empty dir as input, and adds the mount flag `VINE_MOUNT_MKDIR` for output files.  This causes an empty directory to be made in the task sandbox as the "first step" of creating an output object.  It is equivalent to simply peforming `mkdir x` immediately before running the task.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
