### PR TITLE
vine: correctly rc files on manager exiting

### DIFF
--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -43,7 +43,7 @@ int vine_file_delete(struct vine_file *f)
 		}
 
 		if (f->refcount < 0) {
-			notice(D_VINE, "vine_file_delete: prevented multiple-free of file: %s", f->source);
+			debug(D_VINE, "vine_file_delete: prevented multiple-free of file: %s", f->source);
 			return 0;
 		}
 


### PR DESCRIPTION
Even if python is being weird about it. (I.e., the manager is collected before the tasks.)

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
