### PR TITLE
Vine: add wait and as_completed for futures

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -321,9 +321,9 @@ class FutureFunctionCall(FunctionCall):
                 return RESULT_PENDING
             self._saved_output = result
             if not self._ran_functions:
+                self._ran_functions = True
                 for fn in self._future._callback_fns:
                     fn(self._future)
-                self._ran_functions = True
             return self._saved_output
 
         # for retriever task: fetch the result of its retrievee on completion
@@ -345,6 +345,7 @@ class FutureFunctionCall(FunctionCall):
 
                     except Exception as e:
                         self._saved_output = e
+                        raise e
                 else:
                     self._saved_output = FunctionCallNoResult()
             return self._saved_output
@@ -419,9 +420,9 @@ class FuturePythonTask(PythonTask):
                 self._output = result
                 self._output_loaded = True
             if not self._ran_functions:
+                self._ran_functions = True
                 for fn in self._future._callback_fns:
                     fn(self._future)
-                self._ran_functions = True
             return self._output
 
         else:
@@ -441,6 +442,7 @@ class FuturePythonTask(PythonTask):
                                 self._output = f.read()
                     except Exception as e:
                         self._output = e
+                        raise e
                 else:
                     self._output = PythonTaskNoResult()
                 self._output_loaded = True

--- a/taskvine/test/TR_vine_python_future_module.sh
+++ b/taskvine/test/TR_vine_python_future_module.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+set -e
+
+. ../../dttools/test/test_runner_common.sh
+
+import_config_val CCTOOLS_PYTHON_TEST_EXEC
+import_config_val CCTOOLS_PYTHON_TEST_DIR
+
+export PYTHONPATH=$(pwd)/../../test_support/python_modules/${CCTOOLS_PYTHON_TEST_DIR}:$PYTHONPATH
+
+STATUS_FILE=vine.status
+PORT_FILE=vine.port
+
+check_needed()
+{
+	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
+
+	# Poncho currently requires ast.unparse to serialize the function,
+	# which only became available in Python 3.9.  Some older platforms
+	# (e.g. almalinux8) will not have this natively.
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "from ast import unparse" || return 1
+
+	# In some limited build circumstances (e.g. macos build on github),
+	# poncho doesn't work due to lack of conda-pack or cloudpickle
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import conda_pack" || return 1
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import cloudpickle" || return 1
+
+        return 0
+}
+
+prepare()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+	return 0
+}
+
+run()
+{
+	( ${CCTOOLS_PYTHON_TEST_EXEC} vine_python_future_module.py $PORT_FILE; echo $? > $STATUS_FILE ) &
+
+	# wait at most 15 seconds for vine to find a port.
+	wait_for_file_creation $PORT_FILE 15
+
+	run_taskvine_worker $PORT_FILE worker.log --cores 2 --memory 2000 --disk 2000
+
+	# wait for vine to exit.
+	wait_for_file_creation $STATUS_FILE 15
+
+	# retrieve exit status
+	status=$(cat $STATUS_FILE)
+	if [ $status -ne 0 ]
+	then
+		# display log files in case of failure.
+		logfile=$(latest_vine_debug_log)
+		if [ -f ${logfile}  ]
+		then
+			echo "master log:"
+			cat ${logfile}
+		fi
+
+		if [ -f worker.log  ]
+		then
+			echo "worker log:"
+			cat worker.log
+		fi
+
+		exit 1
+	fi
+
+	exit 0
+}
+
+clean()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+	rm -rf vine-run-info
+	exit 0
+}
+
+
+dispatch "$@"

--- a/taskvine/test/vine_python_future_module.py
+++ b/taskvine/test/vine_python_future_module.py
@@ -46,7 +46,7 @@ def main():
     c = executor.submit(t3)
     
     print("waiting for result...")
-    results = vine.futures.wait([t1, t2, t3])
+    results = vine.futures.wait([a, b, c])
     done = results.done
     not_done = result.not_done
     print(f"results = DONE: {done}\n NOT DONE: not_done")
@@ -67,7 +67,7 @@ def main():
     c = executor.submit(t3)
     
     print("waiting for result...")
-    results = vine.futures.as_completed([t1, t2, t3])
+    results = vine.futures.as_completed([a, b, c])
     print(f"results = {results}")
 
 if __name__ == "__main__":

--- a/taskvine/test/vine_python_future_module.py
+++ b/taskvine/test/vine_python_future_module.py
@@ -1,0 +1,77 @@
+#! /usr/bin/env python
+
+import sys
+import ndcctools.taskvine as vine
+
+port_file = None
+try:
+    port_file = sys.argv[1]
+except IndexError:
+    sys.stderr.write("Usage: {} PORTFILE\n".format(sys.argv[0]))
+    raise
+
+
+# Define a function to invoke remotely
+def my_sum(x, y, negate=False):
+    from operator import add, mul
+
+    f = 1
+    if negate:
+        f = -1
+    s = mul(f, add(x, y))
+    return s
+
+
+def main():
+    executor = vine.FuturesExecutor(
+        port=[9123, 9129], manager_name="vine_matrtix_build_test", factory=False
+    )
+    print("listening on port {}".format(executor.manager.port))
+    with open(port_file, "w") as f:
+        f.write(str(executor.manager.port))
+
+    # Submit several tasks for wait function:
+    print("submitting tasks...")
+
+    t1 = executor.future_task(my_sum, 7, 4)
+    t1.set_cores(1)
+    a = executor.submit(t1)
+
+    t2 = executor.future_task(my_sum, a, a)
+    t2.set_cores(1)
+    b = executor.submit(t2)
+
+    t3 = executor.future_task(my_sum, a, b)
+    t3.set_cores(1)
+    c = executor.submit(t3)
+    
+    print("waiting for result...")
+    results = vine.futures.wait([t1, t2, t3])
+    done = results.done
+    not_done = result.not_done
+    print(f"results = DONE: {done}\n NOT DONE: not_done")
+
+    # Submit several tasks for as_completed function:
+    print("submitting tasks...")
+
+    t1 = executor.future_task(my_sum, 7, 4)
+    t1.set_cores(1)
+    a = executor.submit(t1)
+
+    t2 = executor.future_task(my_sum, a, a)
+    t2.set_cores(1)
+    b = executor.submit(t2)
+
+    t3 = executor.future_task(my_sum, a, b)
+    t3.set_cores(1)
+    c = executor.submit(t3)
+    
+    print("waiting for result...")
+    results = vine.futures.as_completed([t1, t2, t3])
+    print(f"results = {results}")
+
+if __name__ == "__main__":
+    main()
+
+
+# vim: set sts=4 sw=4 ts=4 expandtab ft=python:

--- a/taskvine/test/vine_python_future_module.py
+++ b/taskvine/test/vine_python_future_module.py
@@ -48,7 +48,7 @@ def main():
     print("waiting for result...")
     results = vine.futures.wait([a, b, c])
     done = results.done
-    not_done = result.not_done
+    not_done = results.not_done
     print(f"results = DONE: {done}\n NOT DONE: not_done")
 
     # Submit several tasks for as_completed function:


### PR DESCRIPTION
## Proposed Changes

This adds module functions `wait` and `as_completed` to the vine futures. in regard to #3835
## Merge Checklist 

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [x] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
