### PR TITLE
vine: small task fixes related to mem leaks

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -1085,20 +1085,25 @@ class FunctionCall(PythonTask):
 
             else:
                 self._output = FunctionCallNoResult()
-                print(self.std_output)
 
             self.manager.undeclare_file(self._input_file)
             self._input_file = None
 
+            self.manager.undeclare_file(self._output_file)
+            self._output_file = None
+
             self._output_loaded = True
         return self._output
 
-    # Remove input and output buffers under some circumstances `output` is not called
+    # Remove input and output buffers if self.output was not called.
     def __del__(self):
         try:
             if self._input_file:
                 self.manager.undeclare_file(self._input_file)
                 self._input_file = None
+            if self._output_file and not self._tmp_output_enabled:
+                self.manager.undeclare_file(self._output_file)
+                self._output_file = None
             super().__del__()
         except TypeError:
             pass

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -1123,6 +1123,7 @@ class LibraryTask(Task):
     # @param name       The name of this Library.
     def __init__(self, fn, name):
         Task.__init__(self, fn)
+        self._manager_will_free = True
         self.provides_library(name)
 
 # vim: set sts=4 sw=4 ts=4 expandtab ft=python:

--- a/taskvine/src/bindings/python3/taskvine.i
+++ b/taskvine/src/bindings/python3/taskvine.i
@@ -29,6 +29,7 @@ long long int is guaranteed to be at least 64bit. */
 /* return a char*, enable automatic free */
 %newobject vine_get_status;
 %newobject vine_get_runtime_path_staging;
+%newobject vine_get_runtime_path_caching;
 
 /* These return pointers to lists defined in list.h. We aren't
  * wrapping methods in list.h and so ignore these. */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4089,9 +4089,10 @@ void vine_delete(struct vine_manager *q)
 	itable_clear(q->tasks, (void *)vine_task_delete);
 	itable_delete(q->tasks);
 
-	/* delete files after deleting tasks so that rc are correctly updated.
-	 * we make more than one pass to the file_table to make deal with
-	 * reference counts of unlink_when_done files associated with declare_temp outputs */
+	hash_table_clear(q->libraries, (void *)vine_task_delete);
+	hash_table_delete(q->libraries);
+
+	/* delete files after deleting tasks so that rc are correctly updated. */
 	hash_table_clear(q->file_table, (void *)vine_file_delete);
 	hash_table_delete(q->file_table);
 
@@ -4107,7 +4108,6 @@ void vine_delete(struct vine_manager *q)
 	itable_delete(q->running_table);
 	list_delete(q->waiting_retrieval_list);
 	list_delete(q->retrieved_list);
-	hash_table_delete(q->libraries);
 	hash_table_delete(q->workers_with_available_results);
 
 	list_clear(q->task_info_list, (void *)vine_task_info_delete);


### PR DESCRIPTION
This do not fix the mismatch of clones for FunctionCalls.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
