### PR TITLE
vine: change `clone` to `addref`

### DIFF
--- a/taskvine/src/manager/vine_counters.c
+++ b/taskvine/src/manager/vine_counters.c
@@ -15,17 +15,17 @@ struct vine_counters vine_counters = {{0}, {0}, {0}, {0}, {0}};
 
 static void vine_counter_print(const char *name, struct vine_counter *c)
 {
-	int nleaked = c->created + c->refadded - c->deleted;
+	int nleaked = c->created + c->ref_added - c->deleted;
 	if (nleaked == 0) {
-		printf("%8s %8d %8d %8d ok", name, c->created, c->refadded, c->deleted);
+		printf("%8s %8d %8d %8d ok", name, c->created, c->ref_added, c->deleted);
 	} else {
-		printf("%8s %8d %8d %8d leaked %d", name, c->created, c->refadded, c->deleted, nleaked);
+		printf("%8s %8d %8d %8d leaked %d", name, c->created, c->ref_added, c->deleted, nleaked);
 	}
 }
 
 void vine_counters_print()
 {
-	printf("  object  created   refadded  deleted\n");
+	printf("  object  created   ref_added  deleted\n");
 	printf("-----------------------------------\n");
 
 	vine_counter_print("tasks", &vine_counters.task);
@@ -37,17 +37,17 @@ void vine_counters_print()
 
 static void vine_counter_debug(const char *name, struct vine_counter *c)
 {
-	int nleaked = c->created + c->refadded - c->deleted;
+	int nleaked = c->created + c->ref_added - c->deleted;
 	if (nleaked == 0) {
-		debug(D_VINE, "%8s %8d %8d %8d ok", name, c->created, c->refadded, c->deleted);
+		debug(D_VINE, "%8s %8d %8d %8d ok", name, c->created, c->ref_added, c->deleted);
 	} else {
-		debug(D_VINE, "%8s %8d %8d %8d leaked %d", name, c->created, c->refadded, c->deleted, nleaked);
+		debug(D_VINE, "%8s %8d %8d %8d leaked %d", name, c->created, c->ref_added, c->deleted, nleaked);
 	}
 }
 
 void vine_counters_debug()
 {
-	debug(D_VINE, "  object  created   refadded  deleted\n");
+	debug(D_VINE, "  object  created   ref_added  deleted\n");
 	debug(D_VINE, "-----------------------------------\n");
 
 	vine_counter_debug("tasks", &vine_counters.task);

--- a/taskvine/src/manager/vine_counters.c
+++ b/taskvine/src/manager/vine_counters.c
@@ -15,17 +15,17 @@ struct vine_counters vine_counters = {{0}, {0}, {0}, {0}, {0}};
 
 static void vine_counter_print(const char *name, struct vine_counter *c)
 {
-	int nleaked = c->created + c->cloned - c->deleted;
+	int nleaked = c->created + c->refadded - c->deleted;
 	if (nleaked == 0) {
-		printf("%8s %8d %8d %8d ok", name, c->created, c->cloned, c->deleted);
+		printf("%8s %8d %8d %8d ok", name, c->created, c->refadded, c->deleted);
 	} else {
-		printf("%8s %8d %8d %8d leaked %d", name, c->created, c->cloned, c->deleted, nleaked);
+		printf("%8s %8d %8d %8d leaked %d", name, c->created, c->refadded, c->deleted, nleaked);
 	}
 }
 
 void vine_counters_print()
 {
-	printf("  object  created   cloned  deleted\n");
+	printf("  object  created   refadded  deleted\n");
 	printf("-----------------------------------\n");
 
 	vine_counter_print("tasks", &vine_counters.task);
@@ -37,17 +37,17 @@ void vine_counters_print()
 
 static void vine_counter_debug(const char *name, struct vine_counter *c)
 {
-	int nleaked = c->created + c->cloned - c->deleted;
+	int nleaked = c->created + c->refadded - c->deleted;
 	if (nleaked == 0) {
-		debug(D_VINE, "%8s %8d %8d %8d ok", name, c->created, c->cloned, c->deleted);
+		debug(D_VINE, "%8s %8d %8d %8d ok", name, c->created, c->refadded, c->deleted);
 	} else {
-		debug(D_VINE, "%8s %8d %8d %8d leaked %d", name, c->created, c->cloned, c->deleted, nleaked);
+		debug(D_VINE, "%8s %8d %8d %8d leaked %d", name, c->created, c->refadded, c->deleted, nleaked);
 	}
 }
 
 void vine_counters_debug()
 {
-	debug(D_VINE, "  object  created   cloned  deleted\n");
+	debug(D_VINE, "  object  created   refadded  deleted\n");
 	debug(D_VINE, "-----------------------------------\n");
 
 	vine_counter_debug("tasks", &vine_counters.task);

--- a/taskvine/src/manager/vine_counters.h
+++ b/taskvine/src/manager/vine_counters.h
@@ -11,14 +11,14 @@ See the file COPYING for details.
 
 /*
 For internal troubleshooting and profiling purposes, track the number of
-creates/clones/deletes of objects of various types, so they can be
+creates/refaddes/deletes of objects of various types, so they can be
 displayed at the end of a run.  vine_counters is a global object
 that is access directly by vine_task_create/delete() and similar functions. 
 */
 
 struct vine_counter {
 	uint32_t created;
-	uint32_t cloned;
+	uint32_t refadded;
 	uint32_t deleted;
 };
 

--- a/taskvine/src/manager/vine_counters.h
+++ b/taskvine/src/manager/vine_counters.h
@@ -11,14 +11,14 @@ See the file COPYING for details.
 
 /*
 For internal troubleshooting and profiling purposes, track the number of
-creates/refaddes/deletes of objects of various types, so they can be
+creates, added references and deleted of objects of various types, so they can be
 displayed at the end of a run.  vine_counters is a global object
 that is access directly by vine_task_create/delete() and similar functions. 
 */
 
 struct vine_counter {
 	uint32_t created;
-	uint32_t refadded;
+	uint32_t ref_added;
 	uint32_t deleted;
 };
 

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -107,7 +107,7 @@ struct vine_file *vine_file_create(const char *source, const char *cached_name, 
 		/* On the worker, the source (name on disk) is already the cached name. */
 		f->cached_name = xxstrdup(f->source);
 	} else if (cached_name) {
-		/* If the cached name is provided, just use it.  (Likely a refadded object.) */
+		/* If the cached name is provided, just use it.  (Likely a referenced object.) */
 		f->cached_name = xxstrdup(cached_name);
 	} else {
 		/* Otherwise we need to figure it out ourselves from the content. */
@@ -144,7 +144,7 @@ struct vine_file *vine_file_addref(struct vine_file *f)
 	if (!f)
 		return 0;
 	f->refcount++;
-	vine_counters.file.refadded++;
+	vine_counters.file.ref_added++;
 	return f;
 }
 

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -107,7 +107,7 @@ struct vine_file *vine_file_create(const char *source, const char *cached_name, 
 		/* On the worker, the source (name on disk) is already the cached name. */
 		f->cached_name = xxstrdup(f->source);
 	} else if (cached_name) {
-		/* If the cached name is provided, just use it.  (Likely a cloned object.) */
+		/* If the cached name is provided, just use it.  (Likely a refadded object.) */
 		f->cached_name = xxstrdup(cached_name);
 	} else {
 		/* Otherwise we need to figure it out ourselves from the content. */
@@ -139,12 +139,12 @@ struct vine_file *vine_file_create(const char *source, const char *cached_name, 
 
 /* Make a reference counted copy of a file object. */
 
-struct vine_file *vine_file_clone(struct vine_file *f)
+struct vine_file *vine_file_addref(struct vine_file *f)
 {
 	if (!f)
 		return 0;
 	f->refcount++;
-	vine_counters.file.cloned++;
+	vine_counters.file.refadded++;
 	return f;
 }
 

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -60,7 +60,7 @@ struct vine_file * vine_file_create( const char *source, const char *cached_name
 
 struct vine_file * vine_file_substitute_url( struct vine_file *f, const char *source, struct vine_worker_info *w );
 
-struct vine_file *vine_file_clone( struct vine_file *f );
+struct vine_file *vine_file_addref( struct vine_file *f );
 
 /* Decreases reference count of file, and frees if zero. */
 int vine_file_delete( struct vine_file *f );

--- a/taskvine/src/manager/vine_mount.c
+++ b/taskvine/src/manager/vine_mount.c
@@ -20,7 +20,7 @@ struct vine_mount *vine_mount_create(
 	struct vine_mount *m = malloc(sizeof(*m));
 
 	/* Add a reference each time a file is connected. */
-	m->file = vine_file_clone(file);
+	m->file = vine_file_addref(file);
 
 	if (remote_name) {
 		m->remote_name = xxstrdup(remote_name);
@@ -28,7 +28,7 @@ struct vine_mount *vine_mount_create(
 		m->remote_name = 0;
 	}
 	m->flags = flags;
-	m->substitute = vine_file_clone(substitute);
+	m->substitute = vine_file_addref(substitute);
 
 	vine_counters.mount.created++;
 

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -188,7 +188,7 @@ struct vine_task *vine_task_addref(struct vine_task *t)
 	if (!t)
 		return 0;
 	t->refcount++;
-	vine_counters.task.refadded++;
+	vine_counters.task.ref_added++;
 	return t;
 }
 

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -183,12 +183,12 @@ static struct list *vine_task_string_list_copy(struct list *string_list)
 	return new;
 }
 
-struct vine_task *vine_task_clone(struct vine_task *t)
+struct vine_task *vine_task_addref(struct vine_task *t)
 {
 	if (!t)
 		return 0;
 	t->refcount++;
-	vine_counters.task.cloned++;
+	vine_counters.task.refadded++;
 	return t;
 }
 

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -124,7 +124,7 @@ struct vine_task {
 
 void vine_task_delete(struct vine_task *t);
 /* Add a reference to an existing task object, return the same object. */
-struct vine_task * vine_task_clone( struct vine_task *t );
+struct vine_task * vine_task_addref( struct vine_task *t );
 
 /* Deep-copy an existing task object, return a pointer to a new object. */
 struct vine_task * vine_task_copy( const struct vine_task *t );


### PR DESCRIPTION
## Proposed changes

This PR changes all clones from various objects to addrefs as agreed in https://github.com/cooperative-computing-lab/cctools/issues/3797.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
