### PR TITLE
vine: fixed_location flag check

### DIFF
--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -30,7 +30,7 @@ int check_fixed_location_worker(struct vine_manager *m, struct vine_worker_info 
 	if (t->has_fixed_locations) {
 		LIST_ITERATE(t->input_mounts, mt)
 		{
-			if (mt->file->flags & VINE_FIXED_LOCATION) {
+			if (mt->flags & VINE_FIXED_LOCATION) {
 				replica = hash_table_lookup(w->current_files, mt->file->cached_name);
 				if (!replica) {
 					all_present = 0;
@@ -613,6 +613,6 @@ int vine_schedule_check_fixed_location(struct vine_manager *q, struct vine_task 
 			return 1;
 		}
 	}
-
+	debug(D_VINE, "Missing fixed_location dependencies for task: %d", t->task_id);
 	return 0;
 }


### PR DESCRIPTION
## Proposed changes

The fixed location check routine was looking at file flags, rather than mount flags, causing some unpredictable task forsaking.

Also added a debug to make it more visible in the event we cannot find a worker with the file.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
