### PR TITLE
Vine: Add counters for performance and leak detection.

### DIFF
--- a/taskvine/src/manager/Makefile
+++ b/taskvine/src/manager/Makefile
@@ -10,6 +10,7 @@ SOURCES = \
 	vine_schedule.c \
 	vine_worker_info.c \
 	vine_catalog.c \
+	vine_counters.c \
 	vine_resources.c \
 	vine_task.c \
 	vine_file.c \

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -1337,7 +1337,10 @@ void vine_log_debug_app(struct vine_manager *q, const char *entry);
 */
 void vine_log_txn_app(struct vine_manager *q, const char *entry);
 
+/** Display internal reference counts for troubleshooting purposes.
+*/
 
+void vine_counters_print();
 
 //@}
 

--- a/taskvine/src/manager/vine_counters.c
+++ b/taskvine/src/manager/vine_counters.c
@@ -11,7 +11,7 @@ See the file COPYING for details.
 
 #include <stdio.h>
 
-struct vine_counters vine_counters = {{0},{0},{0},{0},{0}};
+struct vine_counters vine_counters = {{0}, {0}, {0}, {0}, {0}};
 
 static void vine_counter_print(const char *name, struct vine_counter *c)
 {

--- a/taskvine/src/manager/vine_counters.c
+++ b/taskvine/src/manager/vine_counters.c
@@ -11,7 +11,7 @@ See the file COPYING for details.
 
 #include <stdio.h>
 
-struct vine_counters vine_counters = {0};
+struct vine_counters vine_counters = {{0}};
 
 static void vine_counter_print(const char *name, struct vine_counter *c)
 {

--- a/taskvine/src/manager/vine_counters.c
+++ b/taskvine/src/manager/vine_counters.c
@@ -11,7 +11,7 @@ See the file COPYING for details.
 
 #include <stdio.h>
 
-struct vine_counters vine_counters = {{0}};
+struct vine_counters vine_counters = {{0},{0},{0},{0},{0}};
 
 static void vine_counter_print(const char *name, struct vine_counter *c)
 {

--- a/taskvine/src/manager/vine_counters.c
+++ b/taskvine/src/manager/vine_counters.c
@@ -7,6 +7,8 @@ See the file COPYING for details.
 
 #include "vine_counters.h"
 
+#include "debug.h"
+
 #include <stdio.h>
 
 struct vine_counters vine_counters = {0};

--- a/taskvine/src/manager/vine_counters.c
+++ b/taskvine/src/manager/vine_counters.c
@@ -1,0 +1,58 @@
+
+/*
+Copyright (C) 2022- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include "vine_counters.h"
+
+#include <stdio.h>
+
+struct vine_counters vine_counters = {0};
+
+static void vine_counter_print(const char *name, struct vine_counter *c)
+{
+	printf("%8s %8d %8d %8d ", name, c->create, c->clone, c->delete);
+	int nleaked = c->create + c->clone - c->delete;
+	if (nleaked == 0) {
+		printf("ok\n");
+	} else {
+		printf("leaked %d\n", nleaked);
+	}
+}
+
+void vine_counters_print()
+{
+	printf("  object  created   cloned  deleted\n");
+	printf("-----------------------------------\n");
+
+	vine_counter_print("tasks", &vine_counters.task);
+	vine_counter_print("mounts", &vine_counters.mount);
+	vine_counter_print("files", &vine_counters.file);
+	vine_counter_print("replicas", &vine_counters.replica);
+	vine_counter_print("workers", &vine_counters.worker);
+}
+
+static void vine_counter_debug(const char *name, struct vine_counter *c)
+{
+	debug(D_VINE, "%8s %8d %8d %8d ", name, c->create, c->clone, c->delete);
+	int nleaked = c->create + c->clone - c->delete;
+	if (nleaked == 0) {
+		debug(D_VINE, "ok\n");
+	} else {
+		debug(D_VINE, "leaked %d\n", nleaked);
+	}
+}
+
+void vine_counters_debug()
+{
+	debug(D_VINE, "  object  created   cloned  deleted\n");
+	debug(D_VINE, "-----------------------------------\n");
+
+	vine_counter_debug("tasks", &vine_counters.task);
+	vine_counter_debug("mounts", &vine_counters.mount);
+	vine_counter_debug("files", &vine_counters.file);
+	vine_counter_debug("replicas", &vine_counters.replica);
+	vine_counter_debug("workers", &vine_counters.worker);
+}

--- a/taskvine/src/manager/vine_counters.c
+++ b/taskvine/src/manager/vine_counters.c
@@ -15,11 +15,11 @@ struct vine_counters vine_counters = {{0}, {0}, {0}, {0}, {0}};
 
 static void vine_counter_print(const char *name, struct vine_counter *c)
 {
-	int nleaked = c->create + c->clone - c->delete;
+	int nleaked = c->created + c->cloned - c->deleted;
 	if (nleaked == 0) {
-		printf("%8s %8d %8d %8d ok", name, c->create, c->clone, c->delete);
+		printf("%8s %8d %8d %8d ok", name, c->created, c->cloned, c->deleted);
 	} else {
-		printf("%8s %8d %8d %8d leaked %d", name, c->create, c->clone, c->delete, nleaked);
+		printf("%8s %8d %8d %8d leaked %d", name, c->created, c->cloned, c->deleted, nleaked);
 	}
 }
 
@@ -37,11 +37,11 @@ void vine_counters_print()
 
 static void vine_counter_debug(const char *name, struct vine_counter *c)
 {
-	int nleaked = c->create + c->clone - c->delete;
+	int nleaked = c->created + c->cloned - c->deleted;
 	if (nleaked == 0) {
-		debug(D_VINE,"%8s %8d %8d %8d ok", name, c->create, c->clone, c->delete);
+		debug(D_VINE, "%8s %8d %8d %8d ok", name, c->created, c->cloned, c->deleted);
 	} else {
-		debug(D_VINE,"%8s %8d %8d %8d leaked %d", name, c->create, c->clone, c->delete, nleaked);
+		debug(D_VINE, "%8s %8d %8d %8d leaked %d", name, c->created, c->cloned, c->deleted, nleaked);
 	}
 }
 

--- a/taskvine/src/manager/vine_counters.c
+++ b/taskvine/src/manager/vine_counters.c
@@ -15,12 +15,11 @@ struct vine_counters vine_counters = {{0}, {0}, {0}, {0}, {0}};
 
 static void vine_counter_print(const char *name, struct vine_counter *c)
 {
-	printf("%8s %8d %8d %8d ", name, c->create, c->clone, c->delete);
 	int nleaked = c->create + c->clone - c->delete;
 	if (nleaked == 0) {
-		printf("ok\n");
+		printf("%8s %8d %8d %8d ok", name, c->create, c->clone, c->delete);
 	} else {
-		printf("leaked %d\n", nleaked);
+		printf("%8s %8d %8d %8d leaked %d", name, c->create, c->clone, c->delete, nleaked);
 	}
 }
 
@@ -38,12 +37,11 @@ void vine_counters_print()
 
 static void vine_counter_debug(const char *name, struct vine_counter *c)
 {
-	debug(D_VINE, "%8s %8d %8d %8d ", name, c->create, c->clone, c->delete);
 	int nleaked = c->create + c->clone - c->delete;
 	if (nleaked == 0) {
-		debug(D_VINE, "ok\n");
+		debug(D_VINE,"%8s %8d %8d %8d ok", name, c->create, c->clone, c->delete);
 	} else {
-		debug(D_VINE, "leaked %d\n", nleaked);
+		debug(D_VINE,"%8s %8d %8d %8d leaked %d", name, c->create, c->clone, c->delete, nleaked);
 	}
 }
 

--- a/taskvine/src/manager/vine_counters.h
+++ b/taskvine/src/manager/vine_counters.h
@@ -17,9 +17,9 @@ that is access directly by vine_task_create/delete() and similar functions.
 */
 
 struct vine_counter {
-	uint32_t create;
-	uint32_t clone;
-	uint32_t delete;
+	uint32_t created;
+	uint32_t cloned;
+	uint32_t deleted;
 };
 
 struct vine_counters {

--- a/taskvine/src/manager/vine_counters.h
+++ b/taskvine/src/manager/vine_counters.h
@@ -1,0 +1,41 @@
+/*
+Copyright (C) 2022- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#ifndef VINE_COUNTERS_H
+#define VINE_COUNTERS_H
+
+#include <stdint.h>
+
+/*
+For internal troubleshooting and profiling purposes, track the number of
+creates/clones/deletes of objects of various types, so they can be
+displayed at the end of a run.  vine_counters is a global object
+that is access directly by vine_task_create/delete() and similar functions. 
+*/
+
+struct vine_counter {
+	uint32_t create;
+	uint32_t clone;
+	uint32_t delete;
+};
+
+struct vine_counters {
+	struct vine_counter task;
+	struct vine_counter file;
+	struct vine_counter replica;
+	struct vine_counter mount;
+	struct vine_counter worker;
+};
+
+extern struct vine_counters vine_counters;
+
+/* Send performance counters to the debug log */
+void vine_counters_debug();
+
+/* Send performance counters to standard out. */
+void vine_counters_print();
+
+#endif

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -7,6 +7,7 @@ See the file COPYING for details.
 #include "vine_file.h"
 #include "vine_cached_name.h"
 #include "vine_task.h"
+#include "vine_counters.h"
 
 #include "copy_stream.h"
 #include "debug.h"
@@ -30,6 +31,8 @@ int vine_file_delete(struct vine_file *f)
 {
 	if (f) {
 		f->refcount--;
+
+		vine_counters.file.delete++;
 
 		if (f->refcount == 1 && f->recovery_task) {
 			/* delete the recovery task for this file, if any, to break the refcount cycle.
@@ -129,7 +132,8 @@ struct vine_file *vine_file_create(const char *source, const char *cached_name, 
 	}
 
 	f->refcount = 1;
-
+	vine_counters.file.create++;
+	
 	return f;
 }
 
@@ -140,6 +144,7 @@ struct vine_file *vine_file_clone(struct vine_file *f)
 	if (!f)
 		return 0;
 	f->refcount++;
+	vine_counters.file.clone++;
 	return f;
 }
 

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -32,7 +32,7 @@ int vine_file_delete(struct vine_file *f)
 	if (f) {
 		f->refcount--;
 
-		vine_counters.file.delete ++;
+		vine_counters.file.deleted++;
 
 		if (f->refcount == 1 && f->recovery_task) {
 			/* delete the recovery task for this file, if any, to break the refcount cycle.
@@ -132,7 +132,7 @@ struct vine_file *vine_file_create(const char *source, const char *cached_name, 
 	}
 
 	f->refcount = 1;
-	vine_counters.file.create++;
+	vine_counters.file.created++;
 
 	return f;
 }
@@ -144,7 +144,7 @@ struct vine_file *vine_file_clone(struct vine_file *f)
 	if (!f)
 		return 0;
 	f->refcount++;
-	vine_counters.file.clone++;
+	vine_counters.file.cloned++;
 	return f;
 }
 

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -6,8 +6,8 @@ See the file COPYING for details.
 
 #include "vine_file.h"
 #include "vine_cached_name.h"
-#include "vine_task.h"
 #include "vine_counters.h"
+#include "vine_task.h"
 
 #include "copy_stream.h"
 #include "debug.h"
@@ -32,7 +32,7 @@ int vine_file_delete(struct vine_file *f)
 	if (f) {
 		f->refcount--;
 
-		vine_counters.file.delete++;
+		vine_counters.file.delete ++;
 
 		if (f->refcount == 1 && f->recovery_task) {
 			/* delete the recovery task for this file, if any, to break the refcount cycle.
@@ -133,7 +133,7 @@ struct vine_file *vine_file_create(const char *source, const char *cached_name, 
 
 	f->refcount = 1;
 	vine_counters.file.create++;
-	
+
 	return f;
 }
 

--- a/taskvine/src/manager/vine_file_replica.c
+++ b/taskvine/src/manager/vine_file_replica.c
@@ -26,5 +26,5 @@ struct vine_file_replica *vine_file_replica_create(
 void vine_file_replica_delete(struct vine_file_replica *r)
 {
 	free(r);
-	vine_counters.replica.delete++;
+	vine_counters.replica.delete ++;
 }

--- a/taskvine/src/manager/vine_file_replica.c
+++ b/taskvine/src/manager/vine_file_replica.c
@@ -19,12 +19,12 @@ struct vine_file_replica *vine_file_replica_create(
 	r->last_failure_time = 0;
 	r->state = VINE_FILE_REPLICA_STATE_PENDING;
 
-	vine_counters.replica.create++;
+	vine_counters.replica.created++;
 	return r;
 }
 
 void vine_file_replica_delete(struct vine_file_replica *r)
 {
 	free(r);
-	vine_counters.replica.delete ++;
+	vine_counters.replica.deleted++;
 }

--- a/taskvine/src/manager/vine_file_replica.c
+++ b/taskvine/src/manager/vine_file_replica.c
@@ -5,6 +5,7 @@ See the file COPYING for details.
 */
 
 #include "vine_file_replica.h"
+#include "vine_counters.h"
 
 struct vine_file_replica *vine_file_replica_create(
 		vine_file_type_t type, vine_cache_level_t cache_level, int64_t size, time_t mtime)
@@ -17,10 +18,13 @@ struct vine_file_replica *vine_file_replica_create(
 	r->transfer_time = 0;
 	r->last_failure_time = 0;
 	r->state = VINE_FILE_REPLICA_STATE_PENDING;
+
+	vine_counters.replica.create++;
 	return r;
 }
 
 void vine_file_replica_delete(struct vine_file_replica *r)
 {
 	free(r);
+	vine_counters.replica.delete++;
 }

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -6,6 +6,7 @@ See the file COPYING for details.
 
 #include "vine_manager.h"
 #include "vine_blocklist.h"
+#include "vine_counters.h"
 #include "vine_current_transfers.h"
 #include "vine_factory_info.h"
 #include "vine_fair.h"
@@ -27,7 +28,6 @@ See the file COPYING for details.
 #include "vine_taskgraph_log.h"
 #include "vine_txn_log.h"
 #include "vine_worker_info.h"
-#include "vine_counters.h"
 
 #include "address.h"
 #include "buffer.h"

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -27,6 +27,7 @@ See the file COPYING for details.
 #include "vine_taskgraph_log.h"
 #include "vine_txn_log.h"
 #include "vine_worker_info.h"
+#include "vine_counters.h"
 
 #include "address.h"
 #include "buffer.h"
@@ -4156,6 +4157,8 @@ void vine_delete(struct vine_manager *q)
 	free(q->stats);
 	free(q->stats_disconnected_workers);
 	free(q->stats_measure);
+
+	vine_counters_debug();
 
 	debug(D_VINE, "manager end\n");
 

--- a/taskvine/src/manager/vine_mount.c
+++ b/taskvine/src/manager/vine_mount.c
@@ -31,7 +31,7 @@ struct vine_mount *vine_mount_create(
 	m->substitute = vine_file_clone(substitute);
 
 	vine_counters.mount.create++;
-	
+
 	return m;
 }
 
@@ -42,7 +42,7 @@ void vine_mount_delete(struct vine_mount *m)
 	vine_file_delete(m->file);
 	free(m->remote_name);
 	free(m);
-	vine_counters.mount.delete++;
+	vine_counters.mount.delete ++;
 }
 
 struct vine_mount *vine_mount_copy(struct vine_mount *m)

--- a/taskvine/src/manager/vine_mount.c
+++ b/taskvine/src/manager/vine_mount.c
@@ -30,7 +30,7 @@ struct vine_mount *vine_mount_create(
 	m->flags = flags;
 	m->substitute = vine_file_clone(substitute);
 
-	vine_counters.mount.create++;
+	vine_counters.mount.created++;
 
 	return m;
 }
@@ -42,7 +42,7 @@ void vine_mount_delete(struct vine_mount *m)
 	vine_file_delete(m->file);
 	free(m->remote_name);
 	free(m);
-	vine_counters.mount.delete ++;
+	vine_counters.mount.deleted++;
 }
 
 struct vine_mount *vine_mount_copy(struct vine_mount *m)

--- a/taskvine/src/manager/vine_mount.c
+++ b/taskvine/src/manager/vine_mount.c
@@ -5,6 +5,8 @@ See the file COPYING for details.
 */
 
 #include "vine_mount.h"
+#include "vine_counters.h"
+
 #include "debug.h"
 
 #include <stdlib.h>
@@ -28,6 +30,8 @@ struct vine_mount *vine_mount_create(
 	m->flags = flags;
 	m->substitute = vine_file_clone(substitute);
 
+	vine_counters.mount.create++;
+	
 	return m;
 }
 
@@ -38,6 +42,7 @@ void vine_mount_delete(struct vine_mount *m)
 	vine_file_delete(m->file);
 	free(m->remote_name);
 	free(m);
+	vine_counters.mount.delete++;
 }
 
 struct vine_mount *vine_mount_copy(struct vine_mount *m)

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -705,6 +705,8 @@ void vine_task_delete(struct vine_task *t)
 		return;
 
 	t->refcount--;
+	vine_counters.task.delete ++;
+
 	if (t->refcount > 0)
 		return;
 
@@ -744,8 +746,6 @@ void vine_task_delete(struct vine_task *t)
 	rmsummary_delete(t->current_resource_box);
 
 	free(t);
-
-	vine_counters.task.delete ++;
 }
 
 const char *vine_task_get_command(struct vine_task *t)

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -5,11 +5,11 @@ See the file COPYING for details.
 */
 
 #include "vine_task.h"
+#include "vine_counters.h"
 #include "vine_file.h"
 #include "vine_manager.h"
 #include "vine_mount.h"
 #include "vine_worker_info.h"
-#include "vine_counters.h"
 
 #include "debug.h"
 #include "list.h"
@@ -75,7 +75,7 @@ struct vine_task *vine_task_create(const char *command_line)
 	t->refcount = 1;
 
 	vine_counters.task.create++;
-	
+
 	return t;
 }
 
@@ -745,7 +745,7 @@ void vine_task_delete(struct vine_task *t)
 
 	free(t);
 
-	vine_counters.task.delete++;
+	vine_counters.task.delete ++;
 }
 
 const char *vine_task_get_command(struct vine_task *t)

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -9,6 +9,7 @@ See the file COPYING for details.
 #include "vine_manager.h"
 #include "vine_mount.h"
 #include "vine_worker_info.h"
+#include "vine_counters.h"
 
 #include "debug.h"
 #include "list.h"
@@ -73,6 +74,8 @@ struct vine_task *vine_task_create(const char *command_line)
 
 	t->refcount = 1;
 
+	vine_counters.task.create++;
+	
 	return t;
 }
 
