### PR TITLE
change LIBRARY to TEMPLATE and INSTANCE

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2993,7 +2993,13 @@ static void reap_task_from_worker(
 			change_task_state(q, t, new_state);
 		}
 		break;
-	case VINE_TASK_TYPE_LIBRARY:
+	case VINE_TASK_TYPE_LIBRARY_INSTANCE:
+		change_task_state(q, t, VINE_TASK_RETRIEVED);
+		break;
+		return;
+	
+	case VINE_TASK_TYPE_LIBRARY_TEMPLATE:
+		/* A library template should not be scheduled... */
 		change_task_state(q, t, VINE_TASK_RETRIEVED);
 		break;
 		return;
@@ -4033,7 +4039,7 @@ static void delete_task_at_exit(struct vine_task *t)
 
 	vine_task_delete(t);
 
-	if (t->type == VINE_TASK_TYPE_LIBRARY) { /* change to VINE_TASK_LIBRARY_INSTANCE */
+	if (t->type == VINE_TASK_TYPE_LIBRARY_INSTANCE) {
 		/* manager created this task, so it is not the API caller's reponsibility. */
 		vine_task_delete(t);
 	}
@@ -4353,7 +4359,7 @@ static vine_task_state_t change_task_state(struct vine_manager *q, struct vine_t
 		c->vine_stats->tasks_with_results++;
 		break;
 	case VINE_TASK_RETRIEVED:
-		if (t->type == VINE_TASK_TYPE_LIBRARY) {
+		if (t->type == VINE_TASK_TYPE_LIBRARY_INSTANCE) {
 			vine_task_set_result(t, VINE_RESULT_LIBRARY_EXIT);
 		}
 		list_push_head(q->retrieved_list, t);
@@ -4588,7 +4594,7 @@ struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_wor
 
 void vine_manager_install_library(struct vine_manager *q, struct vine_task *t, const char *name)
 {
-	t->type = VINE_TASK_TYPE_LIBRARY;
+	t->type = VINE_TASK_TYPE_LIBRARY_INSTANCE;
 	t->task_id = -1;
 	vine_task_set_library_provided(t, name);
 	hash_table_insert(q->libraries, name, t);
@@ -4819,8 +4825,12 @@ struct vine_task *find_task_to_return(struct vine_manager *q, const char *tag, i
 		case VINE_TASK_TYPE_RECOVERY:
 			/* do nothing and let vine_manager_consider_recovery_task do its job */
 			break;
-		case VINE_TASK_TYPE_LIBRARY:
+		case VINE_TASK_TYPE_LIBRARY_INSTANCE:
 			/* silently delete it */
+			vine_task_delete(t);
+			break;
+		case VINE_TASK_TYPE_LIBRARY_TEMPLATE:
+			/* A template shouldn't be scheduled but delete it anyway */
 			vine_task_delete(t);
 			break;
 		}

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2997,7 +2997,7 @@ static void reap_task_from_worker(
 		change_task_state(q, t, VINE_TASK_RETRIEVED);
 		break;
 		return;
-	
+
 	case VINE_TASK_TYPE_LIBRARY_TEMPLATE:
 		/* A library template should not be scheduled... */
 		change_task_state(q, t, VINE_TASK_RETRIEVED);

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -24,7 +24,8 @@ End user may only use the API described in taskvine.h
 typedef enum {
       VINE_TASK_TYPE_STANDARD,    /**< A normal task that should be returned to the user. */
       VINE_TASK_TYPE_RECOVERY,    /**< An internally-created recovery task that should not be returned to the user. */
-      VINE_TASK_TYPE_LIBRARY,     /**< An internally-created library task that should not be returned to the user. */
+      VINE_TASK_TYPE_LIBRARY_TEMPLATE,     /**< An internally-created library task that should not be returned to the user. */
+      VINE_TASK_TYPE_LIBRARY_INSTANCE,     /**< An internally-created library task that should not be returned to the user. */
 } vine_task_type_t;
 
 typedef enum {


### PR DESCRIPTION
## Proposed changes
Splits VINE_TASK_TYPE_LIBRARY to VINE_TASK_TYPE_LIBRARY_TEMPLATE and VINE_TASK_TYPE_LIBRARY_INSTANCE. 


## Post-change actions

- [ ] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
