### PR TITLE
do not measure disk at the manager

### DIFF
--- a/dttools/src/rmonitor_poll.c
+++ b/dttools/src/rmonitor_poll.c
@@ -866,7 +866,7 @@ void rmonitor_info_to_rmsummary(struct rmsummary *tr, struct rmonitor_process_in
 	tr->machine_cpus = p->load.cpus;
 }
 
-struct rmsummary *rmonitor_measure_process(pid_t pid)
+struct rmsummary *rmonitor_measure_process(pid_t pid, int include_disk)
 {
 	int err;
 
@@ -880,20 +880,23 @@ struct rmsummary *rmonitor_measure_process(pid_t pid)
 	if (err != 0)
 		return NULL;
 
-	char cwd_link[PATH_MAX];
-	char cwd_org[PATH_MAX];
-
 	struct rmonitor_wdir_info *d = NULL;
-	snprintf(cwd_link, PATH_MAX, "/proc/%d/cwd", pid);
-	ssize_t n = readlink(cwd_link, cwd_org, PATH_MAX - 1);
 
-	if (n != -1) {
-		cwd_org[n] = '\0';
-		d = malloc(sizeof(struct rmonitor_wdir_info));
-		d->path = cwd_org;
-		d->state = NULL;
+	if (include_disk) {
+		char cwd_link[PATH_MAX];
+		char cwd_org[PATH_MAX];
 
-		rmonitor_poll_wd_once(d, -1);
+		snprintf(cwd_link, PATH_MAX, "/proc/%d/cwd", pid);
+		ssize_t n = readlink(cwd_link, cwd_org, PATH_MAX - 1);
+
+		if (n != -1) {
+			cwd_org[n] = '\0';
+			d = malloc(sizeof(struct rmonitor_wdir_info));
+			d->path = cwd_org;
+			d->state = NULL;
+
+			rmonitor_poll_wd_once(d, -1);
+		}
 	}
 
 	uint64_t start;
@@ -912,13 +915,14 @@ struct rmsummary *rmonitor_measure_process(pid_t pid)
 	return tr;
 }
 
-int rmonitor_measure_process_update_to_peak(struct rmsummary *tr, pid_t pid)
+int rmonitor_measure_process_update_to_peak(struct rmsummary *tr, pid_t pid, int include_disk)
 {
 
-	struct rmsummary *now = rmonitor_measure_process(pid);
+	struct rmsummary *now = rmonitor_measure_process(pid, include_disk);
 
-	if (!now)
+	if (!now) {
 		return 0;
+	}
 
 	rmsummary_merge_max(tr, now);
 

--- a/dttools/src/rmonitor_poll.h
+++ b/dttools/src/rmonitor_poll.h
@@ -9,8 +9,8 @@ See the file COPYING for details.
 
 #include "rmsummary.h"
 
-struct rmsummary *rmonitor_measure_process(pid_t pid);
-int rmonitor_measure_process_update_to_peak(struct rmsummary *tr, pid_t pid);
+struct rmsummary *rmonitor_measure_process(pid_t pid, int include_disk);
+int rmonitor_measure_process_update_to_peak(struct rmsummary *tr, pid_t pid, int include_disk);
 struct rmsummary *rmonitor_measure_host(char *);
 
 int rmonitor_get_children(pid_t pid, uint64_t **children);

--- a/resource_monitor/src/bindings/python3/ndcctools/resource_monitor.py
+++ b/resource_monitor/src/bindings/python3/ndcctools/resource_monitor.py
@@ -187,7 +187,7 @@ class ResourceInternalError(Exception):
 
 
 def __measure_update_to_peak(pid, old_summary=None):
-    new_summary = rmonitor_measure_process(pid)
+    new_summary = rmonitor_measure_process(pid, 1)
 
     if old_summary is None:
         return new_summary

--- a/resource_monitor/src/rmonitor_poll_example.c
+++ b/resource_monitor/src/rmonitor_poll_example.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
 {
 	sleep(2);
 
-	struct rmsummary *resources = rmonitor_measure_process(getpid());
+	struct rmsummary *resources = rmonitor_measure_process(getpid(), /* include disk */ 1);
 
 	fprintf(stdout, "command: %s, ", resources->command);
 

--- a/taskvine/src/manager/vine_fair.c
+++ b/taskvine/src/manager/vine_fair.c
@@ -25,7 +25,8 @@ void vine_fair_write_workflow_info(struct vine_manager *m)
 	}
 
 	if (m->monitor_mode != VINE_MON_DISABLED) {
-		rmonitor_measure_process_update_to_peak(m->measured_local_resources, getpid());
+		rmonitor_measure_process_update_to_peak(
+				m->measured_local_resources, getpid(), /* do not include disk */ 0);
 
 		if (!m->measured_local_resources->exit_type) {
 			m->measured_local_resources->exit_type = xxstrdup("normal");

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3863,7 +3863,7 @@ int vine_enable_monitoring(struct vine_manager *q, int watchdog, int series)
 	if (q->measured_local_resources) {
 		rmsummary_delete(q->measured_local_resources);
 	}
-	q->measured_local_resources = rmonitor_measure_process(getpid());
+	q->measured_local_resources = rmonitor_measure_process(getpid(), /* do not include disk */ 0);
 
 	q->monitor_mode = VINE_MON_SUMMARY;
 	if (series) {
@@ -4097,7 +4097,7 @@ static void update_resource_report(struct vine_manager *q)
 	if ((time(0) - q->resources_last_update_time) < q->resource_management_interval)
 		return;
 
-	rmonitor_measure_process_update_to_peak(q->measured_local_resources, getpid());
+	rmonitor_measure_process_update_to_peak(q->measured_local_resources, getpid(), /* do not include disk */ 0);
 
 	q->resources_last_update_time = time(0);
 }

--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -6002,7 +6002,7 @@ int work_queue_enable_monitoring(struct work_queue *q, char *monitor_output_dire
 	if(q->measured_local_resources)
 		rmsummary_delete(q->measured_local_resources);
 
-	q->measured_local_resources = rmonitor_measure_process(getpid());
+	q->measured_local_resources = rmonitor_measure_process(getpid(), /* do not include disk */ 0);
 	q->monitor_mode = MON_SUMMARY;
 
 	if(watchdog) {
@@ -6261,7 +6261,7 @@ void update_resource_report(struct work_queue *q) {
 	if((time(0) - q->resources_last_update_time) < WORK_QUEUE_RESOURCE_MEASUREMENT_INTERVAL)
 		return;
 
-	rmonitor_measure_process_update_to_peak(q->measured_local_resources, getpid());
+	rmonitor_measure_process_update_to_peak(q->measured_local_resources, getpid(), /* do not include disk */ 0);
 
 	q->resources_last_update_time = time(0);
 }
@@ -6270,7 +6270,7 @@ void work_queue_disable_monitoring(struct work_queue *q) {
 	if(q->monitor_mode == MON_DISABLED)
 		return;
 
-	rmonitor_measure_process_update_to_peak(q->measured_local_resources, getpid());
+	rmonitor_measure_process_update_to_peak(q->measured_local_resources, getpid(), /* do not include disk */ 0);
 	if(!q->measured_local_resources->exit_type)
 		q->measured_local_resources->exit_type = xxstrdup("normal");
 
@@ -6978,8 +6978,9 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 			update_catalog(q, foreman_uplink, 0);
 		}
 
-		if(q->monitor_mode)
+		if(q->monitor_mode) {
 			update_resource_report(q);
+		}
 
 		END_ACCUM_TIME(q, time_internal);
 

--- a/work_queue/src/work_queue_coprocess.c
+++ b/work_queue/src/work_queue_coprocess.c
@@ -256,7 +256,7 @@ void work_queue_coprocess_measure_resources(struct work_queue_coprocess *coproce
 		if (curr_coprocess->state == WORK_QUEUE_COPROCESS_DEAD || curr_coprocess->state == WORK_QUEUE_COPROCESS_UNINITIALIZED) {
 			continue;
 		}
-		struct rmsummary *resources = rmonitor_measure_process(curr_coprocess->pid);
+		struct rmsummary *resources = rmonitor_measure_process(curr_coprocess->pid, /* include disk */ 1);
 
 		if(!resources)
 			continue;


### PR DESCRIPTION
Measuring disk at the manager may take a long time, and it is information that we never really use. Further, it is noisy, as the manager's working directory may have files (such as previous logs) that are not related to the workflow.

@BarrySlyDelgado I think you were observing this a couple of months ago.

## Proposed changes

Please describe your changes (e.g., what problems they attempt to solve, what results are expected, etc.) Additional motivation and context are welcome.
Please also mention relevant issues and pull requests as appropriate.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
