### PR TITLE
vine: use number to represent a port in FuturesExecutor

### DIFF
--- a/taskvine/test/vine_python_future_funcall.py
+++ b/taskvine/test/vine_python_future_funcall.py
@@ -24,7 +24,7 @@ def my_sum(x, y, negate=False):
 
 def main():
     executor = vine.FuturesExecutor(
-        port=[9123, 9129], manager_name="test-executor", factory=False
+        port=9123, manager_name="test-executor", factory=False
     )
     print("listening on port {}".format(executor.port))
     with open(port_file, "w") as f:

--- a/taskvine/test/vine_python_future_pythontask.py
+++ b/taskvine/test/vine_python_future_pythontask.py
@@ -24,7 +24,7 @@ def my_sum(x, y, negate=False):
 
 def main():
     executor = vine.FuturesExecutor(
-        port=[9123, 9129], manager_name="vine_matrtix_build_test", factory=False
+        port=9123, manager_name="test-executor", factory=False
     )
     print("listening on port {}".format(executor.manager.port))
     with open(port_file, "w") as f:


### PR DESCRIPTION
## Proposed changes

In the two test scripts for _futures_ we are using a list like `port=[9123, 9129]` to represent the port, but the constructor only accepts a number. 

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [ ] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [ ] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
