### PR TITLE
vine: worker<->file association

### DIFF
--- a/dttools/src/set.c
+++ b/dttools/src/set.c
@@ -304,4 +304,56 @@ void *set_next_element(struct set *s)
 	}
 }
 
+void set_random_element(struct set *s, int *offset_bookkeep)
+{
+	s->ientry = 0;
+	int ibucket_start = random() % s->bucket_count;
+
+	for (s->ibucket = ibucket_start; s->ibucket < s->bucket_count; s->ibucket++) {
+		s->ientry = s->buckets[s->ibucket];
+		if (s->ientry) {
+			*offset_bookkeep = s->ibucket;
+			return;
+		}
+	}
+
+	for (s->ibucket = 0; s->ibucket < ibucket_start; s->ibucket++) {
+		s->ientry = s->buckets[s->ibucket];
+		if (s->ientry) {
+			*offset_bookkeep = s->ibucket;
+			return;
+		}
+	}
+}
+
+void *set_next_element_with_offset(struct set *s, int offset_bookkeep)
+{
+	if (s->bucket_count < 1) {
+		return 0;
+	}
+
+	void *element = NULL;
+
+	offset_bookkeep = offset_bookkeep % s->bucket_count;
+
+	if (s->ientry) {
+		element = (void *)s->ientry->element;
+
+		s->ientry = s->ientry->next;
+		if (!s->ientry) {
+			s->ibucket = (s->ibucket + 1) % s->bucket_count;
+			for (; s->ibucket != offset_bookkeep; s->ibucket = (s->ibucket + 1) % s->bucket_count) {
+				s->ientry = s->buckets[s->ibucket];
+				if (s->ientry) {
+					break;
+				}
+			}
+		}
+
+		return element;
+	}
+
+	return 0;
+}
+
 /* vim: set noexpandtab tabstop=8: */

--- a/dttools/src/set.h
+++ b/dttools/src/set.h
@@ -41,6 +41,10 @@ while(element = set_next_element(s)) {
 
 */
 
+#define SET_ITERATE( set, element ) set_first_element(set); while((element = set_next_element(set)))
+
+#define SET_ITERATE_RANDOM_START( set, offset_bookkeep, element ) set_random_element(set, &offset_bookkeep); while((element = set_next_element_with_offset(set, offset_bookkeep)))
+
 /** Create a new set.
 @param buckets The number of elements in the set.  If zero, a default element will be used. Increases dynamically as needed.
 @return A pointer to a new set.
@@ -163,5 +167,23 @@ This function returns the next element in the iteration.
 */
 
 void *set_next_element(struct set *s);
+
+/** Begin iteration over all elements from a random offset.
+This function begins a new iteration over a set,
+allowing you to visit every element in the set.
+Next, invoke @ref set_next_element_with_offset to retrieve each value in order.
+@param s A pointer to a set.
+@param offset_bookkeep An integer to pointer where the origin to the iteration is recorded.
+*/
+
+void set_random_element(struct set *s, int *offset_bookkeep);
+
+/** Continue iteration over all elements from an arbitray offset.
+This function returns the next element in the iteration.
+@param s A pointer to a set.
+@param offset_bookkeep The origin for this iteration. See @ref set_random_element
+*/
+
+void *set_next_element_with_offset(struct set *s, int offset_bookkeep);
 
 #endif

--- a/taskvine/src/manager/vine_file_replica_table.h
+++ b/taskvine/src/manager/vine_file_replica_table.h
@@ -17,9 +17,9 @@ See the file COPYING for details.
 #include "vine_file_replica.h"
 #include "vine_worker_info.h"
 
-int vine_file_replica_table_insert(struct vine_worker_info *w, const char *cachename, struct vine_file_replica *replica);
+int vine_file_replica_table_insert(struct vine_manager *m, struct vine_worker_info *w, const char *cachename, struct vine_file_replica *replica);
 
-struct vine_file_replica *vine_file_replica_table_remove(struct vine_worker_info *w, const char *cachename);
+struct vine_file_replica *vine_file_replica_table_remove(struct vine_manager *m, struct vine_worker_info *w, const char *cachename);
 
 struct vine_file_replica *vine_file_replica_table_lookup(struct vine_worker_info *w, const char *cachename);
 

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -119,7 +119,8 @@ struct vine_manager {
 
 	/* Primary data structures for tracking files. */
 
-    	struct hash_table *file_table;      /* Maps fileid -> struct vine_file.* */
+	struct hash_table *file_table;      /* Maps fileid -> struct vine_file.* */
+	struct hash_table *file_worker_table; /* Maps cachename -> struct set of workers with a replica of the file.* */
 
 	/* Primary scheduling controls. */
 

--- a/taskvine/src/manager/vine_manager_get.c
+++ b/taskvine/src/manager/vine_manager_get.c
@@ -446,7 +446,7 @@ vine_result_code_t vine_manager_get_output_file(struct vine_manager *q, struct v
 		}
 
 		if (replica) {
-			vine_file_replica_table_insert(w, f->cached_name, replica);
+			vine_file_replica_table_insert(q, w, f->cached_name, replica);
 		}
 	}
 

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -445,7 +445,7 @@ static vine_result_code_t vine_manager_put_input_file_if_needed(struct vine_mana
 	if (result == VINE_SUCCESS) {
 		struct vine_file_replica *replica =
 				vine_file_replica_create(f->type, f->cache_level, f->size, f->mtime);
-		vine_file_replica_table_insert(w, f->cached_name, replica);
+		vine_file_replica_table_insert(q, w, f->cached_name, replica);
 
 		switch (file_to_send->type) {
 		case VINE_URL:


### PR DESCRIPTION
To make the random selection efficient, a table that maps cachename->set of files was added.


## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
