### PR TITLE
vine: consider cached output buffers as replicas at workers

### DIFF
--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -179,7 +179,8 @@ int vine_file_has_changed(struct vine_file *f)
 			f->size = info.st_size;
 		} else {
 			/* If we have seen it before, it should not have changed. */
-			if (f->mtime != info.st_mtime || ((int64_t)f->size) != ((int64_t)info.st_size)) {
+			if (f->mtime != info.st_mtime ||
+					(!S_ISDIR(info.st_mode) && ((int64_t)f->size) != ((int64_t)info.st_size))) {
 				if (!f->change_message_shown) {
 					debug(D_VINE | D_NOTICE,
 							"input file %s was modified by someone in the middle of the workflow!\n",

--- a/taskvine/src/manager/vine_manager_get.c
+++ b/taskvine/src/manager/vine_manager_get.c
@@ -426,7 +426,7 @@ vine_result_code_t vine_manager_get_output_file(struct vine_manager *q, struct v
 	// If the transfer was successful, make a record of it in the cache.
 	if (result == VINE_SUCCESS && (f->cache_level > VINE_CACHE_LEVEL_TASK)) {
 		struct stat local_info;
-		if (stat(f->source, &local_info) == 0) {
+		if (f->type == VINE_BUFFER || stat(f->source, &local_info) == 0) {
 			struct vine_file_replica *replica = vine_file_replica_create(
 					f->type, f->cache_level, local_info.st_size, local_info.st_mtime);
 			vine_file_replica_table_insert(w, f->cached_name, replica);

--- a/taskvine/src/manager/vine_manager_get.c
+++ b/taskvine/src/manager/vine_manager_get.c
@@ -425,13 +425,28 @@ vine_result_code_t vine_manager_get_output_file(struct vine_manager *q, struct v
 
 	// If the transfer was successful, make a record of it in the cache.
 	if (result == VINE_SUCCESS && (f->cache_level > VINE_CACHE_LEVEL_TASK)) {
-		struct stat local_info;
-		if (f->type == VINE_BUFFER || stat(f->source, &local_info) == 0) {
-			struct vine_file_replica *replica = vine_file_replica_create(
-					f->type, f->cache_level, local_info.st_size, local_info.st_mtime);
-			vine_file_replica_table_insert(w, f->cached_name, replica);
+		struct vine_file_replica *replica = NULL;
+
+		if (f->type == VINE_BUFFER) {
+			replica = vine_file_replica_create(
+					f->type, f->cache_level, total_bytes, /* no mtime available */ 0);
 		} else {
-			debug(D_NOTICE, "Cannot stat file %s(%s): %s", f->cached_name, f->source, strerror(errno));
+			struct stat local_info;
+
+			if (stat(f->source, &local_info) == 0) {
+				replica = vine_file_replica_create(
+						f->type, f->cache_level, total_bytes, local_info.st_mtime);
+			} else {
+				debug(D_NOTICE,
+						"Cannot stat file %s(%s): %s",
+						f->cached_name,
+						f->source,
+						strerror(errno));
+			}
+		}
+
+		if (replica) {
+			vine_file_replica_table_insert(w, f->cached_name, replica);
 		}
 	}
 

--- a/taskvine/src/manager/vine_manager_get.c
+++ b/taskvine/src/manager/vine_manager_get.c
@@ -58,7 +58,7 @@ static vine_result_code_t vine_manager_get_buffer(struct vine_manager *q, struct
 		f->size = size;
 		debug(D_VINE,
 				"Receiving buffer %s (size: %" PRId64 " bytes) from %s (%s) ...",
-				f->source,
+				f->cached_name,
 				(int64_t)f->size,
 				w->addrport,
 				w->hostname);
@@ -88,7 +88,7 @@ static vine_result_code_t vine_manager_get_buffer(struct vine_manager *q, struct
 				"%s (%s): could not access buffer %s (%s)",
 				w->hostname,
 				w->addrport,
-				f->source,
+				f->cached_name,
 				strerror(errornum));
 		/* Mark the task as missing an output, but return success to keep going. */
 		vine_task_set_result(t, VINE_RESULT_OUTPUT_MISSING);
@@ -431,7 +431,7 @@ vine_result_code_t vine_manager_get_output_file(struct vine_manager *q, struct v
 					f->type, f->cache_level, local_info.st_size, local_info.st_mtime);
 			vine_file_replica_table_insert(w, f->cached_name, replica);
 		} else {
-			debug(D_NOTICE, "Cannot stat file %s: %s", f->source, strerror(errno));
+			debug(D_NOTICE, "Cannot stat file %s(%s): %s", f->cached_name, f->source, strerror(errno));
 		}
 	}
 


### PR DESCRIPTION


- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
