### PR TITLE
Catalog: Make Tests More Robust

### DIFF
--- a/deltadb/src/catalog_server.c
+++ b/deltadb/src/catalog_server.c
@@ -85,7 +85,10 @@ static const char *ssl_cert_filename = 0;
 /* Filename containing the SSL private key. */
 static const char *ssl_key_filename = 0;
 
-/* The file for writing out the port number. */
+/* The file for writing out the SSL port number. */
+const char *ssl_port_file = 0;
+
+/* The file for writing out the query port number. */
 const char *port_file = 0;
 
 /* The preferred hostname set on the command line. */
@@ -762,6 +765,7 @@ static void show_help(const char *cmd)
 	fprintf(stdout, " %-30s Send status updates at this interval.\n", "-U,--update-interval=<time>");
 	fprintf(stdout, " %-30s (default is 5m)\n", "");
 	fprintf(stdout, " %-30s Show version string\n", "-v,--version");
+	fprintf(stdout, " %-30s Select SSL port at random and write it to\n", "-Y,--ssl-port-file=<file>");
 	fprintf(stdout, " %-30s Select port at random and write it to\n", "-Z,--port-file=<file>");
 	fprintf(stdout, " %-30s this file. (default: disabled)\n", "");
 }
@@ -806,6 +810,7 @@ int main(int argc, char *argv[])
 		{"update-host", required_argument, 0, 'u'},
 		{"update-interval", required_argument, 0, 'U'},
 		{"version", no_argument, 0, 'v'},
+		{"ssl-port-file", required_argument, 0, 'Y'},
 		{"port-file", required_argument, 0, 'Z'},
 		{0,0,0,0}};
 
@@ -881,6 +886,14 @@ int main(int argc, char *argv[])
 			case 'v':
 				cctools_version_print(stdout, argv[0]);
 				return 0;
+			case 'X':
+				ssl_port_file = optarg;
+				ssl_port = 0;
+				break;
+			case 'Y':
+				update_port_file = optarg;
+				update_port = 0;
+				break;
 			case 'Z':
 				port_file = optarg;
 				port = 0;
@@ -946,7 +959,6 @@ int main(int argc, char *argv[])
 
 	if(ssl_port || ssl_key_filename || ssl_cert_filename) {
 
-		if(!ssl_port) fatal("--ssl-port is also required for SSL.");
 		if(!ssl_key_filename) fatal("--ssl-key is also required for SSL.");
 		if(!ssl_cert_filename) fatal("--ssl-cert is also required for SSL.");
 
@@ -983,6 +995,7 @@ int main(int argc, char *argv[])
 	}
 
 	opts_write_port_file(port_file,port);
+	opts_write_port_file(ssl_port_file,ssl_port);
 
 	while(1) {
 		fd_set rfds;

--- a/deltadb/test/TR_catalog_server.sh
+++ b/deltadb/test/TR_catalog_server.sh
@@ -11,13 +11,18 @@ prepare()
 run()
 {
 	echo "starting the catalog server"
-	../src/catalog_server -d all -o catalog.log &
+	../src/catalog_server -d all -o catalog.log --port-file catalog.port &
 	pid=$!
 
+	echo "waiting for catalog server to start"
+	wait_for_file_creation catalog.port 5
+
+	port=`cat catalog.port`
+	
 	echo "sending udp updates to the server"
 	for i in 1 2 3 4 5
 	do
-		../../dttools/src/catalog_update --catalog localhost:9097 --file update.json -d all
+		../../dttools/src/catalog_update --catalog localhost:$port --file update.json -d all
 		sleep 1
 	done
 
@@ -25,7 +30,7 @@ run()
 	# echo 'type=="cctools-test"' | base64
 
 	echo "fetching the results via http"
-	curl http://localhost:9097/query/dHlwZT09ImNjdG9vbHMtdGVzdCIK > query.out
+	curl http://localhost:$port/query/dHlwZT09ImNjdG9vbHMtdGVzdCIK > query.out
 
 	if ../../dttools/src/jx2json < query.out
 	then
@@ -39,7 +44,7 @@ run()
 	fi
 
 	echo "killing the catalog server"
-	kill -9 $pid
+	kill $pid
 	wait $pid
 	
 	if [ $result != 0 ]
@@ -53,7 +58,7 @@ run()
 
 clean()
 {
-	rm -f cert.pem key.pem catalog.log update.json query.out
+	rm -f cert.pem key.pem catalog.log catalog.port update.json query.out
 	rm -rf catalog.history
 	return 0
 }

--- a/deltadb/test/TR_catalog_server_ssl.sh
+++ b/deltadb/test/TR_catalog_server_ssl.sh
@@ -23,13 +23,20 @@ prepare()
 run()
 {
 	echo "starting the catalog server"
-	../src/catalog_server -d all -o catalog.log --ssl-port 9099 --ssl-cert cert.pem --ssl-key key.pem &
+	../src/catalog_server -d all -o catalog.log --port-file catalog.port --ssl-port-file catalog.ssl.port --ssl-cert cert.pem --ssl-key key.pem &
 	pid=$!
 
+	echo "waiting for catalog server to start"
+	wait_for_file_creation catalog.port 5
+	wait_for_file_creation catalog.ssl.port 5
+
+	port=`cat catalog.port`
+	ssl_port=`cat catalog.ssl.port`
+	
 	echo "sending udp updates to the server"
 	for i in 1 2 3 4 5
 	do
-		../../dttools/src/catalog_update --catalog localhost:9097 --file update.json
+		../../dttools/src/catalog_update --catalog localhost:$port --file update.json
 		sleep 1
 	done
 
@@ -37,7 +44,7 @@ run()
 	# echo 'type=="cctools-test"' | base64
 
 	echo "fetching the results via https"
-	curl --insecure https://localhost:9099/query/dHlwZT09ImNjdG9vbHMtdGVzdCIK > query.out
+	curl --insecure https://localhost:${ssl_port}/query/dHlwZT09ImNjdG9vbHMtdGVzdCIK > query.out
 
 	if ../../dttools/src/jx2json < query.out
 	then
@@ -51,7 +58,7 @@ run()
 	fi
 
 	echo "killing the catalog server"
-	kill -9 $pid
+	kill $pid
 	wait $pid
 	
 	if [ $result != 0 ]
@@ -65,7 +72,7 @@ run()
 
 clean()
 {
-	rm -f cert.pem key.pem catalog.log update.json query.out
+	rm -f cert.pem key.pem catalog.log catalog.port catalog.ssl.port update.json query.out
 	rm -rf catalog.history
 	return 0
 }


### PR DESCRIPTION
## Proposed Changes

Make catalog tests more robust and flexible by allowing them to operate on ordinary ports.
Fixes transient problems with testing in which second catalog run cannot get same ports as the first.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
