### PR TITLE
Batch Job: Use vine_set_framework to indicate when makeflow is using taskvine.

### DIFF
--- a/batch_job/src/batch_job_vine.c
+++ b/batch_job/src/batch_job_vine.c
@@ -196,7 +196,10 @@ static int batch_queue_vine_create (struct batch_queue *q )
 
 	if(!q->tv_manager) return -1;
 
+	vine_set_property(q->tv_manager,"framework","makeflow");
+	
 	vine_manager_enable_process_shortcut(q->tv_manager);
+
 	batch_queue_set_feature(q, "absolute_path", NULL);
 	batch_queue_set_feature(q, "remote_rename", "%s=%s");
 	batch_queue_set_feature(q, "batch_log_name", "%s.vine.log");


### PR DESCRIPTION
## Proposed Changes

Report framework as "makeflow" through vine_set_property.  Addresses #2642

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Update the manual to reflect user-visible changes.
- [x] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
