### PR TITLE
vine: don't reap on task app failure

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -106,6 +106,7 @@ double vine_option_blocklist_slow_workers_timeout = 900;
 
 static void handle_failure(
 		struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, vine_result_code_t fail_type);
+static void handle_worker_failure(struct vine_manager *q, struct vine_worker_info *w);
 static void remove_worker(struct vine_manager *q, struct vine_worker_info *w, vine_worker_disconnect_reason_t reason);
 
 static void reap_task_from_worker(
@@ -1009,12 +1010,16 @@ static int fetch_output_from_worker(struct vine_manager *q, struct vine_worker_i
 
 	if (result != VINE_SUCCESS) {
 		debug(D_VINE, "Failed to receive output from worker %s (%s).", w->hostname, w->addrport);
-		handle_failure(q, w, t, result);
-	}
 
-	if (result == VINE_WORKER_FAILURE) {
-		t->time_when_done = timestamp_get();
-		return 0;
+		if (result == VINE_WORKER_FAILURE) {
+			handle_worker_failure(q, w);
+			t->time_when_done = timestamp_get();
+			return 0;
+		}
+
+		if (t->time_when_commit_end > 0) {
+			delete_task_output_files(q, w, t);
+		}
 	}
 
 	delete_uncacheable_files(q, w, t);


### PR DESCRIPTION


## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
