### PR TITLE
configure: turn on max debug symbols with --debug

### DIFF
--- a/configure
+++ b/configure
@@ -1345,7 +1345,16 @@ ccflags_append_define \
 	"_GNU_SOURCE" \
 	"_REENTRANT"
 
-debug_flags="-g"
+# If debug flag is on, turn on compiler for debugging experience.
+if [ "$optdebug" = 1 ]; then
+	debug_flags=" -g3 -O3 -ggdb3 "
+else
+	# Appending "-Og" to various compiler flags to have some optimizations and
+	# still be able to debug in most cases.
+	# "-O0" is a common but suboptimal choice.
+	debug_flags=" -g -Og "
+fi
+
 ccflags_append "$debug_flags"
 ldflags="${ldflags} ${debug_flags}"
 
@@ -1432,17 +1441,6 @@ then
 		echo "*** building inside a conda environment without linking static openssl."
 		echo "*** probably this is not what you want. binaries may not work outside the environment"
 	fi
-fi
-
-# If debug flag is on, turn on compiler optimization for debugging experience.
-# Appending "-Og" to various compiler flags ensures that.
-# Only applied to base cctools flags.
-# "-O0" is a common but suboptimal choice.
-if [ "$optdebug" = 1 ]; then
-	ccflags+=" -Og "
-	internal_ccflags+=" -Og "
-	c_only_flags+=" -Og "
-	
 fi
 
 cat <<EOF >>config.mk

--- a/configure
+++ b/configure
@@ -1352,7 +1352,7 @@ else
 	# Appending "-Og" to various compiler flags to have some optimizations and
 	# still be able to debug in most cases.
 	# "-O0" is a common but suboptimal choice.
-	debug_flags=" -g -Og "
+	debug_flags=" -g "
 fi
 
 ccflags_append "$debug_flags"

--- a/parrot/src/pfs_service_cvmfs.cc
+++ b/parrot/src/pfs_service_cvmfs.cc
@@ -1136,7 +1136,7 @@ static bool path_expand_symlink(struct pfs_name *path, struct pfs_name *xpath)
 
 	memcpy(xpath, path, sizeof(pfs_name));
 	xpath->rest[0] = '\0';
-	strncpy(path_tail, path->rest, PFS_PATH_MAX);
+	strncpy(path_tail, path->rest, PFS_PATH_MAX - 1);
 
 	do
 	{
@@ -1175,9 +1175,9 @@ static bool path_expand_symlink(struct pfs_name *path, struct pfs_name *xpath)
 					char path_relative[PFS_PATH_MAX];
 					*(last_d + 1) = '\0';
 
-					strncat(xpath->rest, link_target, PFS_PATH_MAX);
+					strncat(xpath->rest, link_target, PFS_PATH_MAX - 1);
 					path_collapse(xpath->rest, path_relative, 1);
-					string_nformat(link_target, PFS_PATH_MAX, "/cvmfs/%s%s",
+					string_nformat(link_target, PFS_PATH_MAX - 1, "/cvmfs/%s%s",
 						 xpath->host, path_relative);
 				}
 			}


### PR DESCRIPTION
Previous --debug only turned on optimizations that could be used with debug. Traditionally we always included debugging symbols.

## Proposed changes

Please describe your changes (e.g., what problems they attempt to solve, what results are expected, etc.) Additional motivation and context are welcome.
Please also mention relevant issues and pull requests as appropriate.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