@@ -185,6 +188,7 @@ struct vine_task *vine_task_clone(struct vine_task *t)
 	if (!t)
 		return 0;
 	t->refcount++;
+	vine_counters.task.clone++;
 	return t;
 }
 
@@ -740,6 +744,8 @@ void vine_task_delete(struct vine_task *t)
 	rmsummary_delete(t->current_resource_box);
 
 	free(t);
+
+	vine_counters.task.delete++;
 }
 
 const char *vine_task_get_command(struct vine_task *t)

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -74,7 +74,7 @@ struct vine_task *vine_task_create(const char *command_line)
 
 	t->refcount = 1;
 
-	vine_counters.task.create++;
+	vine_counters.task.created++;
 
 	return t;
 }
@@ -188,7 +188,7 @@ struct vine_task *vine_task_clone(struct vine_task *t)
 	if (!t)
 		return 0;
 	t->refcount++;
-	vine_counters.task.clone++;
+	vine_counters.task.cloned++;
 	return t;
 }
 
@@ -705,7 +705,7 @@ void vine_task_delete(struct vine_task *t)
 		return;
 
 	t->refcount--;
-	vine_counters.task.delete ++;
+	vine_counters.task.deleted++;
 
 	if (t->refcount > 0)
 		return;

--- a/taskvine/src/manager/vine_worker_info.c
+++ b/taskvine/src/manager/vine_worker_info.c
@@ -42,7 +42,7 @@ struct vine_worker_info *vine_worker_create(struct link *lnk)
 	w->last_transfer_failure = 0;
 	w->last_failure_time = 0;
 
