### PR TITLE
vine: consistently use int64 in copy_file_to_file

### DIFF
--- a/batch_job/src/batch_job.c
+++ b/batch_job/src/batch_job.c
@@ -287,7 +287,7 @@ int batch_fs_mkdir (struct batch_queue *q, const char *path, mode_t mode, int re
 	return q->module->fs.mkdir(q, path, mode, recursive);
 }
 
-int batch_fs_putfile (struct batch_queue *q, const char *lpath, const char *rpath)
+int64_t batch_fs_putfile (struct batch_queue *q, const char *lpath, const char *rpath)
 {
 	return q->module->fs.putfile(q, lpath, rpath);
 }

--- a/batch_job/src/batch_job.h
+++ b/batch_job/src/batch_job.h
@@ -134,7 +134,7 @@ int batch_job_remove(struct batch_queue *q, batch_job_id_t jobid);
 int batch_fs_chdir (struct batch_queue *q, const char *path);
 int batch_fs_getcwd (struct batch_queue *q, char *buf, size_t size);
 int batch_fs_mkdir (struct batch_queue *q, const char *path, mode_t mode, int recursive);
-int batch_fs_putfile (struct batch_queue *q, const char *lpath, const char *rpath);
+int64_t batch_fs_putfile (struct batch_queue *q, const char *lpath, const char *rpath);
 int batch_fs_rename (struct batch_queue *q, const char *lpath, const char *rpath);
 int batch_fs_stat (struct batch_queue *q, const char *path, struct stat *buf);
 int batch_fs_unlink (struct batch_queue *q, const char *path);

--- a/batch_job/src/batch_job_chirp.c
+++ b/batch_job/src/batch_job_chirp.c
@@ -319,14 +319,14 @@ int batch_fs_chirp_mkdir (struct batch_queue *q, const char *path, mode_t mode, 
 		return chirp_reli_mkdir(gethost(q), resolved, mode, STOPTIME);
 }
 
-int batch_fs_chirp_putfile (struct batch_queue *q, const char *lpath, const char *rpath)
+int64_t batch_fs_chirp_putfile (struct batch_queue *q, const char *lpath, const char *rpath)
 {
 	char resolved[CHIRP_PATH_MAX];
 	struct stat buf;
 	FILE *file = fopen(lpath, "r");
 	snprintf(resolved, sizeof(resolved), "%s/%s", getroot(q), rpath);
 	if (file && fstat(fileno(file), &buf) == 0) {
-		int n = chirp_reli_putfile(gethost(q), resolved, file, buf.st_mode, buf.st_size, STOPTIME);
+		int64_t n = chirp_reli_putfile(gethost(q), resolved, file, buf.st_mode, buf.st_size, STOPTIME);
 		fclose(file);
 		return n;
 	}

--- a/batch_job/src/batch_job_dryrun.c
+++ b/batch_job/src/batch_job_dryrun.c
@@ -181,7 +181,7 @@ static int batch_fs_dryrun_unlink (struct batch_queue *q, const char *path) {
 	}
 }
 
