### PR TITLE
Chirp: Use openssl pkeyutl instead of rsautl

### DIFF
--- a/configure
+++ b/configure
@@ -1123,6 +1123,20 @@ then
 	report_detection openssl_static "${openssl_static_avail}" auto "${openssl_path}"
 fi
 
+if check_path openssl
+then
+    echon "checking for pkeyutl/rsautl..."
+    # In openssl3, "openssl rsautl" is deprecated in favor of "openssl pkeyutl"
+    if openssl pkeyutl --help >/dev/null 2>&1
+    then
+	echo "using newer openssl pkeyutl"
+	ccflags_append_define HAS_OPENSSL_PKEYUTL
+    else
+	echo "using older openssl rsautl"
+	ccflags_append_define HAS_OPENSSL_RSAUTL
+    fi	
+fi
+
 
 # from glibc:
 library_search_standard resolv ${base_root}

--- a/dttools/src/auth_ticket.c
+++ b/dttools/src/auth_ticket.c
@@ -269,9 +269,9 @@ static int server_accepts_ticket(struct link *link, const char *ticket_digest, t
 	int result = system(cmd);
 	free(cmd);
 
-	// unlink(signature_file);
-	// unlink(challenge_file);
-	// unlink(ticket_file);
+	unlink(signature_file);
+	unlink(challenge_file);
+	unlink(ticket_file);
 
 	if (result != 0) {
 		debug(D_AUTH, "ticket: failed challenge for %s", ticket_digest);

--- a/dttools/src/auth_ticket.c
+++ b/dttools/src/auth_ticket.c
@@ -114,11 +114,13 @@ static int auth_ticket_assert(struct link *link, time_t stoptime)
 
 		{
 			/* reads challenge from stdin */
+			/* clang-format off */
 #if defined(HAS_OPENSSL_PKEYUTL)
 			static const char cmd[] = OPENSSL_RANDFILE "openssl pkeyutl -inkey \"$TICKET\" -sign\n";
 #else
 			static const char cmd[] = OPENSSL_RANDFILE "openssl rsautl -inkey \"$TICKET\" -sign\n";
 #endif
+			/* clang-format on */
 			const char *env[] = {NULL, NULL};
 			BUFFER_STACK_ABORT(Benv, 8192);
 			BUFFER_STACK_ABORT(Bout, 65536);
@@ -270,15 +272,13 @@ static int server_accepts_ticket(struct link *link, const char *ticket_digest, t
 	the correspponding signature as a separate file, and then just returns success or failure.
 	*/
 
+	/* clang-format off */
 #if defined(HAS_OPENSSL_PKEYUTL)
-	char *cmd = string_format("openssl pkeyutl -pubin -inkey \"%s\" -in \"%s\" -sigfile \"%s\" -verify",
-			ticket_file,
-			challenge_file,
-			signature_file);
+	char *cmd = string_format("openssl pkeyutl -pubin -inkey \"%s\" -in \"%s\" -sigfile \"%s\" -verify", ticket_file, challenge_file, signature_file);
 #else
-	char *cmd = string_format(
-			"openssl rsautl -pubin -inkey \"%s\" -in \"%s\" -verify", ticket_file, signature_file);
+	char *cmd = string_format("openssl rsautl -pubin -inkey \"%s\" -in \"%s\" -verify", ticket_file, signature_file);
 #endif
+	/* clang-format on */
 
 	debug(D_DEBUG, "ticket: %s\n", cmd);
 	int result = system(cmd);

--- a/dttools/src/auth_ticket.c
+++ b/dttools/src/auth_ticket.c
@@ -262,6 +262,14 @@ static int server_accepts_ticket(struct link *link, const char *ticket_digest, t
 		return 0;
 	}
 
+	/*
+	Note that "openssl rsautl" is the older command, now deprecated in favor of "openssl pkeyutl".
+	rsautl -verify expects a signature (challenge + signed hash) on the input,
+	and produces the challenge plaintext on the output, returning true on success.
+	However, pkeyutl -verify expects the challenge plaintext on the input,
+	the correspponding signature as a separate file, and then just returns success or failure.
+	*/
+
 #if defined(HAS_OPENSSL_PKEYUTL)
 	char *cmd = string_format("openssl pkeyutl -pubin -inkey \"%s\" -in \"%s\" -sigfile \"%s\" -verify",
 			ticket_file,

--- a/dttools/src/auth_ticket.c
+++ b/dttools/src/auth_ticket.c
@@ -264,12 +264,14 @@ static int server_accepts_ticket(struct link *link, const char *ticket_digest, t
 
 #if defined(HAS_OPENSSL_PKEYUTL)
 	char *cmd = string_format("openssl pkeyutl -pubin -inkey \"%s\" -in \"%s\" -sigfile \"%s\" -verify",
-#else
-	char *cmd = string_format("openssl rsautl -pubin -inkey \"%s\" -in \"%s\" -verify",
-#endif
 			ticket_file,
 			challenge_file,
 			signature_file);
+#else
+	char *cmd = string_format("openssl rsautl -pubin -inkey \"%s\" -in \"%s\" -verify",
+			ticket_file,
+			signature_file);
+#endif
 
 	debug(D_DEBUG, "ticket: %s\n", cmd);
 	int result = system(cmd);

--- a/dttools/src/auth_ticket.c
+++ b/dttools/src/auth_ticket.c
@@ -118,7 +118,7 @@ static int auth_ticket_assert(struct link *link, time_t stoptime)
 			static const char cmd[] = OPENSSL_RANDFILE "openssl pkeyutl -inkey \"$TICKET\" -sign\n";
 #else
 			static const char cmd[] = OPENSSL_RANDFILE "openssl rsautl -inkey \"$TICKET\" -sign\n";
-#endif			
+#endif
 			const char *env[] = {NULL, NULL};
 			BUFFER_STACK_ABORT(Benv, 8192);
 			BUFFER_STACK_ABORT(Bout, 65536);
@@ -268,9 +268,8 @@ static int server_accepts_ticket(struct link *link, const char *ticket_digest, t
 			challenge_file,
 			signature_file);
 #else
-	char *cmd = string_format("openssl rsautl -pubin -inkey \"%s\" -in \"%s\" -verify",
-			ticket_file,
-			signature_file);
+	char *cmd = string_format(
+			"openssl rsautl -pubin -inkey \"%s\" -in \"%s\" -verify", ticket_file, signature_file);
 #endif
 
 	debug(D_DEBUG, "ticket: %s\n", cmd);

--- a/dttools/src/auth_ticket.c
+++ b/dttools/src/auth_ticket.c
@@ -344,11 +344,11 @@ void auth_ticket_load(const char *tickets)
 {
 	if (tickets) {
 		char *tickets_copy = strdup(tickets);
-		char *t = strtok(tickets_copy,",");
-		while(t) {
+		char *t = strtok(tickets_copy, ",");
+		while (t) {
 			debug(D_CHIRP, "adding %s", t);
 			list_push_tail(client_ticket_list, strdup(t));
-			t = strtok(0,",");
+			t = strtok(0, ",");
 		}
 		free(tickets_copy);
 	} else {

--- a/dttools/src/auth_ticket.c
+++ b/dttools/src/auth_ticket.c
@@ -343,18 +343,14 @@ void auth_ticket_server_callback(auth_ticket_server_callback_t sc)
 void auth_ticket_load(const char *tickets)
 {
 	if (tickets) {
-		const char *start, *end;
-		for (start = end = tickets; start < tickets + strlen(tickets); start = ++end) {
-			while (*end != '\0' && *end != ',')
-				end++;
-			if (start == end)
-				continue;
-			char *value = xxmalloc(end - start + 1);
-			memset(value, 0, end - start + 1);
-			strncpy(value, start, end - start);
-			debug(D_CHIRP, "adding %s", value);
-			list_push_tail(client_ticket_list, value);
+		char *tickets_copy = strdup(tickets);
+		char *t = strtok(tickets_copy,",");
+		while(t) {
+			debug(D_CHIRP, "adding %s", t);
+			list_push_tail(client_ticket_list, strdup(t));
+			t = strtok(0,",");
 		}
+		free(tickets_copy);
 	} else {
 		/* populate a list with tickets in the current directory */
 		int i;


### PR DESCRIPTION
## Proposed Changes

Modify `auth_ticket.c` to use openssl pkeyutl instead of (deprecated) rsautl.  Also used the opportunity to make this code more like idiomatic cctools code.  Fixes #3183 

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Update the manual to reflect user-visible changes.
- [x] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
