### PR TITLE
Makeflow: Fix handling of dashes in filenames.

### DIFF
--- a/makeflow/src/lexer.c
+++ b/makeflow/src/lexer.c
@@ -515,12 +515,15 @@ int lexer_read_filename_recursive(struct lexer *lx)
 	if(count < 1)
 		return count;
 
-	if(lexer_next_peek(lx) == '-' && !lexer_peek_remote_rename_syntax(lx)) {
+	/* Check for any number of dashes not followed by a > */
+	while(lexer_next_peek(lx) == '-' && !lexer_peek_remote_rename_syntax(lx)) {
 		lexer_add_to_lexeme(lx, '-');
 		lexer_next_char(lx);
 		count++;
-		count += lexer_read_filename_recursive(lx);
 	}
+
+	/* If there is more, keep adding it to this filename. */
+	count += lexer_read_filename_recursive(lx);
 
 	return count;
 }

--- a/makeflow/test/TR_makeflow_020_syntax_dashes.sh
+++ b/makeflow/test/TR_makeflow_020_syntax_dashes.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+. ../../dttools/test/test_runner_common.sh
+
+prepare()
+{
+	exit 0
+}
+
+run()
+{
+	cd syntax && ../../src/makeflow dashes.makeflow
+}
+
+clean()
+{
+	cd syntax && ../../src/makeflow -c dashes.makeflow 
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:

--- a/makeflow/test/syntax/dashes.makeflow
+++ b/makeflow/test/syntax/dashes.makeflow
@@ -1,0 +1,21 @@
+#
+# Test various configurations of multiple dashes in filenames.
+# Note that any sequence of dashes is permitted, but the
+# characters -> indicate a remote rename operation.
+#
+
+ab:
+	echo hello > ab
+
+a-b: ab
+	cat ab > a-b
+
+a--b: a-b
+	cat a-b > a--b
+
+a---b: a--b
+	cat a--b > a---b
+
+a----b: a---b
+	cat a---b > a----b
+


### PR DESCRIPTION
## Proposed changes

Per issue #3700 Makeflow was not accepting filenames with multiple dashes. The problem here is that the lexer is looking for a remote rename operator `->` as a terminator for a filename.  It correctly handled a single dash, but didn't look for more.  This fix consumes any number of dashes not followed by a `>`.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
