### PR TITLE
vine: dask executor worker transfers segfault fix

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -67,8 +67,8 @@ class DaskVine(Manager):
     # @param environment   A taskvine file representing an environment to run the tasks.
     # @param extra_files   A dictionary of {taskvine.File: "remote_name"} to add to each
     #                      task.
-    # @param lazy_transfers Whether to keep intermediate results only at workers (True)
-    #                      or to bring back each result to the manager (False, default).
+    # @param worker_transfers Whether to keep intermediate results only at workers (True, default)
+    #                      or to bring back each result to the manager (False).
     #                      True is more IO efficient, but runs the risk of needing to
     #                      recompute results if workers are lost.
     # @param env_vars      A dictionary of VAR=VALUE environment variables to set per task. A value
@@ -76,7 +76,7 @@ class DaskVine(Manager):
     #                      and task, and that returns a string.
     # @param low_memory_mode Split graph vertices to reduce memory needed per function call. It
     #                      removes some of the dask graph optimizations, thus proceed with care.
-    # @param  checkpoint_fn When using lazy_transfers, a predicate with arguments (dag, key)
+    # @param checkpoint_fn When using worker_transfers, a predicate with arguments (dag, key)
     #                      called before submitting a task. If True, the result is brought back
     #                      to the manager.
     # @param resources     A dictionary with optional keys of cores, memory and disk (MB)
@@ -107,7 +107,7 @@ class DaskVine(Manager):
     def get(self, dsk, keys, *,
             environment=None,
             extra_files=None,
-            lazy_transfers=False,
+            worker_transfers=True,
             env_vars=None,
             low_memory_mode=False,
             checkpoint_fn=None,
@@ -128,6 +128,7 @@ class DaskVine(Manager):
             wrapper=None,
             wrapper_proc=print,
             import_modules=None  # Deprecated, use lib_modules
+            lazy_transfers=True, # Deprecated, use worker_tranfers
             ):
         try:
             self.set_property("framework", "dask")
@@ -140,7 +141,7 @@ class DaskVine(Manager):
                 self.environment = environment
 
             self.extra_files = extra_files
-            self.lazy_transfers = lazy_transfers
+            self.worker_transfers = worker_transfers or lazy_transfers
             self.env_vars = env_vars
             self.low_memory_mode = low_memory_mode
             self.checkpoint_fn = checkpoint_fn
@@ -320,7 +321,7 @@ class DaskVine(Manager):
     def _enqueue_dask_calls(self, dag, tag, rs, retries, enqueued_calls):
         targets = dag.get_targets()
         for (k, sexpr) in rs:
-            lazy = self.lazy_transfers and k not in targets
+            lazy = self.worker_transfers and k not in targets
             if lazy and self.checkpoint_fn:
                 lazy = self.checkpoint_fn(dag, k)
 
@@ -343,7 +344,7 @@ class DaskVine(Manager):
                                    extra_files=self.extra_files,
                                    env_vars=self.env_vars,
                                    retries=retries,
-                                   lazy_transfers=lazy,
+                                   worker_transfers=lazy,
                                    wrapper=self.wrapper)
 
                 if self.env_per_task:
@@ -360,7 +361,7 @@ class DaskVine(Manager):
                                      category=cat,
                                      extra_files=self.extra_files,
                                      retries=retries,
-                                     lazy_transfers=lazy,
+                                     worker_transfers=lazy,
                                      wrapper=self.wrapper)
 
                 t.set_tag(tag)  # tag that identifies this dag
@@ -490,7 +491,7 @@ class PythonTaskDask(PythonTask):
     # @param extra_files    Additional files to provide to the task.
     # @param env_vars       A dictionary of environment variables.
     # @param retries        Number of times to retry failed task.
-    # @param lazy_transfers If true, do not return outputs to manager until required.
+    # @param worker_transfers If true, do not return outputs to manager until required.
     # @param wrapper
     #
     def __init__(self, m,
@@ -500,7 +501,7 @@ class PythonTaskDask(PythonTask):
                  extra_files=None,
                  env_vars=None,
                  retries=5,
-                 lazy_transfers=False,
+                 worker_transfers=False,
                  wrapper=None):
         self._key = key
         self._sexpr = sexpr
@@ -533,7 +534,7 @@ class PythonTaskDask(PythonTask):
 
         if category:
             self.set_category(category)
-        if lazy_transfers:
+        if worker_transfers:
             self.enable_temp_output()
         if environment:
             self.add_environment(environment)
@@ -592,7 +593,7 @@ class FunctionCallDask(FunctionCall):
     # @param resources      Resources to be set for a FunctionCall.
     # @param extra_files    Additional files to provide to the task.
     # @param retries        Number of times to retry failed task.
