### PR TITLE
vine: combine imports when calculating function hash

### DIFF
--- a/poncho/src/poncho/package_serverize.py
+++ b/poncho/src/poncho/package_serverize.py
@@ -103,11 +103,6 @@ def create_library_code(path, funcs, dest, version, import_modules=None):
             output_file.write("@remote_execute\n")
             output_file.write(function_code)
             output_file.write("\n")
-        
-        # write a retriever function for retriever tasks used in FutureFunctionCall tasks
-        output_file.write("@remote_execute\n")
-        output_file.write("def retrieve_output(arg):\n")
-        output_file.write("    return arg\n")
 
         output_file.write(init_function)
 
@@ -172,19 +167,24 @@ def pack_library_code(path, envpath):
 # Python's exec or Jupyter Notebooks won't work here.
 # @param functions  A list of functions to generate the hash value from.
 # @return           a string of hex characters resulted from hashing the contents and names of functions.
-def generate_functions_hash(functions: list) -> str:
-    source_code = ""
+def generate_functions_hash(functions: list, import_modules=None) -> str:
+    import sys
+
+    source_code = []
+    if import_modules:
+        source_code.extend(["import " + module.__name__ + "\n" for module in import_modules])
+
     for fnc in functions:
         try:
-            source_code += fnc.__name__
-            source_code += inspect.getsource(fnc)
+            source_code.append(inspect.getsource(fnc))
         except OSError as e:
             print(
                 f"Can't retrieve source code of function {fnc.__name__}.",
                 file=sys.stderr,
             )
             raise
-    return hashlib.md5(source_code.encode("utf-8")).hexdigest()
+    
+    return hashlib.md5(" ".join(source_code).encode("utf-8")).hexdigest()
 
 
 # Create a library file and a poncho environment tarball from a list of functions as needed.

--- a/poncho/src/poncho/package_serverize.py
+++ b/poncho/src/poncho/package_serverize.py
@@ -104,6 +104,11 @@ def create_library_code(path, funcs, dest, version, import_modules=None):
             output_file.write(function_code)
             output_file.write("\n")
 
+        # write a retriever function for retriever tasks used in FutureFunctionCall tasks
+        output_file.write("@remote_execute\n")
+        output_file.write("def retrieve_output(arg):\n")
+        output_file.write("    return arg\n")
+        
         output_file.write(init_function)
 
     st = os.stat(dest)

--- a/poncho/src/poncho/package_serverize.py
+++ b/poncho/src/poncho/package_serverize.py
@@ -168,29 +168,23 @@ def pack_library_code(path, envpath):
 # @param functions  A list of functions to generate the hash value from.
 # @return           a string of hex characters resulted from hashing the contents and names of functions.
 def generate_functions_hash(functions: list, import_modules=None) -> str:
-    import re
     import sys
 
-    source_code = ""
+    source_code = []
     if import_modules:
-        source_code += " ".join(["import " + module.__name__ + "\n" for module in import_modules])
+        source_code.extend(["import " + module.__name__ + "\n" for module in import_modules])
 
     for fnc in functions:
         try:
-            # get function source code, remove single-line comments, blank lines and excessive newlines
-            function_source = inspect.getsource(fnc)
-            function_source = re.sub(r"^\s*#.*$", "", function_source, flags=re.MULTILINE)
-            function_source = re.sub(r"^\s*$", "", function_source, flags=re.MULTILINE)
-            function_source = re.sub(r"\n{2,}", "\n", function_source)
-            source_code += function_source
+            source_code.append(inspect.getsource(fnc))
         except OSError as e:
             print(
                 f"Can't retrieve source code of function {fnc.__name__}.",
                 file=sys.stderr,
             )
             raise
-
-    return hashlib.md5(source_code.encode("utf-8")).hexdigest()
+    
+    return hashlib.md5(" ".join(source_code).encode("utf-8")).hexdigest()
 
 
 # Create a library file and a poncho environment tarball from a list of functions as needed.

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -924,7 +924,7 @@ class Manager(object):
 
         # Positional arguments are the list of functions to include in the library.
         # Create a unique hash of a combination of function names and bodies.
-        functions_hash = package_serverize.generate_functions_hash(function_list)
+        functions_hash = package_serverize.generate_functions_hash(function_list, import_modules)
 
         # Create path for caching library code and environment based on function hash.
         library_cache_path = f"{self.cache_directory}/vine-library-cache/{functions_hash}"


### PR DESCRIPTION
## Proposed changes

Fix for #3569, while calculating the hash for library functions, this pr does two things to avoid creating a new environment with minor modifications that do not affect the execution of functions:

- consider the module names in `import_modules`
- remove comments, blank lines and extraneous newlines 

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
