### PR TITLE
vine: temp fix, worker does not fail on repeated put_url

### DIFF
--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -282,7 +282,7 @@ int vine_cache_add_transfer(struct vine_cache *c, const char *cachename, const c
 	struct vine_cache_file *f = hash_table_lookup(c->table, cachename);
 	if (f) {
 		/* The transfer is already queued up. */
-		return 0;
+		return 1;
 	}
 
 	/* Create the object and fill in the metadata. */


### PR DESCRIPTION
This commit should be reverted once we track all the places that trigger a put url, url_now, or mini_task.

## Proposed changes

Please describe your changes (e.g., what problems they attempt to solve, what results are expected, etc.) Additional motivation and context are welcome.
Please also mention relevant issues and pull requests as appropriate.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
