### PR TITLE
S3: Fix use of HMAC_CTX

### DIFF
--- a/dttools/src/s3_file_io.c
+++ b/dttools/src/s3_file_io.c
@@ -422,17 +422,17 @@ static int s3_do_check ( char * const signature,
 
 static char* __aws_sign ( char * const str )
 {
-  HMAC_CTX ctx;
+  HMAC_CTX *ctx;
   unsigned char MD[256];
   unsigned len;
 
   __debug("StrToSign:%s", str );
 
-  HMAC_CTX_init(&ctx);
-  HMAC_Init(&ctx, awsKey, strlen(awsKey), EVP_sha1());
-  HMAC_Update(&ctx,(unsigned char*)str, strlen(str));
-  HMAC_Final(&ctx,(unsigned char*)MD,&len);
-  HMAC_CTX_cleanup(&ctx);
+  ctx = HMAC_CTX_new();
+  HMAC_Init(ctx, awsKey, strlen(awsKey), EVP_sha1());
+  HMAC_Update(ctx,(unsigned char*)str, strlen(str));
+  HMAC_Final(ctx,(unsigned char*)MD,&len);
+  HMAC_CTX_free(ctx);
 
   char * b64 = __b64_encode (MD,len);
   __debug("Signature:  %s", b64 );


### PR DESCRIPTION
s3_file_io.c used an older code pattern of allocating HMAC_CTX on the stack,
and the current practice in SSL is to instead use HMAC_CTX_new/free.

Note that this module has a number of other code smells that I am not cleaning up at this moment.
Also, it was not compiled in CI due to the lack of lib curl.

## Proposed changes

Please describe your changes (e.g., what problems they attempt to solve, what results are expected, etc.) Additional motivation and context are welcome.
Please also mention relevant issues and pull requests as appropriate.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
