### PR TITLE
vine: fix recovery tasks multiple creation

### DIFF
--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -183,14 +183,5 @@ int vine_file_replica_table_exists_somewhere(struct vine_manager *q, const char 
 		return 0;
 	}
 
-	struct vine_worker_info *w;
-	struct vine_file_replica *r;
-	SET_ITERATE(workers, w)
-	{
-		r = hash_table_lookup(w->current_files, cachename);
-		if (r && r->state == VINE_FILE_REPLICA_STATE_READY)
-			return 1;
-	}
-
-	return 0;
+	return set_size(workers) > 0;
 }

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -154,21 +154,28 @@ struct vine_worker_info **vine_file_replica_table_find_replication_targets(
 
 /*
 Count number of replicas of a file in the system.
-XXX Note that this implementation is another inefficient linear search.
 */
-
-int vine_file_replica_table_count_replicas(struct vine_manager *q, const char *cachename)
+int vine_file_replica_table_count_replicas(
+		struct vine_manager *q, const char *cachename, vine_file_replica_state_t state)
 {
+	struct vine_worker_info *w;
+	struct vine_file_replica *r;
+	int count = 0;
+
 	struct set *workers = hash_table_lookup(q->file_worker_table, cachename);
-	if (!workers) {
-		return 0;
+	if (workers) {
+		SET_ITERATE(workers, w)
+		{
+			r = hash_table_lookup(w->current_files, cachename);
+			if (r && r->state == state) {
+				count++;
+			}
+		}
 	}
 
-	return set_size(workers);
+	return count;
 }
 
-/*
- */
 int vine_file_replica_table_exists_somewhere(struct vine_manager *q, const char *cachename)
 {
 	struct set *workers = hash_table_lookup(q->file_worker_table, cachename);

--- a/taskvine/src/manager/vine_file_replica_table.h
+++ b/taskvine/src/manager/vine_file_replica_table.h
@@ -29,7 +29,7 @@ struct vine_worker_info **vine_file_replica_table_find_replication_targets(struc
 
 int vine_file_replica_table_exists_somewhere( struct vine_manager *q, const char *cachename );
 
-int vine_file_replica_table_count_replicas( struct vine_manager *q, const char *cachename );
+int vine_file_replica_table_count_replicas( struct vine_manager *q, const char *cachename, vine_file_replica_state_t state );
 
 
 #endif

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -269,7 +269,7 @@ static void handle_worker_timeout(struct vine_manager *q, struct vine_worker_inf
 	// debug(D_VINE, "Handling timeout request");
 	HASH_TABLE_ITERATE(w->current_files, cachename, replica)
 	{
-		if (strncmp(cachename, "temp-rnd-", 9) == 0) {
+		if (replica->type == VINE_TEMP) {
 			int c = vine_file_replica_table_count_replicas(q, cachename, VINE_FILE_REPLICA_STATE_READY);
 			if (c == 1) {
 				debug(D_VINE,

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -269,10 +269,8 @@ static void handle_worker_timeout(struct vine_manager *q, struct vine_worker_inf
 	// debug(D_VINE, "Handling timeout request");
 	HASH_TABLE_ITERATE(w->current_files, cachename, replica)
 	{
-		//	debug(D_VINE, "Looking at file %s", cachename);
 		if (strncmp(cachename, "temp-rnd-", 9) == 0) {
-			int c = vine_file_replica_table_count_replicas(q, cachename);
-			//		debug(D_VINE, "Temp file found with %d replicas", c);
+			int c = vine_file_replica_table_count_replicas(q, cachename, VINE_FILE_REPLICA_STATE_READY);
 			if (c == 1) {
 				debug(D_VINE,
 						"Rejecting timeout request from worker %s (%s). Has unique file %s",


### PR DESCRIPTION
If we restrict the check for replica availability only for replicas that are ready, then multiple recovery tasks for the same file are created.

This commit simply checks if there is a replica somewhere, even if it just in a pending state.

This means that #3692 is not fixed.

## Proposed changes

Please describe your changes (e.g., what problems they attempt to solve, what results are expected, etc.) Additional motivation and context are welcome.
Please also mention relevant issues and pull requests as appropriate.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
