### PR TITLE
vine: Worker contact address

### DIFF
--- a/doc/man/m4/vine_worker.m4
+++ b/doc/man/m4/vine_worker.m4
@@ -68,7 +68,7 @@ OPTION_ARG_LONG(feature, feature)Specifies a user-defined feature the worker pro
 OPTION_ARG_LONG(volatility, chance)Set the percent chance per minute that the worker will shut down (simulates worker failures, for testing only).
 OPTION_ARG_LONG(connection-mode, mode)When using -M, override manager preference to resolve its address. One of by_ip, by_hostname, or by_apparent_ip. Default is set by manager.
 OPTION_ARG_LONG(transfer-port,port) Listening port for worker-worker transfers.  (default: any))
-OPTION_ARG_LONG(transfer-address,addr) Explicit contact address for worker-worker transfers. (default: :<transfer_port>)
+OPTION_ARG_LONG(contact-hostport,hostport) Explicit contact host:port for worker-worker transfers, e.g., when routing is used. (default: :<transfer_port>)
 
 OPTION_FLAG_LONG(ssl)Enable tls connection to manager (manager should support it).
 OPTION_ARG_LONG(tls-sni)SNI domain name if different from manager hostname. Implies --ssl.

--- a/doc/man/m4/vine_worker.m4
+++ b/doc/man/m4/vine_worker.m4
@@ -68,6 +68,7 @@ OPTION_ARG_LONG(feature, feature)Specifies a user-defined feature the worker pro
 OPTION_ARG_LONG(volatility, chance)Set the percent chance per minute that the worker will shut down (simulates worker failures, for testing only).
 OPTION_ARG_LONG(connection-mode, mode)When using -M, override manager preference to resolve its address. One of by_ip, by_hostname, or by_apparent_ip. Default is set by manager.
 OPTION_ARG_LONG(transfer-port,port) Listening port for worker-worker transfers.  (default: any))
+OPTION_ARG_LONG(transfer-address,addr) Explicit contact address for worker-worker transfers. (default: :<transfer_port>)
 
 OPTION_FLAG_LONG(ssl)Enable tls connection to manager (manager should support it).
 OPTION_ARG_LONG(tls-sni)SNI domain name if different from manager hostname. Implies --ssl.

--- a/doc/man/md/vine_worker.md
+++ b/doc/man/md/vine_worker.md
@@ -90,6 +90,7 @@ OPTION_LONG(keep-workspace) Do not delete the contents of the workspace on worke
 - **--volatility=_&lt;chance&gt;_**<br />Set the percent chance per minute that the worker will shut down (simulates worker failures, for testing only).
 - **--connection-mode=_&lt;mode&gt;_**<br />When using -M, override manager preference to resolve its address. One of by_ip, by_hostname, or by_apparent_ip. Default is set by manager.
 - **--transfer-port=_&lt;port&gt;_**<br /> Listening port for worker-worker transfers.  (default: any))
+- **--transfer-address=_&lt;addr&gt;_**<br /> Explicit contact address for worker-worker transfers. (default: :<transfer_port>)
 
 - **--ssl**<br />Enable tls connection to manager (manager should support it).
 - **--tls-sni=_&lt;&gt;_**<br />SNI domain name if different from manager hostname. Implies --ssl.

--- a/doc/man/md/vine_worker.md
+++ b/doc/man/md/vine_worker.md
@@ -90,7 +90,7 @@ OPTION_LONG(keep-workspace) Do not delete the contents of the workspace on worke
 - **--volatility=_&lt;chance&gt;_**<br />Set the percent chance per minute that the worker will shut down (simulates worker failures, for testing only).
 - **--connection-mode=_&lt;mode&gt;_**<br />When using -M, override manager preference to resolve its address. One of by_ip, by_hostname, or by_apparent_ip. Default is set by manager.
 - **--transfer-port=_&lt;port&gt;_**<br /> Listening port for worker-worker transfers.  (default: any))
