### PR TITLE
vine: Wait no wait

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -239,7 +239,7 @@ class DaskVine(Manager):
                     submitted += 1
                     pending += 1
 
-                t = self.wait(tag, timeout)
+                t = self.wait_for_tag(tag, timeout)
                 if t:
                     timeout = 0
                     pending -= 1

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -239,7 +239,7 @@ class DaskVine(Manager):
                     submitted += 1
                     pending += 1
 
-                t = self.wait_maybe_not_wait(tag, timeout)
+                t = self.wait(tag, timeout)
                 if t:
                     timeout = 0
                     pending -= 1
@@ -266,12 +266,6 @@ class DaskVine(Manager):
                 else:
                     timeout = 5
             return self._load_results(dag, indices, keys)
-
-    def wait_maybe_not_wait(self, tag, timeout):
-        if timeout > 0:
-            return self.wait_for_tag(tag, 5)
-        else:
-            return self.wait_no_wait(tag)
 
     def _make_progress_bar(self, total):
         if rich:

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1076,7 +1076,12 @@ class Manager(object):
             return task
         return None
 
-
+    ##
+    # Return any completed task without doing any manager work.
+    # If there is not a completed task, then it returns without any wait.
+    # @param task_id The desired task_id. If -1, then tasks are returned regardless of their task_id.
+    # @param tag The desired tag. If NULL, then tasks are returned regardless of their tag.
+    # @returns A completed task description, or None if there is not one.
     def wait_no_wait(self, tag=None, task_id=-1):
         task_pointer = cvine.vine_wait_no_wait(self._taskvine, tag, task_id)
         if task_pointer:

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1076,6 +1076,15 @@ class Manager(object):
             return task
         return None
 
+
+    def wait_no_wait(self, tag=None, task_id=-1):
+        task_pointer = cvine.vine_wait_no_wait(self._taskvine, tag, task_id)
+        if task_pointer:
+            task = self._task_table[cvine.vine_task_get_id(task_pointer)]
+            del self._task_table[cvine.vine_task_get_id(task_pointer)]
+            return task
+        return None
+
     ##
     # Should return a dictionary with information for the status display.
     # This method is meant to be overriden by custom applications.

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1024,6 +1024,7 @@ class Manager(object):
     # @param timeout    The number of seconds to wait for a completed task
     #                   before returning.  Use an integer to set the timeout or the value
     #                   "wait_forever" to block until a task has completed.
+    #                   If 0, return immediately with a complete task if one available, or None otherwise.
     def wait(self, timeout="wait_forever"):
         if timeout == "wait_forever":
             timeout = get_c_constant("wait_forever")
@@ -1039,6 +1040,7 @@ class Manager(object):
     # @param tag        Desired tag. If None, then it is equivalent to self.wait(timeout)
     # @param timeout    The number of seconds to wait for a completed task
     #                   before returning.
+    #                   If 0, return immediately with a complete task if one available, or None otherwise.
     def wait_for_tag(self, tag, timeout="wait_forever"):
         if timeout == "wait_forever":
             timeout = get_c_constant("wait_forever")
@@ -1064,26 +1066,13 @@ class Manager(object):
     # @param self       Reference to the current manager object.
     # @param task_id    Desired task_id. If -1, then it is equivalent to self.wait(timeout)
     # @param timeout    The number of seconds to wait for a completed task
-    #                   before returning.
+    #                   before returning. If 0, return immediately with a complete task if one available,
+    #                   or None otherwise.
     def wait_for_task_id(self, task_id, timeout="wait_forever"):
         if timeout == "wait_forever":
             timeout = get_c_constant("wait_forever")
 
         task_pointer = cvine.vine_wait_for_task_id(self._taskvine, task_id, timeout)
-        if task_pointer:
-            task = self._task_table[cvine.vine_task_get_id(task_pointer)]
-            del self._task_table[cvine.vine_task_get_id(task_pointer)]
-            return task
-        return None
-
-    ##
-    # Return any completed task without doing any manager work.
-    # If there is not a completed task, then it returns without any wait.
-    # @param task_id The desired task_id. If -1, then tasks are returned regardless of their task_id.
-    # @param tag The desired tag. If NULL, then tasks are returned regardless of their tag.
-    # @returns A completed task description, or None if there is not one.
-    def wait_no_wait(self, tag=None, task_id=-1):
-        task_pointer = cvine.vine_wait_no_wait(self._taskvine, tag, task_id)
         if task_pointer:
             task = self._task_table[cvine.vine_task_get_id(task_pointer)]
             del self._task_table[cvine.vine_task_get_id(task_pointer)]

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -924,6 +924,12 @@ Similar to @ref vine_wait, but guarantees that the returned task has the specifi
 */
 struct vine_task *vine_wait_for_task_id(struct vine_manager *m, int task_id, int timeout);
 
