### PR TITLE
vine: fixed_location task groups 

### DIFF
--- a/taskvine/src/manager/Makefile
+++ b/taskvine/src/manager/Makefile
@@ -27,7 +27,8 @@ SOURCES = \
 	vine_current_transfers.c \
 	vine_file_replica_table.c \
 	vine_fair.c \
-	vine_runtime_dir.c
+	vine_runtime_dir.c \
+	vine_task_groups.c
 
 PUBLIC_HEADERS = taskvine.h
 

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -73,11 +73,12 @@ typedef enum {
 /** Select overall scheduling algorithm for matching tasks to workers. */
 typedef enum {
 	VINE_SCHEDULE_UNSET = 0, /**< Internal use only. */
-	VINE_SCHEDULE_FCFS,	 /**< Select worker on a first-come-first-serve basis. */
-	VINE_SCHEDULE_FILES,	 /**< Select worker that has the most data required by the task. (default) */
-	VINE_SCHEDULE_TIME,	 /**< Select worker that has the fastest execution time on previous tasks. */
-	VINE_SCHEDULE_RAND,	 /**< Select a random worker. */
-	VINE_SCHEDULE_WORST	 /**< Select the worst fit worker (the worker with more unused resources). */
+	VINE_SCHEDULE_FCFS,      /**< Select worker on a first-come-first-serve basis. */
+	VINE_SCHEDULE_FILES,     /**< Select worker that has the most data required by the task. (default) */
+	VINE_SCHEDULE_GROUPS,     /**< Select a worker running a task in the task group */
+	VINE_SCHEDULE_TIME,      /**< Select worker that has the fastest execution time on previous tasks. */
+	VINE_SCHEDULE_RAND,      /**< Select a random worker. */
+	VINE_SCHEDULE_WORST      /**< Select the worst fit worker (the worker with more unused resources). */
 } vine_schedule_t;
 
 /** Possible outcomes for a task, returned by @ref vine_task_get_result.

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -75,7 +75,6 @@ typedef enum {
 	VINE_SCHEDULE_UNSET = 0, /**< Internal use only. */
 	VINE_SCHEDULE_FCFS,      /**< Select worker on a first-come-first-serve basis. */
 	VINE_SCHEDULE_FILES,     /**< Select worker that has the most data required by the task. (default) */
-	VINE_SCHEDULE_GROUPS,     /**< Select a worker running a task in the task group */
 	VINE_SCHEDULE_TIME,      /**< Select worker that has the fastest execution time on previous tasks. */
 	VINE_SCHEDULE_RAND,      /**< Select a random worker. */
 	VINE_SCHEDULE_WORST      /**< Select the worst fit worker (the worker with more unused resources). */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2997,7 +2997,7 @@ static vine_result_code_t commit_task_group_to_worker(struct vine_manager *q, st
 
 	struct list *l = NULL;
 	if (t->group_id) {
-		l = hash_table_lookup(q->task_group_table, t->group_id);
+		l = itable_lookup(q->task_group_table, t->group_id);
 		list_remove(l, t);
 		// decrement refcount
 		vine_task_delete(t);
@@ -3328,7 +3328,7 @@ static void vine_manager_consider_recovery_task(struct vine_manager *q, struct v
 		return;
 
 	/* Do not try to group recovery tasks */
-	rt->group_id = NULL;
+	rt->group_id = 0;
 
 	switch (rt->state) {
 	case VINE_TASK_INITIAL:
@@ -3995,7 +3995,7 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 
 	q->factory_table = hash_table_create(0, 0);
 	q->current_transfer_table = hash_table_create(0, 0);
-	q->task_group_table = hash_table_create(0, 0);
+	q->task_group_table = itable_create(0);
 	q->group_id_counter = 1;
 	q->fetch_factory = 0;
 
@@ -4342,7 +4342,7 @@ void vine_delete(struct vine_manager *q)
 	hash_table_delete(q->current_transfer_table);
 
 	vine_task_groups_clear(q);
-	hash_table_delete(q->task_group_table);
+	itable_delete(q->task_group_table);
 
 	itable_clear(q->tasks, (void *)delete_task_at_exit);
 	itable_delete(q->tasks);
@@ -5537,11 +5537,11 @@ int vine_cancel_by_task_id(struct vine_manager *q, int task_id)
 	}
 
 	if (task->group_id) {
-		struct list *l = hash_table_lookup(q->task_group_table, task->group_id);
+		struct list *l = itable_lookup(q->task_group_table, task->group_id);
 		if (l) {
 			list_remove(l, task);
 		}
-		task->group_id = NULL;
+		task->group_id = 0;
 		vine_task_delete(task);
 	}
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2935,13 +2935,8 @@ static vine_result_code_t commit_task_to_worker(struct vine_manager *q, struct v
 {
 	vine_result_code_t result = VINE_SUCCESS;
 
-<<<<<<< HEAD
 	/* Kill unused libraries on this worker to reclaim resources. */
 	/* Matches assumption in vine_schedule.c:check_available_resources() */
-=======
-	/* Kill empty libraries to reclaim resources. Match the assumption of
-	 * @vine.schedule.c:check_worker_have_enough_resources() */
->>>>>>> 09771acca (merge in priority queue)
 	kill_empty_libraries_on_worker(q, w, t);
 
 	/* If this is a function needing a library, dispatch the library. */
@@ -2951,7 +2946,6 @@ static vine_result_code_t commit_task_to_worker(struct vine_manager *q, struct v
 		if (!t->library_task) {
 			/* Otherwise send the library to the worker. */
 			/* Note that this call will re-enter commit_task_to_worker. */
-<<<<<<< HEAD
 			t->library_task = send_library_to_worker(q, w, t->needs_library);
 
 			/*
@@ -2966,14 +2960,6 @@ static vine_result_code_t commit_task_to_worker(struct vine_manager *q, struct v
 
 			if (!t->library_task) {
 				return VINE_MGR_FAILURE;
-=======
-			t->library_task = send_library_to_worker(q, w, t->needs_library, &result);
-
-			/* Careful: if the above failed, then w may no longer be valid */
-			/* In that case return immediately without making further changes. */
-			if (!t->library_task) {
-				return result;
->>>>>>> 09771acca (merge in priority queue)
 			}
 		}
 		/* If start_one_task_fails, this will be decremented in handle_failure below. */
@@ -2984,10 +2970,6 @@ static vine_result_code_t commit_task_to_worker(struct vine_manager *q, struct v
 	t->addrport = xxstrdup(w->addrport);
 
 	t->time_when_commit_start = timestamp_get();
-<<<<<<< HEAD
-	result = VINE_SUCCESS;
-	struct list *l = 0;
-=======
 	result = start_one_task(q, w, t);
 	t->time_when_commit_end = timestamp_get();
 
@@ -3014,7 +2996,6 @@ static vine_result_code_t commit_task_group_to_worker(struct vine_manager *q, st
 	vine_result_code_t result = VINE_SUCCESS;
 
 	struct list *l = NULL;
->>>>>>> 09771acca (merge in priority queue)
 	if (t->group_id) {
 		debug(D_VINE, "Task %d has GroupID of %s. Should Send:", t->task_id, t->group_id);
 		l = hash_table_lookup(q->task_group_table, t->group_id);
@@ -3353,6 +3334,9 @@ static void vine_manager_consider_recovery_task(struct vine_manager *q, struct v
 {
 	if (!rt)
 		return;
+
+	/* Do not try to group recovery tasks */
+	rt->group_id = NULL;
 
 	switch (rt->state) {
 	case VINE_TASK_INITIAL:

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2970,7 +2970,7 @@ static vine_result_code_t commit_task_to_worker(struct vine_manager *q, struct v
 	t->addrport = xxstrdup(w->addrport);
 
 	t->time_when_commit_start = timestamp_get();
-	vine_result_code_t result = 0;
+	result = VINE_SUCCESS;
 	struct list *l = 0;
 	l = hash_table_lookup(q->task_group_table, t->group_id);
 	int counter = 0;
@@ -2992,7 +2992,7 @@ static vine_result_code_t commit_task_to_worker(struct vine_manager *q, struct v
 		 * If the manager fails to send this function task to the worker however,
 		 * then the count will be decremented properly in @handle_failure() below. */
 		if (t->needs_library) {
-			t->library_task = find_library_on_worker_for_task(w, t->needs_library);
+			t->library_task = vine_schedule_find_lbrary(w, t->needs_library);
 			t->library_task->function_slots_inuse++;
 			vine_txn_log_write_library_update(q, w, t->task_id, VINE_LIBRARY_SENT);
 		}

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3033,13 +3033,13 @@ static vine_result_code_t commit_task_group_to_worker(struct vine_manager *q, st
 	int counter = 0;
 	do {
 
-		result = commit_task_to_worker(q, w, t);
 		if (counter && (result == VINE_SUCCESS)) {
 			int t_idx = priority_queue_find_idx(q->ready_tasks, t);
 			priority_queue_remove(q->ready_tasks, t_idx);
 			// decrement refcount
 			vine_task_delete(t);
 		}
+		result = commit_task_to_worker(q, w, t);
 		counter++;
 	} while ((l && (t = list_pop_head(l))));
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4070,6 +4070,8 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 	// peer transfers enabled by default
 	q->peer_transfers_enabled = 1;
 
+	q->task_groups_enabled = 0;
+
 	q->load_from_shared_fs_enabled = 0;
 
 	q->file_source_max_transfers = VINE_FILE_SOURCE_MAX_TRANSFERS;
@@ -4731,8 +4733,10 @@ int vine_submit(struct vine_manager *q, struct vine_task *t)
 	/* Ensure category structure is created. */
 	vine_category_lookup_or_create(q, t->category);
 
-	/* Attemp to group this task based on temp dependencies. */
-	vine_task_groups_assign_task(q, t);
+	/* Attempt to group this task based on temp dependencies. */
+	if(q->task_groups_enabled) { 
+		vine_task_groups_assign_task(q, t);
+	}
 
 	change_task_state(q, t, VINE_TASK_READY);
 
@@ -5748,6 +5752,9 @@ int vine_tune(struct vine_manager *q, const char *name, double value)
 
 	} else if (!strcmp(name, "update-interval")) {
 		q->update_interval = MAX(1, (int)value);
+
+	} else if (!strcmp(name, "task-groups")) {
+		q->task_groups_enabled = MIN(1, (int)value);
 
 	} else if (!strcmp(name, "resource-management-interval")) {
 		q->resource_management_interval = MAX(1, (int)value);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3477,10 +3477,9 @@ static int send_one_task(struct vine_manager *q)
 		struct vine_worker_info *w = vine_schedule_task_to_worker(q, t);
 		q->stats->time_scheduling += timestamp_get() - q->stats_measure->time_scheduling;
 
-
 		if (w) {
 			priority_queue_remove(q->ready_tasks, t_idx);
-			
+
 			// do not continue if this worker is running a group task
 			if (q->task_groups_enabled) {
 				struct vine_task *it;

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4734,7 +4734,7 @@ int vine_submit(struct vine_manager *q, struct vine_task *t)
 	vine_category_lookup_or_create(q, t->category);
 
 	/* Attempt to group this task based on temp dependencies. */
-	if(q->task_groups_enabled) { 
+	if (q->task_groups_enabled) {
 		vine_task_groups_assign_task(q, t);
 	}
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2997,15 +2997,7 @@ static vine_result_code_t commit_task_group_to_worker(struct vine_manager *q, st
 
 	struct list *l = NULL;
 	if (t->group_id) {
-		debug(D_VINE, "Task %d has GroupID of %s. Should Send:", t->task_id, t->group_id);
 		l = hash_table_lookup(q->task_group_table, t->group_id);
-
-		struct vine_task *logt;
-		LIST_ITERATE(l, logt)
-		{
-			debug(D_VINE, "Task ID: %d", logt->task_id);
-		}
-
 		list_remove(l, t);
 		// decrement refcount
 		vine_task_delete(t);
@@ -4004,6 +3996,7 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 	q->factory_table = hash_table_create(0, 0);
 	q->current_transfer_table = hash_table_create(0, 0);
 	q->task_group_table = hash_table_create(0, 0);
+	q->group_id_counter = 1;
 	q->fetch_factory = 0;
 
 	q->measured_local_resources = rmsummary_create(-1);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4721,6 +4721,11 @@ int vine_submit(struct vine_manager *q, struct vine_task *t)
 		vine_task_set_scheduler(t, VINE_SCHEDULE_FILES);
 	}
 
+	/* Attempt to group this task based on temp dependencies. */
+	if (q->task_groups_enabled) {
+		vine_task_groups_assign_task(q, t);
+	}
+
 	/* If the task produces temporary files, create recovery tasks for those. */
 	vine_manager_create_recovery_tasks(q, t);
 
@@ -4732,11 +4737,6 @@ int vine_submit(struct vine_manager *q, struct vine_task *t)
 
 	/* Ensure category structure is created. */
 	vine_category_lookup_or_create(q, t->category);
-
-	/* Attempt to group this task based on temp dependencies. */
-	if (q->task_groups_enabled) {
-		vine_task_groups_assign_task(q, t);
-	}
 
 	change_task_state(q, t, VINE_TASK_READY);
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5540,6 +5540,14 @@ int vine_cancel_by_task_id(struct vine_manager *q, int task_id)
 		return 0;
 	}
 
+	if (task->group_id && (task->refcount > 1)) {
+		struct list *l = hash_table_lookup(q->task_group_table, task->group_id);
+		if (l) {
+			list_remove(l, task);
+		}
+		vine_task_delete(task);
+	}
+
 	reset_task_to_state(q, task, VINE_TASK_RETRIEVED);
 
 	task->result = VINE_RESULT_CANCELLED;

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2933,7 +2933,6 @@ task/worker back into the proper state.
 
 static vine_result_code_t commit_task_to_worker(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
 {
-<<<<<<< HEAD
 	vine_result_code_t result = VINE_SUCCESS;
 
 	/* Kill unused libraries on this worker to reclaim resources. */
@@ -2971,14 +2970,11 @@ static vine_result_code_t commit_task_to_worker(struct vine_manager *q, struct v
 	t->addrport = xxstrdup(w->addrport);
 
 	t->time_when_commit_start = timestamp_get();
-	vine_result_code_t result;
-=======
 	vine_result_code_t result = 0;
->>>>>>> 5ab8af678 (add worker code)
 	struct list *l = 0;
 	l = hash_table_lookup(q->task_group_table, t->group_id);
 	int counter = 0;
-	do {	
+	do {
 		/* Kill empty libraries to reclaim resources. Match the assumption of
 		 * @vine.schedule.c:check_worker_have_enough_resources() */
 		kill_empty_libraries_on_worker(q, w, t);
@@ -3014,8 +3010,8 @@ static vine_result_code_t commit_task_to_worker(struct vine_manager *q, struct v
 		}
 
 		counter++;
-	
-	} while((t = list_next_item(l)));
+
+	} while ((t = list_next_item(l)));
 
 	debug(D_VINE, "Sent batch of %d tasks to worker %s", counter, w->hostname);
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5536,11 +5536,12 @@ int vine_cancel_by_task_id(struct vine_manager *q, int task_id)
 		return 0;
 	}
 
-	if (task->group_id && (task->refcount > 1)) {
+	if (task->group_id) {
 		struct list *l = hash_table_lookup(q->task_group_table, task->group_id);
 		if (l) {
 			list_remove(l, task);
 		}
+		task->group_id = NULL;
 		vine_task_delete(task);
 	}
 

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -118,7 +118,7 @@ struct vine_manager {
 	struct hash_table *workers_with_watched_file_updates;  /* Maps link -> vine_worker_info */
 	struct hash_table *workers_with_complete_tasks;  /* Maps link -> vine_worker_info */
 	struct hash_table *current_transfer_table; 	/* Maps uuid -> struct transfer_pair */
-	struct hash_table *task_group_table; 	/* Maps uuid -> list vine_task */
+	struct itable     *task_group_table; 	/* Maps group id -> list vine_task */
 
 	/* Primary data structures for tracking files. */
 

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -185,6 +185,7 @@ struct vine_manager {
 
 	/* Task Groups Configuration */
 	int task_groups_enabled; 
+	int group_id_counter; 
 
 	/* Various performance knobs that can be tuned. */
 	int short_timeout;            /* Timeout in seconds to send/recv a brief message from worker */

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -183,6 +183,9 @@ struct vine_manager {
 	int tasks_waiting_last_hungry;     /* Number of tasks originally waiting when call to vine_hungry_computation was made. */
 	timestamp_t hungry_check_interval; /* Maximum interval between vine_hungry_computation checks. */
 
+	/* Task Groups Configuration */
+	int task_groups_enabled; 
+
 	/* Various performance knobs that can be tuned. */
 	int short_timeout;            /* Timeout in seconds to send/recv a brief message from worker */
 	int long_timeout;             /* Timeout if in the middle of an incomplete message. */

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -118,6 +118,7 @@ struct vine_manager {
 	struct hash_table *workers_with_watched_file_updates;  /* Maps link -> vine_worker_info */
 	struct hash_table *workers_with_complete_tasks;  /* Maps link -> vine_worker_info */
 	struct hash_table *current_transfer_table; 	/* Maps uuid -> struct transfer_pair */
+	struct hash_table *task_group_table; 	/* Maps uuid -> list vine_task */
 
 	/* Primary data structures for tracking files. */
 

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -562,7 +562,7 @@ vine_result_code_t vine_manager_put_task(
 	}
 
 	if (t->group_id) {
-		vine_manager_send(q, w, "groupid %s\n", t->group_id);
+		vine_manager_send(q, w, "groupid %d\n", t->group_id);
 	}
 
 	// vine_manager_send returns the number of bytes sent, or a number less than

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -561,7 +561,7 @@ vine_result_code_t vine_manager_put_task(
 		}
 	}
 
-	if(t->group_id) {
+	if (t->group_id) {
 		vine_manager_send(q, w, "groupid %s\n", t->group_id);
 	}
 

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -561,6 +561,10 @@ vine_result_code_t vine_manager_put_task(
 		}
 	}
 
+	if(t->group_id) {
+		vine_manager_send(q, w, "groupid %s\n", t->group_id);
+	}
+
 	// vine_manager_send returns the number of bytes sent, or a number less than
 	// zero to indicate errors. We are lazy here, we only check the last
 	// message we sent to the worker (other messages may have failed above).

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -383,61 +383,6 @@ static struct vine_worker_info *find_worker_by_files(struct vine_manager *q, str
 }
 
 /*
-Find the worker that has the largest quantity of cached data needed
-by this task, so as to minimize transfer work that must be done
-by the manager.
-*/
-
-static struct vine_worker_info *find_worker_by_task_groups(struct vine_manager *q, struct vine_task *t)
-{
-	char *key;
-	struct vine_worker_info *w;
-	struct vine_worker_info *best_worker = 0;
-	int offset_bookkeep;
-	int64_t most_task_cached_bytes = 0;
-	int64_t task_cached_bytes;
-	uint8_t has_all_files;
-	struct vine_file_replica *replica;
-	struct vine_mount *m;
-
-	int ramp_down = vine_schedule_in_ramp_down(q);
-
-	HASH_TABLE_ITERATE_RANDOM_START(q->worker_table, offset_bookkeep, key, w)
-	{
-		/* Careful: If check_worker_against task fails, then w may no longer be valid. */
-		if (check_worker_against_task(q, w, t)) {
-			task_cached_bytes = 0;
-			has_all_files = 1;
-
-			LIST_ITERATE(t->input_mounts, m)
-			{
-				replica = hash_table_lookup(w->current_files, m->file->cached_name);
-
-				if (replica && m->file->type == VINE_FILE) {
-					task_cached_bytes += replica->size;
-				} else if (m->file->cache_level > VINE_CACHE_LEVEL_TASK) {
-					has_all_files = 0;
-				}
-			}
-
-			/* Return the worker if it was in possession of all cacheable files */
-			if (has_all_files && !ramp_down) {
-				return w;
-			}
-
-			if (!best_worker || task_cached_bytes > most_task_cached_bytes ||
-					(ramp_down && task_cached_bytes == most_task_cached_bytes &&
-							candidate_has_worse_fit(best_worker, w))) {
-				best_worker = w;
-				most_task_cached_bytes = task_cached_bytes;
-			}
-		}
-	}
-
-	return best_worker;
-}
-
-/*
 Find the first available worker in first-come, first-served order.
 Since the order of workers in the hashtable is somewhat arbitrary,
 this amounts to simply "find the first available worker".
@@ -576,8 +521,6 @@ struct vine_worker_info *vine_schedule_task_to_worker(struct vine_manager *q, st
 		return find_worker_by_worst_fit(q, t);
 	case VINE_SCHEDULE_FCFS:
 		return find_worker_by_fcfs(q, t);
-	case VINE_SCHEDULE_GROUPS:
-		return find_worker_by_task_groups(q, t);
 	case VINE_SCHEDULE_RAND:
 	default:
 		return find_worker_by_random(q, t);

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -81,6 +81,7 @@ struct vine_task *vine_task_create(const char *command_line)
 	t->priority = 0;
 
 	vine_counters.task.created++;
+	t->group_id = 0;
 
 	return t;
 }
@@ -254,6 +255,11 @@ struct vine_task *vine_task_copy(const struct vine_task *task)
 	if (task->resources_requested) {
 		rmsummary_delete(new->resources_requested);
 		new->resources_requested = rmsummary_copy(task->resources_requested, 0);
+	}
+
+	/* Group ID is copied. */
+	if (task->group_id) {
+		new->group_id = strdup(task->group_id);
 	}
 
 	return new;

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -259,7 +259,7 @@ struct vine_task *vine_task_copy(const struct vine_task *task)
 
 	/* Group ID is copied. */
 	if (task->group_id) {
-		new->group_id = strdup(task->group_id);
+		new->group_id = task->group_id;
 	}
 
 	return new;

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -136,7 +136,7 @@ struct vine_task {
 	int has_fixed_locations;                               /**< Whether at least one file was added with the VINE_FIXED_LOCATION flag. Task fails immediately if no
 															 worker can satisfy all the strict inputs of the task. */
 
-	char *group_id;					       /**< When enabled, group ID will be assigned based on temp file dependencies of this task */	
+	int group_id;					       /**< When enabled, group ID will be assigned based on temp file dependencies of this task */	
 
 	int refcount;                                          /**< Number of remaining references to this object. */
 };

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -131,11 +131,12 @@ struct vine_task {
 	struct rmsummary *resources_requested;                 /**< Number of cores, disk, memory, time, etc. the task requires. */
 	struct rmsummary *current_resource_box;                /**< Resources allocated to the task on this specific worker. */
 
-	double sandbox_measured;                              /**< On completion, the maximum size observed of the disk used by the task for output and ephemeral files. */
+	double sandbox_measured;                               /**< On completion, the maximum size observed of the disk used by the task for output and ephemeral files. */
 		
 	int has_fixed_locations;                               /**< Whether at least one file was added with the VINE_FIXED_LOCATION flag. Task fails immediately if no
 															 worker can satisfy all the strict inputs of the task. */
-	char *group_id;
+
+	char *group_id;					       /**< When enabled, group ID will be assigned based on temp file dependencies of this task */	
 
 	int refcount;                                          /**< Number of remaining references to this object. */
 };

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -18,6 +18,7 @@ End user may only use the API described in taskvine.h
 
 #include "list.h"
 #include "category.h"
+#include "uuid.h"
 
 #include <stdint.h>
 
@@ -134,6 +135,7 @@ struct vine_task {
 		
 	int has_fixed_locations;                               /**< Whether at least one file was added with the VINE_FIXED_LOCATION flag. Task fails immediately if no
 															 worker can satisfy all the strict inputs of the task. */
+	char *group_id;
 
 	int refcount;                                          /**< Number of remaining references to this object. */
 };

--- a/taskvine/src/manager/vine_task_groups.c
+++ b/taskvine/src/manager/vine_task_groups.c
@@ -13,9 +13,7 @@ See the file COPYING for details.
 // create a new task group for this task based on the temp mount file
 static int vine_task_groups_create_group(struct vine_manager *q, struct vine_task *t, struct vine_mount *m)
 {
-	static int group_id_counter = 1;
-
-	char *id = string_format("%d", group_id_counter++);
+	char *id = string_format("%d", q->group_id_counter++);
 	struct list *l = list_create();
 
 	t->group_id = id;

--- a/taskvine/src/manager/vine_task_groups.c
+++ b/taskvine/src/manager/vine_task_groups.c
@@ -19,7 +19,7 @@ static int vine_task_groups_create_group(struct vine_manager *q, struct vine_tas
 
 	t->group_id = id;
 
-	struct vine_task *tc = vine_task_clone(t);
+	struct vine_task *tc = vine_task_addref(t);
 
 	list_push_head(l, tc);
 	hash_table_insert(q->task_group_table, id, l);
@@ -41,7 +41,7 @@ static int vine_task_groups_add_to_group(struct vine_manager *q, struct vine_tas
 			{
 				if (m->file == lm->file) {
 					t->group_id = lt->group_id;
-					struct vine_task *tc = vine_task_clone(t);
+					struct vine_task *tc = vine_task_addref(t);
 					list_push_tail(l, tc);
 					return 1;
 				}

--- a/taskvine/src/manager/vine_task_groups.c
+++ b/taskvine/src/manager/vine_task_groups.c
@@ -91,3 +91,15 @@ int vine_task_groups_assign_task(struct vine_manager *q, struct vine_task *t)
 
 	return inputs_present || outputs_present;
 }
+
+static void vine_task_group_delete(struct list *l)
+{
+	if (l) {
+		list_delete(l);
+	}
+}
+
+void vine_task_groups_clear(struct vine_manager *q)
+{
+	hash_table_clear(q->task_group_table, (void *)vine_task_group_delete);
+}

--- a/taskvine/src/manager/vine_task_groups.c
+++ b/taskvine/src/manager/vine_task_groups.c
@@ -1,0 +1,86 @@
+/*
+Copyright (C) 2022- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include "vine_task_groups.h"
+#include "debug.h"
+#include "vine_mount.h"
+#include "vine_task.h"
+
+// create a new task group for this task based on the temp mount file
+static int vine_task_groups_create_group(struct vine_manager *q, struct vine_task *t, struct vine_mount *m)
+{
+	cctools_uuid_t uuid;
+	cctools_uuid_create(&uuid);
+	char *id = strdup(uuid.str);
+	struct list *l = list_create();
+
+	t->group_id = id;
+
+	struct vine_task *tc = vine_task_copy(t);
+
+	list_push_head(l, tc);
+	hash_table_insert(q->task_group_table, id, l);
+	return 1;
+}
+
+// locate the group with the task which outputs the desired file, and add the new task
+static int vine_task_groups_add_to_group(struct vine_manager *q, struct vine_task *t, struct vine_mount *m)
+{
+	struct list *l;
+	char *id;
+	HASH_TABLE_ITERATE(q->task_group_table, id, l)
+	{
+		struct vine_file *f;
+		LIST_ITERATE(l, f)
+		{
+			if (f == m->file) {
+				struct vine_task *tc = vine_task_copy(t);
+				list_push_tail(l, tc);
+				return 1;
+			}
+		}
+	}
+	return 0;
+}
+
+/*
+When a task comes in through vine_submit, look for temp files in its inputs/outputs
+If there is a temp file on the input there is already a task group it should be assigned to.
+If there is only a temp output it would be the first of a new group.
+*/
+int vine_task_groups_assign_task(struct vine_manager *q, struct vine_task *t)
+{
+	struct vine_mount *input_mount;
+	struct vine_mount *output_mount;
+
+	int inputs_present = 0;
+	int outputs_present = 0;
+
+	LIST_ITERATE(t->input_mounts, input_mount)
+	{
+		if (input_mount->file->type == VINE_TEMP) {
+			inputs_present++;
+			break;
+		}
+	}
+
+	LIST_ITERATE(t->output_mounts, output_mount)
+	{
+		if (output_mount->file->type == VINE_TEMP) {
+			outputs_present++;
+			break;
+		}
+	}
+
+	// could also be inputs_present && outputs_present
+	if (inputs_present) {
+		vine_task_groups_add_to_group(q, t, input_mount);
+	} else if (outputs_present) {
+		vine_task_groups_create_group(q, t, output_mount);
+	}
+
+	return inputs_present || outputs_present;
+}

--- a/taskvine/src/manager/vine_task_groups.c
+++ b/taskvine/src/manager/vine_task_groups.c
@@ -13,7 +13,7 @@ See the file COPYING for details.
 // create a new task group for this task based on the temp mount file
 static int vine_task_groups_create_group(struct vine_manager *q, struct vine_task *t, struct vine_mount *m)
 {
-	char *id = string_format("%d", q->group_id_counter++);
+	int id = q->group_id_counter++;
 	struct list *l = list_create();
 
 	t->group_id = id;
@@ -21,17 +21,17 @@ static int vine_task_groups_create_group(struct vine_manager *q, struct vine_tas
 	struct vine_task *tc = vine_task_addref(t);
 
 	list_push_head(l, tc);
-	hash_table_insert(q->task_group_table, id, l);
+	itable_insert(q->task_group_table, id, l);
 	return 1;
 }
 
 // locate the group with the task which outputs the desired file, and add the new task
 static int vine_task_groups_add_to_group(struct vine_manager *q, struct vine_task *t, struct vine_mount *m)
 {
-	char *id = m->file->recovery_task->group_id;
+	int id = m->file->recovery_task->group_id;
 
 	if (id) {
-		struct list *group = hash_table_lookup(q->task_group_table, id);
+		struct list *group = itable_lookup(q->task_group_table, id);
 		t->group_id = id;
 		struct vine_task *tc = vine_task_addref(t);
 		list_push_tail(group, tc);
@@ -72,10 +72,10 @@ int vine_task_groups_assign_task(struct vine_manager *q, struct vine_task *t)
 	// could also be inputs_present && outputs_present
 	if (inputs_present) {
 		vine_task_groups_add_to_group(q, t, input_mount);
-		debug(D_VINE, "Assigned task to group %s", t->group_id);
+		debug(D_VINE, "Assigned task to group %d", t->group_id);
 	} else if (outputs_present) {
 		vine_task_groups_create_group(q, t, output_mount);
-		debug(D_VINE, "Create task with group %s", t->group_id);
+		debug(D_VINE, "Create task with group %d", t->group_id);
 	}
 
 	return inputs_present || outputs_present;
@@ -90,5 +90,5 @@ static void vine_task_group_delete(struct list *l)
 
 void vine_task_groups_clear(struct vine_manager *q)
 {
-	hash_table_clear(q->task_group_table, (void *)vine_task_group_delete);
+	itable_clear(q->task_group_table, (void *)vine_task_group_delete);
 }

--- a/taskvine/src/manager/vine_task_groups.c
+++ b/taskvine/src/manager/vine_task_groups.c
@@ -40,7 +40,7 @@ static int vine_task_groups_add_to_group(struct vine_manager *q, struct vine_tas
 			LIST_ITERATE(lt->output_mounts, lm)
 			{
 				if (m->file == lm->file) {
-					t->group_id = lt->group_id; 
+					t->group_id = lt->group_id;
 					struct vine_task *tc = vine_task_clone(t);
 					list_push_tail(l, tc);
 					return 1;

--- a/taskvine/src/manager/vine_task_groups.h
+++ b/taskvine/src/manager/vine_task_groups.h
@@ -1,0 +1,12 @@
+/*
+Copyright (C) 2022- The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file COPYING for details.
+*/
+
+#include "taskvine.h"
+#include "vine_manager.h"
+#include "uuid.h"
+
+
+int vine_task_groups_assign_task(struct vine_manager *q, struct vine_task *t);

--- a/taskvine/src/manager/vine_task_groups.h
+++ b/taskvine/src/manager/vine_task_groups.h
@@ -10,3 +10,5 @@ See the file COPYING for details.
 
 
 int vine_task_groups_assign_task(struct vine_manager *q, struct vine_task *t);
+
+void vine_task_groups_clear(struct vine_manager *q);

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -43,7 +43,7 @@ vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cach
 	LIST_ITERATE(p->task->input_mounts, m)
 	{
 		vine_cache_status_t cache_status = vine_cache_ensure(cache, m->file->cached_name);
-		
+
 		switch (cache_status) {
 		case VINE_CACHE_STATUS_PENDING:
 		case VINE_CACHE_STATUS_PROCESSING:
@@ -54,8 +54,7 @@ vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cach
 			break;
 		case VINE_CACHE_STATUS_UNKNOWN:
 		case VINE_CACHE_STATUS_FAILED:
-			if(p->task->group_id)
-			{
+			if (p->task->group_id) {
 				processing++;
 				break;
 			}

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -35,7 +35,7 @@ Return VINE_STATUS_PROCESSING if some are not ready.
 Return VINE_STATUS_FAILED if some have definitely failed.
 */
 
-vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cache *cache, struct link *manager)
+vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cache *cache, struct link *manager, struct itable *procs_table)
 {
 	int processing = 0;
 
@@ -52,12 +52,36 @@ vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cach
 			break;
 		case VINE_CACHE_STATUS_READY:
 			break;
-		case VINE_CACHE_STATUS_UNKNOWN:
-		case VINE_CACHE_STATUS_FAILED:
-			if (p->task->group_id) {
+		case VINE_CACHE_STATUS_UNKNOWN: {
+			struct vine_process *lp;
+			uint64_t task_id;
+			int found_file = 0;
+			debug(D_VINE, "iterate proc list");
+			debug(D_VINE, "procs table %p", procs_table);
+			ITABLE_ITERATE(procs_table, task_id, lp)
+			{
+				debug(D_VINE, "index proc");
+				struct vine_mount *lm;
+				LIST_ITERATE(lp->task->output_mounts, lm)
+				{
+					debug(D_VINE, "comparing %s and %s", lm->file->cached_name, m->file->cached_name);
+					if (strcmp(lm->file->cached_name, m->file->cached_name) == 0) {
+						found_file = 1;
+						break;
+					}
+				}
+				if (found_file) {
+					break;
+				}
+			}
+			if (found_file) {
+				debug(D_VINE, "Found file in process queue");
 				processing++;
 				break;
 			}
+		}
+			return VINE_CACHE_STATUS_FAILED;
+		case VINE_CACHE_STATUS_FAILED:
 			return VINE_CACHE_STATUS_FAILED;
 		}
 	}

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -43,7 +43,7 @@ vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cach
 	LIST_ITERATE(p->task->input_mounts, m)
 	{
 		vine_cache_status_t cache_status = vine_cache_ensure(cache, m->file->cached_name);
-
+		
 		switch (cache_status) {
 		case VINE_CACHE_STATUS_PENDING:
 		case VINE_CACHE_STATUS_PROCESSING:
@@ -54,6 +54,11 @@ vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cach
 			break;
 		case VINE_CACHE_STATUS_UNKNOWN:
 		case VINE_CACHE_STATUS_FAILED:
+			if(p->task->group_id)
+			{
+				processing++;
+				break;
+			}
 			return VINE_CACHE_STATUS_FAILED;
 		}
 	}

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -56,15 +56,11 @@ vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cach
 			struct vine_process *lp;
 			uint64_t task_id;
 			int found_file = 0;
-			debug(D_VINE, "iterate proc list");
-			debug(D_VINE, "procs table %p", procs_table);
 			ITABLE_ITERATE(procs_table, task_id, lp)
 			{
-				debug(D_VINE, "index proc");
 				struct vine_mount *lm;
 				LIST_ITERATE(lp->task->output_mounts, lm)
 				{
-					debug(D_VINE, "comparing %s and %s", lm->file->cached_name, m->file->cached_name);
 					if (strcmp(lm->file->cached_name, m->file->cached_name) == 0) {
 						found_file = 1;
 						break;
@@ -75,7 +71,6 @@ vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cach
 				}
 			}
 			if (found_file) {
-				debug(D_VINE, "Found file in process queue");
 				processing++;
 				break;
 			}

--- a/taskvine/src/worker/vine_sandbox.h
+++ b/taskvine/src/worker/vine_sandbox.h
@@ -13,7 +13,7 @@ See the file COPYING for details.
 
 char *vine_sandbox_full_path(struct vine_process *p, const char *sandbox_name);
 
-vine_cache_status_t vine_sandbox_ensure( struct vine_process *p, struct vine_cache *c, struct link *manager );
+vine_cache_status_t vine_sandbox_ensure( struct vine_process *p, struct vine_cache *c, struct link *manager, struct itable  *procs_table );
 
 int vine_sandbox_stagein( struct vine_process *p, struct vine_cache *c);
 

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -838,6 +838,7 @@ static struct vine_task *do_task_body(struct link *manager, int task_id, time_t 
 	char taskname_encoded[VINE_LINE_MAX];
 	char library_name[VINE_LINE_MAX];
 	char category[VINE_LINE_MAX];
+	char groupid[VINE_LINE_MAX];
 	int flags, length;
 	int64_t n;
 
@@ -891,6 +892,8 @@ static struct vine_task *do_task_body(struct link *manager, int task_id, time_t 
 			vine_task_set_disk(task, n);
 		} else if (sscanf(line, "gpus %" PRId64, &n)) {
 			vine_task_set_gpus(task, n);
+		} else if (sscanf(line, "groupid %s", groupid)) {
+			task->group_id = xxstrdup(groupid);	
 		} else if (sscanf(line, "wall_time %" PRIu64, &nt)) {
 			vine_task_set_time_max(task, nt);
 		} else if (sscanf(line, "end_time %" PRIu64, &nt)) {

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -893,7 +893,7 @@ static struct vine_task *do_task_body(struct link *manager, int task_id, time_t 
 		} else if (sscanf(line, "gpus %" PRId64, &n)) {
 			vine_task_set_gpus(task, n);
 		} else if (sscanf(line, "groupid %s", groupid)) {
-			task->group_id = xxstrdup(groupid);	
+			task->group_id = xxstrdup(groupid);
 		} else if (sscanf(line, "wall_time %" PRIu64, &nt)) {
 			vine_task_set_time_max(task, nt);
 		} else if (sscanf(line, "end_time %" PRIu64, &nt)) {

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1400,8 +1400,8 @@ static int process_ready_to_run_now(struct vine_process *p, struct vine_cache *c
 			return 0;
 	}
 
-	vine_cache_status_t status = vine_sandbox_ensure(p, cache, manager);
-	if (status == VINE_CACHE_STATUS_PROCESSING)
+	vine_cache_status_t status = vine_sandbox_ensure(p, cache, manager, procs_table);
+	if (status != VINE_CACHE_STATUS_READY)
 		return 0;
 
 	return 1;
@@ -1445,7 +1445,7 @@ static int process_can_run_eventually(struct vine_process *p, struct vine_cache 
 		}
 	}
 
-	vine_cache_status_t status = vine_sandbox_ensure(p, cache, manager);
+	vine_cache_status_t status = vine_sandbox_ensure(p, cache, manager, procs_table);
 	switch (status) {
 	case VINE_CACHE_STATUS_FAILED:
 	case VINE_CACHE_STATUS_UNKNOWN:

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -838,8 +838,7 @@ static struct vine_task *do_task_body(struct link *manager, int task_id, time_t 
 	char taskname_encoded[VINE_LINE_MAX];
 	char library_name[VINE_LINE_MAX];
 	char category[VINE_LINE_MAX];
-	char groupid[VINE_LINE_MAX];
-	int flags, length;
+	int flags, length, groupid;
 	int64_t n;
 
 	timestamp_t nt;
@@ -892,8 +891,8 @@ static struct vine_task *do_task_body(struct link *manager, int task_id, time_t 
 			vine_task_set_disk(task, n);
 		} else if (sscanf(line, "gpus %" PRId64, &n)) {
 			vine_task_set_gpus(task, n);
-		} else if (sscanf(line, "groupid %s", groupid)) {
-			task->group_id = xxstrdup(groupid);
+		} else if (sscanf(line, "groupid %d", &groupid)) {
+			task->group_id = groupid;
 		} else if (sscanf(line, "wall_time %" PRIu64, &nt)) {
 			vine_task_set_time_max(task, nt);
 		} else if (sscanf(line, "end_time %" PRIu64, &nt)) {


### PR DESCRIPTION
## Proposed changes

With task groups enabled, detect groups of sequential, temp-file dependent tasks, and send them in batches to a single worker, avoiding the overhead and complexity of maintaining fixed_location policy. 

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
