### PR TITLE
Vine: Forsake functions when library exits.

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -1029,6 +1029,9 @@ static int fetch_output_from_worker(struct vine_manager *q, struct vine_worker_i
 		break;
 	}
 
+	/* Regardless of the exit status, remove the task and sandbox from the worker. */
+	vine_manager_send(q, w, "kill %d\n", t->task_id);
+
 	if (result != VINE_SUCCESS) {
 		debug(D_VINE, "Failed to receive output from worker %s (%s).", w->hostname, w->addrport);
 		t->time_when_last_failure = timestamp_get();

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -1549,6 +1549,17 @@ static vine_result_code_t get_result(struct vine_manager *q, struct vine_worker_
 		}
 	}
 
+	/*
+	A library should not ordinarily exit by any means.
+	If it does, count that as a failure in the original object,
+	which will cause future dispatches of the library to be throttled.
+	*/
+
+	if(t->provides_library) {
+		struct vine_task *original = hash_table_lookup(q->libraries,t->provides_library);
+		if(original) original->time_when_last_failure = timestamp_get();
+	}
+	
 	itable_remove(q->running_table, t->task_id);
 	change_task_state(q, t, VINE_TASK_WAITING_RETRIEVAL);
 

--- a/taskvine/src/manager/vine_manager_get.c
+++ b/taskvine/src/manager/vine_manager_get.c
@@ -489,9 +489,6 @@ vine_result_code_t vine_manager_get_output_files(
 		}
 	}
 
-	// tell the worker you no longer need that task's output directory.
-	vine_manager_send(q, w, "kill %d\n", t->task_id);
-
 	return result;
 }
 
@@ -517,9 +514,6 @@ vine_result_code_t vine_manager_get_monitor_output_file(
 			}
 		}
 	}
-
-	// tell the worker you no longer need that task's output directory.
-	vine_manager_send(q, w, "kill %d\n", t->task_id);
 
 	return result;
 }