+/** Return any completed task without doing any manager work.
+If there is not a completed task, then it returns without any wait.
+@param task_id The desired task_id. If -1, then tasks are returned regardless of their task_id.
+@param tag The desired tag. If NULL, then tasks are returned regardless of their tag.
+@returns A completed task description, or null if there is not one.
+*/
 struct vine_task *vine_wait_no_wait(struct vine_manager *q, const char *tag, int task_id);
 
 /** Determine whether the manager is 'hungry' for more tasks.

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -924,6 +924,8 @@ Similar to @ref vine_wait, but guarantees that the returned task has the specifi
 */
 struct vine_task *vine_wait_for_task_id(struct vine_manager *m, int task_id, int timeout);
 
+struct vine_task *vine_wait_no_wait(struct vine_manager *q, const char *tag, int task_id);
+
 /** Determine whether the manager is 'hungry' for more tasks.
 While the manager can handle a very large number of tasks,
 it runs most efficiently when the number of tasks is slightly

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -900,8 +900,12 @@ If the task could not, then the <tt>result</tt> field will be non-zero and the
 <tt>return_status</tt> field will be undefined.
 
 @param m A manager object
-@param timeout The number of seconds to wait for a completed task before returning.  Use an integer time to set the timeout or the constant @ref VINE_WAIT_FOREVER to block until a task has completed.
-@returns A completed task description, or null if the manager is empty, or the timeout was reached without a completed task, or there is completed child process (call @ref process_wait to retrieve the status of the completed child process).
+@param timeout The number of seconds to wait for a completed task before returning.  Use an integer time to set the
+timeout or the constant @ref VINE_WAIT_FOREVER to block until a task has completed.
+If timeout is zero, return immediately a completed task, if one available, without performing any more manager's work.
+@returns A completed task description, or null if the manager is empty, or the timeout was reached without a completed
+task, or there is completed child process (call @ref process_wait to retrieve the status of the completed child
+process).
 */
 struct vine_task *vine_wait(struct vine_manager *m, int timeout);
 
@@ -910,7 +914,7 @@ struct vine_task *vine_wait(struct vine_manager *m, int timeout);
 Similar to @ref vine_wait, but guarantees that the returned task has the specified tag.
 @param m A manager object
 @param tag The desired tag. If NULL, then tasks are returned regardless of their tag.
-@param timeout The number of seconds to wait for a completed task before returning.  Use an integer time to set the timeout or the constant @ref VINE_WAIT_FOREVER to block until a task has completed.
+@param timeout The number of seconds to wait for a completed task before returning.  Use an integer time to set the timeout or the constant @ref VINE_WAIT_FOREVER to block until a task has completed. If timeout is zero, return immediately a completed task, if one available, without performing any more manager's work.
 @returns A completed task description, or null if the manager is empty, or the timeout was reached without a completed task, or there is completed child process (call @ref process_wait to retrieve the status of the completed child process).
 */
 struct vine_task *vine_wait_for_tag(struct vine_manager *m, const char *tag, int timeout);
