### PR TITLE
vine: release lib tasks

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -1072,16 +1072,16 @@ class FunctionCall(PythonTask):
     #
     # @param self 	Reference to the current python task object
     def submit_finalize(self):
+        name = os.path.join(self.manager.staging_directory, "arguments", self._id)
+        with open(name, "wb") as wf:
+            cloudpickle.dump(self._event, wf)
+        self._input_file = self.manager.declare_file(name, unlink_when_done=True, cache=False, peer_transfer=True)
+
         if self._tmp_output_enabled:
-            # output survives task, writing input to disk to reduce mem usage.
-            name = os.path.join(self.manager.staging_directory, "arguments", self._id)
-            with open(name, "wb") as wf:
-                cloudpickle.dump(self._event, wf)
-            self._input_file = self.manager.declare_file(name, unlink_when_done=True, cache=False, peer_transfer=True)
             self._output_file = self.manager.declare_temp()
         else:
-            self._input_file = self.manager.declare_buffer(buffer=cloudpickle.dumps(self._event), cache=False, peer_transfer=True)
-            self._output_file = self.manager.declare_buffer(buffer=None, cache=self._cache_output, peer_transfer=False)
+            name = os.path.join(self.manager.staging_directory, "outputs", self._id)
+            self._output_file = self.manager.declare_file(name, cache=self._cache_output, unlink_when_done=False)
 
         self._event = None  # free args memory. Once in a file they are not needed anymore.
         self.add_input(self._input_file, "infile")

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4547,15 +4547,15 @@ struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_wor
 		return 0;
 	}
 
+	/* Check if this library task can fit in this worker. */
+	/* check_worker_against_task needs original to check whether a previous attempts failed. */
+	if (!check_worker_against_task(q, w, original)) {
+		return 0;
+	}
+
 	/* Duplicate the original task */
 	struct vine_task *t = vine_task_copy(original);
 	t->type = VINE_TASK_TYPE_LIBRARY_INSTANCE;
