### PR TITLE
Infra: Update GitHub actions to v4

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,10 +32,12 @@ jobs:
     steps:
       - name: checkout CCTools from branch head
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v4
+	# note this should be actions/checkout@v4, however v4 doesn't work on centos7.  Change to v4 when that platform is retired.
+        uses: actions/checkout@v3
       - name: checkout CCTools from tag
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
+	# note this should be actions/checkout@v4, however v4 doesn't work on centos7.  Change to v4 when that platform is retired.
+	uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.tag }}
       - name: Get sha of tag

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,10 +32,10 @@ jobs:
     steps:
       - name: checkout CCTools from branch head
         if: github.event_name != 'workflow_dispatch'
-	uses: actions/checkout@v3
+        uses: actions/checkout@v3
       - name: checkout CCTools from tag
         if: github.event_name == 'workflow_dispatch'
-	uses: actions/checkout@v3
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.tag }}
       - name: Get sha of tag

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,11 +32,9 @@ jobs:
     steps:
       - name: checkout CCTools from branch head
         if: github.event_name != 'workflow_dispatch'
-	# note this should be actions/checkout@v4, however v4 doesn't work on centos7.  Change to v4 when that platform is retired.
         uses: actions/checkout@v3
       - name: checkout CCTools from tag
         if: github.event_name == 'workflow_dispatch'
-	# note this should be actions/checkout@v4, however v4 doesn't work on centos7.  Change to v4 when that platform is retired.
 	uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.tag }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,10 +32,10 @@ jobs:
     steps:
       - name: checkout CCTools from branch head
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: checkout CCTools from tag
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.tag }}
       - name: Get sha of tag
@@ -68,10 +68,10 @@ jobs:
     steps:
       - name: Checkout CCTools from branch head
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout CCTools from tag
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.tag }}
       - name: Get sha of tag
@@ -115,7 +115,7 @@ jobs:
       CCTOOLS_SOURCE_PROFILE: yes
     steps:
       - name: checkout CCTools from branch head
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get sha of tag
         id: vars
         shell: bash
@@ -152,10 +152,10 @@ jobs:
     steps:
       - name: checkout CCTools from branch head
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: checkout CCTools from tag
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.tag }}
       - name: lint code

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: checkout CCTools from branch head
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v3
+	uses: actions/checkout@v3
       - name: checkout CCTools from tag
         if: github.event_name == 'workflow_dispatch'
 	uses: actions/checkout@v3


### PR DESCRIPTION
## Proposed changes

Github complains about actions v3 using NodeJS 16.  Updated to v4 using NodeJS 20.

## Post-change actions

Put an 'x' in the boxes that describe post-change actions that you have done.
The more 'x' ticked, the faster your changes are accepted by maintainers.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Did you update the manual to reflect your changes, if appropriate? This action should be done after your changes are approved but not merged.
- [x] Type Labels       Select github labels for the type of this change: bug, enhancement, etc.
- [x] Product Labels    Select github labels for the product affected: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.

## Additional comments
This section is dedicated to changes that are ambitious or complex and require substantial discussions. Feel free to start the ball rolling.
