### PR TITLE
Daskvine fix repeated keys

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -267,7 +267,8 @@ class DaskVine(Manager):
                                    lazy_transfers=lazy)
 
                 if self.env_per_task:
-                    t.set_command(f"mkdir envdir && tar -xf {self._environment_name} -C envdir && envdir/bin/run_in_env {t._command}")
+                    t.set_command(
+                        f"mkdir envdir && tar -xf {self._environment_name} -C envdir && envdir/bin/run_in_env {t._command}")
                     t.add_input(self.environment_file, self.environment_name)
 
                 t.set_tag(tag)  # tag that identifies this dag


### PR DESCRIPTION
vine: avoid running keys twice

    Seldom on init, some keys would get schedule for execution twice. Changed from
    list to dictionaries to eliminate repetitions.


## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
