### PR TITLE
Vine: File/Replica Code Cleanup

### DIFF
--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -83,7 +83,7 @@ struct vine_file *vine_file_create(const char *source, const char *cached_name, 
 	f->size = size;
 	f->mini_task = mini_task;
 	f->recovery_task = 0;
-	f->created = 0;
+	f->state = VINE_FILE_STATE_PENDING;
 	f->flags = flags;
 
 	if (data) {

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -73,7 +73,7 @@ int vine_file_delete(struct vine_file *f)
 
 /* Create a new file object with the given properties. */
 struct vine_file *vine_file_create(const char *source, const char *cached_name, const char *data, size_t size,
-		vine_file_t type, struct vine_task *mini_task, vine_file_flags_t flags)
+		vine_file_type_t type, struct vine_task *mini_task, vine_file_flags_t flags)
 {
 	struct vine_file *f = xxmalloc(sizeof(*f));
 	memset(f, 0, sizeof(*f));

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -35,16 +35,22 @@ typedef enum {
 	VINE_EMPTY_DIR,              /**< An empty directory to create in the task sandbox. */
 } vine_file_t;
 
+typedef enum {
+        VINE_FILE_STATE_PENDING, /**< This file has not yet been created by a task. */
+	VINE_FILE_STATE_CREATED   /**< This file has been created at some point.  (although it might have been lost!) */
+} vine_file_state_t;
+
+
 struct vine_file {
 	vine_file_t type;   // Type of data source: VINE_FILE, VINE_BUFFER, VINE_URL, etc.
-	vine_file_flags_t flags; // whether or not to transfer this file between workers.
+	vine_file_flags_t flags; // Whether or not to transfer this file between workers.
+	vine_file_state_t state; // Whether the file is PENDING or has been CREATED
 	char *source;       // Name of source file, url, buffer.
 	char *cached_name;  // Name of file in the worker's cache directory.
 	size_t size;        // Length of source data, if known.
 	char *data;         // Raw data for an input or output buffer.
 	struct vine_task *mini_task; // Mini task used to generate the desired output file.
 	struct vine_task *recovery_task; // For temp files, a copy of the task that created it.
-	int created;        // File has been created at least once.
 	int refcount;       // Number of references from a task object, delete when zero.
 };
 

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -33,16 +33,15 @@ typedef enum {
 	VINE_BUFFER,                /**< A file obtained from data in the manager's memory space. */
 	VINE_MINI_TASK,             /**< A file obtained by executing a Unix command line. */
 	VINE_EMPTY_DIR,              /**< An empty directory to create in the task sandbox. */
-} vine_file_t;
+} vine_file_type_t;
 
 typedef enum {
         VINE_FILE_STATE_PENDING, /**< This file has not yet been created by a task. */
 	VINE_FILE_STATE_CREATED   /**< This file has been created at some point.  (although it might have been lost!) */
 } vine_file_state_t;
 
-
 struct vine_file {
-	vine_file_t type;   // Type of data source: VINE_FILE, VINE_BUFFER, VINE_URL, etc.
+	vine_file_type_t  type;  // Type of data source: VINE_FILE, VINE_BUFFER, VINE_URL, etc.
 	vine_file_flags_t flags; // Whether or not to transfer this file between workers.
 	vine_file_state_t state; // Whether the file is PENDING or has been CREATED
 	char *source;       // Name of source file, url, buffer.
@@ -54,7 +53,7 @@ struct vine_file {
 	int refcount;       // Number of references from a task object, delete when zero.
 };
 
-struct vine_file * vine_file_create( const char *source, const char *cached_name, const char *data, size_t size, vine_file_t type, struct vine_task *mini_task, vine_file_flags_t flags);
+struct vine_file * vine_file_create( const char *source, const char *cached_name, const char *data, size_t size, vine_file_type_t type, struct vine_task *mini_task, vine_file_flags_t flags);
 
 struct vine_file * vine_file_substitute_url( struct vine_file *f, const char *source );
 

--- a/taskvine/src/manager/vine_file_replica.c
+++ b/taskvine/src/manager/vine_file_replica.c
@@ -12,7 +12,7 @@ struct vine_file_replica *vine_file_replica_create(int64_t size, time_t mtime)
 	rinfo->size = size;
 	rinfo->mtime = mtime;
 	rinfo->transfer_time = 0;
-	rinfo->in_cache = 0;
+	rinfo->state = VINE_FILE_REPLICA_STATE_PENDING;
 	return rinfo;
 }
 

--- a/taskvine/src/manager/vine_file_replica.h
+++ b/taskvine/src/manager/vine_file_replica.h
@@ -4,16 +4,21 @@ This software is distributed under the GNU General Public License.
 See the file COPYING for details.
 */
 
-#ifndef VINE_REMOTE_FILE_INFO_H
-#define VINE_REMOTE_FILE_INFO_H
+#ifndef VINE_FILE_REPLICA_H
+#define VINE_FILE_REPLICA_H
 
 #include "taskvine.h"
+
+typedef enum {
+	VINE_FILE_REPLICA_STATE_PENDING, // The replica is in the process of being transferred/created.
+	VINE_FILE_REPLICA_STATE_READY,   // The replica exists and is ready to be used.
+} vine_file_replica_state_t;
 
 struct vine_file_replica {
 	int64_t           size;
 	time_t            mtime;
 	timestamp_t       transfer_time;
-	uint8_t           in_cache;
+	vine_file_replica_state_t state;
 };
 
 struct vine_file_replica * vine_file_replica_create( int64_t size, time_t mtime );

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -49,7 +49,7 @@ struct vine_worker_info *vine_file_replica_table_find_worker(struct vine_manager
 
 		// generate a peer address stub as it would appear in the transfer table
 		char *peer_addr = string_format("worker://%s:%d", peer->transfer_addr, peer->transfer_port);
-		if ((remote_info = hash_table_lookup(peer->current_files, cachename)) && remote_info->in_cache) {
+		if ((remote_info = hash_table_lookup(peer->current_files, cachename)) && remote_info->state==VINE_FILE_REPLICA_STATE_READY) {
 			if (vine_current_transfers_worker_in_use(q, peer_addr) < q->worker_source_max_transfers) {
 				free(peer_addr);
 				return peer;

--- a/taskvine/src/manager/vine_file_replica_table.h
+++ b/taskvine/src/manager/vine_file_replica_table.h
@@ -17,7 +17,7 @@ See the file COPYING for details.
 #include "vine_file_replica.h"
 #include "vine_worker_info.h"
 
-int vine_file_replica_table_insert(struct vine_worker_info *w, const char *cachename, struct vine_file_replica *remote_info);
+int vine_file_replica_table_insert(struct vine_worker_info *w, const char *cachename, struct vine_file_replica *replica);
 
 struct vine_file_replica *vine_file_replica_table_remove(struct vine_worker_info *w, const char *cachename);
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -396,7 +396,8 @@ static int handle_cache_update(struct vine_manager *q, struct vine_worker_info *
 
 		remote_info->size = size;
 		remote_info->transfer_time = transfer_time;
-		remote_info->in_cache = 1;
+		remote_info->state = VINE_FILE_REPLICA_STATE_READY;
+
 		struct vine_file *f = hash_table_lookup(q->file_table, cachename);
 		if (f)
 			f->state = VINE_FILE_STATE_CREATED;

--- a/taskvine/src/manager/vine_manager_get.c
+++ b/taskvine/src/manager/vine_manager_get.c
@@ -426,9 +426,9 @@ vine_result_code_t vine_manager_get_output_file(struct vine_manager *q, struct v
 	if (result == VINE_SUCCESS && m->flags & VINE_CACHE) {
 		struct stat local_info;
 		if (stat(f->source, &local_info) == 0) {
-			struct vine_file_replica *remote_info =
+			struct vine_file_replica *replica =
 					vine_file_replica_create(local_info.st_size, local_info.st_mtime);
-			vine_file_replica_table_insert(w, f->cached_name, remote_info);
+			vine_file_replica_table_insert(w, f->cached_name, replica);
 		} else {
 			debug(D_NOTICE, "Cannot stat file %s: %s", f->source, strerror(errno));
 		}

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -448,17 +448,18 @@ static vine_result_code_t vine_manager_put_input_file_if_needed(struct vine_mana
 		struct vine_file_replica *remote_info = vine_file_replica_create(info.st_size, info.st_mtime);
 		vine_file_replica_table_insert(w, f->cached_name, remote_info);
 
-		/* If the file came from the manager we already sent it synchronously and we will not receive a cache
-		 * update */
 		switch (file_to_send->type) {
 		case VINE_URL:
 		case VINE_TEMP:
 		case VINE_EMPTY_DIR:
+			/* For these types, a cache-update will arrive when the replica actually exists. */
+			remote_info->state = VINE_FILE_REPLICA_STATE_PENDING;
 			break;
 		case VINE_FILE:
 		case VINE_MINI_TASK:
 		case VINE_BUFFER:
-			remote_info->in_cache = 1;
+			/* For these types, we sent the data, so we know it exists. */
+			remote_info->state = VINE_FILE_REPLICA_STATE_READY;
 			f->state = VINE_FILE_STATE_CREATED;
 			break;
 		}

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -459,7 +459,8 @@ static vine_result_code_t vine_manager_put_input_file_if_needed(struct vine_mana
 		case VINE_MINI_TASK:
 		case VINE_BUFFER:
 			remote_info->in_cache = 1;
-			f->created = 1;
+			f->state = VINE_FILE_STATE_CREATED;
+			break;
 		}
 	}
 

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -25,14 +25,14 @@ int check_fixed_location_worker(struct vine_manager *m, struct vine_worker_info 
 {
 	int all_present = 1;
 	struct vine_mount *mt;
-	struct vine_file_replica *remote_info;
+	struct vine_file_replica *replica;
 
 	if (t->has_fixed_locations) {
 		LIST_ITERATE(t->input_mounts, mt)
 		{
 			if (mt->file->flags & VINE_FIXED_LOCATION) {
-				remote_info = hash_table_lookup(w->current_files, mt->file->cached_name);
-				if (!remote_info) {
+				replica = hash_table_lookup(w->current_files, mt->file->cached_name);
+				if (!replica) {
 					all_present = 0;
 					break;
 				}
@@ -256,7 +256,7 @@ static struct vine_worker_info *find_worker_by_files(struct vine_manager *q, str
 	int64_t most_task_cached_bytes = 0;
 	int64_t task_cached_bytes;
 	uint8_t has_all_files;
-	struct vine_file_replica *remote_info;
+	struct vine_file_replica *replica;
 	struct vine_mount *m;
 
 	int ramp_down = vine_schedule_in_ramp_down(q);
@@ -269,10 +269,10 @@ static struct vine_worker_info *find_worker_by_files(struct vine_manager *q, str
 
 			LIST_ITERATE(t->input_mounts, m)
 			{
-				remote_info = hash_table_lookup(w->current_files, m->file->cached_name);
+				replica = hash_table_lookup(w->current_files, m->file->cached_name);
 
-				if (remote_info && m->file->type == VINE_FILE) {
-					task_cached_bytes += remote_info->size;
+				if (replica && m->file->type == VINE_FILE) {
+					task_cached_bytes += replica->size;
 				} else if ((m->file->flags & (VINE_CACHE | VINE_CACHE_ALWAYS))) {
 					has_all_files = 0;
 				}


### PR DESCRIPTION
## Proposed changes

Cleanup surrounding vine file and replica type names and constants.
Laying the groundwork for some bigger changes around caching and metadata tracking.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
