### PR TITLE
vine: move retry logic into a proper place

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1178,9 +1178,10 @@ limit on the number of retries:
     vine_set_retries(t, 5)
     ```
 
-When a task cannot be completed in the set number of tries,
-then the task result is set to `"max retries"` in python and
-`VINE_RESULT_MAX_RETRIES` in C.
+When a task cannot be completed in the set number of tries, then the its result
+is set to the result of the last attempt (e.g. `"resource exhaustion"` in python,
+or `VINE_RESULT_RESOURCE_EXHAUSTION` in C).
+
 
 ### Pipelined Submission
 

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -91,7 +91,7 @@ typedef enum {
 	VINE_RESULT_MAX_END_TIME        = 3 << 3, /**< The task ran after the specified (absolute since epoch) end time. **/
 	VINE_RESULT_UNKNOWN             = 4 << 3, /**< The result could not be classified. **/
 	VINE_RESULT_FORSAKEN            = 5 << 3, /**< The task failed, but it was not a task error **/
-	VINE_RESULT_MAX_RETRIES         = 6 << 3, /**< The task could not be completed successfully in the given number of retries. **/
+	VINE_RESULT_MAX_RETRIES         = 6 << 3, /**< Currently unused. **/
 	VINE_RESULT_MAX_WALL_TIME       = 7 << 3, /**< The task ran for more than the specified time (relative since running in a worker). **/
 	VINE_RESULT_RMONITOR_ERROR      = 8 << 3, /**< The task failed because the monitor did not produce a summary report. **/
 	VINE_RESULT_OUTPUT_TRANSFER_ERROR = 9 << 3,  /**< The task failed because an output could be transfered to the manager (not enough disk space, incorrect write permissions. */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -1133,14 +1133,11 @@ static int expire_waiting_tasks(struct vine_manager *q)
 			list_remove(q->ready_list, t);
 			change_task_state(q, t, VINE_TASK_RETRIEVED);
 			expired++;
-		} else if (t->max_retries > 0 && t->try_count > t->max_retries) {
-			vine_task_set_result(t, VINE_RESULT_MAX_RETRIES);
-			list_remove(q->ready_list, t);
-			change_task_state(q, t, VINE_TASK_RETRIEVED);
-			expired++;
 		}
+
 		tasks_considered++;
 	}
+
 	return expired;
 }
 
@@ -2741,15 +2738,31 @@ static int resubmit_task_on_exhaustion(struct vine_manager *q, struct vine_worke
 
 static int resubmit_if_needed(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
 {
+	/* in this function, any change_task_state should only be to VINE_TASK_READY */
+
+	if (t->result == VINE_RESULT_FORSAKEN) {
+		/* forsaken tasks are always resubmitted. they also get a retry back as they are victims of circumstance
+		 */
+		t->try_count -= 1;
+		change_task_state(q, t, VINE_TASK_READY);
+		return 1;
+	}
+
+	if (t->max_retries > 0 && t->try_count > t->max_retries) {
+		/* XXX: should task be returned with the last result or with max retries? */
+		// vine_task_set_result(t, VINE_RESULT_MAX_RETRIES);
+		return 0;
+	}
+
+	/* special handlings per result. note that most results are terminal, that is tasks are not retried even if they
+	 * have not reached max_retries. max_retries is only used for transient errors, or for modified tasks (such as a
+	 * change in the resource request). */
 	switch (t->result) {
 	case VINE_RESULT_RESOURCE_EXHAUSTION:
 		return resubmit_task_on_exhaustion(q, w, t);
 		break;
-	case VINE_RESULT_FORSAKEN:
-		change_task_state(q, t, VINE_TASK_READY);
-		return 1;
-		break;
 	default:
+		/* by default tasks are not resumitted */
 		return 0;
 	}
 }

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2749,8 +2749,7 @@ static int resubmit_if_needed(struct vine_manager *q, struct vine_worker_info *w
 	}
 
 	if (t->max_retries > 0 && t->try_count > t->max_retries) {
-		/* XXX: should task be returned with the last result or with max retries? */
-		// vine_task_set_result(t, VINE_RESULT_MAX_RETRIES);
+		// tasks returns to user with the VINE_RESULT_* of the last attempt
 		return 0;
 	}
 


### PR DESCRIPTION
Before it was with the exhausted tasks check. This made sense at the time because it was only used for exhausted resources. It is likely we soon we will use it more for transient failures, etc.

## Proposed changes

Please describe your changes (e.g., what problems they attempt to solve, what results are expected, etc.) Additional motivation and context are welcome.
Please also mention relevant issues and pull requests as appropriate.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
