### PR TITLE
vine: check if the library exists when submitting FunctionCall tasks

### DIFF
--- a/poncho/src/poncho/package_serverize.py
+++ b/poncho/src/poncho/package_serverize.py
@@ -103,11 +103,6 @@ def create_library_code(path, funcs, dest, version, import_modules=None):
             output_file.write("@remote_execute\n")
             output_file.write(function_code)
             output_file.write("\n")
-        
-        # write a retriever function for retriever tasks used in FutureFunctionCall tasks
-        output_file.write("@remote_execute\n")
-        output_file.write("def retrieve_output(arg):\n")
-        output_file.write("    return arg\n")
 
         output_file.write(init_function)
 
@@ -203,6 +198,7 @@ def serverize_library_from_code(
         temp_source_file.write("".join([inspect.getsource(fnc) for fnc in functions]))
         temp_source_file.write(f"def name():\n\treturn '{name}'")
 
+    print(functions)
     # create the final library code from that temporary file
     create_library_code(
         tmp_library_path,

--- a/poncho/src/poncho/package_serverize.py
+++ b/poncho/src/poncho/package_serverize.py
@@ -198,7 +198,6 @@ def serverize_library_from_code(
         temp_source_file.write("".join([inspect.getsource(fnc) for fnc in functions]))
         temp_source_file.write(f"def name():\n\treturn '{name}'")
 
-    print(functions)
     # create the final library code from that temporary file
     create_library_code(
         tmp_library_path,

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -77,8 +77,7 @@ class FuturesExecutor(Executor):
         return FuturePythonTask(self.manager, False, fn, *args, **kwargs)
 
     def create_library_from_functions(self, name, *function_list, poncho_env=None, init_command=None, add_env=True, import_modules=None):
-        function_list = function_list + (retrieve_output,)
-        return self.manager.create_library_from_functions(name, *function_list, poncho_env=poncho_env, init_command=init_command, add_env=add_env, import_modules=import_modules)
+        return self.manager.create_library_from_functions(name, *function_list, retrieve_output, poncho_env=poncho_env, init_command=init_command, add_env=add_env, import_modules=import_modules)
 
     def install_library(self, libtask):
         self.manager.install_library(libtask)

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -26,7 +26,7 @@ except Exception:
     pythontask_available = False
 
 
-# To be installed on the library for FutureFunctionCalls
+# To be installed in the library for FutureFunctionCalls
 def retrieve_output(arg):
     return arg
 

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -26,6 +26,11 @@ except Exception:
     pythontask_available = False
 
 
+# To be installed on the library for FutureFunctionCalls
+def retrieve_output(arg):
+    return arg
+
+
 ##
 # \class FuturesExecutor
 #
@@ -72,6 +77,7 @@ class FuturesExecutor(Executor):
         return FuturePythonTask(self.manager, False, fn, *args, **kwargs)
 
     def create_library_from_functions(self, name, *function_list, poncho_env=None, init_command=None, add_env=True, import_modules=None):
+        function_list = function_list + (retrieve_output,)
         return self.manager.create_library_from_functions(name, *function_list, poncho_env=poncho_env, init_command=init_command, add_env=add_env, import_modules=import_modules)
 
     def install_library(self, libtask):

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -890,14 +890,12 @@ class Manager(object):
     # @param task    A FunctionCall task
     def check_funcall_validity(self, task):
         library_name = task.get_library_name()
-        available_library_names = [library_name for library_name in self._library_table.keys()]
-        if library_name not in available_library_names:
-            raise ValueError(f"invalid library name \'{library_name}\', available libraries are {available_library_names}")
+        if library_name not in [library_name for library_name in self._library_table.keys()]:
+            raise ValueError(f"invalid library name \'{library_name}\'")
         library_task = self._library_table[library_name]
-        function_names_on_library = library_task.get_function_names()
         function_name_to_be_called = task.get_function_name()
-        if function_name_to_be_called not in function_names_on_library:
-            raise ValueError(f"invalid function name \'{function_name_to_be_called}\', available libraries are {function_names_on_library}")
+        if function_name_to_be_called not in library_task.get_function_names():
+            raise ValueError(f"invalid function name \'{function_name_to_be_called}\'")
 
     ##
     # Submit a library to install on all connected workers
@@ -977,11 +975,9 @@ class Manager(object):
 
         # Create Task to execute the Library and prepend it with some setup code if needed.
         if init_command:
-            t = LibraryTask(f"{init_command} python ./library_code.py", library_name)
+            t = LibraryTask(f"{init_command} python ./library_code.py", library_name, function_list=function_list, library_code_path=library_code_path)
         else:
-            t = LibraryTask("python ./library_code.py", library_name)
-        function_names = [function.__name__ for function in function_list]
-        t.set_function_names(function_names)
+            t = LibraryTask("python ./library_code.py", library_name, function_list, function_list=function_list, library_code_path=library_code_path)
 
         # Declare the environment if needed.
         if add_env:

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -906,6 +906,8 @@ class Manager(object):
     # @param self           Reference to the current manager object.
     # @param library_name   Name of the library to be checked
     def check_library_exists(self, library_name):
+        if not isinstance(library_name, str):
+            raise TypeError(f"library_name should be str, not {type(library_name)}")
         return cvine.vine_manager_get_library(self._taskvine, library_name) is not None
 
     ##

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -977,7 +977,7 @@ class Manager(object):
         if init_command:
             t = LibraryTask(f"{init_command} python ./library_code.py", library_name, function_list=function_list, library_code_path=library_code_path)
         else:
-            t = LibraryTask("python ./library_code.py", library_name, function_list, function_list=function_list, library_code_path=library_code_path)
+            t = LibraryTask("python ./library_code.py", library_name, function_list=function_list, library_code_path=library_code_path)
 
         # Declare the environment if needed.
         if add_env:

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -908,7 +908,7 @@ class Manager(object):
     def check_library_exists(self, library_name):
         if not isinstance(library_name, str):
             raise TypeError(f"library_name should be str, not {type(library_name)}")
-        return cvine.vine_manager_get_library(self._taskvine, library_name) is not None
+        return cvine.vine_manager_find_library_template(self._taskvine, library_name) is not None
 
     ##
     # Turn a list of python functions into a Library Task.

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -906,7 +906,7 @@ class Manager(object):
     # @param self           Reference to the current manager object.
     # @param library_name   Name of the library to be checked
     def check_library_exists(self, library_name):
-        return cvine.vine_manager_get_library(self._taskvine, library_name)
+        return cvine.vine_manager_get_library(self._taskvine, library_name) is not None
 
     ##
     # Turn a list of python functions into a Library Task.

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -906,7 +906,7 @@ class Manager(object):
     # @param self           Reference to the current manager object.
     # @param library_name   Name of the library to be checked
     def check_library_exists(self, library_name):
-        return cvine.vine_manager_check_library_exists(self._taskvine, library_name)
+        return cvine.vine_manager_get_library(self._taskvine, library_name)
 
     ##
     # Turn a list of python functions into a Library Task.

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -893,9 +893,8 @@ class Manager(object):
         if library_name not in [library_name for library_name in self._library_table.keys()]:
             raise ValueError(f"invalid library name \'{library_name}\'")
         library_task = self._library_table[library_name]
-        function_name_to_be_called = task.get_function_name()
-        if function_name_to_be_called not in library_task.get_function_names():
-            raise ValueError(f"invalid function name \'{function_name_to_be_called}\'")
+        if task.get_function_name() not in library_task.get_function_names():
+            raise ValueError(f"invalid function name \'{task.get_function_name()}\'")
 
     ##
     # Submit a library to install on all connected workers

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -902,7 +902,7 @@ class Manager(object):
 
     ##
     # Check whether a libray exists on the manager or not
-    #    
+    #
     # @param self           Reference to the current manager object.
     # @param library_name   Name of the library to be checked
     def check_library_exists(self, library_name):

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -218,6 +218,7 @@ class Task(object):
             raise ValueError(f"{library} is not a valid library")
 
         return library_name
+
     ##
     # Set the name of the library at the worker that should execute the task's command.
     # This is not needed for regular tasks.

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -1185,6 +1185,9 @@ class LibraryTask(Task):
     def set_function_names(self, function_names):
         self.function_names = function_names
 
+    def append_function_name(self, function_name):
+        self.function_names.append(function_name)
+
     def get_function_names(self):
         return self.function_names
 

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -1172,23 +1172,22 @@ class LibraryTask(Task):
     ##
     # Create a new LibraryTask task specification.
     #
-    # @param self           Reference to the current remote task object.
-    # @param fn             The command for this LibraryTask to run
-    # @param library_name   The name of this Library.
-    def __init__(self, fn, library_name):
+    # @param self               Reference to the current remote task object.
+    # @param fn                 The command for this LibraryTask to run
+    # @param library_name       The name of this Library.
+    # @param function_list      A list of functions to be added to the library (used for create_library_from_functions).
+    # @param library_code_path  The path to the library code.
+    def __init__(self, fn, library_name, function_list=None, library_code_path=None):
         Task.__init__(self, fn)
         self.library_name = library_name
-        self.function_names = []
+        self.function_list = function_list
+        self.library_code_path = library_code_path
         self._manager_will_free = True
         self.provides_library(self.library_name)
 
-    def set_function_names(self, function_names):
-        self.function_names = function_names
-
-    def append_function_name(self, function_name):
-        self.function_names.append(function_name)
-
     def get_function_names(self):
-        return self.function_names
+        if not self.function_list is None:
+            return [f.__name__ for f in self.function_list]
+        return None
 
 # vim: set sts=4 sw=4 ts=4 expandtab ft=python:

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -229,7 +229,7 @@ class Task(object):
         library_name = self._compute_library_name(library)
         if self.get_libray_provided():
             raise ValueError(
-                f"A task cannot both provide ({self.get_libray_provided()}) and require ({library_name}) a library."
+                f"A task cannot both provide ({library_name}) and require ({library_name}) a library."
             )
         return cvine.vine_task_set_library_required(self._task, library_name)
 
@@ -1081,8 +1081,10 @@ class FunctionCall(PythonTask):
     #
     # @param self 	Reference to the current python task object
     def submit_finalize(self):
-        if not self.manager.check_library_exists(self._library_name):
-            raise ValueError(f"invalid library name \'{self._library_name}\'")
+        library_name = self.get_library_required()
+        if not self.manager.check_library_exists(library_name):
+            raise ValueError(f"invalid library name \'{library_name}\'")
+        
         name = os.path.join(self.manager.staging_directory, "arguments", self._id)
         with open(name, "wb") as wf:
             cloudpickle.dump(self._event, wf)

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -1083,6 +1083,9 @@ class FunctionCall(PythonTask):
     #
     # @param self 	Reference to the current python task object
     def submit_finalize(self):
+        library_name = self.get_library_name()
+        if not self.manager.check_library_exists(library_name):
+            raise ValueError(f"invalid library name \'{library_name}\'")
         name = os.path.join(self.manager.staging_directory, "arguments", self._id)
         with open(name, "wb") as wf:
             cloudpickle.dump(self._event, wf)
@@ -1175,19 +1178,9 @@ class LibraryTask(Task):
     # @param self               Reference to the current remote task object.
     # @param fn                 The command for this LibraryTask to run
     # @param library_name       The name of this Library.
-    # @param function_list      A list of functions to be added to the library (used for create_library_from_functions).
-    # @param library_code_path  The path to the library code.
-    def __init__(self, fn, library_name, function_list=None, library_code_path=None):
+    def __init__(self, fn, library_name):
         Task.__init__(self, fn)
-        self.library_name = library_name
-        self.function_list = function_list
-        self.library_code_path = library_code_path
         self._manager_will_free = True
-        self.provides_library(self.library_name)
-
-    def get_function_names(self):
-        if self.function_list:
-            return [f.__name__ for f in self.function_list]
-        return None
+        self.provides_library(library_name)
 
 # vim: set sts=4 sw=4 ts=4 expandtab ft=python:

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -1084,7 +1084,7 @@ class FunctionCall(PythonTask):
         library_name = self.get_library_required()
         if not self.manager.check_library_exists(library_name):
             raise ValueError(f"invalid library name \'{library_name}\'")
-        
+
         name = os.path.join(self.manager.staging_directory, "arguments", self._id)
         with open(name, "wb") as wf:
             cloudpickle.dump(self._event, wf)

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -201,12 +201,31 @@ class Task(object):
         return cvine.vine_task_set_command(self._task, command)
 
     ##
+    # Compute the name of a given library
+    # @param self          Reference to the current task object.
+    # @param library       The library or the name of the library
+    def _compute_library_name(self, library):
+        library_name = None
+        if isinstance(library, Task):
+            try:
+                library_name = library.provides_library()
+            except Exception:
+                pass
+        else:
+            library_name = library
+
+        if not isinstance(library, str):
+            raise ValueError(f"{library} is not a valid library")
+
+        return library_name
+    ##
     # Set the name of the library at the worker that should execute the task's command.
     # This is not needed for regular tasks.
     #
     # @param self          Reference to the current task object.
-    # @param library_name  The name of the library
-    def set_library_required(self, library_name):
+    # @param library       The library or the name of the library
+    def set_library_required(self, library):
+        library_name = self._compute_library_name(library)
         if self.get_libray_provided():
             raise ValueError(
                 f"A task cannot both provide ({self.get_libray_provided()}) and require ({library_name}) a library."
@@ -1047,36 +1066,12 @@ class FunctionCall(PythonTask):
         # function calls at worker only need the name of the function.
         self.set_command(fn)
 
-        self._library_name = self._compute_library_name(library)
-        self._function_name = fn
-
         self._event = {}
         self._event["fn_args"] = args
         self._event["fn_kwargs"] = kwargs
 
         self._saved_output = None
-        self.set_library_required(self._library_name)
-
-    def get_library_name(self):
-        return self._library_name
-
-    def _compute_library_name(self, library):
-        library_name = None
-        if isinstance(library, Task):
-            try:
-                library_name = library.provides_library()
-            except Exception:
-                pass
-        else:
-            library_name = library
-
-        if not isinstance(library, str):
-            raise ValueError(f"{library} is not a valid library")
-
-        return library_name
-
-    def get_function_name(self):
-        return self._function_name
+        self.set_library_required(library)
 
     ##
     # Finalizes the task definition once the manager that will execute is run.

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -1186,7 +1186,7 @@ class LibraryTask(Task):
         self.provides_library(self.library_name)
 
     def get_function_names(self):
-        if not self.function_list is None:
+        if not self.function_list:
             return [f.__name__ for f in self.function_list]
         return None
 

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -1186,7 +1186,7 @@ class LibraryTask(Task):
         self.provides_library(self.library_name)
 
     def get_function_names(self):
-        if not self.function_list:
+        if self.function_list:
             return [f.__name__ for f in self.function_list]
         return None
 

--- a/taskvine/src/bindings/python3/taskvine.i
+++ b/taskvine/src/bindings/python3/taskvine.i
@@ -16,6 +16,7 @@
     #include "vine_task.h"
     #include "vine_file.h"
     #include "vine_runtime_dir.h"
+    #include "vine_manager.h"
 %}
 
 /* We compile with -D__LARGE64_FILES, thus off_t is at least 64bit.
@@ -81,4 +82,5 @@ into a swig function f(data) */
 %include "vine_file.h"
 %include "vine_runtime_dir.h"
 %include "cctools.h"
+%include "vine_manager.h"
 

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -889,12 +889,6 @@ void vine_manager_install_library( struct vine_manager *m, struct vine_task *t, 
 */
 void vine_manager_remove_library( struct vine_manager *m, const char *name );
 
-/** Get the library task with the given name, return null if not found.
-@param m A manager object
-@param library_name The library name
-*/
-struct vine_task *vine_manager_get_library(struct vine_manager *m, const char *library_name);
-
 /** Wait for a task to complete.
 This call will block until either a task has completed, the timeout has expired, or the manager is empty.
 If a task has completed, the corresponding task object will be returned by this function.
@@ -914,7 +908,6 @@ task, or there is completed child process (call @ref process_wait to retrieve th
 process).
 */
 struct vine_task *vine_wait(struct vine_manager *m, int timeout);
-
 
 /** Wait for a task with a given task to complete.
 Similar to @ref vine_wait, but guarantees that the returned task has the specified tag.
@@ -1082,7 +1075,6 @@ vine_enable_disconnect_slow_workers_category was not explicitely called.
 @returns 0 if activated, 1 if deactivated.
 */
 int vine_enable_disconnect_slow_workers(struct vine_manager *m, double multiplier);
-
 
 /** Enable disconnect slow workers functionality for a given category. As @ref vine_enable_disconnect_slow_workers, but for a single
 task category.

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -889,11 +889,11 @@ void vine_manager_install_library( struct vine_manager *m, struct vine_task *t, 
 */
 void vine_manager_remove_library( struct vine_manager *m, const char *name );
 
-/** Check if a given library name exists on the manager.
+/** Get the library task with the given name, return null if not found.
 @param m A manager object
-@param library_name The library name to be checked
+@param library_name The library name
 */
-int vine_manager_check_library_exists(struct vine_manager *m, const char *library_name);
+struct vine_task *vine_manager_get_library(struct vine_manager *m, const char *library_name);
 
 /** Wait for a task to complete.
 This call will block until either a task has completed, the timeout has expired, or the manager is empty.

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -889,6 +889,12 @@ void vine_manager_install_library( struct vine_manager *m, struct vine_task *t, 
 */
 void vine_manager_remove_library( struct vine_manager *m, const char *name );
 
+/** Find a library template on the manager
+@param m A manager object
+@param name The name of the library of interest
+*/
+struct vine_task *vine_manager_find_library_template(struct vine_manager *q, const char *library_name);
+
 /** Wait for a task to complete.
 This call will block until either a task has completed, the timeout has expired, or the manager is empty.
 If a task has completed, the corresponding task object will be returned by this function.

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -889,6 +889,12 @@ void vine_manager_install_library( struct vine_manager *m, struct vine_task *t, 
 */
 void vine_manager_remove_library( struct vine_manager *m, const char *name );
 
+/** Check if a given library name exists on the manager.
+@param m A manager object
+@param library_name The library name to be checked
+*/
+int vine_manager_check_library_exists(struct vine_manager *m, const char *library_name);
+
 /** Wait for a task to complete.
 This call will block until either a task has completed, the timeout has expired, or the manager is empty.
 If a task has completed, the corresponding task object will be returned by this function.

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4603,6 +4603,14 @@ void vine_manager_remove_library(struct vine_manager *q, const char *name)
 	hash_table_remove(q->library_templates, name);
 }
 
+int vine_manager_check_library_exists(struct vine_manager *q, const char *library_name)
+{
+	if (hash_table_lookup(q->library_templates, library_name)) {
+		return 1;
+	}
+	return 0;
+}
+
 static void handle_library_update(struct vine_manager *q, struct vine_worker_info *w, const char *line)
 {
 	int library_id = 0;

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4603,12 +4603,9 @@ void vine_manager_remove_library(struct vine_manager *q, const char *name)
 	hash_table_remove(q->library_templates, name);
 }
 
-int vine_manager_check_library_exists(struct vine_manager *q, const char *library_name)
+struct vine_task *vine_manager_get_library(struct vine_manager *q, const char *library_name)
 {
-	if (hash_table_lookup(q->library_templates, library_name)) {
-		return 1;
-	}
-	return 0;
+	return hash_table_lookup(q->library_templates, library_name);
 }
 
 static void handle_library_update(struct vine_manager *q, struct vine_worker_info *w, const char *line)

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4603,7 +4603,7 @@ void vine_manager_remove_library(struct vine_manager *q, const char *name)
 	hash_table_remove(q->library_templates, name);
 }
 
-struct vine_task *vine_manager_get_library(struct vine_manager *q, const char *library_name)
+struct vine_task *vine_manager_find_library_template(struct vine_manager *q, const char *library_name)
 {
 	return hash_table_lookup(q->library_templates, library_name);
 }

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -271,6 +271,8 @@ struct vine_task *vine_manager_no_wait(struct vine_manager *q, const char *tag, 
 
 void vine_manager_remove_worker(struct vine_manager *q, struct vine_worker_info *w, vine_worker_disconnect_reason_t reason);
 
+/* Check if a given library name exists on the manager */
+int vine_manager_check_library_exists(struct vine_manager *q, const char *library_name);
 
 /* The expected format of files created by the resource monitor.*/
 #define RESOURCE_MONITOR_TASK_LOCAL_NAME "vine-task-%d"

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -248,8 +248,8 @@ int vine_manager_transfer_time( struct vine_manager *q, struct vine_worker_info 
 const struct rmsummary *vine_manager_task_resources_min(struct vine_manager *q, struct vine_task *t);
 const struct rmsummary *vine_manager_task_resources_max(struct vine_manager *q, struct vine_task *t);
 
-/* Internal: Find a library task running on a specific worker by name. */
-struct vine_task *vine_manager_find_library_on_worker( struct vine_manager *q, struct vine_worker_info *w, const char *library_name);
+/* Find a library template on the manager */
+struct vine_task *vine_manager_find_library_template(struct vine_manager *q, const char *library_name);
 
 /* Internal: Enable shortcut of main loop upon child process completion. Needed for Makeflow to interleave local and remote execution. */
 void vine_manager_enable_process_shortcut(struct vine_manager *q);
@@ -257,9 +257,6 @@ void vine_manager_enable_process_shortcut(struct vine_manager *q);
 struct rmsummary *vine_manager_choose_resources_for_task( struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t );
 
 int64_t overcommitted_resource_total(struct vine_manager *q, int64_t total);
-
-/* Internal: Enable checking and sending library tasks as necessary. Needed for @vine_schedule.c to check if a worker is compatible to a function task. */
-int vine_manager_check_worker_can_run_function_task(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t);
 
 /* Internal: Shut down a specific worker. */
 int vine_manager_shut_down_worker(struct vine_manager *q, struct vine_worker_info *w);
@@ -270,9 +267,6 @@ struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_wor
 struct vine_task *vine_manager_no_wait(struct vine_manager *q, const char *tag, int task_id);
 
 void vine_manager_remove_worker(struct vine_manager *q, struct vine_worker_info *w, vine_worker_disconnect_reason_t reason);
-
-/* Get the library task on a worker */
-struct vine_task *vine_manager_get_library(struct vine_manager *q, const char *library_name);
 
 /* The expected format of files created by the resource monitor.*/
 #define RESOURCE_MONITOR_TASK_LOCAL_NAME "vine-task-%d"

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -271,8 +271,8 @@ struct vine_task *vine_manager_no_wait(struct vine_manager *q, const char *tag, 
 
 void vine_manager_remove_worker(struct vine_manager *q, struct vine_worker_info *w, vine_worker_disconnect_reason_t reason);
 
-/* Check if a given library name exists on the manager */
-int vine_manager_check_library_exists(struct vine_manager *q, const char *library_name);
+/* Get the library task on a worker */
+struct vine_task *vine_manager_get_library(struct vine_manager *q, const char *library_name);
 
 /* The expected format of files created by the resource monitor.*/
 #define RESOURCE_MONITOR_TASK_LOCAL_NAME "vine-task-%d"


### PR DESCRIPTION
## Proposed changes

While constructing and submitting a FunctionCall task, for example, `task = vine.FunctionCall('test-library', 'my_func', args.size)`, this PR checks one thing:
- `test-library` should exist in current libraries

It also comes with some renaming just for better readability 

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
