### PR TITLE
vine: send library memleak

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4529,14 +4529,13 @@ struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_wor
 		return 0;
 	}
 
-	/* Duplicate the original task */
-	struct vine_task *t = vine_task_copy(original);
-
 	/* Check if this library task can fit in this worker. */
-	if (!check_worker_against_task(q, w, t)) {
-		vine_task_delete(t);
+	if (!check_worker_against_task(q, w, original)) {
 		return 0;
 	}
+
+	/* Duplicate the original task */
+	struct vine_task *t = vine_task_copy(original);
 
 	/* Give it a unique taskid if library fits the worker. */
 	t->task_id = q->next_task_id++;

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4523,12 +4523,6 @@ int vine_submit(struct vine_manager *q, struct vine_task *t)
  */
 struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_worker_info *w, const char *name)
 {
-	struct vine_task *library = vine_schedule_find_library(w, name);
-	if (library) {
-		/* worker already has this library, not sending again. */
-		return library;
-	}
-
 	/* Find the original prototype library task by name, if it exists. */
 	struct vine_task *original = hash_table_lookup(q->libraries, name);
 	if (!original) {

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3200,12 +3200,11 @@ int vine_manager_check_worker_can_run_function_task(
 	if (!library) {
 		library = send_library_to_worker(q, w, t->needs_library);
 		/* Careful: If this failed, then the worker object may longer be valid! */
-		if (!library)
+		if (!library) {
 			return 0;
+		}
 	}
 
-	// Mark that this function task will be run on this library.
-	t->library_task = library;
 	return 1;
 }
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4553,13 +4553,15 @@ struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_wor
 	itable_insert(q->tasks, t->task_id, vine_task_clone(t));
 
 	/* Send the task to the worker in the usual way. */
+	/* Careful: If this failed, then the worker object or task object may no longer be valid! */
 	vine_result_code_t result = commit_task_to_worker(q, w, t);
 
-	/* Careful: If this failed, then the worker object may longer be valid! */
+	/* Careful again: If commit_task_to_worker failed the worker object or task object may no longer be valid! */
 	if (result == VINE_SUCCESS) {
 		vine_txn_log_write_library_update(q, w, t->task_id, VINE_LIBRARY_SENT);
 		return t;
 	} else {
+		/* if failure, tasks was handled by handle_failure(...) according to result. */
 		return 0;
 	}
 }

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -144,8 +144,6 @@ static void handle_library_update(struct vine_manager *q, struct vine_worker_inf
 static struct jx *manager_to_jx(struct vine_manager *q);
 static struct jx *manager_lean_to_jx(struct vine_manager *q);
 
-static struct vine_task *find_library_on_worker_for_task(struct vine_worker_info *w, const char *library_name);
-
 char *vine_monitor_wrap(
 		struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct rmsummary *limits);
 
@@ -163,8 +161,6 @@ static int vine_manager_check_inputs_available(struct vine_manager *q, struct vi
 
 static int delete_worker_file(struct vine_manager *q, struct vine_worker_info *w, const char *filename,
 		vine_cache_level_t cache_level, vine_cache_level_t delete_upto_level);
-
-static struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_worker_info *w, const char *name);
 
 /* Return the number of workers matching a given type: WORKER, STATUS, etc */
 
@@ -2826,9 +2822,8 @@ static vine_result_code_t commit_task_to_worker(struct vine_manager *q, struct v
 	 * If the manager fails to send this function task to the worker however,
 	 * then the count will be decremented properly in @handle_failure() below. */
 	if (t->needs_library) {
-		t->library_task = find_library_on_worker_for_task(w, t->needs_library);
+		t->library_task = vine_schedule_find_library(w, t->needs_library);
 		t->library_task->function_slots_inuse++;
-		vine_txn_log_write_library_update(q, w, t->task_id, VINE_LIBRARY_SENT);
 	}
 
 	change_task_state(q, t, VINE_TASK_RUNNING);
@@ -3168,43 +3163,6 @@ static int vine_manager_check_inputs_available(struct vine_manager *q, struct vi
 			}
 		}
 	}
-	return 1;
-}
-
-/* Find a library task running on a specific worker that has an available slot.
- * @return pointer to the library task if there's one, 0 otherwise. */
-
-static struct vine_task *find_library_on_worker_for_task(struct vine_worker_info *w, const char *library_name)
-{
-	uint64_t task_id;
-	struct vine_task *task;
-
-	ITABLE_ITERATE(w->current_tasks, task_id, task)
-	{
-		if (task->provides_library && !strcmp(task->provides_library, library_name) &&
-				task->function_slots_inuse < task->function_slots) {
-			return task;
-		}
-	}
-
-	return 0;
-}
-
-/* Check if this worker can run the function task.
- * @return 1 if it can, 0 otherwise.
- */
-int vine_manager_check_worker_can_run_function_task(
-		struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
-{
-	struct vine_task *library = find_library_on_worker_for_task(w, t->needs_library);
-	if (!library) {
-		library = send_library_to_worker(q, w, t->needs_library);
-		/* Careful: If this failed, then the worker object may longer be valid! */
-		if (!library) {
-			return 0;
-		}
-	}
-
 	return 1;
 }
 
@@ -4545,13 +4503,19 @@ int vine_submit(struct vine_manager *q, struct vine_task *t)
  * @param name The name of the library to be sent.
  * @return pointer to the library task if the operation succeeds, 0 otherwise.
  */
-
-static struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_worker_info *w, const char *name)
+struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_worker_info *w, const char *name)
 {
+	struct vine_task *library = vine_schedule_find_library(w, name);
+	if (library) {
+		/* worker already has this library, not sending again. */
+		return library;
+	}
+
 	/* Find the original prototype library task by name, if it exists. */
 	struct vine_task *original = hash_table_lookup(q->libraries, name);
-	if (!original)
+	if (!original) {
 		return 0;
+	}
 
 	/*
 	If an instance of this library has recently failed,
@@ -4559,7 +4523,6 @@ static struct vine_task *send_library_to_worker(struct vine_manager *q, struct v
 	point at which to notice this, but we don't know that we are starting
 	a new library until the moment of scheduling a function to that worker.
 	*/
-
 	timestamp_t lastfail = original->time_when_last_failure;
 	timestamp_t current = timestamp_get();
 	if (current < lastfail + q->transient_error_interval) {
@@ -4585,28 +4548,12 @@ static struct vine_task *send_library_to_worker(struct vine_manager *q, struct v
 	vine_result_code_t result = commit_task_to_worker(q, w, t);
 
 	/* Careful: If this failed, then the worker object may longer be valid! */
-
 	if (result == VINE_SUCCESS) {
+		vine_txn_log_write_library_update(q, w, t->task_id, VINE_LIBRARY_SENT);
 		return t;
 	} else {
 		return 0;
 	}
-}
-
-struct vine_task *vine_manager_find_library_on_worker(
-		struct vine_manager *q, struct vine_worker_info *w, const char *library_name)
-{
-	uint64_t task_id;
-	struct vine_task *task;
-
-	ITABLE_ITERATE(w->current_tasks, task_id, task)
-	{
-		if (task->provides_library && !strcmp(task->provides_library, library_name)) {
-			return task;
-		}
-	}
-
-	return 0;
 }
 
 void vine_manager_install_library(struct vine_manager *q, struct vine_task *t, const char *name)
@@ -4625,9 +4572,9 @@ void vine_manager_remove_library(struct vine_manager *q, const char *name)
 
 	HASH_TABLE_ITERATE(q->worker_table, worker_key, w)
 	{
-		struct vine_task *t = vine_manager_find_library_on_worker(q, w, name);
-		if (t) {
-			reset_task_to_state(q, t, VINE_TASK_RETRIEVED);
+		struct vine_task *library = vine_schedule_find_library(w, name);
+		if (library) {
+			reset_task_to_state(q, library, VINE_TASK_RETRIEVED);
 		}
 	}
 	hash_table_remove(q->libraries, name);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4011,14 +4011,10 @@ static void delete_task_at_exit(struct vine_task *t)
 		return;
 	}
 
-	if (t->type == VINE_TASK_TYPE_LIBRARY) {
-		/* library tasks should not survive the manager. */
-		int rc = t->refcount;
-		while (rc > 0) {
-			rc--;
-			vine_task_delete(t);
-		}
-	} else {
+	vine_task_delete(t);
+
+	if (t->type == VINE_TASK_TYPE_LIBRARY) { /* change to VINE_TASK_LIBRARY_INSTANCE */
+		/* manager created this task, so it is not the API caller's reponsibility. */
 		vine_task_delete(t);
 	}
 }

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4537,13 +4537,14 @@ struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_wor
 		return 0;
 	}
 
-	/* Check if this library task can fit in this worker. */
-	if (!check_worker_against_task(q, w, original)) {
-		return 0;
-	}
-
 	/* Duplicate the original task */
 	struct vine_task *t = vine_task_copy(original);
+
+	/* Check if this library task can fit in this worker. */
+	if (!check_worker_against_task(q, w, t)) {
+		vine_task_delete(t);
+		return 0;
+	}
 
 	/* Give it a unique taskid if library fits the worker. */
 	t->task_id = q->next_task_id++;

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -262,6 +262,8 @@ int vine_manager_check_worker_can_run_function_task(struct vine_manager *q, stru
 /* Internal: Shut down a specific worker. */
 int vine_manager_shut_down_worker(struct vine_manager *q, struct vine_worker_info *w);
 
+struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_worker_info *w, const char *name);
+
 /* The expected format of files created by the resource monitor.*/
 #define RESOURCE_MONITOR_TASK_LOCAL_NAME "vine-task-%d"
 #define RESOURCE_MONITOR_REMOTE_NAME "cctools-monitor"

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -233,7 +233,6 @@ struct vine_task *vine_schedule_find_library(struct vine_worker_info *w, const c
 	ITABLE_ITERATE(w->current_tasks, task_id, task)
 	{
 		if (task->provides_library && !strcmp(task->provides_library, library_name)) {
-			notice(D_VINE, "%s %s", task->provides_library, library_name);
 			return task;
 		}
 	}

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -168,13 +168,6 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 	}
 	rmsummary_delete(l);
 
-	/* If this is a function task, check if the worker can run it.
-	 * May require the manager to send a library to the worker first. */
-	if (t->needs_library && !vine_manager_check_worker_can_run_function_task(q, w, t)) {
-		/* Careful: If this failed, then the worker object may longer be valid! */
-		return 0;
-	}
-
 	// if worker's end time has not been received
 	if (w->end_time < 0) {
 		return 0;
@@ -211,7 +204,41 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 		}
 	}
 