-
-	/* Check if this library task can fit in this worker. */
-	if (!check_worker_against_task(q, w, t)) {
-		vine_task_delete(t);
-		return 0;
-	}
 
 	/* Give it a unique taskid if library fits the worker. */
 	t->task_id = q->next_task_id++;

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4761,7 +4761,7 @@ struct vine_task *find_task_to_return(struct vine_manager *q, const char *tag, i
 			int tasks_to_consider = list_size(q->retrieved_list);
 			while (tasks_to_consider > 0) {
 				tasks_to_consider--;
-				temp = list_peek_head(q->ready_list);
+				temp = list_peek_head(q->retrieved_list);
 				// a small hack, if task is not standard we accepted it so it can be deleted below.
 				if (temp->type != VINE_TASK_TYPE_STANDARD || task_tag_comparator(temp, tag)) {
 					// temp points to head of list

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4548,7 +4548,7 @@ struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_wor
 	}
 
 	/* Check if this library task can fit in this worker. */
-	/* check_worker_against_task needs original to check whether a previous attempts failed. */
+	/* check_worker_against_task does not, and should not, modify the task */
 	if (!check_worker_against_task(q, w, original)) {
 		return 0;
 	}

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4803,11 +4803,10 @@ struct vine_task *find_task_to_return(struct vine_manager *q, const char *tag, i
 			break;
 		case VINE_TASK_TYPE_LIBRARY_INSTANCE:
 			/* silently delete it */
-			vine_task_delete(t);
+			vine_task_delete(t); // delete as manager created this task
 			break;
 		case VINE_TASK_TYPE_LIBRARY_TEMPLATE:
-			/* A template shouldn't be scheduled but delete it anyway */
-			vine_task_delete(t);
+			/* A template shouldn't be scheduled. It's deleted when template table is deleted.*/
 			break;
 		}
 	}

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -178,7 +178,7 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 
 	// if wall time for worker is specified and there's not enough time for task, then not ok
 	if (w->end_time > 0) {
-		double current_time = timestamp_get() / ONE_SECOND;
+		double current_time = ((double) timestamp_get()) / ONE_SECOND;
 		if (t->resources_requested->end > 0 && w->end_time < t->resources_requested->end) {
 			return 0;
 		}

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -178,7 +178,7 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 
 	// if wall time for worker is specified and there's not enough time for task, then not ok
 	if (w->end_time > 0) {
-		double current_time = ((double) timestamp_get()) / ONE_SECOND;
+		double current_time = ((double)timestamp_get()) / ONE_SECOND;
 		if (t->resources_requested->end > 0 && w->end_time < t->resources_requested->end) {
 			return 0;
 		}

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -132,6 +132,9 @@ int check_worker_have_enough_resources(
 
 int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
 {
+	/* THIS FUNCTION SHOULD NOT MODIFY t IN ANY WAY. */
+	/* Otherwise library templates are modified during the run. */
+
 	/* worker has not reported any resources yet */
 	if (w->resources->tag < 0 || w->resources->workers.total < 1) {
 		return 0;

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -245,6 +245,7 @@ struct vine_task *vine_task_copy(const struct vine_task *task)
 	/* Resource requests are copied. */
 
 	if (task->resources_requested) {
+		rmsummary_delete(new->resources_requested);
 		new->resources_requested = rmsummary_copy(task->resources_requested, 0);
 	}
 

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -157,30 +157,25 @@ void vine_task_reset(struct vine_task *t)
 	retract_mounts_on_reset(t->output_mounts);
 }
 
-static struct list *vine_task_mount_list_copy(struct list *list)
+static void vine_task_mount_list_copy(struct list *destination, struct list *list)
 {
-	struct list *new = list_create();
 	struct vine_mount *old_mount, *new_mount;
 
 	LIST_ITERATE(list, old_mount)
 	{
 		new_mount = vine_mount_copy(old_mount);
-		list_push_tail(new, new_mount);
+		list_push_tail(destination, new_mount);
 	}
-	return new;
 }
 
-static struct list *vine_task_string_list_copy(struct list *string_list)
+static void vine_task_string_list_copy(struct list *destination, struct list *string_list)
 {
-	struct list *new = list_create();
 	char *var;
 
 	LIST_ITERATE(string_list, var)
 	{
-		list_push_tail(new, xxstrdup(var));
+		list_push_tail(destination, xxstrdup(var));
 	}
-
-	return new;
 }
 
 struct vine_task *vine_task_addref(struct vine_task *t)
@@ -222,17 +217,10 @@ struct vine_task *vine_task_copy(const struct vine_task *task)
 		vine_task_set_snapshot_file(new, task->monitor_snapshot_file);
 	}
 
-	list_delete(new->input_mounts);
-	new->input_mounts = vine_task_mount_list_copy(task->input_mounts);
-
-	list_delete(new->output_mounts);
-	new->output_mounts = vine_task_mount_list_copy(task->output_mounts);
-
-	list_delete(new->env_list);
-	new->env_list = vine_task_string_list_copy(task->env_list);
-
-	list_delete(new->feature_list);
-	new->feature_list = vine_task_string_list_copy(task->feature_list);
+	vine_task_mount_list_copy(new->input_mounts, task->input_mounts);
+	vine_task_mount_list_copy(new->output_mounts, task->output_mounts);
+	vine_task_string_list_copy(new->env_list, task->env_list);
+	vine_task_string_list_copy(new->feature_list, task->feature_list);
 
 	/* Scheduling features of task are copied. */
 	new->resource_request = task->resource_request;

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -222,11 +222,17 @@ struct vine_task *vine_task_copy(const struct vine_task *task)
 		vine_task_set_snapshot_file(new, task->monitor_snapshot_file);
 	}
 
+	list_delete(new->input_mounts);
 	new->input_mounts = vine_task_mount_list_copy(task->input_mounts);
+
+	list_delete(new->output_mounts);
 	new->output_mounts = vine_task_mount_list_copy(task->output_mounts);
+
+	list_delete(new->env_list);
 	new->env_list = vine_task_string_list_copy(task->env_list);
+
+	list_delete(new->feature_list);
 	new->feature_list = vine_task_string_list_copy(task->feature_list);
-	new->function_slots = task->function_slots;
 
 	/* Scheduling features of task are copied. */
 	new->resource_request = task->resource_request;

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -221,6 +221,7 @@ struct vine_task *vine_task_copy(const struct vine_task *task)
 	vine_task_mount_list_copy(new->output_mounts, task->output_mounts);
 	vine_task_string_list_copy(new->env_list, task->env_list);
 	vine_task_string_list_copy(new->feature_list, task->feature_list);
+	new->function_slots = task->function_slots;
 
 	/* Scheduling features of task are copied. */
 	new->resource_request = task->resource_request;


### PR DESCRIPTION
Remove library instances from retrieved list when waiting by tag.
Still need to fix when waiting by task id.


## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
