### PR TITLE
TaskVine: Fix logging of library deployment

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2825,6 +2825,7 @@ static vine_result_code_t commit_task_to_worker(struct vine_manager *q, struct v
 	 * If the manager fails to send this function task to the worker however,
 	 * then the count will be decremented properly in @handle_failure() below. */
 	if (t->needs_library) {
+		t->library_task = find_library_on_worker_for_task(w, t->needs_library);
 		t->library_task->function_slots_inuse++;
 	}
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2825,8 +2825,10 @@ static vine_result_code_t commit_task_to_worker(struct vine_manager *q, struct v
 	 * If the manager fails to send this function task to the worker however,
 	 * then the count will be decremented properly in @handle_failure() below. */
 	if (t->needs_library) {
-		t->library_task = find_library_on_worker_for_task(w, t->needs_library);
 		t->library_task->function_slots_inuse++;
+	}
+
+	if (t->provides_library) {
 		vine_txn_log_write_library_update(q, w, t->task_id, VINE_LIBRARY_SENT);
 	}
 


### PR DESCRIPTION
## Proposed changes

Previously whenever a function call is about to be dispatched, the manager writes `VINE_LIBRARY_SENT` to the transaction log which is incorrect. This is fixed so that the manager only writes it when a library is about to be dispatched.

Also finding the library in `commit_task_to_worker()` is redundant as `t->library_task` is set in vine_manager_check_worker_can_run_function_task()`, so it is removed.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