-    # @param lazy_transfers If true, do not return outputs to manager until required.
+    # @param worker_transfers If true, do not return outputs to manager until required.
     #
 
     def __init__(self, m,
@@ -601,7 +602,7 @@ class FunctionCallDask(FunctionCall):
                  resources=None,
                  extra_files=None,
                  retries=5,
-                 lazy_transfers=False,
+                 worker_transfers=False,
                  wrapper=None):
 
         self._key = key
@@ -632,7 +633,7 @@ class FunctionCallDask(FunctionCall):
 
         if category:
             self.set_category(category)
-        if lazy_transfers:
+        if worker_transfers:
             self.enable_temp_output()
         if extra_files:
             for f, name in extra_files.items():

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -127,8 +127,8 @@ class DaskVine(Manager):
             progress_label="[green]tasks",
             wrapper=None,
             wrapper_proc=print,
-            import_modules=None  # Deprecated, use lib_modules
-            lazy_transfers=True, # Deprecated, use worker_tranfers
+            import_modules=None,  # Deprecated, use lib_modules
+            lazy_transfers=True,  # Deprecated, use worker_tranfers
             ):
         try:
             self.set_property("framework", "dask")

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -878,6 +878,7 @@ class PythonTask(Task):
         try:
             if self._input_file:
                 self.manager.undeclare_file(self._input_file)
+                self._input_file = None
             super().__del__()
         except TypeError:
             # in case the interpreter is shuting down. staging files will be deleted by manager atexit function.
@@ -1133,26 +1134,17 @@ class FunctionCall(PythonTask):
             else:
                 self._output = FunctionCallNoResult()
 
-            self.manager.undeclare_file(self._input_file)
-            self._input_file = None
-
-            self.manager.undeclare_file(self._output_file)
-            self._output_file = None
-
             self._output_loaded = True
         return self._output
 
-    # Remove input and output buffers if self.output was not called.
     def __del__(self):
         try:
             if self._input_file:
                 self.manager.undeclare_file(self._input_file)
                 self._input_file = None
-            if self._output_file and not self._tmp_output_enabled:
-                self.manager.undeclare_file(self._output_file)
-                self._output_file = None
             super().__del__()
         except TypeError:
+            # in case the interpreter is shuting down. staging files will be deleted by manager atexit function.
             pass
 
 

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -133,7 +133,7 @@ int vine_file_replica_table_replicate(struct vine_manager *m, struct vine_file *
 		return found;
 	}
 
-	debug(D_VINE, "Found %d workers to holding %s, %d replicas needed", nsources, f->cached_name, to_find);
+	debug(D_VINE, "Found %d workers holding %s, %d replicas needed", nsources, f->cached_name, to_find);
 
 	/* get the elements of set so we can insert new replicas to sources */
 	struct vine_worker_info **sources_frozen = (struct vine_worker_info **)set_values(sources);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -313,7 +313,7 @@ static vine_msg_code_t handle_info(struct vine_manager *q, struct vine_worker_in
 		handle_worker_timeout(q, w);
 	} else if (string_prefix_is(field, "worker-id")) {
 		free(w->workerid);
-		w->workerid = string_format("%s", w->hashkey);
+		w->workerid = xxstrdup(field);
 		vine_txn_log_write_worker(q, w, 0, 0);
 	} else if (string_prefix_is(field, "worker-end-time")) {
 		w->end_time = MAX(0, atoll(value));

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -313,7 +313,7 @@ static vine_msg_code_t handle_info(struct vine_manager *q, struct vine_worker_in
 		handle_worker_timeout(q, w);
 	} else if (string_prefix_is(field, "worker-id")) {
 		free(w->workerid);
-		w->workerid = xxstrdup(value);
+		w->workerid = string_format("%s", w->hashkey);
 		vine_txn_log_write_worker(q, w, 0, 0);
 	} else if (string_prefix_is(field, "worker-end-time")) {
 		w->end_time = MAX(0, atoll(value));

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -313,7 +313,7 @@ static vine_msg_code_t handle_info(struct vine_manager *q, struct vine_worker_in
 		handle_worker_timeout(q, w);
 	} else if (string_prefix_is(field, "worker-id")) {
 		free(w->workerid);
-		w->workerid = xxstrdup(field);
+		w->workerid = xxstrdup(value);
 		vine_txn_log_write_worker(q, w, 0, 0);
 	} else if (string_prefix_is(field, "worker-end-time")) {
 		w->end_time = MAX(0, atoll(value));


### PR DESCRIPTION
Makes the behavior of python tasks and function calls the same when dealing with input and output files. The caller should be in charge of undeclaring outputs. Function calls used to undeclare output when calling `t.output`, but this side effect made it hard to the caller to decide what to do with files.

This change also makes it easier to achieve #3828 and #3829.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
