### PR TITLE
vine, wq: version strings

### DIFF
--- a/dttools/src/cctools.c
+++ b/dttools/src/cctools.c
@@ -20,7 +20,7 @@ void cctools_version_print(FILE *stream, const char *cmd)
 	fprintf(stream, "\tConfiguration: %s\n", CCTOOLS_CONFIGURE_ARGUMENTS);
 }
 
-char *cctools_version_string(FILE *stream, const char *cmd)
+char *cctools_version_string()
 {
 	return string_format("%d.%d.%d", CCTOOLS_VERSION_MAJOR, CCTOOLS_VERSION_MINOR, CCTOOLS_VERSION_MICRO);
 }

--- a/dttools/src/cctools.c
+++ b/dttools/src/cctools.c
@@ -6,6 +6,7 @@ See the file COPYING for details.
 
 #include "cctools.h"
 #include "debug.h"
+#include "stringtools.h"
 
 #include <assert.h>
 #include <stdio.h>
@@ -17,6 +18,11 @@ void cctools_version_print(FILE *stream, const char *cmd)
 	fprintf(stream, "\tBuilt by %s@%s on %s\n", BUILD_USER, BUILD_HOST, BUILD_DATE);
 	fprintf(stream, "\tSystem: %s\n", CCTOOLS_SYSTEM_INFORMATION);
 	fprintf(stream, "\tConfiguration: %s\n", CCTOOLS_CONFIGURE_ARGUMENTS);
+}
+
+char *cctools_version_string(FILE *stream, const char *cmd)
+{
+	return string_format("%d.%d.%d", CCTOOLS_VERSION_MAJOR, CCTOOLS_VERSION_MINOR, CCTOOLS_VERSION_MICRO);
 }
 
 void cctools_version_debug(uint64_t type, const char *cmd)

--- a/dttools/src/cctools.h
+++ b/dttools/src/cctools.h
@@ -21,6 +21,13 @@ See the file COPYING for details.
   */
 void cctools_version_print (FILE *stream, const char *cmd);
 
+
+/** Return a string with MAJOR.MINOR.MICRO version.
+ * It is the responsibility of the caller to free the string.
+@return version string
+*/
+char *cctools_version_string();
+
 /** Create a new buffer.
 	@param type   The debug type.
 	@param cmd    The name of the program running (argv[0]).

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/__init__.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/__init__.py
@@ -59,6 +59,8 @@ from .task import (
 )
 from .dask_dag import DaskVineDag
 
+from . import cvine
+
 try:
     from .dask_executor import DaskVine
 except ImportError as e:
@@ -91,5 +93,7 @@ __all__ = [
     "DaskVine",
     "DaskVineDag",
 ]
+
+__version__ = cvine.cctools_version_string()
 
 # vim: set sts=4 sw=4 ts=4 expandtab ft=python:

--- a/taskvine/src/bindings/python3/taskvine.i
+++ b/taskvine/src/bindings/python3/taskvine.i
@@ -9,6 +9,7 @@
 %}
 
 %{
+	#include "cctools.h"
 	#include "int_sizes.h"
 	#include "timestamp.h"
 	#include "taskvine.h"
@@ -30,6 +31,7 @@ long long int is guaranteed to be at least 64bit. */
 %newobject vine_get_status;
 %newobject vine_get_runtime_path_staging;
 %newobject vine_get_runtime_path_caching;
+%newobject cctools_version_string;
 
 /* These return pointers to lists defined in list.h. We aren't
  * wrapping methods in list.h and so ignore these. */
@@ -78,4 +80,5 @@ into a swig function f(data) */
 %include "vine_task.h"
 %include "vine_file.h"
 %include "vine_runtime_dir.h"
+%include "cctools.h"
 

--- a/work_queue/src/bindings/python3/ndcctools/work_queue.py
+++ b/work_queue/src/bindings/python3/ndcctools/work_queue.py
@@ -42,6 +42,8 @@ import atexit
 import time
 import math
 
+__version__ = cctools_version_string()
+
 
 def set_debug_flag(*flags):
     for flag in flags:

--- a/work_queue/src/work_queue.i
+++ b/work_queue/src/work_queue.i
@@ -13,6 +13,7 @@
 	#include "int_sizes.h"
 	#include "timestamp.h"
 	#include "work_queue.h"
+	#include "cctools.h"
 %}
 
 /* We compile with -D__LARGE64_FILES, thus off_t is at least 64bit.
@@ -25,6 +26,7 @@ long long int is guaranteed to be at least 64bit. */
 
 /* returns a char*, enable automatic free */
 %newobject work_queue_status;
+%newobject cctools_version_string;
 
 /* These return pointers to lists defined in list.h. We aren't
  * wrapping methods in list.h and so ignore these. */
@@ -37,4 +39,5 @@ long long int is guaranteed to be at least 64bit. */
 %include "int_sizes.h"
 %include "timestamp.h"
 %include "work_queue.h"
+%include "cctools.h"
 


### PR DESCRIPTION
For #3775 

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
