### PR TITLE
vine: remove transfer pairs with sources

### DIFF
--- a/taskvine/src/manager/vine_current_transfers.c
+++ b/taskvine/src/manager/vine_current_transfers.c
@@ -150,7 +150,7 @@ int vine_current_transfers_wipe_worker(struct vine_manager *q, struct vine_worke
 	struct vine_transfer_pair *t;
 	HASH_TABLE_ITERATE(q->current_transfer_table, id, t)
 	{
-		if (t->to == w || t->source_worker == w ) {
+		if (t->to == w || t->source_worker == w) {
 			vine_current_transfers_remove(q, id);
 			removed++;
 		}

--- a/taskvine/src/manager/vine_current_transfers.c
+++ b/taskvine/src/manager/vine_current_transfers.c
@@ -127,16 +127,24 @@ int vine_current_transfers_dest_in_use(struct vine_manager *q, struct vine_worke
 // intentionally
 int vine_current_transfers_wipe_worker(struct vine_manager *q, struct vine_worker_info *w)
 {
+	debug(D_VINE, "Removing instances of worker from transfer table");
+
+	int removed = 0;
+	if (!w) {
+		return removed;
+	}
+
 	char *id;
 	struct vine_transfer_pair *t;
-	debug(D_VINE, "Removing instances of worker from transfer table");
 	HASH_TABLE_ITERATE(q->current_transfer_table, id, t)
 	{
-		if (t->to == w) {
+		if (t->to == w || t->source_worker == w ) {
 			vine_current_transfers_remove(q, id);
+			removed++;
 		}
 	}
-	return 1;
+
+	return removed;
 }
 
 void vine_current_transfers_print_table(struct vine_manager *q)

--- a/taskvine/test/vine_python.py
+++ b/taskvine/test/vine_python.py
@@ -81,6 +81,7 @@ if __name__ == "__main__":
     os.chmod(path.join(test_dir, exec_name), stat.S_IRWXU)
 
     q = vine.Manager(port=0, ssl=(args.ssl_key, args.ssl_cert))
+    q.tune("transient-error-interval", 1)
 
     exec_file = q.declare_file(path.join(test_dir, exec_name), cache=True)
     input_file = q.declare_file(path.join(test_dir, input_name), cache=True)
@@ -281,13 +282,20 @@ if __name__ == "__main__":
     t = q.wait(wait_time)
     report_task(t, "success", 0)
 
-    data = q.fetch_file(temp)
-    if(data == "howdy\n"):
-        print("correct data returned from temp file")
-    else:
-        print("INCORRECT data returned from temp file: {}".format(data))
+    got_file = False
+    for i in range(3):
+        data = q.fetch_file(temp)
+        if data == "howdy\n":
+            print("correct data returned from temp file")
+            got_file = True
+            break
+        else:
+            print("INCORRECT data returned from temp file: {}".format(data))
+            print("Trying again...")
+            time.sleep(1)
+    if not got_file:
         error = True
-    
+
     if error:
         sys.exit(1)
 


### PR DESCRIPTION
Avoid segfault with race condition where source worker disconnects before it can be blamed from a failed transfer.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