--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -591,16 +591,17 @@ vine_cache_status_t vine_cache_ensure(struct vine_cache *c, const char *cachenam
 	struct vine_cache_file *f = hash_table_lookup(c->table, cachename);
 	if (!f) {
 		debug(D_VINE, "cache: %s is unknown, perhaps it failed to transfer earlier?", cachename);
-		return VINE_CACHE_STATUS_FAILED;
+		return VINE_CACHE_STATUS_UNKNOWN;
 	}
 
 	switch (f->status) {
-	case VINE_CACHE_STATUS_READY:
-	case VINE_CACHE_STATUS_FAILED:
 	case VINE_CACHE_STATUS_PROCESSING:
 	case VINE_CACHE_STATUS_TRANSFERRED:
+	case VINE_CACHE_STATUS_READY:
+	case VINE_CACHE_STATUS_FAILED:
+	case VINE_CACHE_STATUS_UNKNOWN:
 		return f->status;
-	case VINE_CACHE_STATUS_NOT_PRESENT:
+	case VINE_CACHE_STATUS_PENDING:
 		/* keep going */
 		break;
 	}

--- a/taskvine/src/worker/vine_cache.h
+++ b/taskvine/src/worker/vine_cache.h
@@ -36,11 +36,12 @@ typedef enum {
 } vine_cache_flags_t;
 
 typedef enum {
-	VINE_CACHE_STATUS_NOT_PRESENT,  /**< Not present in cache at all. */
+	VINE_CACHE_STATUS_PENDING,      /**< File is known but does not exist yet. */
 	VINE_CACHE_STATUS_PROCESSING,   /**< Transfer process is running now. */
 	VINE_CACHE_STATUS_TRANSFERRED,  /**< Transfer process complete, not ingested yet. */
 	VINE_CACHE_STATUS_READY,        /**< File is present and ready to use. */
 	VINE_CACHE_STATUS_FAILED,       /**< Transfer process failed. */
+	VINE_CACHE_STATUS_UNKNOWN,      /**< File is not known at all to the cache manager. */
 } vine_cache_status_t;
 
 struct vine_cache * vine_cache_create( const char *cachedir );

--- a/taskvine/src/worker/vine_cache_file.c
+++ b/taskvine/src/worker/vine_cache_file.c
@@ -25,7 +25,7 @@ struct vine_cache_file *vine_cache_file_create(
 	f->source = xxstrdup(source);
 	f->mini_task = mini_task;
 
-	f->status = VINE_CACHE_STATUS_NOT_PRESENT;
+	f->status = VINE_CACHE_STATUS_PENDING;
 
 	/* Remaining items default to zero. */
 	return f;

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -44,17 +44,18 @@ vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cach
 	{
 		vine_cache_status_t cache_status = vine_cache_ensure(cache, m->file->cached_name);
 
-		/* If transfer process is running now. */
-		if (cache_status == VINE_CACHE_STATUS_PROCESSING)
-			processing = 1;
-
-		/* If transfer complete but not ingested. */
-		if (cache_status == VINE_CACHE_STATUS_TRANSFERRED)
-			processing = 1;
-
-		/* If transfer definitely failed. */
-		if (cache_status == VINE_CACHE_STATUS_FAILED)
+		switch(cache_status){
+		case VINE_CACHE_STATUS_PENDING:
+		case VINE_CACHE_STATUS_PROCESSING:
+		case VINE_CACHE_STATUS_TRANSFERRED:	
+			processing++;
+			break;
+		case VINE_CACHE_STATUS_READY:
+			break;
+		case VINE_CACHE_STATUS_UNKNOWN:
+		case VINE_CACHE_STATUS_FAILED:
 			return VINE_CACHE_STATUS_FAILED;
+		}
 	}
 
 	if (processing) {

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -44,10 +44,10 @@ vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cach
 	{
 		vine_cache_status_t cache_status = vine_cache_ensure(cache, m->file->cached_name);
 
-		switch(cache_status){
+		switch (cache_status) {
 		case VINE_CACHE_STATUS_PENDING:
 		case VINE_CACHE_STATUS_PROCESSING:
-		case VINE_CACHE_STATUS_TRANSFERRED:	
+		case VINE_CACHE_STATUS_TRANSFERRED:
 			processing++;
 			break;
 		case VINE_CACHE_STATUS_READY:

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1263,7 +1263,7 @@ static int task_resources_fit_eventually(struct vine_task *t)
 Find a suitable library process that can provide a slot to run this library right NOW.
 */
 
-static struct vine_process *find_running_library_for_function( const char *library_name)
+static struct vine_process *find_running_library_for_function(const char *library_name)
 {
 	uint64_t task_id;
 	struct vine_process *p;
@@ -1306,7 +1306,7 @@ static int process_ready_to_run_now(struct vine_process *p, struct vine_cache *c
 Find a suitable library process that could serve this function in the future.
 */
 
-static struct vine_process *find_future_library_for_function( const char *library_name )
+static struct vine_process *find_future_library_for_function(const char *library_name)
 {
 	uint64_t task_id;
 	struct vine_process *p;

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1305,7 +1305,7 @@ static int process_ready_to_run_now(struct vine_process *p, struct vine_cache *c
 Return true if this process can run eventually, supposing that other processes will complete.
 */
 
-static int process_can_run_eventually(struct vine_process *p, struct vine_cache *cache, struct link *manager )
+static int process_can_run_eventually(struct vine_process *p, struct vine_cache *cache, struct link *manager)
 {
 	if (!task_resources_fit_eventually(p->task))
 		return 0;
@@ -1317,7 +1317,7 @@ static int process_can_run_eventually(struct vine_process *p, struct vine_cache 
 	}
 
 	vine_cache_status_t status = vine_sandbox_ensure(p, cache, manager);
-	switch(status) {
+	switch (status) {
 	case VINE_CACHE_STATUS_FAILED:
 	case VINE_CACHE_STATUS_UNKNOWN:
 		return 0;


### PR DESCRIPTION
## Proposed changes

Previously, when a library would exit (success or otherwise), two problems resulted:
1 - The function calls sent subsequent to that library would simply sit on the worker doing nothing.
2 - The manager would quickly re-dispatch a library to that same worker, resulting in a tight loop of failures.

This PR fixes these as follows:
1 - The worker now has extended logic for `task_can_fit_eventually` so that functions will be forsaken if there is no library process at all that could execute them.
2 - Forsaken tasks are now handled correctly by deleting their sandboxes once they are retrieved.
3 - The most recent failure of a library is recorded in the library prototype object and used to throttle re-dispatch of failed library tasks.
4 - Fetching of task stdout is factored out of get_result to make the logic of fetching a result more clearly visible.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
