### PR TITLE
vine: remove redundant library duplications

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2840,7 +2840,8 @@ static vine_result_code_t commit_task_to_worker(struct vine_manager *q, struct v
 	 * If the manager fails to send this function task to the worker however,
 	 * then the count will be decremented properly in @handle_failure() below. */
 	if (t->needs_library) {
-		t->library_task = vine_schedule_find_library(w, t->needs_library);
+		int status;
+		t->library_task = vine_schedule_find_library(w, t->needs_library, &status);
 		t->library_task->function_slots_inuse++;
 	}
 
@@ -4535,7 +4536,6 @@ struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_wor
 	if (!original) {
 		return 0;
 	}
-
 	/*
 	If an instance of this library has recently failed,
 	don't send another right away.  This is a rather late (and inefficient)
@@ -4594,7 +4594,8 @@ void vine_manager_remove_library(struct vine_manager *q, const char *name)
 
 	HASH_TABLE_ITERATE(q->worker_table, worker_key, w)
 	{
-		struct vine_task *library = vine_schedule_find_library(w, name);
+		int status;
+		struct vine_task *library = vine_schedule_find_library(w, name, &status);
 		if (library) {
 			reset_task_to_state(q, library, VINE_TASK_RETRIEVED);
 			library->refcount--;

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -215,7 +215,7 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 			/* If the library is already running on this worker, then it's ok. */
 			return 1;
 		} else if (status == LIBRARY_TASK_FOUND_NO_AVAILABLE_SLOT) {
-			/* If the library is already running on this worker, but there are no available slots, then it's not ok. */
+			/* If the library exists, but there are no available slots, then it's not ok. */
 			return 0;
 		} else if (status == LIBRARY_TASK_NOT_FOUND) {
 			/* XXX: checking for matches should not modify the state of workers. */

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -209,8 +209,15 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 
 	/* do this check last! otherwise the library is sent to workers that can't fit it. */
 	if (t->needs_library) {
-		struct vine_task *library = vine_schedule_find_library(w, t->needs_library);
-		if (!library) {
+		int status;
+		struct vine_task *library = vine_schedule_find_library(w, t->needs_library, &status);
+		if (status == LIBRARY_TASK_FOUND_WITH_AVAILABLE_SLOT) {
+			/* If the library is already running on this worker, then it's ok. */
+			return 1;
+		} else if (status == LIBRARY_TASK_FOUND_NO_AVAILABLE_SLOT) {
+			/* If the library is already running on this worker, but there are no available slots, then it's not ok. */
+			return 0;
+		} else if (status == LIBRARY_TASK_NOT_FOUND) {
 			/* XXX: checking for matches should not modify the state of workers. */
 			library = send_library_to_worker(q, w, t->needs_library);
 			/* Careful: If this failed, then the worker object may longer be valid! */
@@ -225,19 +232,26 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 
 /* Find a library task running on a specific worker that has an available slot.
  * @return pointer to the library task if there's one, 0 otherwise. */
-struct vine_task *vine_schedule_find_library(struct vine_worker_info *w, const char *library_name)
+struct vine_task *vine_schedule_find_library(struct vine_worker_info *w, const char *library_name, int *status)
 {
 	uint64_t task_id;
 	struct vine_task *task;
 	ITABLE_ITERATE(w->current_tasks, task_id, task)
 	{
 		if (task->type == VINE_TASK_TYPE_LIBRARY_INSTANCE && task->provides_library &&
-				!strcmp(task->provides_library, library_name) &&
-				(task->function_slots_inuse < task->function_slots)) {
-			return task;
+				!strcmp(task->provides_library, library_name)) {
+			if (task->function_slots_inuse < task->function_slots) {
+				*status = LIBRARY_TASK_FOUND_WITH_AVAILABLE_SLOT;
+				return task;
+			}
+			if (task->function_slots_inuse == task->function_slots) {
+				*status = LIBRARY_TASK_FOUND_NO_AVAILABLE_SLOT;
+				return task;
+			}
 		}
 	}
 
+	*status = LIBRARY_TASK_NOT_FOUND;
 	return 0;
 }
 

--- a/taskvine/src/manager/vine_schedule.h
+++ b/taskvine/src/manager/vine_schedule.h
@@ -18,10 +18,14 @@ This module is private to the manager and should not be invoked by the end user.
 #include "vine_task.h"
 #include "vine_worker_info.h"
 
+#define LIBRARY_TASK_FOUND_WITH_AVAILABLE_SLOT 1
+#define LIBRARY_TASK_FOUND_NO_AVAILABLE_SLOT 0
+#define LIBRARY_TASK_NOT_FOUND -1
+
 struct vine_worker_info *vine_schedule_task_to_worker( struct vine_manager *q, struct vine_task *t );
 void vine_schedule_check_for_large_tasks( struct vine_manager *q );
 int vine_schedule_check_fixed_location(struct vine_manager *q, struct vine_task *t);
 int vine_schedule_in_ramp_down(struct vine_manager *q);
-struct vine_task *vine_schedule_find_library(struct vine_worker_info *w, const char *library_name);
+struct vine_task *vine_schedule_find_library(struct vine_worker_info *w, const char *library_name, int *status);
 int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t);
 #endif

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -284,6 +284,7 @@ static void measure_worker_resources()
 	struct vine_resources *r = total_resources;
 
 	vine_resources_measure_locally(r, workspace->workspace_dir);
+	printf("cores total = %ld\n", r->cores.total);
 
 	if (options->cores_total > 0)
 		r->cores.total = options->cores_total;

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -284,7 +284,6 @@ static void measure_worker_resources()
 	struct vine_resources *r = total_resources;
 
 	vine_resources_measure_locally(r, workspace->workspace_dir);
-	printf("cores total = %ld\n", r->cores.total);
 
 	if (options->cores_total > 0)
 		r->cores.total = options->cores_total;

--- a/taskvine/src/worker/vine_worker_options.c
+++ b/taskvine/src/worker/vine_worker_options.c
@@ -28,6 +28,7 @@ struct vine_worker_options *vine_worker_options_create()
 	struct vine_worker_options *self = malloc(sizeof(*self));
 	memset(self, 0, sizeof(*self));
 
+	self->cores_total = 0;
 	self->gpus_total = -1;
 	self->idle_timeout = 900;
 	self->connect_timeout = 900;


### PR DESCRIPTION
## Proposed changes

When checking if a task is compatible with a given worker (in `check_worker_against_task`), the last step is to check whether the required library exists on that particular worker or not. Previously, there were two cases:
1. the library exists, with available function slots
2. the library doesn't exist, or exists but no available function slots (all are busy)

However, it comes with a problem: If the total cores are 64, but the `function_slots` of a library is 16, each consuming 1 core. Though as users we want there to be 16 tasks running concurrently as we specifically assigned that much, the actual concurrent tasks are 64, with 4 libraries running simultaneously.

To mitigate this redundant duplication, we can extract a status from the second one and it becomes:

1. the library exists, with available function slots
2. the library exists, no available function slots
3. the library doesn't exist

By carefully handle each case, we can make sure that there is only one library running on a single worker and no redundant libraries are duplicated.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
