### PR TITLE
vine: function call exit code

### DIFF
--- a/poncho/src/poncho/library_network_code.py
+++ b/poncho/src/poncho/library_network_code.py
@@ -10,7 +10,6 @@
 # function and run on a worker as a pilot task. Upcoming Python
 # Function Calls will be executed by this pilot task.
 def library_network_code():
-
     # import relevant libraries.
     import json
     import os
@@ -38,13 +37,14 @@ def library_network_code():
             self.reason = reason
 
         def generate(self):
-            return {'Result': self.result,
-                    'Success': self.success,
-                    'Reason': self.reason}
+            return {
+                "Result": self.result,
+                "Success": self.success,
+                "Reason": self.reason,
+            }
 
     # A wrapper around functions in library to extract arguments and formulate responses.
     def remote_execute(func):
-
         def remote_wrapper(event):
             args = event.get("fn_args", [])
             kwargs = event.get("fn_kwargs", {})
@@ -53,7 +53,7 @@ def library_network_code():
             new_args = []
             for arg in args:
                 if isinstance(arg, dict) and "VineFutureFile" in arg:
-                    with open(arg["VineFutureFile"], 'rb') as f:
+                    with open(arg["VineFutureFile"], "rb") as f:
                         output = cloudpickle.load(f)["Result"]
                         new_args.append(output)
                 else:
@@ -64,11 +64,12 @@ def library_network_code():
                 result = func(*args, **kwargs)
                 success = True
                 reason = None
-            except Exception as e:  # noqa: F841
+            except Exception:
                 result = None
                 success = False
                 reason = traceback.format_exc()
             return LibraryResponse(result, success, reason).generate()
+
         return remote_wrapper
 
     # Self-identifying message to send back to the worker, including the name of this library.
@@ -76,42 +77,44 @@ def library_network_code():
     def send_configuration(config, out_pipe_fd, worker_pid):
         config_string = json.dumps(config)
         config_cmd = f"{len(config_string)}\n{config_string}"
-        os.writev(out_pipe_fd, [bytes(config_cmd, 'utf-8')])
+        os.writev(out_pipe_fd, [bytes(config_cmd, "utf-8")])
         os.kill(worker_pid, signal.SIGCHLD)
 
     # Handler to sigchld when child exits.
     def sigchld_handler(signum, frame):
         # write any byte to signal that there's at least 1 child
-        os.writev(w, [b'a'])
+        os.writev(w, [b"a"])
 
     # Read data from worker, start function, and dump result to `outfile`.
     def start_function(in_pipe_fd, thread_limit=1):
         # read length of buffer to read
-        buffer_len = b''
+        buffer_len = b""
         while True:
             c = os.read(in_pipe_fd, 1)
-            if c == b'':
-                print('Library code: cant get length', file=sys.stderr)
+            if c == b"":
+                print("Library code: cant get length", file=sys.stderr)
                 exit(1)
-            elif c == b'\n':
+            elif c == b"\n":
                 break
             else:
                 buffer_len += c
         buffer_len = int(buffer_len)
 
         # now read the buffer to get invocation details
-        line = str(os.read(in_pipe_fd, buffer_len), encoding='utf-8')
-        function_id, function_name, function_sandbox, function_stdout_file = line.split(" ", maxsplit=3)
+        line = str(os.read(in_pipe_fd, buffer_len), encoding="utf-8")
+        function_id, function_name, function_sandbox, function_stdout_file = line.split(
+            " ", maxsplit=3
+        )
         function_id = int(function_id)
 
         if not function_name:
             # malformed message from worker so we exit
-            print('malformed message from worker. Exiting..', file=sys.stderr)
+            print("malformed message from worker. Exiting..", file=sys.stderr)
             exit(1)
 
         with threadpool_limits(limits=thread_limit):
             # exec method for now is fork only, direct will be supported later
-            exec_method = 'fork'
+            exec_method = "fork"
             if exec_method == "direct":
                 library_sandbox = os.getcwd()
                 try:
@@ -119,17 +122,17 @@ def library_network_code():
 
                     # parameters are represented as infile.
                     os.chdir(function_sandbox)
-                    with open('infile', 'rb') as f:
+                    with open("infile", "rb") as f:
                         event = cloudpickle.load(f)
 
                     # output of execution should be dumped to outfile.
                     result = globals()[function_name](event)
                     try:
-                        with open('outfile', 'wb') as f:
+                        with open("outfile", "wb") as f:
                             cloudpickle.dump(result, f)
                     except Exception:
-                        if os.path.exits('outfile'):
-                            os.remove('outfile')
+                        if os.path.exits("outfile"):
+                            os.remove("outfile")
                         raise
 
                     try:
@@ -209,31 +212,69 @@ def library_network_code():
 
     # Send result of a function execution to worker. Wake worker up to do work with SIGCHLD.
     def send_result(out_pipe_fd, worker_pid, task_id, exit_code):
