### PR TITLE
vine: dask add progress bar

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,6 @@ dependencies:
  - packaging            # required for Poncho packaging
  - cloudpickle          # required for WorkQueue/TaskVine remote function invocation
  - threadpoolctl        # required for WorkQueue/TaskVine remote function invocation
- - rich                 # required for TaskVine Dask executor
  - gdb                  # optional debugger to match compiler
  - flake8               # optional to lint and format Python code
  - clang-format         # optional to lint and format C code

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
  - packaging            # required for Poncho packaging
  - cloudpickle          # required for WorkQueue/TaskVine remote function invocation
  - threadpoolctl        # required for WorkQueue/TaskVine remote function invocation
+ - rich                 # required for TaskVine Dask executor
  - gdb                  # optional debugger to match compiler
  - flake8               # optional to lint and format Python code
  - clang-format         # optional to lint and format C code

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
@@ -85,6 +85,9 @@ class DaskVineDag:
 
         self.initialize_graph()
 
+    def left_to_compute(self):
+        return len(self._working_graph) - len(self._result_of)
+
     def graph_keyp(self, s):
         if DaskVineDag.keyp(s):
             return s in self._working_graph


### PR DESCRIPTION
`rich` dependency adds ~10MB to conda env. (A bare-bones with cctools and python is 579MB, with rich is 590MB).

Something like this is needed because of long running graphs the user has no indication of the progress. 


## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