-	vine_counters.worker.create++;
+	vine_counters.worker.created++;
 
 	return w;
 }
@@ -72,7 +72,7 @@ void vine_worker_delete(struct vine_worker_info *w)
 
 	free(w);
 
-	vine_counters.worker.delete ++;
+	vine_counters.worker.deleted++;
 }
 
 static void current_tasks_to_jx(struct jx *j, struct vine_worker_info *w)

--- a/taskvine/src/manager/vine_worker_info.c
+++ b/taskvine/src/manager/vine_worker_info.c
@@ -9,6 +9,7 @@ See the file COPYING for details.
 #include "vine_protocol.h"
 #include "vine_resources.h"
 #include "vine_task.h"
+#include "vine_counters.h"
 
 struct vine_worker_info *vine_worker_create(struct link *lnk)
 {
@@ -41,6 +42,8 @@ struct vine_worker_info *vine_worker_create(struct link *lnk)
 	w->last_transfer_failure = 0;
 	w->last_failure_time = 0;
 
+	vine_counters.worker.create++;
+	
 	return w;
 }
 
@@ -67,7 +70,10 @@ void vine_worker_delete(struct vine_worker_info *w)
 	hash_table_delete(w->current_files);
 	itable_delete(w->current_tasks);
 
+
 	free(w);
