### PR TITLE
Test: Wait After Kill

### DIFF
--- a/deltadb/test/TR_catalog_server.sh
+++ b/deltadb/test/TR_catalog_server.sh
@@ -40,7 +40,8 @@ run()
 
 	echo "killing the catalog server"
 	kill -9 $pid
-
+	wait $pid
+	
 	if [ $result != 0 ]
 	then
 		echo "contents of catalog.log:"

--- a/deltadb/test/TR_catalog_server_ssl.sh
+++ b/deltadb/test/TR_catalog_server_ssl.sh
@@ -52,7 +52,8 @@ run()
 
 	echo "killing the catalog server"
 	kill -9 $pid
-
+	wait $pid
+	
 	if [ $result != 0 ]
 	then
 		echo "contents of catalog.log:"


### PR DESCRIPTION
This fixes an occasional bug in CI (on macos) in which TR_catalog_server_ssl fails b/c port 9097 is still in use from the prior test -- the killed server just hasn't exited quickly enough.

## Proposed changes

Wait for catalog server to exit after sending kill signal. This fixes an occasional bug in CI (on macos) in which TR_catalog_server_ssl fails b/c port 9097 is still in use from the prior test -- the killed server just hasn't exited quickly enough.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
