### PR TITLE
dask vine: Report to catalog on end of processing graph

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -149,6 +149,8 @@ class DaskVine(Manager):
         except Exception as e:
             # unhandled exceptions for now
             raise e
+        finally:
+            self.update_catalog()
 
     def __call__(self, *args, **kwargs):
         return self.get(*args, **kwargs)

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -329,6 +329,13 @@ class Manager(object):
         return workers
 
     ##
+    # Send update to catalog server.
+    #
+    # @param self 	Reference to the current manager object.
+    def update_catalog(self):
+        cvine.vine_update_catalog(self._taskvine)
+
+    ##
     # Turn on or off first-allocation labeling for a given category. By
     # default, only cores, memory, and disk are labeled, and gpus are unlabeled.
     # NOTE: autolabeling is only meaningfull when task monitoring is enabled

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -1129,6 +1129,11 @@ void vine_set_tasks_left_count(struct vine_manager *m, int ntasks);
 */
 void vine_set_catalog_servers(struct vine_manager *m, const char *hosts);
 
+/* Send updates to the catalog server.
+@param m A manager object
+*/
+void vine_update_catalog(struct vine_manager *m);
+
 /** Add a global property to the manager which will be included in periodic
 reports to the catalog server and other telemetry destinations.
 This is helpful for distinguishing higher level information about the entire run,

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -698,6 +698,13 @@ static void update_catalog(struct vine_manager *q, int force_update)
 	q->catalog_last_update_time = time(0);
 }
 
+void vine_update_catalog(struct vine_manager *m)
+{
+	if (m) {
+		update_catalog(m, 1);
+	}
+}
+
 static void cleanup_worker_files(struct vine_manager *q, struct vine_worker_info *w)
 {
 	int i = 0;


### PR DESCRIPTION
When the dask executor finished the graph, now it will update the catalog info. Before, the info will not be updated if the manager was run inside a notebook (i.e., no further m.wait calls), which was confusing when running `vine_status`

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
