### PR TITLE
Vine: Factor Out Worker-From-Factory Code

### DIFF
--- a/taskvine/src/manager/Makefile
+++ b/taskvine/src/manager/Makefile
@@ -5,6 +5,7 @@ SOURCES = \
 	vine_manager.c \
 	vine_manager_get.c \
 	vine_manager_put.c \
+	vine_manager_factory.c \
 	vine_manager_summarize.c \
 	vine_schedule.c \
 	vine_worker_info.c \

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5,6 +5,7 @@ See the file COPYING for details.
 */
 
 #include "vine_manager.h"
+#include "vine_manager_factory.h"
 #include "vine_blocklist.h"
 #include "vine_current_transfers.h"
 #include "vine_factory_info.h"
@@ -15,6 +16,7 @@ See the file COPYING for details.
 #include "vine_manager_get.h"
 #include "vine_manager_put.h"
 #include "vine_manager_summarize.h"
+#include "vine_manager_factory.h"
 #include "vine_mount.h"
 #include "vine_perf_log.h"
 #include "vine_protocol.h"
@@ -151,10 +153,6 @@ static void delete_worker_file(
 		struct vine_manager *q, struct vine_worker_info *w, const char *filename, int flags, int except_flags);
 
 static struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_worker_info *w, const char *name);
-
-static int factory_worker_arrive( struct vine_manager *q, struct vine_worker_info *w, const char *factory_name );
-static void factory_worker_leave( struct vine_manager *q, struct vine_worker_info *w );
-static int factory_worker_prune( struct vine_manager *q, struct vine_worker_info *w );
 
 /* Return the number of workers matching a given type: WORKER, STATUS, etc */
 
@@ -331,7 +329,7 @@ static vine_msg_code_t handle_info(struct vine_manager *q, struct vine_worker_in
 	} else if (string_prefix_is(field, "worker-end-time")) {
 		w->end_time = MAX(0, atoll(value));
 	} else if (string_prefix_is(field, "from-factory")) {
-		factory_worker_arrive(q, w, value);
+		vine_manager_factory_worker_arrive(q, w, value);
 	} else if (string_prefix_is(field, "library-update")) {
 		handle_library_update(q, w, value);
 	}
@@ -654,183 +652,6 @@ int vine_manager_transfer_time(struct vine_manager *q, struct vine_worker_info *
 	return timeout;
 }
 
