### PR TITLE
vine: ensure factory scratch dir exists

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1774,6 +1774,7 @@ class Factory(object):
             # since the manager may cleanup before the factory terminates,
             # we need to use some other directory.
             self._opts["scratch-dir"] = os.path.dirname(manager.staging_directory)
+            pathlib.Path.mkdir(pathlib.Path(self._opts["scratch_dir"]), exist_ok=True, parents=True)
 
     def _stop(self):
         if self._factory_proc is not None:
@@ -1902,7 +1903,7 @@ class Factory(object):
                 candidate = os.environ.get("TMPDIR", "/tmp")
             candidate = os.path.join(candidate, f"vine-factory-{os.getuid()}")
             if not os.path.exists(candidate):
-                os.makedirs(candidate)
+                os.makedirs(candidate, exist_ok=True)
             self.scratch_dir = candidate
 
         # specialize scratch_dir for this run


### PR DESCRIPTION
For #3667 


## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
