### PR TITLE
vine: assign size to t->size in stage_output_file

### DIFF
--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -191,6 +191,7 @@ static int stage_output_file(struct vine_process *p, struct vine_mount *m, struc
 				    size,
 				    mtime,
 				    transfer_time)) {
+            f->size = size;
 			vine_worker_send_cache_update(manager,
 					f->cached_name,
 					f->type,

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -191,8 +191,8 @@ static int stage_output_file(struct vine_process *p, struct vine_mount *m, struc
 				    size,
 				    mtime,
 				    transfer_time)) {
-            f->size = size;
-			vine_worker_send_cache_update(manager,
+				f->size = size;
+				vine_worker_send_cache_update(manager,
 					f->cached_name,
 					f->type,
 					f->cache_level,

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -191,8 +191,8 @@ static int stage_output_file(struct vine_process *p, struct vine_mount *m, struc
 				    size,
 				    mtime,
 				    transfer_time)) {
-				f->size = size;
-				vine_worker_send_cache_update(manager,
+			f->size = size;
+			vine_worker_send_cache_update(manager,
 					f->cached_name,
 					f->type,
 					f->cache_level,


### PR DESCRIPTION
## Proposed Changes

Fix for #3864. 

Here the issue is that in the function `stage_output_file`, the parameter size is correctly passed to `vine_cache_add_file` to obtain the file size. However, this does not update the `f->size` field. In `vine_cache_add_file`, a new `f` object is created using `vine_hwache_file_create`, which is not the same as the `vine_file` object from `stage_output_file`. Therefore, despite the local `f` object using this size within `vine_cache_add_file`, it is discarded after the function ends, leaving the original `f->size` in `stage_output_file` unchanged. The correct approach would be to update the original `f->size` with `f->size = size` after the call to `vine_cache_add_file`.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Update the manual to reflect user-visible changes.
- [x] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
