### PR TITLE
TaskVine: remove the link between a function call and a library during a worker's check

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3202,9 +3202,6 @@ int vine_manager_check_worker_can_run_function_task(
 		if (!library)
 			return 0;
 	}
-
-	// Mark that this function task will be run on this library.
-	t->library_task = library;
 	return 1;
 }
 


### PR DESCRIPTION
## Proposed changes

`vine_manager_check_worker_can_run_function_task` should avoid any definite link between a function call and a library as it is only a check (read-only, no write), and should defer that to `commit_task_to_worker`.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
