### PR TITLE
vine: better prefer dispatch

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -142,7 +142,6 @@ class DaskVine(Manager):
             self.tune("prefer-dispatch", 1)
             self.tune("ramp-down-heuristic", 1)
             self.tune("immediate-recovery", 1)
-            self.tune("max-retrievals", 10)
 
             if self.env_per_task:
                 self.environment_file = self.declare_file(environment, cache=True)

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4657,6 +4657,9 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 	int result;
 	struct vine_task *t = NULL;
 
+	// used for q->prefer_dispatch. If 0 and there is a task retrieved, then return task to app.
+	int sent_in_previous_cycle = 1;
+
 	// time left?
 	while ((stoptime == 0) || (time(0) < stoptime)) {
 		BEGIN_ACCUM_TIME(q, time_internal);
@@ -4679,7 +4682,7 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 				END_ACCUM_TIME(q, time_internal);
 			}
 
-			if (t && (!q->prefer_dispatch || list_size(q->ready_list) == 0 || q->busy_waiting_flag)) {
+			if (t && (!q->prefer_dispatch || list_size(q->ready_list) == 0 || !sent_in_previous_cycle)) {
 				break;
 			}
 		}
@@ -4748,6 +4751,7 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 			continue;
 		}
 
+		sent_in_previous_cycle = 0;
 		if (q->wait_for_workers <= hash_table_size(q->worker_table)) {
 			if (q->wait_for_workers > 0) {
 				debug(D_VINE, "Target number of workers reached (%d).", q->wait_for_workers);
@@ -4760,6 +4764,7 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 			if (result) {
 				// sent at least one task
 				events++;
+				sent_in_previous_cycle = 1;
 				continue;
 			}
 		}


### PR DESCRIPTION
Don't use busy waiting flag to decide to break vine's wait loop.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
