### PR TITLE
Vine: Thread Controller for FunctionCalls

### DIFF
--- a/poncho/src/poncho/library_network_code.py
+++ b/poncho/src/poncho/library_network_code.py
@@ -70,7 +70,7 @@ def library_network_code():
             if libc_path:
                 return ctypes.CDLL(libc_path)
             return None
-        
+
         def __enter__(self):
             # Set thread limits
             for controller in self.lib_controllers:
@@ -231,7 +231,6 @@ def library_network_code():
                 # also set related environment variables, not necessary for some situations
                 cores_env = str(library_cores // function_slots)
                 os.environ['OMP_NUM_THREADS'] = cores_env
-                os.environ['CORES'] = cores_env
                 os.environ['CORES'] = cores_env
                 os.environ['OPENBLAS_NUM_THREADS'] = cores_env
                 os.environ['VECLIB_NUM_THREADS'] = cores_env

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -403,7 +403,8 @@ int vine_process_execute(struct vine_process *p)
 		if (p->type != VINE_PROCESS_TYPE_LIBRARY) {
 			execl("/bin/sh", "sh", "-c", p->task->command_line, (char *)0);
 		} else {
-			char *final_command = string_format("%s --input-fd %d --output-fd %d --task-id %d --library-cores %d --function-slots %d --worker-pid %d",
+			char *final_command = string_format(
+					"%s --input-fd %d --output-fd %d --task-id %d --library-cores %d --function-slots %d --worker-pid %d",
 					p->task->command_line,
 					in_pipe_fd,
 					out_pipe_fd,

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -403,10 +403,13 @@ int vine_process_execute(struct vine_process *p)
 		if (p->type != VINE_PROCESS_TYPE_LIBRARY) {
 			execl("/bin/sh", "sh", "-c", p->task->command_line, (char *)0);
 		} else {
-			char *final_command = string_format("%s --input-fd %d --output-fd %d --worker-pid %d",
+			char *final_command = string_format("%s --input-fd %d --output-fd %d --task-id %d --library-cores %d --function-slots %d --worker-pid %d",
 					p->task->command_line,
 					in_pipe_fd,
 					out_pipe_fd,
+					p->task->task_id,
+					(int)p->task->resources_requested->cores,
+					p->task->function_slots,
 					getppid());
 			execl("/bin/sh", "sh", "-c", final_command, (char *)0);
 		}


### PR DESCRIPTION
## Proposed changes

Fix for #3734 

A lightweight thread resource controller for FunctionCall tasks, adopted from [threadpoolctl](https://github.com/joblib/threadpoolctl) but more compact, with the minimum overhead to manage thread numbers at runtime.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
