### PR TITLE
vine: adds --spool to vine_submit_workers -T condor

### DIFF
--- a/taskvine/src/tools/vine_submit_workers
+++ b/taskvine/src/tools/vine_submit_workers
@@ -28,6 +28,7 @@ condor_show_help()
     echo "  -r,--requirements <reqs>  Condor requirements expression."
     echo "  --class-ad <ad>           Extra condor class ad. May be specified multiple times."
     echo "  --autosize                Condor will automatically size the worker to the slot."
+    echo "  --spool                   Spool required input files."
     echo "  --docker-universe <image> Run worker inside <image> using condor's docker universe."
     echo ""
 }
@@ -130,6 +131,10 @@ condor_parse_arguments()
                 disk="ifThenElse($disk > TotalSlotDisk, $disk, TotalSlotDisk)"
             ;;
 
+            --spool)
+            spool="--spool"
+            ;;
+
             --docker-universe)
             shift
             docker_universe="$1"
@@ -211,7 +216,7 @@ EOF
 
     echo "queue $count" >> condor_submit_file
 
-    condor_submit condor_submit_file
+    condor_submit ${spool} condor_submit_file
 }
 
 # SLURM specific


### PR DESCRIPTION
This allows to submit workers inside a docker image that does not share a directory with the host. Per condor_submit documentation:

    Spool all required input files, job event log, and proxy over the
    connection to the condor_schedd. After submission, modify local
    copies of the files without affecting your jobs. Any output files
    for completed jobs need to be retrieved with condor_transfer_data.

This won't work immediately with the factory, as the condor log file needs to be manually transfered back with condor_transfer_data clusterid.jobid

Solves #3715 for coffea-casa.

## Proposed changes

Please describe your changes (e.g., what problems they attempt to solve, what results are expected, etc.) Additional motivation and context are welcome.
Please also mention relevant issues and pull requests as appropriate.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