-        buff = bytes(f"{task_id} {exit_code}", 'utf-8')
+        buff = bytes(f"{task_id} {exit_code}", "utf-8")
         buff = bytes(str(len(buff)), "utf-8") + b"\n" + buff
         os.writev(out_pipe_fd, [buff])
         os.kill(worker_pid, signal.SIGCHLD)
 
     def main():
         ppid = os.getppid()
-        parser = argparse.ArgumentParser('Parse input and output file descriptors this process should use. The relevant fds should already be prepared by the vine_worker.')
-        parser.add_argument('--input-fd', required=True, type=int, help='input fd to receive messages from the vine_worker via a pipe')
-        parser.add_argument('--output-fd', required=True, type=int, help='output fd to send messages to the vine_worker via a pipe')
-        parser.add_argument('--task-id', required=False, type=int, default=-1, help='task id for this library.')
-        parser.add_argument('--library-cores', required=False, type=int, default=1, help='number of cores of this library')
-        parser.add_argument('--function-slots', required=False, type=int, default=1, help='number of function slots of this library')
-        parser.add_argument('--worker-pid', required=True, type=int, help='pid of main vine worker to send sigchild to let it know theres some result.')
+        parser = argparse.ArgumentParser(
+            "Parse input and output file descriptors this process should use. The relevant fds should already be prepared by the vine_worker."
+        )
+        parser.add_argument(
+            "--input-fd",
+            required=True,
+            type=int,
+            help="input fd to receive messages from the vine_worker via a pipe",
+        )
+        parser.add_argument(
+            "--output-fd",
+            required=True,
+            type=int,
+            help="output fd to send messages to the vine_worker via a pipe",
+        )
+        parser.add_argument(
+            "--task-id",
+            required=False,
+            type=int,
+            default=-1,
+            help="task id for this library.",
+        )
+        parser.add_argument(
+            "--library-cores",
+            required=False,
+            type=int,
+            default=1,
+            help="number of cores of this library",
+        )
+        parser.add_argument(
+            "--function-slots",
+            required=False,
+            type=int,
+            default=1,
+            help="number of function slots of this library",
+        )
+        parser.add_argument(
+            "--worker-pid",
+            required=True,
+            type=int,
+            help="pid of main vine worker to send sigchild to let it know theres some result.",
+        )
         args = parser.parse_args()
 
         # check if library cores and function slots are valid
         if args.function_slots > args.library_cores:
-            print('Library code: function slots cannot be more than library cores', file=sys.stderr)
+            print(
+                "Library code: function slots cannot be more than library cores",
+                file=sys.stderr,
+            )
             exit(1)
         elif args.function_slots < 1:
-            print('Library code: function slots cannot be less than 1', file=sys.stderr)
+            print("Library code: function slots cannot be less than 1", file=sys.stderr)
             exit(1)
         elif args.library_cores < 1:
-            print('Library code: library cores cannot be less than 1', file=sys.stderr)
+            print("Library code: library cores cannot be less than 1", file=sys.stderr)
             exit(1)
         thread_limit = args.library_cores // args.function_slots
 
@@ -281,7 +322,12 @@ def library_network_code():
                     while len(pid_to_func_id) > 0:
                         c_pid, c_exit_status = os.waitpid(-1, os.WNOHANG)
                         if c_pid > 0:
-                            send_result(out_pipe_fd, args.worker_pid, pid_to_func_id[c_pid], c_exit_status)
+                            send_result(
+                                out_pipe_fd,
+                                args.worker_pid,
+                                pid_to_func_id[c_pid],
+                                c_exit_status,
+                            )
                             del pid_to_func_id[c_pid]
                         # no exited child to reap, break
                         else:

--- a/poncho/src/poncho/library_network_code.py
+++ b/poncho/src/poncho/library_network_code.py
@@ -189,8 +189,8 @@ def library_network_code():
         return -1
 
     # Send result of a function execution to worker. Wake worker up to do work with SIGCHLD.
-    def send_result(out_pipe_fd, task_id, worker_pid):
-        buff = bytes(str(task_id), 'utf-8')
+    def send_result(out_pipe_fd, worker_pid, task_id, exit_code):
+        buff = bytes(f"{task_id} {exit_code}", 'utf-8')
         buff = bytes(str(len(buff)), "utf-8") + b"\n" + buff
         os.writev(out_pipe_fd, [buff])
         os.kill(worker_pid, signal.SIGCHLD)
@@ -262,7 +262,7 @@ def library_network_code():
                     while len(pid_to_func_id) > 0:
                         c_pid, c_exit_status = os.waitpid(-1, os.WNOHANG)
                         if c_pid > 0:
-                            send_result(out_pipe_fd, pid_to_func_id[c_pid], args.worker_pid)
+                            send_result(out_pipe_fd, args.worker_pid, pid_to_func_id[c_pid], c_exit_status)
                             del pid_to_func_id[c_pid]
                         # no exited child to reap, break
                         else:

--- a/poncho/src/poncho/package_serverize.py
+++ b/poncho/src/poncho/package_serverize.py
@@ -211,7 +211,6 @@ def serverize_library_from_code(
         "taskvine",
         import_modules=import_modules,
     )
