### PR TITLE
Vine: Keep Scheduler Stateless for Libraries/Functions

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -169,6 +169,9 @@ static void delete_uncacheable_files(struct vine_manager *q, struct vine_worker_
 static int delete_worker_file(struct vine_manager *q, struct vine_worker_info *w, const char *filename,
 		vine_cache_level_t cache_level, vine_cache_level_t delete_upto_level);
 
+struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_worker_info *w, const char *name, vine_result_code_t *result );
+
+
 /* Return the number of workers matching a given type: WORKER, STATUS, etc */
 
 static int count_workers(struct vine_manager *q, vine_worker_type_t type)
@@ -2873,26 +2876,38 @@ assignment and the new task state.
 
 static vine_result_code_t commit_task_to_worker(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
 {
-	/* Kill empty libraries to reclaim resources. Match the assumption of
-	 * @vine.schedule.c:check_worker_have_enough_resources() */
+	vine_result_code_t result = VINE_SUCCESS;
+
+	/* Kill unused libraries on this worker to reclaim resources. */
+	/* Matches assumption in vine_schedule.c:check_available_resources() */
 	kill_empty_libraries_on_worker(q, w, t);
+
+	/* If this is a function needing a library, dispatch the library. */
+	if (t->needs_library) {
+		/* Consider whether the library task is already on that machine. */
+		t->library_task = vine_schedule_find_library(q, w, t->needs_library);
+		if(!t->library_task) {
+			/* Otherwise send the library to the worker. */
+			/* Note that this call will re-enter commit_task_to_worker. */
+			t->library_task = send_library_to_worker(q,w,t->needs_library,&result);
+
+			/* Careful: if the above failed, then w may no longer be valid */
+			/* In that case return immediately without making further changes. */
+			if(!t->library_task) return result;
+		}
+		/* If start_one_task_fails, this will be decremented in handle_failure below. */
+		t->library_task->function_slots_inuse++;
+	}
+
 	t->hostname = xxstrdup(w->hostname);
 	t->addrport = xxstrdup(w->addrport);
 
 	t->time_when_commit_start = timestamp_get();
-	vine_result_code_t result = start_one_task(q, w, t);
+	result = start_one_task(q, w, t);
 	t->time_when_commit_end = timestamp_get();
 
 	itable_insert(w->current_tasks, t->task_id, t);
 	t->worker = w;
-
-	/* Increment the function count if this is a function task.
-	 * If the manager fails to send this function task to the worker however,
-	 * then the count will be decremented properly in @handle_failure() below. */
-	if (t->needs_library) {
-		t->library_task = vine_schedule_find_library(w, t->needs_library);
-		t->library_task->function_slots_inuse++;
-	}
 
 	change_task_state(q, t, VINE_TASK_RUNNING);
 
@@ -4604,9 +4619,10 @@ int vine_submit(struct vine_manager *q, struct vine_task *t)
  * @param q The manager structure.
  * @param w The worker info structure.
  * @param name The name of the library to be sent.
+ * @param result A pointer to a result reflecting the reason for any failure.
  * @return pointer to the library task if the operation succeeds, 0 otherwise.
  */
-struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_worker_info *w, const char *name)
+struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_worker_info *w, const char *name, vine_result_code_t *result )
 {
 	/* Find the original prototype library task by name, if it exists. */
 	struct vine_task *original = hash_table_lookup(q->library_templates, name);
@@ -4676,10 +4692,10 @@ struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_wor
 
 	/* Send the task to the worker in the usual way. */
 	/* Careful: If this failed, then the worker object or task object may no longer be valid! */
-	vine_result_code_t result = commit_task_to_worker(q, w, t);
+	*result = commit_task_to_worker(q, w, t);
 
 	/* Careful again: If commit_task_to_worker failed the worker object or task object may no longer be valid! */
-	if (result == VINE_SUCCESS) {
+	if (*result == VINE_SUCCESS) {
 		vine_txn_log_write_library_update(q, w, t->task_id, VINE_LIBRARY_SENT);
 		return t;
 	} else {
@@ -4709,7 +4725,7 @@ void vine_manager_remove_library(struct vine_manager *q, const char *name)
 		struct vine_task *library = vine_schedule_find_library(w, name);
 		while (library) {
 			vine_cancel_by_task_id(q, library->task_id);
-			library = vine_schedule_find_library(w, name);
+			library = vine_schedule_find_library(q, w, name);
 		}
 		hash_table_remove(q->library_templates, name);
 

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -266,8 +266,6 @@ int64_t overcommitted_resource_total(struct vine_manager *q, int64_t total);
 /* Internal: Shut down a specific worker. */
 int vine_manager_shut_down_worker(struct vine_manager *q, struct vine_worker_info *w);
 
-struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_worker_info *w, const char *name);
-
 /** Return any completed task without doing any manager work. */
 struct vine_task *vine_manager_no_wait(struct vine_manager *q, const char *tag, int task_id);
 

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -84,7 +84,7 @@ int check_worker_have_enough_resources(
 	/* Subtract resources from libraries that have slots unused and don't match the current task. */
 	/* These will be killed anyway as needed in commit_task_to_worker. */
 	/* Matches assumption in vine_manager.c:commit_task_to_worker() */
-	
+
 	uint64_t task_id;
 	struct vine_task *ti;
 	ITABLE_ITERATE(w->current_tasks, task_id, ti)
@@ -211,15 +211,15 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 	}
 
 	/* Finally check to see if a function task has the needed library task */
-	
+
 	if (t->needs_library) {
 		struct vine_task *library = vine_schedule_find_library(q, w, t->needs_library);
-		if(library) {
+		if (library) {
 			/* The worker already has the library with a free slot. */
 		} else {
-			library = vine_manager_find_library_template(q,t->needs_library);
-			if(library) {
-				if(check_worker_against_task(q,w,library)) {
+			library = vine_manager_find_library_template(q, t->needs_library);
+			if (library) {
+				if (check_worker_against_task(q, w, library)) {
 					/* The library would fit this worker if it was sent. */
 				} else {
 					/* The library would not fit the worker. */
@@ -236,7 +236,8 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 
 /* Find a library task running on a specific worker that has an available slot.
  * @return pointer to the library task if there's one, 0 otherwise. */
-struct vine_task *vine_schedule_find_library(struct vine_manager *q, struct vine_worker_info *w, const char *library_name)
+struct vine_task *vine_schedule_find_library(
+		struct vine_manager *q, struct vine_worker_info *w, const char *library_name)
 {
 	uint64_t task_id;
 	struct vine_task *task;

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -81,7 +81,10 @@ int check_worker_have_enough_resources(
 {
 	struct vine_resources *worker_net_resources = vine_resources_copy(w->resources);
 
-	/* Pretend to reclaim resources from empty libraries. */
+	/* Subtract resources from libraries that have slots unused and don't match the current task. */
+	/* These will be killed anyway as needed in commit_task_to_worker. */
+	/* Matches assumption in vine_manager.c:commit_task_to_worker() */
+	
 	uint64_t task_id;
 	struct vine_task *ti;
 	ITABLE_ITERATE(w->current_tasks, task_id, ti)
@@ -207,25 +210,33 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 		}
 	}
 
-	/* do this check last! otherwise the library is sent to workers that can't fit it. */
+	/* Finally check to see if a function task has the needed library task */
+	
 	if (t->needs_library) {
-		struct vine_task *library = vine_schedule_find_library(w, t->needs_library);
-		if (!library) {
-			/* XXX: checking for matches should not modify the state of workers. */
-			library = send_library_to_worker(q, w, t->needs_library);
-			/* Careful: If this failed, then the worker object may longer be valid! */
-			if (!library) {
+		struct vine_task *library = vine_schedule_find_library(q, w, t->needs_library);
+		if(library) {
+			/* The worker already has the library with a free slot. */
+		} else {
+			library = vine_manager_find_library_template(q,t->needs_library);
+			if(library) {
+				if(check_worker_against_task(q,w,library)) {
+					/* The library would fit this worker if it was sent. */
+				} else {
+					/* The library would not fit the worker. */
+					return 0;
+				}
+			} else {
+				/* There is no library by that name, yikes! */
 				return 0;
 			}
 		}
 	}
-
 	return 1;
 }
 
 /* Find a library task running on a specific worker that has an available slot.
  * @return pointer to the library task if there's one, 0 otherwise. */
-struct vine_task *vine_schedule_find_library(struct vine_worker_info *w, const char *library_name)
+struct vine_task *vine_schedule_find_library(struct vine_manager *q, struct vine_worker_info *w, const char *library_name)
 {
 	uint64_t task_id;
 	struct vine_task *task;

--- a/taskvine/src/manager/vine_schedule.h
+++ b/taskvine/src/manager/vine_schedule.h
@@ -22,6 +22,6 @@ struct vine_worker_info *vine_schedule_task_to_worker( struct vine_manager *q, s
 void vine_schedule_check_for_large_tasks( struct vine_manager *q );
 int vine_schedule_check_fixed_location(struct vine_manager *q, struct vine_task *t);
 int vine_schedule_in_ramp_down(struct vine_manager *q);
-struct vine_task *vine_schedule_find_library(struct vine_worker_info *w, const char *library_name);
+struct vine_task *vine_schedule_find_library(struct vine_manager *q, struct vine_worker_info *w, const char *library_name);
 int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t);
 #endif


### PR DESCRIPTION
## Proposed Changes

The scheduler should *not* modify the state of the system in check_worker_against_task. Instead, when scheduling a function call, look for compatibility and capacity for library tasks, and then dispatch them in commit_task_to_worker.

Fixes #3825

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [x] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
