### PR TITLE
Vine: Support more thread limits.

### DIFF
--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -177,6 +177,10 @@ static void set_resources_vars(struct vine_process *p)
 	if (p->task->resources_requested->cores > 0) {
 		set_integer_env_var(p, "CORES", p->task->resources_requested->cores);
 		set_integer_env_var(p, "OMP_NUM_THREADS", p->task->resources_requested->cores);
+		set_integer_env_var(p, "OPENBLAS_NUM_THREADS", p->task->resources_requested->cores);
+		set_integer_env_var(p, "VECLIB_NUM_THREADS", p->task->resources_requested->cores);
+		set_integer_env_var(p, "MKL_NUM_THREADS", p->task->resources_requested->cores);
+		set_integer_env_var(p, "NUMEXPR_NUM_THREADS", p->task->resources_requested->cores);
 	}
 
 	if (p->task->resources_requested->memory > 0) {


### PR DESCRIPTION
## Proposed changes

Add environment variables to control thread quantity for MKL, VECLIB, BLAS, and NUMEXPR, in addition to the existing OpenMP.  Numpy and other systems may use any or all of these depending on how they were compiled.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
