### PR TITLE
vine: temporary, release worker that failed to xfer input file

### DIFF
--- a/taskvine/src/manager/vine_blocklist.c
+++ b/taskvine/src/manager/vine_blocklist.c
@@ -111,3 +111,13 @@ int vine_blocklist_is_blocked(struct vine_manager *q, const char *hostname)
 	struct vine_blocklist_info *info = hash_table_lookup(q->worker_blocklist, hostname);
 	return info && info->blocked;
 }
+
+int vine_blocklist_times_blocked(struct vine_manager *q, const char *hostname)
+{
+	struct vine_blocklist_info *info = hash_table_lookup(q->worker_blocklist, hostname);
+	if (info) {
+		return info->blocked;
+	}
+
+	return 0;
+}

--- a/taskvine/src/manager/vine_blocklist.h
+++ b/taskvine/src/manager/vine_blocklist.h
@@ -27,6 +27,7 @@ void       vine_blocklist_block( struct vine_manager *q, const char *hostname, t
 void       vine_blocklist_unblock_all_by_time(struct vine_manager *q, time_t deadline);
 void       vine_blocklist_unblock( struct vine_manager *q, const char *host );
 int        vine_blocklist_is_blocked( struct vine_manager *q, const char *host );
+int        vine_blocklist_times_blocked(struct vine_manager *q, const char *hostname);
 struct jx *vine_blocklist_to_jx( struct vine_manager *q );
 
 #endif

--- a/taskvine/src/manager/vine_current_transfers.c
+++ b/taskvine/src/manager/vine_current_transfers.c
@@ -73,7 +73,7 @@ void set_throttle(struct vine_manager *m, struct vine_worker_info *w, int is_des
 	int bad;
 	int streak;
 
-    int grace = 5;   // XXX: make tunable parameter: q->consecutieve_max_xfer_errors;
+	int grace = 5; // XXX: make tunable parameter: q->consecutieve_max_xfer_errors;
 	const char *dir;
 
 	if (is_destination) {
@@ -81,8 +81,9 @@ void set_throttle(struct vine_manager *m, struct vine_worker_info *w, int is_des
 		bad = w->xfer_total_bad_destination_counter;
 		streak = w->xfer_streak_bad_destination_counter;
 		dir = "destination";
-        // since worker can talk to manager, probably the issue is with sources. Give more chances to destinations.
-        grace *= 2;
+		// since worker can talk to manager, probably the issue is with sources. Give more chances to
+		// destinations.
+		grace *= 2;
 	} else {
 		good = w->xfer_total_good_source_counter;
 		bad = w->xfer_total_bad_source_counter;
@@ -90,7 +91,14 @@ void set_throttle(struct vine_manager *m, struct vine_worker_info *w, int is_des
 		dir = "source";
 	}
 
-	debug(D_VINE, "Setting transfer failure (%d,%d/%d) timestamp on %s worker: %s:%d", streak, bad, good+bad, dir, w->hostname, w->transfer_port);
+	debug(D_VINE,
+			"Setting transfer failure (%d,%d/%d) timestamp on %s worker: %s:%d",
+			streak,
+			bad,
+			good + bad,
+			dir,
+			w->hostname,
+			w->transfer_port);
 
 	w->last_transfer_failure = timestamp_get();
 
@@ -107,7 +115,7 @@ void set_throttle(struct vine_manager *m, struct vine_worker_info *w, int is_des
 				w->addrport,
 				bad,
 				bad + good);
-        vine_manager_remove_worker(m, w, VINE_WORKER_DISCONNECT_XFER_ERRORS);
+		vine_manager_remove_worker(m, w, VINE_WORKER_DISCONNECT_XFER_ERRORS);
 	}
 }
 

--- a/taskvine/src/manager/vine_current_transfers.h
+++ b/taskvine/src/manager/vine_current_transfers.h
@@ -16,6 +16,8 @@ int vine_current_transfers_remove(struct vine_manager *q, const char *id);
 
 int vine_current_transfers_set_failure(struct vine_manager *q, char *id);
 
+void vine_current_transfers_set_success(struct vine_manager *q, char *id);
+
 int vine_current_transfers_source_in_use(struct vine_manager *q, struct vine_worker_info *source);
 
 int vine_current_transfers_url_in_use(struct vine_manager *q, const char *source);

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -237,7 +237,7 @@ int vine_file_replica_table_exists_somewhere(struct vine_manager *q, const char 
 
 	SET_ITERATE(workers, peer)
 	{
-		if (peer->transfer_port_active && !vine_blocklist_is_blocked(q, peer->addrport)) {
+		if (peer->transfer_port_active) {
 			return 1;
 		}
 	}

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -6,6 +6,7 @@ See the file COPYING for details.
 
 #include "vine_file_replica_table.h"
 #include "set.h"
+#include "vine_blocklist.h"
 #include "vine_current_transfers.h"
 #include "vine_file.h"
 #include "vine_file_replica.h"
@@ -236,7 +237,7 @@ int vine_file_replica_table_exists_somewhere(struct vine_manager *q, const char 
 
 	SET_ITERATE(workers, peer)
 	{
-		if (peer->transfer_port_active) {
+		if (peer->transfer_port_active && !vine_blocklist_is_blocked(q, peer->addrport)) {
 			return 1;
 		}
 	}

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -868,7 +868,8 @@ static void recall_worker_lost_temp_files(struct vine_manager *q, struct vine_wo
 
 /* Remove a worker from this master by removing all remote state, all local state, and disconnecting. */
 
-void vine_manager_remove_worker(struct vine_manager *q, struct vine_worker_info *w, vine_worker_disconnect_reason_t reason)
+void vine_manager_remove_worker(
+		struct vine_manager *q, struct vine_worker_info *w, vine_worker_disconnect_reason_t reason)
 {
 	if (!q || !w)
 		return;

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -374,6 +374,7 @@ static int handle_cache_update(struct vine_manager *q, struct vine_worker_info *
 		replica->transfer_time = transfer_time;
 		replica->state = VINE_FILE_REPLICA_STATE_READY;
 
+		vine_current_transfers_set_success(q, id);
 		vine_current_transfers_remove(q, id);
 
 		vine_txn_log_write_cache_update(q, w, size, transfer_time, start_time, cachename);
@@ -439,13 +440,13 @@ static int handle_cache_invalid(struct vine_manager *q, struct vine_worker_info 
 			vine_file_replica_delete(replica);
 		}
 
-		/* throttle workers that could transfer a file */
-		w->last_failure_time = timestamp_get();
-
 		/* If the third argument was given, also remove the transfer record */
 		if (n >= 3) {
 			vine_current_transfers_set_failure(q, transfer_id);
 			vine_current_transfers_remove(q, transfer_id);
+		} else {
+			/* throttle workers that could transfer a file */
+			w->last_failure_time = timestamp_get();
 		}
 
 		/* Successfully processed this message. */

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -58,7 +58,8 @@ typedef enum {
 	VINE_WORKER_DISCONNECT_STATUS_WORKER,
 	VINE_WORKER_DISCONNECT_IDLE_OUT,
  	VINE_WORKER_DISCONNECT_FAST_ABORT,
-	VINE_WORKER_DISCONNECT_FAILURE
+	VINE_WORKER_DISCONNECT_FAILURE,
+	VINE_WORKER_DISCONNECT_XFER_ERRORS
 } vine_worker_disconnect_reason_t;
 
 /* States known about libraries */
@@ -267,6 +268,8 @@ struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_wor
 
 /** Return any completed task without doing any manager work. */
 struct vine_task *vine_manager_no_wait(struct vine_manager *q, const char *tag, int task_id);
+
+void vine_manager_remove_worker(struct vine_manager *q, struct vine_worker_info *w, vine_worker_disconnect_reason_t reason);
 
 
 /* The expected format of files created by the resource monitor.*/

--- a/taskvine/src/manager/vine_txn_log.c
+++ b/taskvine/src/manager/vine_txn_log.c
@@ -36,7 +36,7 @@ void vine_txn_log_write_header(struct vine_manager *q)
 	fprintf(q->txn_logfile, "# time manager_pid MANAGER manager_pid START|END time_from_origin\n");
 	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id CONNECTION host:port\n");
 	fprintf(q->txn_logfile,
-			"# time manager_pid WORKER worker_id DISCONNECTION (UNKNOWN|IDLE_OUT|FAST_ABORT|FAILURE|STATUS_WORKER|EXPLICIT)\n");
+			"# time manager_pid WORKER worker_id DISCONNECTION (UNKNOWN|IDLE_OUT|FAST_ABORT|FAILURE|STATUS_WORKER|EXPLICIT|XFER_ERRORS)\n");
 	fprintf(q->txn_logfile, "# time manager_pid WORKER worker_id RESOURCES {resources}\n");
 	fprintf(q->txn_logfile,
 			"# time manager_pid WORKER worker_id CACHE_UPDATE filename size_in_mb wall_time_us start_time_us\n");
@@ -264,6 +264,9 @@ void vine_txn_log_write_worker(struct vine_manager *q, struct vine_worker_info *
 			break;
 		case VINE_WORKER_DISCONNECT_EXPLICIT:
 			buffer_printf(&B, " EXPLICIT");
+			break;
+		case VINE_WORKER_DISCONNECT_XFER_ERRORS:
+			buffer_printf(&B, " XFER_ERRORS");
 			break;
 		case VINE_WORKER_DISCONNECT_UNKNOWN:
 		default:

--- a/taskvine/src/manager/vine_worker_info.c
+++ b/taskvine/src/manager/vine_worker_info.c
@@ -42,6 +42,10 @@ struct vine_worker_info *vine_worker_create(struct link *lnk)
 	w->last_transfer_failure = 0;
 	w->last_failure_time = 0;
 
+	w->xfer_streak_counter = 0;
+	w->xfer_total_good_counter = 0;
+	w->xfer_total_bad_counter = 0;
+
 	vine_counters.worker.created++;
 
 	return w;

--- a/taskvine/src/manager/vine_worker_info.c
+++ b/taskvine/src/manager/vine_worker_info.c
@@ -42,10 +42,6 @@ struct vine_worker_info *vine_worker_create(struct link *lnk)
 	w->last_transfer_failure = 0;
 	w->last_failure_time = 0;
 
-	w->xfer_streak_counter = 0;
-	w->xfer_total_good_counter = 0;
-	w->xfer_total_bad_counter = 0;
-
 	vine_counters.worker.created++;
 
 	return w;

--- a/taskvine/src/manager/vine_worker_info.h
+++ b/taskvine/src/manager/vine_worker_info.h
@@ -80,6 +80,14 @@ struct vine_worker_info {
 	timestamp_t last_msg_recv_time;
 	timestamp_t last_update_msg_time;
 	timestamp_t last_failure_time;
+
+	/* consecutive success/failed peer transfers with worker serving a source or destination */
+	/* > 0 means successful transfers since last failure, < 0 means failed transfers since last success. */
+	int xfer_streak_counter;
+
+	/* total transfers */
+	int xfer_total_good_counter;
+	int xfer_total_bad_counter;
 };
 
 struct vine_worker_info * vine_worker_create( struct link * lnk );

--- a/taskvine/src/manager/vine_worker_info.h
+++ b/taskvine/src/manager/vine_worker_info.h
@@ -81,13 +81,17 @@ struct vine_worker_info {
 	timestamp_t last_update_msg_time;
 	timestamp_t last_failure_time;
 
-	/* consecutive success/failed peer transfers with worker serving a source or destination */
-	/* > 0 means successful transfers since last failure, < 0 means failed transfers since last success. */
-	int xfer_streak_counter;
+	/* consecutive failed peer transfers with worker serving as source or destination */
+	int xfer_streak_bad_source_counter;
+
+	/* consecutive failed peer transfers with worker serving as destination or destination */
+	int xfer_streak_bad_destination_counter;
 
 	/* total transfers */
-	int xfer_total_good_counter;
-	int xfer_total_bad_counter;
+	int xfer_total_good_source_counter;
+	int xfer_total_bad_source_counter;
+	int xfer_total_good_destination_counter;
+	int xfer_total_bad_destination_counter;
 };
 
 struct vine_worker_info * vine_worker_create( struct link * lnk );


### PR DESCRIPTION
Temporary fix for #3763. If worker can't transfer input file, it is released.
Without this change, coffea casa workflows get stuck, as there is always a worker that can't communicate with other workers.

Maybe we can add a counter so that the worker is released after 3 consecutive failed tasks, or something like that. 

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
