### PR TITLE
vine: increment peer transfer initial timeout to 60s

### DIFF
--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -463,7 +463,7 @@ static int do_worker_transfer(
 	sscanf(f->source, "worker://%99[^:]:%d/%s", addr, &port_num, source_path);
 	debug(D_VINE, "cache: setting up worker transfer file %s", f->source);
 
-	stoptime = time(0) + 15;
+	stoptime = time(0) + 60;
 	worker_link = link_connect(addr, port_num, stoptime);
 
 	if (worker_link == NULL) {


### PR DESCRIPTION
In some runs I am getting more than expected cache-invalid messages because the worker couldn't contact the peer. However, the peer is healthy as it subsequently executes tasks and is able to serve as source of files. It seems that the timeout of 15s is a bit harsh.

For duplication of files this is not such a big deal, but for input files (e.g. puturl), these failures are expensive as the rest of the input files of the respective tasks are cleaned up.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