-- **--transfer-address=_&lt;addr&gt;_**<br /> Explicit contact address for worker-worker transfers. (default: :<transfer_port>)
+- **--contact-hostport=_&lt;hostport&gt;_**<br /> Explicit contact host:port for worker-worker transfers, e.g., when routing is used. (default: :<transfer_port>)
 
 - **--ssl**<br />Enable tls connection to manager (manager should support it).
 - **--tls-sni=_&lt;&gt;_**<br />SNI domain name if different from manager hostname. Implies --ssl.

--- a/dttools/src/address.c
+++ b/dttools/src/address.c
@@ -162,4 +162,13 @@ int address_parse_hostport(const char *hostport, char *host, int *port, int defa
 	}
 }
 
+int address_is_valid_ip(const char *str)
+{
+	struct sockaddr_storage addr;
+	SOCKLEN_T length;
+	int dummy_port = 0;
+
+	return address_to_sockaddr(str, dummy_port, &addr, &length);
+}
+
 /* vim: set noexpandtab tabstop=8: */

--- a/dttools/src/address.h
+++ b/dttools/src/address.h
@@ -21,5 +21,6 @@ int address_from_sockaddr( char *str, struct sockaddr *saddr );
 int address_parse_hostport( const char *hostport, char *host, int *port, int default_port );
 int address_check_mode( struct addrinfo *info );
 char *address_get_tlq_url( int port, const char *log_path );
+int address_is_valid_ip( const char *addr );
 
 #endif