+
+	vine_counters.worker.delete++;
 }
 
 static void current_tasks_to_jx(struct jx *j, struct vine_worker_info *w)

--- a/taskvine/src/manager/vine_worker_info.c
+++ b/taskvine/src/manager/vine_worker_info.c
@@ -5,11 +5,11 @@ See the file COPYING for details.
 */
 
 #include "vine_worker_info.h"
+#include "vine_counters.h"
 #include "vine_file_replica.h"
 #include "vine_protocol.h"
 #include "vine_resources.h"
 #include "vine_task.h"
-#include "vine_counters.h"
 
 struct vine_worker_info *vine_worker_create(struct link *lnk)
 {
@@ -43,7 +43,7 @@ struct vine_worker_info *vine_worker_create(struct link *lnk)
 	w->last_failure_time = 0;
 
 	vine_counters.worker.create++;
-	
+
 	return w;
 }
 
@@ -70,10 +70,9 @@ void vine_worker_delete(struct vine_worker_info *w)
 	hash_table_delete(w->current_files);
 	itable_delete(w->current_tasks);
 
-
 	free(w);
 
-	vine_counters.worker.delete++;
+	vine_counters.worker.delete ++;
 }
 
 static void current_tasks_to_jx(struct jx *j, struct vine_worker_info *w)

--- a/taskvine/test/vine_python_task.py
+++ b/taskvine/test/vine_python_task.py
@@ -59,5 +59,7 @@ while not queue.empty():
         print("task {} completed with result '{}': {}".format(task.id, task.result, task.output))
         negative_sum += task.output
 
+task = None
+
 assert positive_sum == (-1 * negative_sum)
 # vim: set sts=4 sw=4 ts=4 expandtab ft=python:


### PR DESCRIPTION
## Proposed changes

Added vine_counters module to help with leak detection on primary objects.
Call vine_counters_print() to display total number of objects created/cloned/deleted.
Note that it's a bit tricky with Python because dangling references to objects in Python
will continue to reference the C objects as well.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
