### PR TITLE
Vine: Cleanup Worker Info and Stats

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -126,7 +126,7 @@ static vine_msg_code_t handle_http_request(
 static vine_msg_code_t handle_taskvine(struct vine_manager *q, struct vine_worker_info *w, const char *line);
 static vine_msg_code_t handle_manager_status(
 		struct vine_manager *q, struct vine_worker_info *w, const char *line, time_t stoptime);
-static vine_msg_code_t handle_resources(struct vine_manager *q, struct vine_worker_info *w, time_t stoptime );
+static vine_msg_code_t handle_resources(struct vine_manager *q, struct vine_worker_info *w, time_t stoptime);
 static vine_msg_code_t handle_feature(struct vine_manager *q, struct vine_worker_info *w, const char *line);
 static void handle_library_update(struct vine_manager *q, struct vine_worker_info *w, const char *line);
 
@@ -2189,34 +2189,35 @@ Handle a resource update message from the worker describing
 its cores, memory, disk, etc.
 */
 
-static vine_msg_code_t handle_resources(struct vine_manager *q, struct vine_worker_info *w, time_t stoptime )
+static vine_msg_code_t handle_resources(struct vine_manager *q, struct vine_worker_info *w, time_t stoptime)
 {
-	while(1) {
+	while (1) {
 		char line[VINE_LINE_MAX];
 		int64_t total;
-		
-		int result = link_readline(w->link, line, sizeof(line), stoptime);
-		if (result <= 0) return VINE_MSG_FAILURE;
 
-		debug(D_VINE,"%s",line);
-		
-		if(sscanf(line, "cores %" PRId64,&total)) {
+		int result = link_readline(w->link, line, sizeof(line), stoptime);
+		if (result <= 0)
+			return VINE_MSG_FAILURE;
+
+		debug(D_VINE, "%s", line);
+
+		if (sscanf(line, "cores %" PRId64, &total)) {
 			w->resources->cores.total = total;
-		} else if(sscanf(line,"memory %" PRId64,&total)) {
+		} else if (sscanf(line, "memory %" PRId64, &total)) {
 			w->resources->memory.total = total;
-		} else if(sscanf(line,"disk %" PRId64,&total)) {
+		} else if (sscanf(line, "disk %" PRId64, &total)) {
 			w->resources->disk.total = total;
-		} else if(sscanf(line,"gpus %" PRId64,&total)) {
+		} else if (sscanf(line, "gpus %" PRId64, &total)) {
 			w->resources->gpus.total = total;
-		} else if(sscanf(line,"workers %" PRId64,&total)) {
+		} else if (sscanf(line, "workers %" PRId64, &total)) {
 			w->resources->workers.total = total;
-		} else if(sscanf(line,"tag %" PRId64,&total)) {
+		} else if (sscanf(line, "tag %" PRId64, &total)) {
 			w->resources->tag = total;
-		} else if(!strcmp(line,"end")) {
+		} else if (!strcmp(line, "end")) {
 			/* Stop when we get an end marker. */
 			break;
 		} else {
-			debug(D_VINE,"unexpected data in resource update!");
+			debug(D_VINE, "unexpected data in resource update!");
 			/* But keep going until we get an "end" */
 		}
 	}

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -301,24 +301,8 @@ static vine_msg_code_t handle_info(struct vine_manager *q, struct vine_worker_in
 	if (n != 2)
 		return VINE_MSG_FAILURE;
 
-	if (string_prefix_is(field, "workers_joined")) {
-		w->stats->workers_joined = atoll(value);
-	} else if (string_prefix_is(field, "workers_removed")) {
-		w->stats->workers_removed = atoll(value);
-	} else if (string_prefix_is(field, "time_send")) {
-		w->stats->time_send = atoll(value);
-	} else if (string_prefix_is(field, "time_receive")) {
-		w->stats->time_receive = atoll(value);
-	} else if (string_prefix_is(field, "time_execute")) {
-		w->stats->time_workers_execute = atoll(value);
-	} else if (string_prefix_is(field, "bytes_sent")) {
-		w->stats->bytes_sent = atoll(value);
-	} else if (string_prefix_is(field, "bytes_received")) {
-		w->stats->bytes_received = atoll(value);
-	} else if (string_prefix_is(field, "tasks_waiting")) {
-		w->stats->tasks_waiting = atoll(value);
-	} else if (string_prefix_is(field, "tasks_running")) {
-		w->stats->tasks_running = atoll(value);
+	if (string_prefix_is(field, "tasks_running")) {
+		w->dynamic_tasks_running = atoi(value);
 	} else if (string_prefix_is(field, "idle-disconnect-request")) {
 		handle_worker_timeout(q, w);
 	} else if (string_prefix_is(field, "worker-id")) {
@@ -762,32 +746,6 @@ static void cleanup_worker(struct vine_manager *q, struct vine_worker_info *w)
 			delete_worker_file(q, w, f->cached_name, f->flags, (~VINE_CACHE & VINE_CACHE_ALWAYS));
 		}
 	}
-}
-
-#define accumulate_stat(qs, ws, field) (qs)->field += (ws)->field
-
-static void record_removed_worker_stats(struct vine_manager *q, struct vine_worker_info *w)
-{
-	struct vine_stats *qs = q->stats_disconnected_workers;
-	struct vine_stats *ws = w->stats;
-
-	accumulate_stat(qs, ws, workers_joined);
-	accumulate_stat(qs, ws, workers_removed);
-	accumulate_stat(qs, ws, workers_released);
-	accumulate_stat(qs, ws, workers_idled_out);
-	accumulate_stat(qs, ws, workers_slow);
-	accumulate_stat(qs, ws, workers_blocked);
-	accumulate_stat(qs, ws, workers_lost);
-
-	accumulate_stat(qs, ws, time_send);
-	accumulate_stat(qs, ws, time_receive);
-	accumulate_stat(qs, ws, time_workers_execute);
-
-	accumulate_stat(qs, ws, bytes_sent);
-	accumulate_stat(qs, ws, bytes_received);
-
-	// Count all the workers joined as removed.
-	qs->workers_removed = ws->workers_joined;
 }
 
 /* Remove a worker from this master by removing all remote state, all local state, and disconnecting. */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -768,7 +768,6 @@ static void remove_worker(struct vine_manager *q, struct vine_worker_info *w, vi
 	hash_table_remove(q->worker_table, w->hashkey);
 	hash_table_remove(q->workers_with_available_results, w->hashkey);
 
-	record_removed_worker_stats(q, w);
 	vine_manager_factory_worker_leave(q, w);
 
 	vine_worker_delete(w);

--- a/taskvine/src/manager/vine_protocol.h
+++ b/taskvine/src/manager/vine_protocol.h
@@ -13,7 +13,7 @@ worker, and catalog, but should not be visible to the public user API.
 #ifndef VINE_PROTOCOL_H
 #define VINE_PROTOCOL_H
 
-#define VINE_PROTOCOL_VERSION 6
+#define VINE_PROTOCOL_VERSION 7
 
 #define VINE_LINE_MAX 4096       /**< Maximum length of a vine message line. */
 

--- a/taskvine/src/manager/vine_resources.c
+++ b/taskvine/src/manager/vine_resources.c
@@ -78,20 +78,24 @@ static void vine_resource_debug(struct vine_resource *r, const char *name)
 static void vine_resource_send(struct link *manager, struct vine_resource *r, const char *name, time_t stoptime)
 {
 	vine_resource_debug(r, name);
-	link_printf(manager, stoptime, "resource %s %" PRId64 "\n", name, r->total);
+	link_printf(manager, stoptime, "%s %" PRId64 "\n", name, r->total);
 }
 
 void vine_resources_send(struct link *manager, struct vine_resources *r, time_t stoptime)
 {
 	debug(D_VINE, "Sending resource description to manager:");
-	vine_resource_send(manager, &r->workers, "workers", stoptime);
-	vine_resource_send(manager, &r->disk, "disk", stoptime);
-	vine_resource_send(manager, &r->memory, "memory", stoptime);
-	vine_resource_send(manager, &r->gpus, "gpus", stoptime);
-	vine_resource_send(manager, &r->cores, "cores", stoptime);
 
-	/* send the tag last, the manager knows when the resource update is complete */
-	link_printf(manager, stoptime, "resource tag %" PRId64 "\n", r->tag);
+	link_printf(manager, stoptime, "resources\n");
+
+	vine_resource_send(manager, &r->cores, "cores", stoptime);
+	vine_resource_send(manager, &r->memory, "memory", stoptime);
+	vine_resource_send(manager, &r->disk, "disk", stoptime);
+	vine_resource_send(manager, &r->gpus, "gpus", stoptime);
+	vine_resource_send(manager, &r->workers, "workers", stoptime);
+
+	link_printf(manager, stoptime, "tag %" PRId64 "\n", r->tag);
+
+	link_printf(manager, stoptime, "end\n");
 }
 
 void vine_resources_debug(struct vine_resources *r)

--- a/taskvine/src/manager/vine_worker_info.c
+++ b/taskvine/src/manager/vine_worker_info.c
@@ -30,7 +30,6 @@ struct vine_worker_info *vine_worker_create(struct link *lnk)
 
 	w->resources = vine_resources_create();
 	w->features = hash_table_create(4, 0);
-	w->stats = calloc(1, sizeof(struct vine_stats));
 
 	w->current_files = hash_table_create(0, 0);
 	w->current_tasks = itable_create(0);
@@ -60,7 +59,6 @@ void vine_worker_delete(struct vine_worker_info *w)
 	vine_resources_delete(w->resources);
 	hash_table_clear(w->features, 0);
 	hash_table_delete(w->features);
-	free(w->stats);
 
 	hash_table_clear(w->current_files, (void *)vine_file_replica_delete);
 	hash_table_delete(w->current_files);
@@ -116,7 +114,7 @@ struct jx *vine_worker_to_jx(struct vine_worker_info *w)
 	jx_insert_integer(j, "total_tasks_running", itable_size(w->current_tasks));
 	jx_insert_integer(j, "total_bytes_transferred", w->total_bytes_transferred);
 	jx_insert_integer(j, "total_transfer_time", w->total_transfer_time);
-
+	
 	jx_insert_integer(j, "start_time", w->start_time);
 	jx_insert_integer(j, "current_time", timestamp_get());
 

--- a/taskvine/src/manager/vine_worker_info.c
+++ b/taskvine/src/manager/vine_worker_info.c
@@ -114,7 +114,7 @@ struct jx *vine_worker_to_jx(struct vine_worker_info *w)
 	jx_insert_integer(j, "total_tasks_running", itable_size(w->current_tasks));
 	jx_insert_integer(j, "total_bytes_transferred", w->total_bytes_transferred);
 	jx_insert_integer(j, "total_transfer_time", w->total_transfer_time);
-	
+
 	jx_insert_integer(j, "start_time", w->start_time);
 	jx_insert_integer(j, "current_time", timestamp_get());
 

--- a/taskvine/src/manager/vine_worker_info.h
+++ b/taskvine/src/manager/vine_worker_info.h
@@ -56,12 +56,14 @@ struct vine_worker_info {
 	/* Resources and features that describe this worker. */
 	struct vine_resources *resources;
 	struct hash_table     *features;
-	struct vine_stats     *stats;
 
 	/* Current files and tasks that have been transfered to this worker */
 	struct hash_table   *current_files;
 	struct itable       *current_tasks;
 
+	/* The number of tasks running last reported by the worker */
+	int         dynamic_tasks_running;
+	
 	/* Accumulated stats about tasks about this worker. */
 	int         finished_tasks;
 	int64_t     total_tasks_complete;

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -343,7 +343,6 @@ static void send_resource_update(struct link *manager)
 	}
 
 	vine_resources_send(manager, total_resources, stoptime);
-	send_message(manager, "info end_of_resource_update %d\n", 0);
 }
 
 /*


### PR DESCRIPTION
## Proposed changes

In preparation for making some improvements to the manager-worker protocol:
- Clean up handling of resource messages so that they are self-contained, rather than mixing asynchronous and info messages.
- Remove handling of info message that are totally unused by the worker.
- Remove the stats structure from `vine_worker_info` which was no longer filled with data but still being summed up.

The one item remaining is the `info tasks_running` coming from the worker, which is now saved as `w->dynamic_tasks_running`.  This seems useful for troubleshooting, but was never used for any stats or scheduling decisions.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
