### PR TITLE
vine: fixes to SNI handling (coffea-casa)

### DIFF
--- a/batch_job/src/vine_factory.c
+++ b/batch_job/src/vine_factory.c
@@ -252,7 +252,7 @@ struct list* do_direct_query( const char *manager_host, int manager_port )
 	}
 
 	if(manual_ssl_option) {
-		if(link_ssl_wrap_connect(l) < 1) {
+		if(link_ssl_wrap_connect(l, manager_host) < 1) {
 			fprintf(stderr,"vine_factory: could not setup ssl connection.\n");
 			link_close(l);
 			return 0;

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -255,7 +255,7 @@ struct list* do_direct_query( const char *manager_host, int manager_port )
 	}
 
 	if(manual_ssl_option) {
-		if(link_ssl_wrap_connect(l) < 1) {
+		if(link_ssl_wrap_connect(l, manager_host) < 1) {
 			fprintf(stderr,"work_queue_factory: could not setup ssl connection.\n");
 			link_close(l);
 			return 0;

--- a/doc/man/m4/vine_factory.m4
+++ b/doc/man/m4/vine_factory.m4
@@ -60,6 +60,8 @@ OPTION_FLAG_LONG(parent-death) Exit if parent process dies.
 OPTION_ARG(d,debug,subsystem) Enable debugging for this subsystem.
 OPTION_ARG(o,debug-file,file) Send debugging to this file.
 OPTION_ARG(O,debug-file-size,mb) Specify the size of the debug file.
+OPTION_FLAG_LONG(ssl)Enable tls connection to manager (manager should support it).
+OPTION_ARG_LONG(tls-sni)SNI domain name if different from manager hostname. Implies --ssl.
 OPTION_FLAG(v,version) Show the version string.
 OPTION_FLAG(h,help) Show this screen.
 OPTIONS_END

--- a/doc/man/m4/vine_status.m4
+++ b/doc/man/m4/vine_status.m4
@@ -42,6 +42,8 @@ OPTION_ARG(o, debug-file, file)Send debugging to this file. (can also be :stderr
 OPTION_ARG(O, debug-rotate-max, bytes)Rotate debug file once it reaches this size.
 OPTION_FLAG(v,version)Show vine_status version.
 OPTION_FLAG(h,help)Show this help message.
+OPTION_FLAG_LONG(ssl)Enable tls connection to manager (manager should support it).
+OPTION_ARG_LONG(tls-sni)SNI domain name if different from manager hostname. Implies --ssl.
 OPTIONS_END
 
 SECTION(EXAMPLES)

--- a/doc/man/m4/vine_worker.m4
+++ b/doc/man/m4/vine_worker.m4
@@ -69,6 +69,9 @@ OPTION_ARG_LONG(volatility, chance)Set the percent chance per minute that the wo
 OPTION_ARG_LONG(connection-mode, mode)When using -M, override manager preference to resolve its address. One of by_ip, by_hostname, or by_apparent_ip. Default is set by manager.
 OPTION_ARG_LONG(transfer-port,port) Listening port for worker-worker transfers.  (default: any))
 
+OPTION_FLAG_LONG(ssl)Enable tls connection to manager (manager should support it).
+OPTION_ARG_LONG(tls-sni)SNI domain name if different from manager hostname. Implies --ssl.
+
 OPTIONS_END
 
 SECTION(EXIT STATUS)

--- a/doc/man/md/vine_factory.md
+++ b/doc/man/md/vine_factory.md
@@ -82,6 +82,8 @@ Also configurable through environment variables **CCTOOLS_TEMP** or **TMPDIR**
 - **-d**,**--debug=_&lt;subsystem&gt;_**<br /> Enable debugging for this subsystem.
 - **-o**,**--debug-file=_&lt;file&gt;_**<br /> Send debugging to this file.
 - **-O**,**--debug-file-size=_&lt;mb&gt;_**<br /> Specify the size of the debug file.
+- **--ssl**<br />Enable tls connection to manager (manager should support it).
+- **--tls-sni=_&lt;&gt;_**<br />SNI domain name if different from manager hostname. Implies --ssl.
 - **-v**,**--version**<br /> Show the version string.
 - **-h**,**--help**<br /> Show this screen.
 

--- a/doc/man/md/vine_status.md
+++ b/doc/man/md/vine_status.md
@@ -64,6 +64,8 @@ more detailed information about tasks and workers.
 - **-O**,**--debug-rotate-max=_&lt;bytes&gt;_**<br />Rotate debug file once it reaches this size.
 - **-v**,**--version**<br />Show vine_status version.
 - **-h**,**--help**<br />Show this help message.
+- **--ssl**<br />Enable tls connection to manager (manager should support it).
+- **--tls-sni=_&lt;&gt;_**<br />SNI domain name if different from manager hostname. Implies --ssl.
 
 
 ## EXAMPLES

--- a/doc/man/md/vine_worker.md
+++ b/doc/man/md/vine_worker.md
@@ -91,6 +91,9 @@ OPTION_LONG(keep-workspace) Do not delete the contents of the workspace on worke
 - **--connection-mode=_&lt;mode&gt;_**<br />When using -M, override manager preference to resolve its address. One of by_ip, by_hostname, or by_apparent_ip. Default is set by manager.
 - **--transfer-port=_&lt;port&gt;_**<br /> Listening port for worker-worker transfers.  (default: any))
 
+- **--ssl**<br />Enable tls connection to manager (manager should support it).
+- **--tls-sni=_&lt;&gt;_**<br />SNI domain name if different from manager hostname. Implies --ssl.
+
 
 
 ## EXIT STATUS

--- a/dttools/src/link.c
+++ b/dttools/src/link.c
@@ -586,9 +586,10 @@ int link_ssl_wrap_connect(struct link *link, const char *sni_hostname)
 	// set hostname for SNI
 	const char *name = link->raddr;
 	if (sni_hostname) {
-	    name = sni_hostname;
+		name = sni_hostname;
 	}
 
+	debug(D_SSL, "Setting SNI to: %s", name);
 	SSL_set_tlsext_host_name(link->ssl, name);
 
 	int result;

--- a/dttools/src/link.c
+++ b/dttools/src/link.c
@@ -570,7 +570,7 @@ int link_ssl_wrap_accept(struct link *link, const char *key, const char *cert)
 	return 0;
 }
 
-int link_ssl_wrap_connect(struct link *link)
+int link_ssl_wrap_connect(struct link *link, const char *sni_hostname)
 {
 #ifdef HAS_OPENSSL
 
@@ -584,7 +584,12 @@ int link_ssl_wrap_connect(struct link *link)
 	SSL_set_fd(link->ssl, link->fd);
 
 	// set hostname for SNI
-	SSL_set_tlsext_host_name(link->ssl, link->raddr);
+	const char *name = link->raddr;
+	if (sni_hostname) {
+	    name = sni_hostname;
+	}
+
+	SSL_set_tlsext_host_name(link->ssl, name);
 
 	int result;
 	while ((result = SSL_connect(link->ssl)) <= 0) {

--- a/dttools/src/link.h
+++ b/dttools/src/link.h
@@ -70,9 +70,10 @@ struct link *link_connect(const char *addr, int port, time_t stoptime);
 
 /** Wrap a connect link with an ssl context and state
 @param link A link returned from @ref link_connect
+@param sni_hostname Optional domain name for tls routing.
 @return 0 on failure, 1 on success
 */
-int link_ssl_wrap_connect(struct link *link);
+int link_ssl_wrap_connect(struct link *link, const char *sni_hostname);
 
 /** Turn a FILE* into a link.  Useful when trying to poll both remote and local connections using @ref link_poll
 @param file File to create the link from.

--- a/dttools/src/link.h
+++ b/dttools/src/link.h
@@ -70,7 +70,7 @@ struct link *link_connect(const char *addr, int port, time_t stoptime);
 
 /** Wrap a connect link with an ssl context and state
 @param link A link returned from @ref link_connect
-@param sni_hostname Optional domain name for tls routing.
+@param sni_hostname Optional domainame for tls routing.
 @return 0 on failure, 1 on success
 */
 int link_ssl_wrap_connect(struct link *link, const char *sni_hostname);

--- a/taskvine/src/tools/vine_status.c
+++ b/taskvine/src/tools/vine_status.c
@@ -486,7 +486,7 @@ int do_direct_query( const char *manager_host, int manager_port, time_t stoptime
 		return 1;
 	}
 
-	if(manual_ssl_option && link_ssl_wrap_connect(l) < 1) {
+	if(manual_ssl_option && link_ssl_wrap_connect(l, manager_host) < 1) {
 		fprintf(stderr,"could not setup ssl connection.\n");
 		return 1;
 	}

--- a/taskvine/src/tools/vine_status.c
+++ b/taskvine/src/tools/vine_status.c
@@ -51,6 +51,7 @@ static struct jx **global_catalog = NULL; //pointer to an array of jx pointers
 struct jx *jexpr = NULL;
 static int columns = 80;
 int manual_ssl_option = 0;
+static char *manual_tls_sni = NULL;
 
 /* negative columns mean a minimum of abs(value), but the column may expand if
  * columns available. */
@@ -150,13 +151,15 @@ static void show_help(const char *progname)
 	fprintf(stdout, " %-30s Rotate debug file once it reaches this size.\n", "-O,--debug-rotate-max=<bytes>");
 	fprintf(stdout, " %-30s Use SSL when directly connecting to a manager.", "--ssl");
 	fprintf(stdout, " %-30s Show vine_status version.\n", "-v,--version");
+	fprintf(stdout, " %-30s SNI domain name if different from manager hostname. Implies --ssl.\n", "--tls-sni=<domain name>");
 	fprintf(stdout, " %-30s This message.\n", "-h,--help");
 }
 
 enum {
 	LONG_OPT_WHERE=1000,
 	LONG_OPT_CAPACITY,
-	LONG_OPT_USE_SSL
+	LONG_OPT_USE_SSL,
+	LONG_OPT_TLS_SNI
 };
 
 static void vine_status_parse_command_line_arguments(int argc, char *argv[], const char **manager_host, int *manager_port, const char **project_name)
@@ -179,6 +182,7 @@ static void vine_status_parse_command_line_arguments(int argc, char *argv[], con
 		{"help", no_argument, 0, 'h'},
 		{"where", required_argument, 0, LONG_OPT_WHERE},
 		{"ssl", no_argument, 0, LONG_OPT_USE_SSL},
+		{"tls-sni", required_argument, 0, LONG_OPT_TLS_SNI},
 		{0,0,0,0}};
 
 	signed int c;
@@ -255,6 +259,11 @@ static void vine_status_parse_command_line_arguments(int argc, char *argv[], con
 			break;
 		case LONG_OPT_USE_SSL:
 			manual_ssl_option=1;
+			break;
+		case LONG_OPT_TLS_SNI:
+			free(manual_tls_sni);
+			manual_tls_sni = xxstrdup(optarg);
+			manual_ssl_option = 1;
 			break;
 		default:
 			show_help(argv[0]);
@@ -486,9 +495,16 @@ int do_direct_query( const char *manager_host, int manager_port, time_t stoptime
 		return 1;
 	}
 
-	if(manual_ssl_option && link_ssl_wrap_connect(l, manager_host) < 1) {
+	if(manual_ssl_option) {
+	    const char *sni_host = manual_tls_sni;
+	    if (!sni_host) {
+		    sni_host = manager_host;
+	    }
+
+	    if(link_ssl_wrap_connect(l, sni_host) < 1) {
 		fprintf(stderr,"could not setup ssl connection.\n");
 		return 1;
+	    }
 	}
 
 	link_printf(l,stoptime,"%s_status\n",query_string);

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1686,7 +1686,7 @@ static int vine_worker_serve_manager_by_hostport(const char *host, int port, con
 		link_close(manager);
 		return 0;
 	} else if (options->ssl_requested || use_ssl) {
-		if (link_ssl_wrap_connect(manager) < 1) {
+		if (link_ssl_wrap_connect(manager, host) < 1) {
 			fprintf(stderr, "vine_worker: could not setup ssl connection.\n");
 			link_close(manager);
 			return 0;

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1686,7 +1686,12 @@ static int vine_worker_serve_manager_by_hostport(const char *host, int port, con
 		link_close(manager);
 		return 0;
 	} else if (options->ssl_requested || use_ssl) {
-		if (link_ssl_wrap_connect(manager, host) < 1) {
+		const char *sni_host = options->tls_sni;
+		if (!sni_host) {
+			sni_host = host;
+		}
+
+		if (link_ssl_wrap_connect(manager, sni_host) < 1) {
 			fprintf(stderr, "vine_worker: could not setup ssl connection.\n");
 			link_close(manager);
 			return 0;

--- a/taskvine/src/worker/vine_worker_options.c
+++ b/taskvine/src/worker/vine_worker_options.c
@@ -49,6 +49,8 @@ struct vine_worker_options *vine_worker_options_create()
 
 	self->initial_ppid = 0;
 
+	self->tls_sni = NULL;
+
 	return self;
 }
 
@@ -143,6 +145,10 @@ void vine_worker_options_show_help(const char *cmd, struct vine_worker_options *
 	printf(" %-30s Forbid the use of symlinks for cache management.\n", "--disable-symlinks");
 	printf(" %-30s Single-shot mode -- quit immediately after disconnection.\n", "--single-shot");
 	printf(" %-30s Listening port for worker-worker transfers. (default: any)\n", "--transfer-port");
+
+	printf(" %-30s Enable tls connection to manager (manager should support it).\n", "--ssl");
+	printf(" %-30s SNI domain name if different from manager hostname. Implies --ssl.\n",
+			"--tls-sni=<domain name>");
 }
 
 enum {
@@ -163,6 +169,7 @@ enum {
 	LONG_OPT_PARENT_DEATH,
 	LONG_OPT_CONN_MODE,
 	LONG_OPT_USE_SSL,
+	LONG_OPT_TLS_SNI,
 	LONG_OPT_PYTHON_FUNCTION,
 	LONG_OPT_FROM_FACTORY,
 	LONG_OPT_TRANSFER_PORT,
@@ -205,6 +212,7 @@ static const struct option long_options[] = {{"advertise", no_argument, 0, 'a'},
 		{"parent-death", no_argument, 0, LONG_OPT_PARENT_DEATH},
 		{"connection-mode", required_argument, 0, LONG_OPT_CONN_MODE},
 		{"ssl", no_argument, 0, LONG_OPT_USE_SSL},
+		{"tls-sni", required_argument, 0, LONG_OPT_TLS_SNI},
 		{"from-factory", required_argument, 0, LONG_OPT_FROM_FACTORY},
 		{"transfer-port", required_argument, 0, LONG_OPT_TRANSFER_PORT},
 		{0, 0, 0, 0}};
@@ -388,6 +396,11 @@ void vine_worker_options_get(struct vine_worker_options *options, int argc, char
 			}
 			break;
 		case LONG_OPT_USE_SSL:
+			options->ssl_requested = 1;
+			break;
+		case LONG_OPT_TLS_SNI:
+			free(options->tls_sni);
+			options->tls_sni = xxstrdup(optarg);
 			options->ssl_requested = 1;
 			break;
 		case LONG_OPT_FROM_FACTORY:

--- a/taskvine/src/worker/vine_worker_options.h
+++ b/taskvine/src/worker/vine_worker_options.h
@@ -58,6 +58,11 @@ struct vine_worker_options {
 	*/
 	int ssl_requested;
 
+	/*
+	If SNI tls is different from hostname. Implies ssl_requested.
+	*/
+	char *tls_sni;
+
 	/* Manual option given by the user to control the location of the workspace. */
 	char *workspace_dir;
 

--- a/work_queue/src/work_queue_status.c
+++ b/work_queue/src/work_queue_status.c
@@ -491,7 +491,7 @@ int do_direct_query( const char *manager_host, int manager_port, time_t stoptime
 		return 1;
 	}
 
-	if(manual_ssl_option && link_ssl_wrap_connect(l) < 1) {
+	if(manual_ssl_option && link_ssl_wrap_connect(l, manager_host) < 1) {
 		fprintf(stderr,"could not setup ssl connection.\n");
 		return 1;
 	}

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -2054,7 +2054,7 @@ static int serve_manager_by_hostport( const char *host, int port, const char *ve
 		link_close(manager);
 		return 0;
 	} else if(manual_ssl_option || use_ssl) {
-		if(link_ssl_wrap_connect(manager) < 1) {
+		if(link_ssl_wrap_connect(manager, host) < 1) {
 			fprintf(stderr,"work_queue_worker: could not setup ssl connection.\n");
 			link_close(manager);
 			return 0;


### PR DESCRIPTION
Use correct domain name when setting SNI
Adds --tls-sni to change name presented on handshake.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