-/*
-Consider a newly arriving worker that declares it was created
-by a specific factory.  If this puts us over the limit for that
-factory, then disconnect it.
-*/
-
-static int factory_worker_arrive( struct vine_manager *q, struct vine_worker_info *w, const char *factory_name ) {
-			
-	/* The manager is now obliged to query the catalog for factory info. */
-	q->fetch_factory = 1;
-
-	/* Remember that this worker came from this specific factory. */
-	w->factory_name = xxstrdup(factory_name);
-
-	/* If we are over the desired number of workers from this factory, disconnect. */
-	struct vine_factory_info *f = vine_factory_info_lookup(q, w->factory_name);
-	if (f && f->connected_workers + 1 > f->max_workers) {
-		shut_down_worker(q, w);
-		return 0;
-	}
-
-	return 1;
-}
-
-/*
-Consider a worker that is disconnecting, and remove the factory state if needed.
-*/
-
-static void factory_worker_leave( struct vine_manager *q, struct vine_worker_info *w )
-{	
-	if (w->factory_name) {
-		struct vine_factory_info *f = vine_factory_info_lookup(q, w->factory_name);
-		if (f)
-			f->connected_workers--;
-	}
-}
-
-/*
-If this currently connected worker is over the factory limit,
-and isn't running anything, then shut it down.
-*/
-
-static int factory_worker_prune( struct vine_manager *q, struct vine_worker_info *w )
-{
-	if(w->factory_name) {
-		struct vine_factory_info *f = vine_factory_info_lookup(q, w->factory_name);
-		if (f && f->connected_workers > f->max_workers && itable_size(w->current_tasks) < 1) {
-			debug(D_VINE, "Final task received from worker %s, shutting down.", w->hostname);
-			shut_down_worker(q, w);
-			return 1;
-		}
-	}
-
-	return 0;
-}
-
-/*
-Remove idle workers associated with a given factory, so as to scale down
-cleanly by not cancelling active work.
-*/
-
-static int factory_trim_workers(struct vine_manager *q, struct vine_factory_info *f)
-{
-	if (!f)
-		return 0;
-	assert(f->name);
-
-	// Iterate through all workers and shut idle ones down
-	struct vine_worker_info *w;
-	char *key;
-	int trimmed_workers = 0;
-
-	struct hash_table *idle_workers = hash_table_create(0, 0);
-	HASH_TABLE_ITERATE(q->worker_table, key, w)
-	{
-		if (f->connected_workers - trimmed_workers <= f->max_workers)
-			break;
-		if (w->factory_name && !strcmp(f->name, w->factory_name) && itable_size(w->current_tasks) < 1) {
-			hash_table_insert(idle_workers, key, w);
-			trimmed_workers++;
-		}
-	}
-
-	HASH_TABLE_ITERATE(idle_workers, key, w)
-	{
-		hash_table_remove(idle_workers, key);
-		hash_table_firstkey(idle_workers);
-		shut_down_worker(q, w);
-	}
-	hash_table_delete(idle_workers);
-
-	debug(D_VINE, "Trimmed %d workers from %s", trimmed_workers, f->name);
-	return trimmed_workers;
-}
-
-/*
-Given a JX description of a factory, update our internal vine_factory_info
-records to match that description.  If the description indicates that
-we have more workers than desired, trim the workers associated with that
-factory.
-*/
-
-static void factory_update(struct vine_manager *q, struct jx *j)
-{
-	const char *name = jx_lookup_string(j, "factory_name");
-	if (!name)
-		return;
-
-	struct vine_factory_info *f = vine_factory_info_lookup(q, name);
-
-	f->seen_at_catalog = 1;
-	int found = 0;
-	struct jx *m = jx_lookup_guard(j, "max_workers", &found);
-	if (found) {
-		int old_max_workers = f->max_workers;
-		f->max_workers = m->u.integer_value;
-		// Trim workers if max_workers reduced.
-		if (f->max_workers < old_max_workers) {
-			factory_trim_workers(q, f);
-		}
-	}
-}
-
-/*
-Query the catalog to discover what factories are feeding this manager,
-and update all of the factory info to correspond.
-*/
-
-static void factory_update_all(struct vine_manager *q, time_t stoptime)
-{
-	struct catalog_query *cq;
-	struct jx *jexpr = NULL;
-	struct jx *j;
-
-	// Iterate through factory_table to create a query filter.
-	int first_name = 1;
-	buffer_t filter;
-	buffer_init(&filter);
-	char *factory_name = NULL;
-	struct vine_factory_info *f = NULL;
-	buffer_putfstring(&filter, "type == \"vine_factory\" && (");
-
-	HASH_TABLE_ITERATE(q->factory_table, factory_name, f)
-	{
-		buffer_putfstring(&filter, "%sfactory_name == \"%s\"", first_name ? "" : " || ", factory_name);
-		first_name = 0;
-		f->seen_at_catalog = 0;
-	}
-	buffer_putfstring(&filter, ")");
-	jexpr = jx_parse_string(buffer_tolstring(&filter, NULL));
-	buffer_free(&filter);
-
-	// Query the catalog server
-	debug(D_VINE, "Retrieving factory info from catalog server(s) at %s ...", q->catalog_hosts);
-	if ((cq = catalog_query_create(q->catalog_hosts, jexpr, stoptime))) {
-		// Update the table
-		while ((j = catalog_query_read(cq, stoptime))) {
-			factory_update(q, j);
-			jx_delete(j);
-		}
-		catalog_query_delete(cq);
-	} else {
-		debug(D_VINE, "Failed to retrieve factory info from catalog server(s) at %s.", q->catalog_hosts);
-	}
-
-	// Remove outdated factories
-	struct list *outdated_factories = list_create();
-	HASH_TABLE_ITERATE(q->factory_table, factory_name, f)
-	{
-		if (!f->seen_at_catalog && f->connected_workers < 1) {
-			list_push_tail(outdated_factories, f);
-		}
-	}
-	list_clear(outdated_factories, (void *)vine_factory_info_delete);
-	list_delete(outdated_factories);
-}
-
 /* Read from the catalog if fetch_factory is enabled. */
 
 static void update_read_catalog(struct vine_manager *q)
