### PR TITLE
vine: record replicas in transit

### DIFF
--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -151,12 +151,12 @@ int vine_file_replica_table_replicate(struct vine_manager *m, struct vine_file *
 		int offset_bookkeep;
 		HASH_TABLE_ITERATE_RANDOM_START(m->worker_table, offset_bookkeep, id, peer)
 		{
-			/* XXX: commenting this check for now, as otherwise only one replica is created.
-			 * We need to create replicas during wait_internal too.
 			if (found_per_source >= MIN(m->file_source_max_transfers, to_find)) {
-				break;
+				/* XXX: commenting this check for now, as otherwise only one replica is created.
+				 * We need to create replicas during wait_internal too.
+					break;
+				*/
 			}
-			*/
 
 			if (source_in_use >= m->worker_source_max_transfers) {
 				break;

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -182,9 +182,6 @@ int vine_file_replica_table_replicate(struct vine_manager *m, struct vine_file *
 
 			vine_manager_put_url_now(m, peer, source_addr, f);
 
-			replica = vine_file_replica_create(f->type, f->cache_level, f->size, f->mtime);
-			vine_file_replica_table_insert(m, peer, f->cached_name, replica);
-
 			source_in_use++;
 			found_per_source++;
 			found++;

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -10,11 +10,13 @@ See the file COPYING for details.
 #include "vine_file.h"
 #include "vine_file_replica.h"
 #include "vine_manager.h"
+#include "vine_manager_put.h"
 #include "vine_worker_info.h"
 
 #include "stringtools.h"
 
 #include "debug.h"
+#include "macros.h"
 
 // add a file to the remote file table.
 int vine_file_replica_table_insert(struct vine_manager *m, struct vine_worker_info *w, const char *cachename,
@@ -107,49 +109,93 @@ struct vine_worker_info *vine_file_replica_table_find_worker(struct vine_manager
 	return peer_selected;
 }
 
-// return an array of up to q->temp_replica_count workers that do not have the file cachename
-// and are not on the same host as worker w.
-struct vine_worker_info **vine_file_replica_table_find_replication_targets(
-		struct vine_manager *q, struct vine_worker_info *w, const char *cachename, int *count)
+// trigger replications of file to satisfy temp_replica_count
+int vine_file_replica_table_replicate(struct vine_manager *m, struct vine_file *f)
 {
-	char *id;
-	struct vine_worker_info *peer;
-	struct vine_file_replica *replica;
-
 	int found = 0;
 
-	struct set *workers = hash_table_lookup(q->file_worker_table, cachename);
-	struct vine_worker_info **filtered = malloc(sizeof(struct vine_worker_info) * (q->temp_replica_count));
-
-	if (!workers) {
-		*count = 0;
-		return filtered;
+	struct set *sources = hash_table_lookup(m->file_worker_table, f->cached_name);
+	if (!sources) {
+		return found;
 	}
 
-	// some random distribution
-	int offset_bookkeep;
-	HASH_TABLE_ITERATE_RANDOM_START(q->worker_table, offset_bookkeep, id, peer)
-	{
-		if (found == q->temp_replica_count)
+	int to_find = m->temp_replica_count - set_size(sources);
+	if (to_find < 1) {
+		return found;
+	}
+
+	/* get the elements of set so we can insert new replicas to sources */
+	struct vine_worker_info **sources_frozen = (struct vine_worker_info **)set_values(sources);
+	struct vine_worker_info *source;
+
+	int i = 0;
+	int nsources = set_size(sources);
+	for (source = sources_frozen[i]; i < nsources; i++) {
+		if (found >= to_find) {
 			break;
-		if (!peer->transfer_port_active)
-			continue;
-
-		char *peer_addr = string_format("worker://%s:%d", peer->transfer_addr, peer->transfer_port);
-		if (!(replica = hash_table_lookup(peer->current_files, cachename)) &&
-				(strcmp(w->hostname, peer->hostname))) {
-			if ((vine_current_transfers_worker_in_use(q, peer_addr) < q->worker_source_max_transfers) &&
-					(vine_current_transfers_dest_in_use(q, peer) <
-							q->worker_source_max_transfers)) {
-				debug(D_VINE, "found replication target : %s", peer->transfer_addr);
-				filtered[found] = peer;
-				found++;
-			}
 		}
-		free(peer_addr);
+
+		int found_per_source = 0;
+
+		struct vine_file_replica *replica = hash_table_lookup(source->current_files, f->cached_name);
+		if (!replica || replica->state != VINE_FILE_REPLICA_STATE_READY) {
+			continue;
+		}
+
+		char *source_addr = string_format(
+				"worker://%s:%d/%s", source->transfer_addr, source->transfer_port, f->cached_name);
+		int source_in_use = vine_current_transfers_worker_in_use(m, source_addr);
+
+		char *id;
+		struct vine_worker_info *peer;
+		int offset_bookkeep;
+		HASH_TABLE_ITERATE_RANDOM_START(m->worker_table, offset_bookkeep, id, peer)
+		{
+			/* XXX: commenting this check for now, as otherwise only one replica is created.
+			 * We need to create replicas during wait_internal too.
+			if (found_per_source >= MIN(m->file_source_max_transfers, to_find)) {
+				break;
+			}
+			*/
+
+			if (source_in_use >= m->worker_source_max_transfers) {
+				break;
+			}
+
+			if (!peer->transfer_port_active) {
+				continue;
+			}
+
+			if (set_lookup(sources, peer)) {
+				continue;
+			}
+
+			if (vine_current_transfers_dest_in_use(m, peer) >= m->worker_source_max_transfers) {
+				continue;
+			}
+
+			if (strcmp(source->hostname, peer->hostname) == 0) {
+				continue;
+			}
+
+			debug(D_VINE, "replicating %s from %s to %s", f->cached_name, source->addrport, peer->addrport);
+
+			vine_manager_put_url_now(m, peer, source_addr, f);
+
+			replica = vine_file_replica_create(f->type, f->cache_level, f->size, f->mtime);
+			vine_file_replica_table_insert(m, peer, f->cached_name, replica);
+
+			source_in_use++;
+			found_per_source++;
+			found++;
+		}
+
+		free(source_addr);
 	}
-	*count = found;
-	return filtered;
+
+	free(sources_frozen);
+
+	return found;
 }
 
 /*

--- a/taskvine/src/manager/vine_file_replica_table.h
+++ b/taskvine/src/manager/vine_file_replica_table.h
@@ -25,7 +25,7 @@ struct vine_file_replica *vine_file_replica_table_lookup(struct vine_worker_info
 
 struct vine_worker_info *vine_file_replica_table_find_worker(struct vine_manager *q, const char *cachename);
 
-struct vine_worker_info **vine_file_replica_table_find_replication_targets(struct vine_manager *q, struct vine_worker_info *w, const char *cachename, int *count);
+int vine_file_replica_table_replicate(struct vine_manager *q, struct vine_file *f);
 
 int vine_file_replica_table_exists_somewhere( struct vine_manager *q, const char *cachename );
 

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -243,7 +243,7 @@ vine_result_code_t vine_manager_put_url_now(
 	url_encode(f->cached_name, cached_name_encoded, sizeof(cached_name_encoded));
 
 	char *transfer_id = vine_current_transfers_add(q, w, source);
-	int result = vine_manager_send(q,
+	vine_manager_send(q,
 			w,
 			"puturl_now %s %s %d %lld 0%o %s\n",
 			source_encoded,
@@ -253,14 +253,11 @@ vine_result_code_t vine_manager_put_url_now(
 			mode,
 			transfer_id);
 
-	if (result == VINE_SUCCESS) {
-		struct vine_file_replica *replica =
-				vine_file_replica_create(f->type, f->cache_level, f->size, f->mtime);
-		vine_file_replica_table_insert(q, w, f->cached_name, replica);
-	}
+	struct vine_file_replica *replica = vine_file_replica_create(f->type, f->cache_level, f->size, f->mtime);
+	vine_file_replica_table_insert(q, w, f->cached_name, replica);
 
 	free(transfer_id);
-	return result;
+	return VINE_SUCCESS;
 }
 
 /*
@@ -290,7 +287,7 @@ vine_result_code_t vine_manager_put_url(
 	url_encode(f->cached_name, cached_name_encoded, sizeof(cached_name_encoded));
 
 	char *transfer_id = vine_current_transfers_add(q, w, f->source);
-	vine_result_code_t result = vine_manager_send(q,
+	vine_manager_send(q,
 			w,
 			"puturl %s %s %d %lld 0%o %s\n",
 			source_encoded,
@@ -300,14 +297,11 @@ vine_result_code_t vine_manager_put_url(
 			mode,
 			transfer_id);
 
-	if (result == VINE_SUCCESS) {
-		struct vine_file_replica *replica =
-				vine_file_replica_create(f->type, f->cache_level, f->size, f->mtime);
-		vine_file_replica_table_insert(q, w, f->cached_name, replica);
-	}
+	struct vine_file_replica *replica = vine_file_replica_create(f->type, f->cache_level, f->size, f->mtime);
+	vine_file_replica_table_insert(q, w, f->cached_name, replica);
 
 	free(transfer_id);
-	return result;
+	return VINE_SUCCESS;
 }
 
 /* Send a buffer object to the remote worker. */

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -226,6 +226,12 @@ message once the object is actually loaded into the cache.
 vine_result_code_t vine_manager_put_url_now(
 		struct vine_manager *q, struct vine_worker_info *w, const char *source, struct vine_file *f)
 {
+	if (vine_file_replica_table_lookup(w, f->cached_name)) {
+		/* do nothing, file already at worker */
+		debug(D_NOTICE, "cannot puturl_now %s at %s. Already at worker.", f->cached_name, w->addrport);
+		return VINE_SUCCESS;
+	}
+
 	/* XXX The API does not allow the user to choose the mode bits of the target file, so we make it permissive
 	 * here.*/
 	int mode = 0755;
@@ -247,6 +253,12 @@ vine_result_code_t vine_manager_put_url_now(
 			mode,
 			transfer_id);
 
+	if (result == VINE_SUCCESS) {
+		struct vine_file_replica *replica =
+				vine_file_replica_create(f->type, f->cache_level, f->size, f->mtime);
+		vine_file_replica_table_insert(q, w, f->cached_name, replica);
+	}
+
 	free(transfer_id);
 	return result;
 }
@@ -261,6 +273,12 @@ message once the object is actually loaded into the cache.
 vine_result_code_t vine_manager_put_url(
 		struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct vine_file *f)
 {
+	if (vine_file_replica_table_lookup(w, f->cached_name)) {
+		/* do nothing, file already at worker */
+		debug(D_NOTICE, "cannot puturl %s at %s. Already at worker.", f->cached_name, w->addrport);
+		return VINE_SUCCESS;
+	}
+
 	/* XXX The API does not allow the user to choose the mode bits of the target file, so we make it permissive
 	 * here.*/
 	int mode = 0755;
@@ -272,7 +290,7 @@ vine_result_code_t vine_manager_put_url(
 	url_encode(f->cached_name, cached_name_encoded, sizeof(cached_name_encoded));
 
 	char *transfer_id = vine_current_transfers_add(q, w, f->source);
-	vine_manager_send(q,
+	vine_result_code_t result = vine_manager_send(q,
 			w,
 			"puturl %s %s %d %lld 0%o %s\n",
 			source_encoded,
@@ -282,8 +300,14 @@ vine_result_code_t vine_manager_put_url(
 			mode,
 			transfer_id);
 
+	if (result == VINE_SUCCESS) {
+		struct vine_file_replica *replica =
+				vine_file_replica_create(f->type, f->cache_level, f->size, f->mtime);
+		vine_file_replica_table_insert(q, w, f->cached_name, replica);
+	}
+
 	free(transfer_id);
-	return VINE_SUCCESS;
+	return result;
 }
 
 /* Send a buffer object to the remote worker. */
@@ -493,6 +517,17 @@ This allows it to be used for both regular tasks and mini tasks.
 vine_result_code_t vine_manager_put_task(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t,
 		const char *command_line, struct rmsummary *limits, struct vine_file *target)
 {
+	if (target) {
+		if (vine_file_replica_table_lookup(w, target->cached_name)) {
+			/* do nothing, file already at worker */
+			debug(D_NOTICE,
+					"cannot put mini_task %s at %s. Already at worker.",
+					target->cached_name,
+					w->addrport);
+			return VINE_SUCCESS;
+		}
+	}
+
 	vine_result_code_t result = vine_manager_put_input_files(q, w, t);
 	if (result != VINE_SUCCESS)
 		return result;
@@ -595,6 +630,12 @@ vine_result_code_t vine_manager_put_task(struct vine_manager *q, struct vine_wor
 
 	int r = vine_manager_send(q, w, "end\n");
 	if (r >= 0) {
+		if (target) {
+			struct vine_file_replica *replica = vine_file_replica_create(
+					target->type, target->cache_level, target->size, target->mtime);
+			vine_file_replica_table_insert(q, w, target->cached_name, replica);
+		}
+
 		return VINE_SUCCESS;
 	} else {
 		return VINE_WORKER_FAILURE;


### PR DESCRIPTION
Adds pending replicas to the replica table. It also is able to choose different sources for the file, so that we can call this function somewhere in wait_internal to ensure the required number of replicas. (We need to discuss how to do that step efficiently.)

Commented out is the check for file_max_source_transfers, otherwise only one replica is created.

@colinthomas-z80 This one fixes the bug in #3714 for the current release. It conflicts with #3709 because it uses the functions that check for the number of replicas, but I think this should be minor conflicts.


## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