+	if (t->needs_library) {
+		struct vine_task *library = vine_schedule_find_library(w, t->needs_library);
+		if (library) {
+			if (library->function_slots_inuse >= library->function_slots) {
+				return 0;
+			}
+		} else {
+			/* this is bad and we should feel bad. checking for matches should not modify the state of
+			 * workers. */
+			library = send_library_to_worker(q, w, t->needs_library);
+			/* Careful: If this failed, then the worker object may longer be valid! */
+			if (!library) {
+				return 0;
+			}
+		}
+	}
+
 	return 1;
+}
+
+/* Find a library task running on a specific worker that has an available slot.
+ * @return pointer to the library task if there's one, 0 otherwise. */
+struct vine_task *vine_schedule_find_library(struct vine_worker_info *w, const char *library_name)
+{
+	uint64_t task_id;
+	struct vine_task *task;
+	ITABLE_ITERATE(w->current_tasks, task_id, task)
+	{
+		if (task->provides_library && !strcmp(task->provides_library, library_name)) {
+			notice(D_VINE, "%s %s", task->provides_library, library_name);
+			return task;
+		}
+	}
+
+	return 0;
 }
 
 // 0 if current_best has more free resources than candidate, 1 else.

--- a/taskvine/src/manager/vine_schedule.h
+++ b/taskvine/src/manager/vine_schedule.h
@@ -22,5 +22,6 @@ struct vine_worker_info *vine_schedule_task_to_worker( struct vine_manager *q, s
 void vine_schedule_check_for_large_tasks( struct vine_manager *q );
 int vine_schedule_check_fixed_location(struct vine_manager *q, struct vine_task *t);
 int vine_schedule_in_ramp_down(struct vine_manager *q);
+struct vine_task *vine_schedule_find_library(struct vine_worker_info *w, const char *library_name);
 int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t);
 #endif


### PR DESCRIPTION
If a worker had a library with all the slots full, the library would be sent again to the worker. 
Also, library tasks were cloned when submitted, but this is not needed as taskvine is the user of the task. For all other tasks we increase the ref count because is the responsibility of the user to delete them after wait.

These two conditions created a memleak just by checking whether tasks could be run.

I think this is the memleak observed in coffea.casa, but I have not tried yet.

## Proposed changes

Please describe your changes (e.g., what problems they attempt to solve, what results are expected, etc.) Additional motivation and context are welcome.
Please also mention relevant issues and pull requests as appropriate.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