@@ -919,18 +923,10 @@ struct vine_task *vine_wait_for_tag(struct vine_manager *m, const char *tag, int
 Similar to @ref vine_wait, but guarantees that the returned task has the specified task_id.
 @param m A manager object
 @param task_id The desired task_id. If -1, then tasks are returned regardless of their task_id.
-@param timeout The number of seconds to wait for a completed task before returning. Use an integer time to set the timeout or the constant @ref VINE_WAIT_FOREVER to block until a task has completed.
+@param timeout The number of seconds to wait for a completed task before returning. Use an integer time to set the timeout or the constant @ref VINE_WAIT_FOREVER to block until a task has completed. If timeout is zero, return immediately a completed task, if one available, without performing any more manager's work.
 @returns A completed task description, or null if the manager is empty, or the timeout was reached without a completed task, or there is completed child process (call @ref process_wait to retrieve the status of the completed child process).
 */
 struct vine_task *vine_wait_for_task_id(struct vine_manager *m, int task_id, int timeout);
-
-/** Return any completed task without doing any manager work.
-If there is not a completed task, then it returns without any wait.
-@param task_id The desired task_id. If -1, then tasks are returned regardless of their task_id.
-@param tag The desired tag. If NULL, then tasks are returned regardless of their tag.
-@returns A completed task description, or null if there is not one.
-*/
-struct vine_task *vine_wait_no_wait(struct vine_manager *q, const char *tag, int task_id);
 
 /** Determine whether the manager is 'hungry' for more tasks.
 While the manager can handle a very large number of tasks,

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4688,37 +4688,11 @@ struct vine_task *vine_wait(struct vine_manager *q, int timeout)
 
 struct vine_task *vine_wait_for_tag(struct vine_manager *q, const char *tag, int timeout)
 {
-	if (timeout == 0) {
-		// re-establish old, if unintended behavior, where 0 would wait at
-		// least a second. With 0, we would like the loop to be executed at
-		// least once, but right now we cannot enforce that. Making it 1, we
-		// guarantee that the wait loop is executed once.
-		timeout = 1;
-	}
-
-	if (timeout != VINE_WAIT_FOREVER && timeout < 0) {
-		debug(D_NOTICE | D_VINE, "Invalid wait timeout value '%d'. Waiting for 5 seconds.", timeout);
-		timeout = 5;
-	}
-
 	return vine_wait_internal(q, timeout, tag, -1);
 }
 
 struct vine_task *vine_wait_for_task_id(struct vine_manager *q, int task_id, int timeout)
 {
-	if (timeout == 0) {
-		// re-establish old, if unintended behavior, where 0 would wait at
-		// least a second. With 0, we would like the loop to be executed at
-		// least once, but right now we cannot enforce that. Making it 1, we
-		// guarantee that the wait loop is executed once.
-		timeout = 1;
-	}
-
-	if (timeout != VINE_WAIT_FOREVER && timeout < 0) {
-		debug(D_NOTICE | D_VINE, "Invalid wait timeout value '%d'. Waiting for 5 seconds.", timeout);
-		timeout = 5;
-	}
-
 	return vine_wait_internal(q, timeout, NULL, task_id);
 }
 
@@ -4854,8 +4828,6 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 	   - mark as busy-waiting and go to S
 	*/
 
-	int events = 0;
-
 	// account for time we spend outside vine_wait
 	if (q->time_last_wait > 0) {
 		q->stats->time_application += timestamp_get() - q->time_last_wait;
@@ -4863,6 +4835,17 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 		q->stats->time_application += timestamp_get() - q->stats->time_when_started;
 	}
 
+	if (timeout == 0) {
+		// if timeout is 0, just return any completed task if one available.
+		return vine_manager_no_wait(q, NULL, task_id);
+	}
+
+	if (timeout != VINE_WAIT_FOREVER && timeout < 0) {
+		debug(D_NOTICE | D_VINE, "Invalid wait timeout value '%d'. Waiting for 5 seconds.", timeout);
+		timeout = 5;
+	}
+
+	int events = 0;
 	print_password_warning(q);
 
 	// compute stoptime
@@ -5066,7 +5049,7 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 	return t;
 }
 
-struct vine_task *vine_wait_no_wait(struct vine_manager *q, const char *tag, int task_id)
+struct vine_task *vine_manager_no_wait(struct vine_manager *q, const char *tag, int task_id)
 {
 	BEGIN_ACCUM_TIME(q, time_internal);
 	struct vine_task *t = find_task_to_return(q, tag, task_id);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4837,7 +4837,7 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 
 	if (timeout == 0) {
 		// if timeout is 0, just return any completed task if one available.
-		return vine_manager_no_wait(q, NULL, task_id);
+		return vine_manager_no_wait(q, tag, task_id);
 	}
 
 	if (timeout != VINE_WAIT_FOREVER && timeout < 0) {

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5066,6 +5066,18 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 	return t;
 }
 
+
+struct vine_task *vine_wait_no_wait(struct vine_manager *q, const char *tag, int task_id)
+{
+	BEGIN_ACCUM_TIME(q, time_internal);
+	struct vine_task *t = find_task_to_return(q, tag, task_id);
+	END_ACCUM_TIME(q, time_internal);
+
+	return t;
+}
+
+
+
 // check if workers' resources are available to execute more tasks queue should
 // have at least MAX(hungry_minimum, hungry_minimum_factor * number of workers) ready tasks
 //@param: 	struct vine_manager* - pointer to manager

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5066,7 +5066,6 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 	return t;
 }
 
-
 struct vine_task *vine_wait_no_wait(struct vine_manager *q, const char *tag, int task_id)
 {
 	BEGIN_ACCUM_TIME(q, time_internal);
@@ -5075,8 +5074,6 @@ struct vine_task *vine_wait_no_wait(struct vine_manager *q, const char *tag, int
 
 	return t;
 }
-
-
 
 // check if workers' resources are available to execute more tasks queue should
 // have at least MAX(hungry_minimum, hungry_minimum_factor * number of workers) ready tasks

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -265,6 +265,10 @@ int vine_manager_shut_down_worker(struct vine_manager *q, struct vine_worker_inf
 
 struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_worker_info *w, const char *name);
 
+/** Return any completed task without doing any manager work. */
+struct vine_task *vine_manager_no_wait(struct vine_manager *q, const char *tag, int task_id);
+
+
 /* The expected format of files created by the resource monitor.*/
 #define RESOURCE_MONITOR_TASK_LOCAL_NAME "vine-task-%d"
 #define RESOURCE_MONITOR_REMOTE_NAME "cctools-monitor"


### PR DESCRIPTION
Return any completed task to the application without doing any work.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
