### PR TITLE
dttools: add hash iteration from a given key

### DIFF
--- a/dttools/src/Makefile
+++ b/dttools/src/Makefile
@@ -192,7 +192,7 @@ PROGRAMS = $(MOST_PROGRAMS) catalog_query
 
 SCRIPTS = cctools_gpu_autodetect
 TARGETS = $(LIBRARIES) $(PRELOAD_LIBRARIES) $(PROGRAMS) $(TEST_PROGRAMS)
-TEST_PROGRAMS = auth_test disk_alloc_test jx_test microbench multirun jx_count_obj_test jx_canonicalize_test jx_merge_test hash_table_offset_test histogram_test category_test jx_binary_test mq_poll_test mq_wait_test mq_store_test bucketing_base_test bucketing_manager_test
+TEST_PROGRAMS = auth_test disk_alloc_test jx_test microbench multirun jx_count_obj_test jx_canonicalize_test jx_merge_test hash_table_offset_test hash_table_fromkey_test histogram_test category_test jx_binary_test mq_poll_test mq_wait_test mq_store_test bucketing_base_test bucketing_manager_test
 
 all: $(TARGETS) catalog_query
 

--- a/dttools/src/hash_table.c
+++ b/dttools/src/hash_table.c
@@ -218,6 +218,29 @@ void *hash_table_remove(struct hash_table *h, const char *key)
 	return 0;
 }
 
+int hash_table_fromkey(struct hash_table *h, const char *key)
+{
+	if (!key) {
+		/* treat NULL as a special case equivalent to firstkey */
+		hash_table_firstkey(h);
+		return 1;
+	}
+
+	unsigned hash = h->hash_func(key);
+	h->ibucket = hash % h->bucket_count;
+	h->ientry = h->buckets[h->ibucket];
+
+	while (h->ientry) {
+		if (hash == h->ientry->hash && !strcmp(key, h->ientry->key)) {
+			return 1;
+		}
+		h->ientry = h->ientry->next;
+	}
+
+	hash_table_firstkey(h);
+	return 0;
+}
+
 void hash_table_firstkey(struct hash_table *h)
 {
 	h->ientry = 0;

--- a/dttools/src/hash_table.h
+++ b/dttools/src/hash_table.h
@@ -138,6 +138,17 @@ This function returns the next key and value in the iteration.
 
 int hash_table_nextkey_with_offset(struct hash_table *h, int offset_bookkeep, char **key, void **value);
 
+/** Begin iteration at the given key.
+Invoke @ref hash_table_nextkey to retrieve each value in order.
+Note that subsequent calls to this functions may result in different iteration orders as the hash_table may have been
+resized.
+@param h A pointer to a hash table.
+@param key A string key to search for.
+@return Zero if key not in hash table, one otherwise.
+*/
+
+int hash_table_fromkey(struct hash_table *h, const char *key);
+
 /** A default hash function.
 @param s A string to hash.
 @return An integer hash of the string.
@@ -162,5 +173,11 @@ HASH_TABLE_ITERATE(table,key,value) {
 #define HASH_TABLE_ITERATE( table, key, value ) hash_table_firstkey(table); while(hash_table_nextkey(table,&key,(void**)&value))
 
 #define HASH_TABLE_ITERATE_RANDOM_START( table, offset_bookkeep, key, value ) hash_table_randomkey(table, &offset_bookkeep); while(hash_table_nextkey_with_offset(table, offset_bookkeep, &key, (void **)&value))
+
+#define HASH_TABLE_ITERATE_FROM_KEY( table, iter_control, iter_count_var, key_start, key, value ) \
+	iter_control = 0; \
+	iter_count_var = 0; \
+  hash_table_fromkey(table, key_start); \
+	while(iter_count_var < hash_table_size(table) && (iter_count_var+=1 && (hash_table_nextkey(table, &key, (void **)&value) || (!iter_control && (iter_control+=1) && hash_table_fromkey(table, NULL) && hash_table_nextkey(table, &key, (void **)&value)))))
 
 #endif

--- a/dttools/src/hash_table_fromkey_test.c
+++ b/dttools/src/hash_table_fromkey_test.c
@@ -1,0 +1,83 @@
+/*
+Copyright (C) 2024 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include "hash_table.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+struct boxed_int {
+	int value;
+};
+
+int main(int argc, char **argv) {
+
+	struct hash_table *h = hash_table_create(0, 0);
+
+	char i;
+	char *name = malloc(2 * sizeof(char));
+	struct boxed_int *box;
+	name[1] = '\0';
+
+	int total_sum = 0;
+
+	for (i = 0; i < 11; i++) {
+		name[0] = 65 + i;
+		box = malloc(sizeof(struct boxed_int));
+		box->value = i;
+		total_sum += i;
+
+		hash_table_insert(h, name, box);
+	}
+
+	int start;
+	char *key_start = malloc(2 * sizeof(char));
+	for (start = 0; start < 11; start++) {
+		key_start[0] = 65 + start;
+
+		box = hash_table_lookup(h, key_start);
+		if (!box) {
+			return 1;
+		}
+
+		if (box->value != start) {
+			return 1;
+		}
+
+		hash_table_fromkey(h, key_start);
+		if(!hash_table_nextkey(h, (char **)&name, (void **)&box)) {
+			return 1;
+		}
+
+		if (box->value == start) {
+			fprintf(stdout, "correct value from start %s: %d == %d\n", key_start, start, box->value);
+		}
+		else {
+			fprintf(stdout, "incorrect value from start %s: %d == %d\n", key_start, start, box->value);
+			return 1;
+		}
+
+		int current_sum = 0;
+		int iter_control, iter_count_var;
+
+		HASH_TABLE_ITERATE_FROM_KEY( h, iter_control, iter_count_var, key_start, name, box ) {
+			current_sum += box->value;
+			fprintf(stdout, "partial sum from %s: %d, added %s %d\n", key_start, current_sum, name, box->value);
+		}
+
+		if (current_sum == total_sum) {
+			fprintf(stdout, "correct sum from %s: %d == %d\n", key_start, current_sum, total_sum);
+		} else {
+			fprintf(stdout, "error in sum from %s: %d != %d\n", key_start, current_sum, total_sum);
+			return 1;
+		}
+	}
+
+	hash_table_delete(h);
+
+	return 0;
+}

--- a/dttools/test/TR_hash_table_fromkey.sh
+++ b/dttools/test/TR_hash_table_fromkey.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+. ../../dttools/test/test_runner_common.sh
+
+prepare()
+{
+	return 0
+}
+
+run()
+{
+	../src/hash_table_fromkey_test
+}
+
+clean()
+{
+	return 0
+}
+
+dispatch "$@"
+
+# vim: set noexpandtab tabstop=4:


### PR DESCRIPTION
Allows to start iteration from a given key in a hash table. (See example test).
It should be useful when want to restart iterations on a hash without checking every element. (E.g. schedule depth for file replicas.)

```C
		int iter_control, iter_count_var;
		HASH_TABLE_ITERATE_FROM_KEY( h, iter_control, iter_count_var, key_start, name, box ) {
```

Please describe your changes (e.g., what problems they attempt to solve, what results are expected, etc.) Additional motivation and context are welcome.
Please also mention relevant issues and pull requests as appropriate.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