@@ -838,7 +659,7 @@ static void update_read_catalog(struct vine_manager *q)
 	time_t stoptime = time(0) + 5; // Short timeout for query
 
 	if (q->fetch_factory) {
-		factory_update_all(q,stoptime);
+		vine_manager_factory_update_all(q,stoptime);
 	}
 }
 
@@ -991,7 +812,7 @@ static void remove_worker(struct vine_manager *q, struct vine_worker_info *w, vi
 	hash_table_remove(q->workers_with_available_results, w->hashkey);
 
 	record_removed_worker_stats(q, w);
-	factory_worker_leave(q,w);
+	vine_manager_factory_worker_leave(q,w);
 
 	vine_worker_delete(w);
 
@@ -3321,7 +3142,7 @@ static int receive_tasks_from_worker(struct vine_manager *q, struct vine_worker_
 	}
 
 	/* Consider removing the worker if it is empty. */
-	factory_worker_prune(q, w);
+	vine_manager_factory_worker_prune(q, w);
 
 	return tasks_received;
 }
@@ -3341,7 +3162,7 @@ static int receive_one_task(struct vine_manager *q)
 		/* Attempt to fetch from this worker. */
 		if (fetch_output_from_worker(q, w, t->task_id)) {
 			/* Consider whether this worker should be removed. */
-			factory_worker_prune(q, w);
+			vine_manager_factory_worker_prune(q, w);
 			/* If we got a task, then we are done. */
 			return 1;
 		} else {

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5,7 +5,6 @@ See the file COPYING for details.
 */
 
 #include "vine_manager.h"
-#include "vine_manager_factory.h"
 #include "vine_blocklist.h"
 #include "vine_current_transfers.h"
 #include "vine_factory_info.h"
@@ -13,10 +12,10 @@ See the file COPYING for details.
 #include "vine_file.h"
 #include "vine_file_replica.h"
 #include "vine_file_replica_table.h"
+#include "vine_manager_factory.h"
 #include "vine_manager_get.h"
 #include "vine_manager_put.h"
 #include "vine_manager_summarize.h"
-#include "vine_manager_factory.h"
 #include "vine_mount.h"
 #include "vine_perf_log.h"
 #include "vine_protocol.h"
@@ -658,7 +657,7 @@ static void update_read_catalog(struct vine_manager *q)
 	time_t stoptime = time(0) + 5; // Short timeout for query
 
 	if (q->fetch_factory) {
-		vine_manager_factory_update_all(q,stoptime);
+		vine_manager_factory_update_all(q, stoptime);
 	}
 }
 