-
     # remove the temp library file
     os.remove(tmp_library_path)
 

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -510,7 +510,6 @@ int vine_process_library_get_result(struct vine_process *p, uint64_t *done_task_
 	/* null terminate the buffer before treating it as a string. */
 	buffer_data[ok] = 0;
 	sscanf(buffer_data, "%" SCNu64 " %d", done_task_id, done_exit_code);
-	*done_exit_code = rand() % 3;
 	debug(D_VINE, "Received result for function %" PRIu64 ", exit code %d %s", *done_task_id, *done_exit_code, buffer_data);
 
 	return ok;

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -510,7 +510,11 @@ int vine_process_library_get_result(struct vine_process *p, uint64_t *done_task_
 	/* null terminate the buffer before treating it as a string. */
 	buffer_data[ok] = 0;
 	sscanf(buffer_data, "%" SCNu64 " %d", done_task_id, done_exit_code);
-	debug(D_VINE, "Received result for function %" PRIu64 ", exit code %d %s", *done_task_id, *done_exit_code, buffer_data);
+	debug(D_VINE,
+			"Received result for function %" PRIu64 ", exit code %d %s",
+			*done_task_id,
+			*done_exit_code,
+			buffer_data);
 
 	return ok;
 }

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -473,10 +473,10 @@ int vine_process_wait(struct vine_process *p)
 /* Receive a message containing a function call id from the library without blocking.
  * @param p			The vine process encapsulating the function call.
  * @param done_task_id          Pointer to location to store completed task id.
+ * @param done_exit_code        Pointer to location to the completed task exit code.
  * return 			1 if the operation succeeds, 0 otherwise.
  */
-
-int vine_process_library_get_result(struct vine_process *p, uint64_t *done_task_id)
+int vine_process_library_get_result(struct vine_process *p, uint64_t *done_task_id, int *done_exit_code)
 {
 	/* If this is not a library process, don't check. */
 	if (p->type != VINE_PROCESS_TYPE_LIBRARY)
@@ -509,9 +509,9 @@ int vine_process_library_get_result(struct vine_process *p, uint64_t *done_task_
 
 	/* null terminate the buffer before treating it as a string. */
 	buffer_data[ok] = 0;
-
-	*done_task_id = (uint64_t)strtoul(buffer_data, NULL, 10);
-	debug(D_VINE, "Received result for function %" PRIu64, *done_task_id);
+	sscanf(buffer_data, "%" SCNu64 " %d", done_task_id, done_exit_code);
+	*done_exit_code = rand() % 3;
+	debug(D_VINE, "Received result for function %" PRIu64 ", exit code %d %s", *done_task_id, *done_exit_code, buffer_data);
 
 	return ok;
 }

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -510,11 +510,7 @@ int vine_process_library_get_result(struct vine_process *p, uint64_t *done_task_
 	/* null terminate the buffer before treating it as a string. */
 	buffer_data[ok] = 0;
 	sscanf(buffer_data, "%" SCNu64 " %d", done_task_id, done_exit_code);
-	debug(D_VINE,
-			"Received result for function %" PRIu64 ", exit code %d %s",
-			*done_task_id,
-			*done_exit_code,
-			buffer_data);
+	debug(D_VINE, "Received result for function %" PRIu64 ", exit code %d", *done_task_id, *done_exit_code);
 
 	return ok;
 }

--- a/taskvine/src/worker/vine_process.h
+++ b/taskvine/src/worker/vine_process.h
@@ -83,7 +83,7 @@ void  vine_process_delete( struct vine_process *p );
 
 int   vine_process_execute_and_wait( struct vine_process *p );
 
-int   vine_process_library_get_result( struct vine_process *p, uint64_t *done_task_id );
+int   vine_process_library_get_result( struct vine_process *p, uint64_t *done_task_id, int *exit_code );
 
 void  vine_process_compute_disk_needed( struct vine_process *p );
 int   vine_process_measure_disk(struct vine_process *p, int max_time_on_measurement);

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -641,6 +641,7 @@ static int handle_completed_tasks(struct link *manager)
 	struct vine_process *fp;
 	uint64_t task_id;
 	uint64_t done_task_id;
+	int done_exit_code;
 
 	ITABLE_ITERATE(procs_running, task_id, p)
 	{
@@ -655,9 +656,10 @@ static int handle_completed_tasks(struct link *manager)
 
 		/* If p is a library, check to see if any results waiting. */
 
-		while (vine_process_library_get_result(p, &done_task_id)) {
+		while (vine_process_library_get_result(p, &done_task_id, &done_exit_code)) {
 			fp = itable_lookup(procs_table, done_task_id);
 			if (fp) {
+				fp->exit_code = done_exit_code;
 				reap_process(fp, manager);
 				result_retrieved++;
 			}


### PR DESCRIPTION
Second part of #3802.  The exit code of the function call is assigned to its process struct.

Note that no update in the protocol version is needed. The previous version used strtoul for the task id conversion, and discarded any extra characters.


## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