--- a/taskvine/src/manager/vine_current_transfers.c
+++ b/taskvine/src/manager/vine_current_transfers.c
@@ -172,7 +172,7 @@ void vine_current_transfers_print_table(struct vine_manager *q)
 			debug(D_VINE,
 					"%s : source: %s:%d url: %s",
 					id,
-					w->transfer_addr,
+					w->transfer_host,
 					w->transfer_port,
 					t->source_url);
 		} else {

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -97,11 +97,7 @@ struct vine_worker_info *vine_file_replica_table_find_worker(struct vine_manager
 
 		if ((replica = hash_table_lookup(peer->current_files, cachename)) &&
 				replica->state == VINE_FILE_REPLICA_STATE_READY) {
-			// generate a peer address stub as it would appear in the transfer table
-			char *peer_addr = string_format("worker://%s:%d", peer->transfer_addr, peer->transfer_port);
 			int current_transfers = vine_current_transfers_source_in_use(q, peer);
-			free(peer_addr);
-
 			if (current_transfers < q->worker_source_max_transfers) {
 				peer_selected = peer;
 				if (random_index < 0) {

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -91,7 +91,7 @@ struct vine_worker_info *vine_file_replica_table_find_worker(struct vine_manager
 
 		timestamp_t current_time = timestamp_get();
 		if (current_time - peer->last_transfer_failure < q->transient_error_interval) {
-			debug(D_VINE, "Skipping worker source after recent failure : %s", peer->transfer_addr);
+			debug(D_VINE, "Skipping worker source after recent failure : %s", peer->transfer_host);
 			continue;
 		}
 
@@ -143,7 +143,7 @@ int vine_file_replica_table_replicate(struct vine_manager *m, struct vine_file *
 			continue;
 		}
 
-		char *source_addr = string_format("%s/%s", source->transfer_addr_url, f->cached_name);
+		char *source_addr = string_format("%s/%s", source->transfer_url, f->cached_name);
 		int source_in_use = vine_current_transfers_source_in_use(m, source);
 
 		char *id;

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -226,5 +226,14 @@ int vine_file_replica_table_exists_somewhere(struct vine_manager *q, const char 
 		return 0;
 	}
 
-	return set_size(workers) > 0;
+	struct vine_worker_info *peer;
+
+	SET_ITERATE(workers, peer)
+	{
+		if (peer->transfer_port_active) {
+			return 1;
+		}
+	}
+
+	return 0;
 }

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -143,8 +143,7 @@ int vine_file_replica_table_replicate(struct vine_manager *m, struct vine_file *
 			continue;
 		}
 
-		char *source_addr = string_format(
-				"worker://%s:%d/%s", source->transfer_addr, source->transfer_port, f->cached_name);
+		char *source_addr = string_format("%s/%s", source->transfer_addr_url, f->cached_name);
 		int source_in_use = vine_current_transfers_source_in_use(m, source);
 
 		char *id;

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -473,6 +473,8 @@ static int handle_transfer_address(struct vine_manager *q, struct vine_worker_in
 		return VINE_MSG_FAILURE;
 	}
 
+	w->transfer_port_active = 1;
+
 	if (!explicit) {
 		link_address_remote(w->link, w->transfer_addr, &dummy_port);
 	}

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -28,6 +28,7 @@ See the file COPYING for details.
 #include "vine_txn_log.h"
 #include "vine_worker_info.h"
 
+#include "address.h"
 #include "buffer.h"
 #include "catalog_query.h"
 #include "category_internal.h"
@@ -459,30 +460,46 @@ static int handle_cache_invalid(struct vine_manager *q, struct vine_worker_info 
 }
 
 /*
-A transfer-address message indicates that the worker is listening
+A transfer-port message indicates that the worker is listening
 on its own port to receive get requests from other workers.
 */
 
-static int handle_transfer_address(struct vine_manager *q, struct vine_worker_info *w, const char *line)
+static int handle_transfer_port(struct vine_manager *q, struct vine_worker_info *w, const char *line)
 {
 	int dummy_port;
-	int explicit;
 
-	int n = sscanf(line, "transfer-address %d %s %d", &explicit, w->transfer_addr, &w->transfer_port);
-	if (n != 3) {
+	int n = sscanf(line, "transfer-port %d", &w->transfer_port);
+	if (n != 1) {
+		return VINE_MSG_FAILURE;
+	}
+
+	w->transfer_port_active = 1;
+	link_address_remote(w->link, w->transfer_host, &dummy_port);
+
+	free(w->transfer_url);
+	w->transfer_url = string_format("workerip://%s:%d", w->transfer_host, w->transfer_port);
+
+	return VINE_MSG_PROCESSED;
+}
+
+/*
+A transfer-hostport message indicates that the worker is listening
+on one address, but the connections are made to an explicitely set
+host and port, because of rerouting.
+*/
+
+static int handle_transfer_hostport(struct vine_manager *q, struct vine_worker_info *w, const char *line)
+{
+	int n = sscanf(line, "transfer-hostport %s %d", w->transfer_host, &w->transfer_port);
+	if (n != 2) {
 		return VINE_MSG_FAILURE;
 	}
 
 	w->transfer_port_active = 1;
 
-	if (!explicit) {
-		link_address_remote(w->link, w->transfer_addr, &dummy_port);
-	}
-
-	int is_ip = pattern_match(w->transfer_addr, "^%d+%.%d+%.%d+%.%d+$") != -1;
-
-	free(w->transfer_addr_url);
-	w->transfer_addr_url = string_format("worker%s://%s:%d", is_ip ? "ip" : "", w->transfer_addr, w->transfer_port);
+	int is_ip = address_is_valid_ip(w->transfer_host);
+	free(w->transfer_url);
+	w->transfer_url = string_format("worker%s://%s:%d", is_ip ? "ip" : "", w->transfer_host, w->transfer_port);
 
 	return VINE_MSG_PROCESSED;
 }
@@ -539,8 +556,10 @@ static vine_msg_code_t vine_manager_recv_no_retry(
 		result = handle_cache_update(q, w, line);
 	} else if (string_prefix_is(line, "cache-invalid")) {
 		result = handle_cache_invalid(q, w, line);
-	} else if (string_prefix_is(line, "transfer-address")) {
-		result = handle_transfer_address(q, w, line);
+	} else if (string_prefix_is(line, "transfer-hostport")) {
+		result = handle_transfer_hostport(q, w, line);
+	} else if (string_prefix_is(line, "transfer-port")) {
+		result = handle_transfer_port(q, w, line);
 	} else if (sscanf(line, "GET %s HTTP/%*d.%*d", path) == 1) {
 		result = handle_http_request(q, w, path, stoptime);
 	} else {
@@ -2947,8 +2966,7 @@ static int vine_manager_transfer_capacity_available(
 		/* Provide a substitute file object to describe the peer. */
 		if (!(m->file->flags & VINE_PEER_NOSHARE) && (m->file->cache_level > VINE_CACHE_LEVEL_TASK)) {
 			if ((peer = vine_file_replica_table_find_worker(q, m->file->cached_name))) {
-				char *peer_source =
-						string_format("%s/%s", peer->transfer_addr_url, m->file->cached_name);
+				char *peer_source = string_format("%s/%s", peer->transfer_url, m->file->cached_name);
 				m->substitute = vine_file_substitute_url(m->file, peer_source, peer);
 				free(peer_source);
 				found_match = 1;

--- a/taskvine/src/manager/vine_protocol.h
+++ b/taskvine/src/manager/vine_protocol.h
@@ -13,7 +13,7 @@ worker, and catalog, but should not be visible to the public user API.
 #ifndef VINE_PROTOCOL_H
 #define VINE_PROTOCOL_H
 
-#define VINE_PROTOCOL_VERSION 8
+#define VINE_PROTOCOL_VERSION 9
 
 #define VINE_LINE_MAX 4096       /**< Maximum length of a vine message line. */
 

--- a/taskvine/src/manager/vine_worker_info.c
+++ b/taskvine/src/manager/vine_worker_info.c
@@ -57,7 +57,7 @@ void vine_worker_delete(struct vine_worker_info *w)
 	free(w->workerid);
 	free(w->addrport);
 	free(w->hashkey);
-	free(w->transfer_addr_url);
+	free(w->transfer_url);
 
 	vine_resources_delete(w->resources);
 	hash_table_clear(w->features, 0);

--- a/taskvine/src/manager/vine_worker_info.c
+++ b/taskvine/src/manager/vine_worker_info.c
@@ -57,6 +57,7 @@ void vine_worker_delete(struct vine_worker_info *w)
 	free(w->workerid);
 	free(w->addrport);
 	free(w->hashkey);
+	free(w->transfer_addr_url);
 
 	vine_resources_delete(w->resources);
 	hash_table_clear(w->features, 0);

--- a/taskvine/src/manager/vine_worker_info.h
+++ b/taskvine/src/manager/vine_worker_info.h
@@ -42,11 +42,11 @@ struct vine_worker_info {
 	/* Hash key used to locally identify this worker. */
 	char *hashkey;
 
-	/* Address and port where this worker will accept transfers from peers. */
-	char transfer_addr[DOMAIN_NAME_MAX];
+	/* Host (address or hostname) and port where this worker will accept transfers from peers. */
+	char transfer_host[DOMAIN_NAME_MAX];
 	int  transfer_port;
 	int  transfer_port_active;
-	char *transfer_addr_url;       /* worker(ip)?://transfer_addr:transfer_port */
+	char *transfer_url;       /* worker(ip)?://transfer_addr:transfer_port */
 
 	/* Worker condition that may affect task start or cancellation. */
 	int  draining;                          // if 1, worker does not accept anymore tasks. It is shutdown if no task running.

--- a/taskvine/src/manager/vine_worker_info.h
+++ b/taskvine/src/manager/vine_worker_info.h
@@ -46,6 +46,7 @@ struct vine_worker_info {
 	char transfer_addr[DOMAIN_NAME_MAX];
 	int  transfer_port;
 	int  transfer_port_active;
+	char *transfer_addr_url;       /* worker(ip)?://transfer_addr:transfer_port */
 
 	/* Worker condition that may affect task start or cancellation. */
 	int  draining;                          // if 1, worker does not accept anymore tasks. It is shutdown if no task running.

--- a/taskvine/src/manager/vine_worker_info.h
+++ b/taskvine/src/manager/vine_worker_info.h
@@ -10,6 +10,7 @@ See the file COPYING for details.
 #include "taskvine.h"
 #include "vine_resources.h"
 
+#include "domain_name.h"
 #include "hash_table.h"
 #include "link.h"
 #include "itable.h"
@@ -42,7 +43,7 @@ struct vine_worker_info {
 	char *hashkey;
 
 	/* Address and port where this worker will accept transfers from peers. */
-	char transfer_addr[LINK_ADDRESS_MAX];
+	char transfer_addr[DOMAIN_NAME_MAX];
 	int  transfer_port;
 	int  transfer_port_active;
 

--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -460,12 +460,13 @@ static int rewrite_source_to_ip(struct vine_cache_file *f, char **error_message)
 	sscanf(f->source, "worker://%256[^:]:%d/%s", host, &port_num, source_path);
 
 	if (!domain_name_cache_lookup(host, addr)) {
-		*error_message = string_format("Couldn't resolve hostname %s", host);
+		*error_message = string_format("Couldn't resolve hostname %s for %s", host, source_path);
+		debug(D_VINE, "%s", *error_message);
 		return 0;
 	}
 
 	free(f->source);
-	f->source = string_format("worker://%s:%d/%s", addr, port_num, source_path);
+	f->source = string_format("workerip://%s:%d/%s", addr, port_num, source_path);
 
 	return 1;
 }

--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -16,6 +16,7 @@ See the file COPYING for details.
 
 #include "copy_stream.h"
 #include "debug.h"
+#include "domain_name_cache.h"
 #include "hash_table.h"
 #include "link.h"
 #include "link_auth.h"
@@ -448,6 +449,27 @@ static int do_mini_task(struct vine_cache *c, struct vine_cache_file *f, char **
 	}
 }
 
+// rewrite hostname of source as seen from this worker
+static int rewrite_source_to_ip(struct vine_cache_file *f, char **error_message)
+{
+	int port_num;
+	char host[VINE_LINE_MAX], source_path[VINE_LINE_MAX];
+	char addr[LINK_ADDRESS_MAX];
+
+	// expect the form: worker://host:port/path/to/file
+	sscanf(f->source, "worker://%256[^:]:%d/%s", host, &port_num, source_path);
+
+	if (!domain_name_cache_lookup(host, addr)) {
+		*error_message = string_format("Couldn't resolve hostname %s", host);
+		return 0;
+	}
+
+	free(f->source);
+	f->source = string_format("worker://%s:%d/%s", addr, port_num, source_path);
+
+	return 1;
+}
+
 /*
 Transfer a single input file from a worker url to a local file name.
 */
@@ -459,8 +481,9 @@ static int do_worker_transfer(
 	int stoptime;
 	struct link *worker_link;
 
-	// expect the form: worker://addr:port/path/to/file
-	sscanf(f->source, "worker://%99[^:]:%d/%s", addr, &port_num, source_path);
+	// expect the form: workerip://host:port/path/to/file
+	sscanf(f->source, "workerip://%256[^:]:%d/%s", addr, &port_num, source_path);
+
 	debug(D_VINE, "cache: setting up worker transfer file %s", f->source);
 
 	stoptime = time(0) + 15;
@@ -516,8 +539,13 @@ static int do_transfer(struct vine_cache *c, struct vine_cache_file *f, const ch
 
 	int result = 0;
 
-	if (strncmp(f->source, "worker://", 9) == 0) {
+	if (strncmp(f->source, "workerip://", 11) == 0) {
 		result = do_worker_transfer(c, f, cachename, error_message);
+	} else if (strncmp(f->source, "worker://", 9) == 0) {
+		result = rewrite_source_to_ip(f, error_message);
+		if (result) {
+			result = do_worker_transfer(c, f, cachename, error_message);
+		}
 	} else {
 		result = do_curl_transfer(c, f, transfer_path, cache_path, error_message);
 	}

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -421,21 +421,17 @@ static void send_transfer_address(struct link *manager)
 {
 	char addr[LINK_ADDRESS_MAX];
 	int port;
-	int explicit_addr = 0;
 
 	vine_transfer_server_address(addr, &port);
-
-	char *addr_to_send = addr;
-	if (options->contact_address) {
-		addr_to_send = options->contact_address;
-		explicit_addr = 1;
+	if (options->reported_transfer_port > 0) {
+		port = options->reported_transfer_port;
 	}
 
-	if (options->contact_port > 0) {
-		port = options->contact_port;
+	if (options->reported_transfer_host) {
+		send_message(manager, "transfer-hostport %s %d\n", options->reported_transfer_host, port);
+	} else {
+		send_message(manager, "transfer-port %d\n", port);
 	}
-
-	send_message(manager, "transfer-address %d %s %d\n", explicit_addr, addr_to_send, port);
 }
 
 /*

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -421,19 +421,21 @@ static void send_transfer_address(struct link *manager)
 {
 	char addr[LINK_ADDRESS_MAX];
 	int port;
+	int explicit_addr = 0;
 
 	vine_transfer_server_address(addr, &port);
 
 	char *addr_to_send = addr;
 	if (options->contact_address) {
 		addr_to_send = options->contact_address;
+		explicit_addr = 1;
 	}
 
 	if (options->contact_port > 0) {
 		port = options->contact_port;
 	}
 
-	send_message(manager, "transfer-address %s %d\n", addr_to_send, port);
+	send_message(manager, "transfer-address %d %s %d\n", explicit_addr, addr_to_send, port);
 }
 
 /*

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -421,8 +421,19 @@ static void send_transfer_address(struct link *manager)
 {
 	char addr[LINK_ADDRESS_MAX];
 	int port;
+
 	vine_transfer_server_address(addr, &port);
-	send_message(manager, "transfer-address %s %d\n", addr, port);
+
+	char *addr_to_send = addr;
+	if (options->contact_address) {
+		addr_to_send = options->contact_address;
+	}
+
+	if (options->contact_port > 0) {
+		port = options->contact_port;
+	}
+
+	send_message(manager, "transfer-address %s %d\n", addr_to_send, port);
 }
 
 /*

--- a/taskvine/src/worker/vine_worker_options.c
+++ b/taskvine/src/worker/vine_worker_options.c
@@ -157,7 +157,7 @@ void vine_worker_options_show_help(const char *cmd, struct vine_worker_options *
 	printf(" %-30s Listening port for worker-worker transfers. Either port or port_min:port_max (default: any)\n",
 			"--transfer-port");
 	printf(" %-30s Explicit contact address for worker-worker transfers. (default: :<transfer_port>)\n",
-			"--contact-address");
+			"--transfer-address");
 
 	printf(" %-30s Enable tls connection to manager (manager should support it).\n", "--ssl");
 	printf(" %-30s SNI domain name if different from manager hostname. Implies --ssl.\n",
@@ -229,7 +229,7 @@ static const struct option long_options[] = {{"advertise", no_argument, 0, 'a'},
 		{"tls-sni", required_argument, 0, LONG_OPT_TLS_SNI},
 		{"from-factory", required_argument, 0, LONG_OPT_FROM_FACTORY},
 		{"transfer-port", required_argument, 0, LONG_OPT_TRANSFER_PORT},
-		{"contact-address", required_argument, 0, LONG_OPT_CONTACT_ADDRESS},
+		{"transfer-address", required_argument, 0, LONG_OPT_CONTACT_ADDRESS},
 		{0, 0, 0, 0}};
 
 static void vine_worker_options_get_env(const char *name, int64_t *manual_option)

--- a/taskvine/src/worker/vine_worker_options.h
+++ b/taskvine/src/worker/vine_worker_options.h
@@ -104,6 +104,10 @@ struct vine_worker_options {
 	/* Range of ports allowed to set the server for transfers between workers. */
 	int transfer_port_min;
 	int transfer_port_max;
+
+  /* Explicit contact address for transfers bewteen workers. */
+  char *contact_address;
+  int contact_port;
 };
 
 struct vine_worker_options * vine_worker_options_create();

--- a/taskvine/src/worker/vine_worker_options.h
+++ b/taskvine/src/worker/vine_worker_options.h
@@ -105,9 +105,9 @@ struct vine_worker_options {
 	int transfer_port_min;
 	int transfer_port_max;
 
-  /* Explicit contact address for transfers bewteen workers. */
-  char *contact_address;
-  int contact_port;
+  /* Explicit contact host (address or hostname) for transfers bewteen workers. */
+  char *reported_transfer_host;
+  int reported_transfer_port;
 };
 
 struct vine_worker_options * vine_worker_options_create();


### PR DESCRIPTION
Adds explicit --transfer-address to vine worker. If given, manager does nothing to the address. worker urls are now `workerip://` and `worker://`.  If `worker://`, then on get, the worker does a name resolution.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
