### PR TITLE
vine: temporary change: do not fail task if input file changed

### DIFF
--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -203,11 +203,13 @@ int vine_file_has_changed(struct vine_file *f)
 					(!S_ISDIR(info.st_mode) && ((int64_t)f->size) != ((int64_t)info.st_size))) {
 				if (!f->change_message_shown) {
 					debug(D_VINE | D_NOTICE,
-							"input file %s was modified by someone in the middle of the workflow!\n",
+							"input file %s was modified by someone in the middle of the workflow! Workers may use different versions of the file.\n",
 							f->source);
 					f->change_message_shown++;
 				}
-				return 1;
+				// XXX: do nothing for now, as some workflows break after
+				// updating the file times without modifying its contents.
+				return 0;
 			}
 		}
 	}

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -421,8 +421,8 @@ static vine_result_code_t vine_manager_put_input_file_if_needed(struct vine_mana
 		struct vine_task *t, struct vine_mount *m, struct vine_file *f)
 {
 	/* If the file source has changed, it's a violation of the workflow. */
-
 	if (vine_file_has_changed(f)) {
+		// XXX: For now the check only returns true if the file does not exist!
 		vine_task_set_result(t, VINE_RESULT_INPUT_MISSING);
 		return VINE_APP_FAILURE;
 	}


### PR DESCRIPTION
coffea casa touches token files, which modifies file times withouth modifying the contents.

## Proposed changes

Please describe your changes (e.g., what problems they attempt to solve, what results are expected, etc.) Additional motivation and context are welcome.
Please also mention relevant issues and pull requests as appropriate.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