-static int batch_fs_dryrun_putfile (struct batch_queue *q, const char *lpath, const char *rpath) {
+static int64_t batch_fs_dryrun_putfile (struct batch_queue *q, const char *lpath, const char *rpath) {
 	FILE *log;
 
 	if ((log = fopen(q->logfile, "a"))) {

--- a/batch_job/src/batch_job_internal.h
+++ b/batch_job/src/batch_job_internal.h
@@ -68,7 +68,7 @@ struct batch_queue {
 #define batch_fs_stub_chdir(name)  static int batch_fs_##name##_chdir (struct batch_queue *Q, const char *path) { return chdir(path); }
 #define batch_fs_stub_getcwd(name)  static int batch_fs_##name##_getcwd (struct batch_queue *Q, char *buf, size_t size) { getcwd(buf, size); return 0; }
 #define batch_fs_stub_mkdir(name)  static int batch_fs_##name##_mkdir (struct batch_queue *Q, const char *path, mode_t mode, int recursive) { if (recursive) return create_dir(path, mode); else return mkdir(path, mode); }
-#define batch_fs_stub_putfile(name)  static int batch_fs_##name##_putfile (struct batch_queue *Q, const char *lpath, const char *rpath) { return copy_file_to_file(lpath, rpath); }
+#define batch_fs_stub_putfile(name)  static int64_t batch_fs_##name##_putfile (struct batch_queue *Q, const char *lpath, const char *rpath) { return copy_file_to_file(lpath, rpath); }
 #define batch_fs_stub_rename(name)  static int batch_fs_##name##_rename (struct batch_queue *Q, const char *lpath, const char *rpath) { return create_dir_parents(rpath, 0755) && !rename(lpath, rpath) ? 0 : -1; }
 #define batch_fs_stub_stat(name)  static int batch_fs_##name##_stat (struct batch_queue *Q, const char *path, struct stat *buf) { return stat(path, buf); }
 #define batch_fs_stub_unlink(name)  static int batch_fs_##name##_unlink (struct batch_queue *Q, const char *path) { return unlink_recursive(path); }

--- a/batch_job/src/batch_job_internal.h
+++ b/batch_job/src/batch_job_internal.h
@@ -40,7 +40,7 @@ struct batch_queue_module {
 		int (*chdir) (struct batch_queue *q, const char *path);
 		int (*getcwd) (struct batch_queue *q, char *buf, size_t size);
 		int (*mkdir) (struct batch_queue *q, const char *path, mode_t mode, int recursive);
-		int (*putfile) (struct batch_queue *q, const char *lpath, const char *rpath);
+		int64_t (*putfile) (struct batch_queue *q, const char *lpath, const char *rpath);
 		int (*rename) (struct batch_queue *q, const char *lpath, const char *rpath);
 		int (*stat) (struct batch_queue *q, const char *path, struct stat *buf);
 		int (*unlink) (struct batch_queue *q, const char *path);

--- a/batch_job/src/vine_factory.c
+++ b/batch_job/src/vine_factory.c
@@ -1596,7 +1596,7 @@ int main(int argc, char *argv[])
 	list_first_item(wrapper_inputs);
 	while((item = list_next_item(wrapper_inputs))) {
 		char *file_at_scratch_dir = string_format("%s/%s", scratch_dir, path_basename(item));
-		int result = copy_file_to_file(item, file_at_scratch_dir);
+		int64_t result = copy_file_to_file(item, file_at_scratch_dir);
 		if(result < 0) {
 			fprintf(stderr,"vine_factory: Cannot copy wrapper input file %s to factory scratch directory %s:\n", item, file_at_scratch_dir);
 			fprintf(stderr,"%s\n", strerror(errno));

--- a/batch_job/src/work_queue_factory.c
+++ b/batch_job/src/work_queue_factory.c
@@ -1630,7 +1630,7 @@ int main(int argc, char *argv[])
 	list_first_item(wrapper_inputs);
 	while((item = list_next_item(wrapper_inputs))) {
 		char *file_at_scratch_dir = string_format("%s/%s", scratch_dir, path_basename(item));
-		int result = copy_file_to_file(item, file_at_scratch_dir);
+		int64_t result = copy_file_to_file(item, file_at_scratch_dir);
 		if(result < 0) {
 			fprintf(stderr,"work_queue_factory: Cannot copy wrapper input file %s to factory scratch directory %s:\n", item, file_at_scratch_dir);
 			fprintf(stderr,"%s\n", strerror(errno));

--- a/dttools/src/copy_stream.c
+++ b/dttools/src/copy_stream.c
@@ -77,7 +77,7 @@ int64_t copy_fd_to_fd(int in, int out)
 
 int64_t copy_file_to_file(const char *input, const char *output)
 {
-	int64_t in = open(input, O_RDONLY);
+	int in = open(input, O_RDONLY);
 	if (in == -1)
 		return -1;
 	struct stat info;
@@ -86,7 +86,7 @@ int64_t copy_file_to_file(const char *input, const char *output)
 		return -1;
 	}
 
-	int64_t out = open(output, O_WRONLY | O_CREAT | O_TRUNC, info.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO));
+	int out = open(output, O_WRONLY | O_CREAT | O_TRUNC, info.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO));
 	if (out == -1 && errno == ENOTDIR) {
 		char dir[PATH_MAX];
 		path_dirname(output, dir);

--- a/dttools/src/copy_stream.c
+++ b/dttools/src/copy_stream.c
@@ -77,17 +77,16 @@ int64_t copy_fd_to_fd(int in, int out)
 
 int64_t copy_file_to_file(const char *input, const char *output)
 {
-	int in = open(input, O_RDONLY);
+	int64_t in = open(input, O_RDONLY);
 	if (in == -1)
 		return -1;
-
 	struct stat info;
 	if (fstat(in, &info) == -1) {
 		close(in);
 		return -1;
 	}
 
-	int out = open(output, O_WRONLY | O_CREAT | O_TRUNC, info.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO));
+	int64_t out = open(output, O_WRONLY | O_CREAT | O_TRUNC, info.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO));
 	if (out == -1 && errno == ENOTDIR) {
 		char dir[PATH_MAX];
 		path_dirname(output, dir);

--- a/makeflow/src/makeflow_module_archive.c
+++ b/makeflow/src/makeflow_module_archive.c
@@ -740,7 +740,7 @@ int makeflow_archive_copy_preserved_files(struct archive_instance *a, struct bat
 		free(directory_name);
 		// Copy output file or directory over to specified location
 		if(path_is_dir(output_file_path) != 1){
-			int success = copy_file_to_file(output_file_path, file_name);
+			int64_t success = copy_file_to_file(output_file_path, file_name);
 			free(output_file_path);
 			free(file_name);
 			if (!success) {

--- a/makeflow/src/makeflow_module_archive.c
+++ b/makeflow/src/makeflow_module_archive.c
@@ -743,7 +743,7 @@ int makeflow_archive_copy_preserved_files(struct archive_instance *a, struct bat
 			int64_t success = copy_file_to_file(output_file_path, file_name);
 			free(output_file_path);
 			free(file_name);
-			if (!success) {
+			if (success < 0) {
 				list_cursor_destroy(cur);
 				debug(D_ERROR|D_MAKEFLOW_HOOK,"Failed to copy output file %s to %s\n", output_file_path, file_name);
 				return 1;


### PR DESCRIPTION
## Proposed Changes

Fix for #3862

The current returning value of `copy_file_to_file` is `int64` if success. However, there are some places receiving the returned value with `int`, which might be overflowing and causing errors. 

In this PR I simply modified some variable types when using `copy_file_to_file` so that it consistently uses `int64` to avoid overflow.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Update the manual to reflect user-visible changes.
- [x] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
