### PR TITLE
vine: Hash random start

### DIFF
--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -192,7 +192,7 @@ PROGRAMS = $(MOST_PROGRAMS) catalog_query
 
 SCRIPTS = cctools_gpu_autodetect
 TARGETS = $(LIBRARIES) $(PRELOAD_LIBRARIES) $(PROGRAMS) $(TEST_PROGRAMS)
-TEST_PROGRAMS = auth_test disk_alloc_test jx_test microbench multirun jx_count_obj_test jx_canonicalize_test jx_merge_test histogram_test category_test jx_binary_test mq_poll_test mq_wait_test mq_store_test bucketing_base_test bucketing_manager_test
+TEST_PROGRAMS = auth_test disk_alloc_test jx_test microbench multirun jx_count_obj_test jx_canonicalize_test jx_merge_test hash_table_offset_test histogram_test category_test jx_binary_test mq_poll_test mq_wait_test mq_store_test bucketing_base_test bucketing_manager_test
 
 all: $(TARGETS) catalog_query
 

--- a/dttools/src/hash_table.h
+++ b/dttools/src/hash_table.h
@@ -117,6 +117,27 @@ This function returns the next key and value in the iteration.
 
 int hash_table_nextkey(struct hash_table *h, char **key, void **value);
 
+/** Begin iteration over all keys from a random offset.
+This function begins a new iteration over a hash table,
+allowing you to visit every key and value in the table.
+Next, invoke @ref hash_table_nextkey_with_offset to retrieve each value in order.
+@param h A pointer to a hash table.
+@param offset_bookkeep An integer to pointer where the origin to the iteration is recorded.
+*/
+
+void hash_table_randomkey(struct hash_table *h, int *offset_bookkeep);
+
+/** Continue iteration over all keys from an arbitray offset.
+This function returns the next key and value in the iteration.
+@param h A pointer to a hash table.
+@param offset_bookkeep The origin for this iteration. See @ref hash_table_randomkey
+@param key A pointer to a key pointer.
+@param value A pointer to a value pointer.
+@return Zero if there are no more elements to visit, one otherwise.
+*/
+
+int hash_table_nextkey_with_offset(struct hash_table *h, int offset_bookkeep, char **key, void **value);
+
 /** A default hash function.
 @param s A string to hash.
 @return An integer hash of the string.
@@ -139,5 +160,7 @@ HASH_TABLE_ITERATE(table,key,value) {
 */
 
 #define HASH_TABLE_ITERATE( table, key, value ) hash_table_firstkey(table); while(hash_table_nextkey(table,&key,(void**)&value))
+
+#define HASH_TABLE_ITERATE_RANDOM_START( table, offset_bookkeep, key, value ) hash_table_randomkey(table, &offset_bookkeep); while(hash_table_nextkey_with_offset(table, offset_bookkeep, &key, (void **)&value))
 
 #endif

--- a/dttools/src/hash_table_offset_test.c
+++ b/dttools/src/hash_table_offset_test.c
@@ -1,0 +1,49 @@
+/*
+Copyright (C) 2024 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include "hash_table.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+struct boxed_int {
+	int value;
+};
+
+int main(int argc, char **argv) {
+
+	struct hash_table *h = hash_table_create(0, 0);
+
+	char i;
+	char name[2];
+	name[1] = '\0';
+
+	for (i = 0; i < 11; i++) {
+		name[0] = 65 + i;
+		struct boxed_int *box = malloc(sizeof(struct boxed_int));
+		box->value = i;
+		hash_table_insert(h, name, box);
+	}
+
+	for (i = 0; i < 127; i++) {
+		int offset;
+		char *key;
+		struct boxed_int *box;
+		int sum = 0;
+		HASH_TABLE_ITERATE_RANDOM_START(h, offset, key, box) {
+			sum += box->value;
+		}
+
+		if(sum != 55) {
+			return 1;
+		}
+	}
+
+	hash_table_delete(h);
+
+	return 0;
+}

--- a/dttools/test/TR_hash_table_offset.sh
+++ b/dttools/test/TR_hash_table_offset.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+. ../../dttools/test/test_runner_common.sh
+
+prepare()
+{
+	return 0
+}
+
+run()
+{
+	../src/hash_table_offset_test
+}
+
+clean()
+{
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -78,14 +78,11 @@ struct vine_worker_info **vine_file_replica_table_find_replication_targets(
 	struct vine_worker_info **workers = malloc(sizeof(struct vine_worker_info) * (q->temp_replica_count));
 
 	// some random distribution
-	int skip_workers = (rand() % hash_table_size(q->worker_table)) + 1;
-	HASH_TABLE_ITERATE(q->worker_table, id, peer)
+	int offset_bookkeep;
+	HASH_TABLE_ITERATE_RANDOM_START(q->worker_table, offset_bookkeep, id, peer)
 	{
 		if (found == q->temp_replica_count)
 			break;
-		skip_workers--;
-		if (skip_workers > 0)
-			continue;
 		if (!peer->transfer_port_active)
 			continue;
 

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -253,6 +253,7 @@ static struct vine_worker_info *find_worker_by_files(struct vine_manager *q, str
 	char *key;
 	struct vine_worker_info *w;
 	struct vine_worker_info *best_worker = 0;
+	int offset_bookkeep;
 	int64_t most_task_cached_bytes = 0;
 	int64_t task_cached_bytes;
 	uint8_t has_all_files;
@@ -261,7 +262,7 @@ static struct vine_worker_info *find_worker_by_files(struct vine_manager *q, str
 
 	int ramp_down = vine_schedule_in_ramp_down(q);
 
-	HASH_TABLE_ITERATE(q->worker_table, key, w)
+	HASH_TABLE_ITERATE_RANDOM_START(q->worker_table, offset_bookkeep, key, w)
 	{
 		if (check_worker_against_task(q, w, t)) {
 			task_cached_bytes = 0;
@@ -327,6 +328,8 @@ static struct vine_worker_info *find_worker_by_random(struct vine_manager *q, st
 	int random_worker;
 	struct list *valid_workers = list_create();
 
+	// avoid the temptation to use HASH_TABLE_ITERATE_RANDOM_START for this loop.
+	// HASH_TABLE_ITERATE_RANDOM_START would give preference to workers that appear first in a bucket.
 	HASH_TABLE_ITERATE(q->worker_table, key, w)
 	{
 		if (check_worker_against_task(q, w, t)) {


### PR DESCRIPTION
adds HASH_TABLE_ITERATE_RANDOM_START

    like HASH_TABLE_ITERATE, but starting at a random key. Use as:
```C
    int offset_bookkeep;
    char *key;
    some_type *value;
    HASH_TABLE_ITERATE_RANDOM_START(table, offset_bookkeep, key, value) {
    }
```

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