@@ -811,7 +810,7 @@ static void remove_worker(struct vine_manager *q, struct vine_worker_info *w, vi
 	hash_table_remove(q->workers_with_available_results, w->hashkey);
 
 	record_removed_worker_stats(q, w);
-	vine_manager_factory_worker_leave(q,w);
+	vine_manager_factory_worker_leave(q, w);
 
 	vine_worker_delete(w);
 

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -252,6 +252,9 @@ int64_t overcommitted_resource_total(struct vine_manager *q, int64_t total);
 /* Internal: Enable checking and sending library tasks as necessary. Needed for @vine_schedule.c to check if a worker is compatible to a function task. */
 int vine_manager_check_worker_can_run_function_task(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t);
 
+/* Internal: Shut down a specific worker. */
+int vine_manager_shut_down_worker(struct vine_manager *q, struct vine_worker_info *w);
+
 /* The expected format of files created by the resource monitor.*/
 #define RESOURCE_MONITOR_TASK_LOCAL_NAME "vine-task-%d"
 #define RESOURCE_MONITOR_REMOTE_NAME "cctools-monitor"

--- a/taskvine/src/manager/vine_manager_factory.c
+++ b/taskvine/src/manager/vine_manager_factory.c
@@ -1,0 +1,202 @@
+/*
+Copyright (C) 2024- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include "vine_manager_factory.h"
+
+#include "vine_manager.h"
+#include "vine_worker_info.h"
+#include "vine_factory_info.h"
+
+#include "catalog_query.h"
+#include "stringtools.h"
+#include "hash_table.h"
+#include "list.h"
+#include "jx.h"
+#include "jx_parse.h"
+#include "debug.h"
+#include "xxmalloc.h"
+
+#include <assert.h>
+#include <string.h>
+
+extern void shut_down_worker( struct vine_manager *m, struct vine_worker_info *w );
+
+/*
+Consider a newly arriving worker that declares it was created
+by a specific factory.  If this puts us over the limit for that
+factory, then disconnect it.
+*/
+
+int vine_manager_factory_worker_arrive( struct vine_manager *q, struct vine_worker_info *w, const char *factory_name ) {
+			
+	/* The manager is now obliged to query the catalog for factory info. */
+	q->fetch_factory = 1;
+
+	/* Remember that this worker came from this specific factory. */
+	w->factory_name = xxstrdup(factory_name);
+
+	/* If we are over the desired number of workers from this factory, disconnect. */
+	struct vine_factory_info *f = vine_factory_info_lookup(q, w->factory_name);
+	if (f && f->connected_workers + 1 > f->max_workers) {
+		shut_down_worker(q, w);
+		return 0;
+	}
+
+	return 1;
+}
+
+/*
+Consider a worker that is disconnecting, and remove the factory state if needed.
+*/
+
+void vine_manager_factory_worker_leave( struct vine_manager *q, struct vine_worker_info *w )
+{	
+	if (w->factory_name) {
+		struct vine_factory_info *f = vine_factory_info_lookup(q, w->factory_name);
+		if (f)
+			f->connected_workers--;
+	}
+}
+
+/*
+If this currently connected worker is over the factory limit,
+and isn't running anything, then shut it down.
+*/
+
+int vine_manager_factory_worker_prune( struct vine_manager *q, struct vine_worker_info *w )
+{
+	if(w->factory_name) {
+		struct vine_factory_info *f = vine_factory_info_lookup(q, w->factory_name);
+		if (f && f->connected_workers > f->max_workers && itable_size(w->current_tasks) < 1) {
+			debug(D_VINE, "Final task received from worker %s, shutting down.", w->hostname);
+			shut_down_worker(q, w);
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+/*
+Remove idle workers associated with a given factory, so as to scale down
+cleanly by not cancelling active work.
+*/
+
+static int vine_manager_factory_trim_workers(struct vine_manager *q, struct vine_factory_info *f)
+{
+	if (!f)
+		return 0;
+	assert(f->name);
+
+	// Iterate through all workers and shut idle ones down
+	struct vine_worker_info *w;
+	char *key;
+	int trimmed_workers = 0;
+
+	struct hash_table *idle_workers = hash_table_create(0, 0);
+	HASH_TABLE_ITERATE(q->worker_table, key, w)
+	{
+		if (f->connected_workers - trimmed_workers <= f->max_workers)
+			break;
+		if (w->factory_name && !strcmp(f->name, w->factory_name) && itable_size(w->current_tasks) < 1) {
+			hash_table_insert(idle_workers, key, w);
+			trimmed_workers++;
+		}
+	}
+
+	HASH_TABLE_ITERATE(idle_workers, key, w)
+	{
+		hash_table_remove(idle_workers, key);
+		hash_table_firstkey(idle_workers);
+		shut_down_worker(q, w);
+	}
+	hash_table_delete(idle_workers);
+
+	debug(D_VINE, "Trimmed %d workers from %s", trimmed_workers, f->name);
+	return trimmed_workers;
+}
+
+/*
+Given a JX description of a factory, update our internal vine_factory_info
+records to match that description.  If the description indicates that
+we have more workers than desired, trim the workers associated with that
+factory.
+*/
+
+static void vine_manager_factory_update(struct vine_manager *q, struct jx *j)
+{
+	const char *name = jx_lookup_string(j, "factory_name");
+	if (!name)
+		return;
+
+	struct vine_factory_info *f = vine_factory_info_lookup(q, name);
+
+	f->seen_at_catalog = 1;
+	int found = 0;
+	struct jx *m = jx_lookup_guard(j, "max_workers", &found);
+	if (found) {
+		int old_max_workers = f->max_workers;
+		f->max_workers = m->u.integer_value;
+		// Trim workers if max_workers reduced.
+		if (f->max_workers < old_max_workers) {
+			vine_manager_factory_trim_workers(q, f);
+		}
+	}
+}
+
+/*
+Query the catalog to discover what factories are feeding this manager,
+and update all of the factory info to correspond.
+*/
+
+void vine_manager_factory_update_all(struct vine_manager *q, time_t stoptime)
+{
+	struct catalog_query *cq;
+	struct jx *jexpr = NULL;
+	struct jx *j;
+
+	// Iterate through factory_table to create a query filter.
+	int first_name = 1;
+	buffer_t filter;
+	buffer_init(&filter);
+	char *factory_name = NULL;
+	struct vine_factory_info *f = NULL;
+	buffer_putfstring(&filter, "type == \"vine_factory\" && (");
+
+	HASH_TABLE_ITERATE(q->factory_table, factory_name, f)
+	{
+		buffer_putfstring(&filter, "%sfactory_name == \"%s\"", first_name ? "" : " || ", factory_name);
+		first_name = 0;
+		f->seen_at_catalog = 0;
+	}
+	buffer_putfstring(&filter, ")");
+	jexpr = jx_parse_string(buffer_tolstring(&filter, NULL));
+	buffer_free(&filter);
+
+	// Query the catalog server
+	debug(D_VINE, "Retrieving factory info from catalog server(s) at %s ...", q->catalog_hosts);
+	if ((cq = catalog_query_create(q->catalog_hosts, jexpr, stoptime))) {
+		// Update the table
+		while ((j = catalog_query_read(cq, stoptime))) {
+			vine_manager_factory_update(q, j);
+			jx_delete(j);
+		}
+		catalog_query_delete(cq);
+	} else {
+		debug(D_VINE, "Failed to retrieve factory info from catalog server(s) at %s.", q->catalog_hosts);
+	}
+
+	// Remove outdated factories
+	struct list *outdated_factories = list_create();
+	HASH_TABLE_ITERATE(q->factory_table, factory_name, f)
+	{
+		if (!f->seen_at_catalog && f->connected_workers < 1) {
+			list_push_tail(outdated_factories, f);
+		}
+	}
+	list_clear(outdated_factories, (void *)vine_factory_info_delete);
+	list_delete(outdated_factories);
+}

--- a/taskvine/src/manager/vine_manager_factory.c
+++ b/taskvine/src/manager/vine_manager_factory.c
@@ -6,17 +6,17 @@ See the file COPYING for details.
 
 #include "vine_manager_factory.h"
 
+#include "vine_factory_info.h"
 #include "vine_manager.h"
 #include "vine_worker_info.h"
-#include "vine_factory_info.h"
 
 #include "catalog_query.h"
-#include "stringtools.h"
+#include "debug.h"
 #include "hash_table.h"
-#include "list.h"
 #include "jx.h"
 #include "jx_parse.h"
-#include "debug.h"
+#include "list.h"
+#include "stringtools.h"
 #include "xxmalloc.h"
 
 #include <assert.h>
@@ -28,8 +28,9 @@ by a specific factory.  If this puts us over the limit for that
 factory, then disconnect it.
 */
 
-int vine_manager_factory_worker_arrive( struct vine_manager *q, struct vine_worker_info *w, const char *factory_name ) {
-			
+int vine_manager_factory_worker_arrive(struct vine_manager *q, struct vine_worker_info *w, const char *factory_name)
+{
+
 	/* The manager is now obliged to query the catalog for factory info. */
 	q->fetch_factory = 1;
 
@@ -50,8 +51,8 @@ int vine_manager_factory_worker_arrive( struct vine_manager *q, struct vine_work
 Consider a worker that is disconnecting, and remove the factory state if needed.
 */
 
-void vine_manager_factory_worker_leave( struct vine_manager *q, struct vine_worker_info *w )
-{	
+void vine_manager_factory_worker_leave(struct vine_manager *q, struct vine_worker_info *w)
+{
 	if (w->factory_name) {
 		struct vine_factory_info *f = vine_factory_info_lookup(q, w->factory_name);
 		if (f)
@@ -64,9 +65,9 @@ If this currently connected worker is over the factory limit,
 and isn't running anything, then shut it down.
 */
 
-int vine_manager_factory_worker_prune( struct vine_manager *q, struct vine_worker_info *w )
+int vine_manager_factory_worker_prune(struct vine_manager *q, struct vine_worker_info *w)
 {
-	if(w->factory_name) {
+	if (w->factory_name) {
 		struct vine_factory_info *f = vine_factory_info_lookup(q, w->factory_name);
 		if (f && f->connected_workers > f->max_workers && itable_size(w->current_tasks) < 1) {
 			debug(D_VINE, "Final task received from worker %s, shutting down.", w->hostname);

--- a/taskvine/src/manager/vine_manager_factory.c
+++ b/taskvine/src/manager/vine_manager_factory.c
@@ -22,8 +22,6 @@ See the file COPYING for details.
 #include <assert.h>
 #include <string.h>
 
-extern void shut_down_worker( struct vine_manager *m, struct vine_worker_info *w );
-
 /*
 Consider a newly arriving worker that declares it was created
 by a specific factory.  If this puts us over the limit for that
@@ -41,7 +39,7 @@ int vine_manager_factory_worker_arrive( struct vine_manager *q, struct vine_work
 	/* If we are over the desired number of workers from this factory, disconnect. */
 	struct vine_factory_info *f = vine_factory_info_lookup(q, w->factory_name);
 	if (f && f->connected_workers + 1 > f->max_workers) {
-		shut_down_worker(q, w);
+		vine_manager_shut_down_worker(q, w);
 		return 0;
 	}
 
@@ -72,7 +70,7 @@ int vine_manager_factory_worker_prune( struct vine_manager *q, struct vine_worke
 		struct vine_factory_info *f = vine_factory_info_lookup(q, w->factory_name);
 		if (f && f->connected_workers > f->max_workers && itable_size(w->current_tasks) < 1) {
 			debug(D_VINE, "Final task received from worker %s, shutting down.", w->hostname);
-			shut_down_worker(q, w);
+			vine_manager_shut_down_worker(q, w);
 			return 1;
 		}
 	}
@@ -111,7 +109,7 @@ static int vine_manager_factory_trim_workers(struct vine_manager *q, struct vine
 	{
 		hash_table_remove(idle_workers, key);
 		hash_table_firstkey(idle_workers);
-		shut_down_worker(q, w);
+		vine_manager_shut_down_worker(q, w);
 	}
 	hash_table_delete(idle_workers);
 

--- a/taskvine/src/manager/vine_manager_factory.h
+++ b/taskvine/src/manager/vine_manager_factory.h
@@ -1,0 +1,29 @@
+/*
+Copyright (C) 2024- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#ifndef VINE_MANAGER_FACTORY_H
+#define VINE_MANAGER_FACTORY_H
+
+#include "vine_manager.h"
+#include "vine_worker_info.h"
+#include "vine_factory_info.h"
+
+#include <time.h>
+
+/*
+This module handles workers that report themselves
+as coming from a particular factory, then allowing
+the manager to query the catalog for the factory
+status and remove idle workers that overflow the user's
+desired limit.
+*/
+
+int  vine_manager_factory_worker_arrive( struct vine_manager *q, struct vine_worker_info *w, const char *factory_name );
+void vine_manager_factory_worker_leave( struct vine_manager *q, struct vine_worker_info *w );
+int  vine_manager_factory_worker_prune( struct vine_manager *q, struct vine_worker_info *w );
+void vine_manager_factory_update_all(struct vine_manager *q, time_t stoptime);
+
+#endif


### PR DESCRIPTION
## Proposed changes

Pulls out the (infrequently used) code the tracks the relationships between workers and the factories that they came from.  Cleaning things out to make the manager main loop more accessible.  Also keeps these related things clearly together in `vine_manager_factory`.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
