### PR TITLE
Worker id after random init

### DIFF
--- a/dttools/src/random.c
+++ b/dttools/src/random.c
@@ -7,6 +7,7 @@
 #include "random.h"
 #include "debug.h"
 #include "full_io.h"
+#include "timestamp.h"
 #include "twister.h"
 
 #include <fcntl.h>
@@ -17,7 +18,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
 
 void random_init(void)
 {
@@ -38,7 +38,7 @@ void random_init(void)
 		uint64_t seed;
 	nasty_fallback:
 		debug(D_NOTICE, "warning: falling back to low-quality entropy");
-		seed = (uint64_t)getpid() ^ (uint64_t)time(NULL);
+		seed = (uint64_t)getpid() ^ (uint64_t)timestamp_get();
 		seed |= (((uint64_t)(uintptr_t)&seed) << 32); /* using ASLR */
 		srand(seed);
 		twister_init_genrand64(seed);

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -2017,8 +2017,6 @@ static void vine_worker_serve_managers()
 
 static char *make_worker_id()
 {
-	srand(worker_start_time);
-
 	char *salt_and_pepper = string_format("%d%d%d", getpid(), getppid(), rand());
 
 	unsigned char digest[MD5_DIGEST_LENGTH];
@@ -2134,6 +2132,9 @@ int main(int argc, char *argv[])
 	/* Start the clock on the worker operation. */
 	worker_start_time = timestamp_get();
 
+	/* The random number generator must be initialized exactly once at startup. */
+	random_init();
+
 	/* Allocate all of the data structures to track tasks an files. */
 	vine_worker_create_structures();
 
@@ -2171,9 +2172,6 @@ int main(int argc, char *argv[])
 	signal(SIGUSR1, handle_abort);
 	signal(SIGUSR2, handle_abort);
 	signal(SIGCHLD, handle_sigchld);
-
-	/* The random number generator must be initialized exactly once at startup. */
-	random_init();
 
 	/* Create the workspace directory and move there. */
 	workspace = vine_workspace_create(options->workspace_dir);

--- a/work_queue/src/work_queue_worker.c
+++ b/work_queue/src/work_queue_worker.c
@@ -2270,8 +2270,6 @@ static int serve_manager_by_name( const char *catalog_hosts, const char *project
 
 void set_worker_id()
 {
-	srand(worker_start_time);
-
 	char *salt_and_pepper = string_format("%d%d%d", getpid(), getppid(), rand());
 	unsigned char digest[MD5_DIGEST_LENGTH];
 
@@ -2496,6 +2494,8 @@ int main(int argc, char *argv[])
 	catalog_hosts = CATALOG_HOST;
 
 	features = hash_table_create(4, 0);
+
+	random_init();
 
 	worker_start_time = timestamp_get();
 
@@ -2809,8 +2809,6 @@ int main(int argc, char *argv[])
 	signal(SIGUSR1, handle_abort);
 	signal(SIGUSR2, handle_abort);
 	signal(SIGCHLD, handle_sigchld);
-
-	random_init();
 
 	if(!workspace_create()) {
 		fprintf(stderr, "work_queue_worker: failed to setup workspace at %s.\n", workspace);


### PR DESCRIPTION
By using `srand` to compute worker-id, we didn't take advantage of `random_init`. 

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
