### PR TITLE
vine: sum disk usage to avoid overfilling worker allocation

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -368,8 +368,6 @@ static int handle_cache_update(struct vine_manager *q, struct vine_worker_info *
 
 		w->resources->disk.inuse += size / 1e6;
 
-		debug(D_VINE, "Worker disk in use currently %ld", w->resources->disk.inuse);
-
 		/* If the replica corresponds to a declared file. */
 
 		struct vine_file *f = hash_table_lookup(q->file_table, cachename);
@@ -2586,8 +2584,6 @@ struct rmsummary *vine_manager_choose_resources_for_task(struct vine_manager *q,
 			 * thus the proportion is modified by the current overcommit
 			 * multiplier */
 			limits->disk = MAX(1, MAX(limits->disk, floor(w->resources->disk.total * max_proportion / q->resource_submit_multiplier)));
-
-			debug(D_VINE, "disk limit set to %f", limits->disk);
 		}
 	}
 
@@ -2708,8 +2704,6 @@ static void count_worker_resources(struct vine_manager *q, struct vine_worker_in
 	{
 		w->resources->disk.inuse += ((double)replica->size) / 1e6;
 	}
-
-	debug(D_VINE, "worker disk usage %ld", w->resources->disk.inuse);
 }
 
 static void update_max_worker(struct vine_manager *q, struct vine_worker_info *w)

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2509,7 +2509,8 @@ static void vine_manager_estimate_task_disk_min(struct vine_manager *q, struct v
 	{
 		mb += (m->file->size) / 1e6;
 	}
-	t->resources_requested->disk = mb;
+	if (mb > 0)
+		t->resources_requested->disk = mb;
 }
 
 /*

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -366,6 +366,10 @@ static int handle_cache_update(struct vine_manager *q, struct vine_worker_info *
 
 		vine_txn_log_write_cache_update(q, w, size, transfer_time, start_time, cachename);
 
+		w->resources->disk.inuse += size / 1e6;
+
+		debug(D_VINE, "Worker disk in use currently %ld", w->resources->disk.inuse);
+
 		/* If the replica corresponds to a declared file. */
 
 		struct vine_file *f = hash_table_lookup(q->file_table, cachename);
@@ -2582,6 +2586,8 @@ struct rmsummary *vine_manager_choose_resources_for_task(struct vine_manager *q,
 			 * thus the proportion is modified by the current overcommit
 			 * multiplier */
 			limits->disk = MAX(1, MAX(limits->disk, floor(w->resources->disk.total * max_proportion / q->resource_submit_multiplier)));
+
+			debug(D_VINE, "disk limit set to %f", limits->disk);
 		}
 	}
 
@@ -2695,6 +2701,15 @@ static void count_worker_resources(struct vine_manager *q, struct vine_worker_in
 		w->resources->disk.inuse += box->disk;
 		w->resources->gpus.inuse += box->gpus;
 	}
+
+	char *cachename;
+	struct vine_file_replica *replica;
+	HASH_TABLE_ITERATE(w->current_files, cachename, replica)
+	{
+		w->resources->disk.inuse += ((double)replica->size) / 1e6;
+	}
+
+	debug(D_VINE, "worker disk usage %ld", w->resources->disk.inuse);
 }
 
 static void update_max_worker(struct vine_manager *q, struct vine_worker_info *w)

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2509,8 +2509,9 @@ static void vine_manager_estimate_task_disk_min(struct vine_manager *q, struct v
 	{
 		mb += (m->file->size) / 1e6;
 	}
-	if (mb > 0)
+	if (mb > 0) {
 		t->resources_requested->disk = mb;
+	}
 }
 
 /*
@@ -2536,7 +2537,7 @@ struct rmsummary *vine_manager_choose_resources_for_task(struct vine_manager *q,
 		return limits;
 	}
 
-	if (t->resources_requested->disk == -1) {
+	if (t->resources_requested->disk < 0) {
 		vine_manager_estimate_task_disk_min(q, t);
 	}
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2583,7 +2583,7 @@ struct rmsummary *vine_manager_choose_resources_for_task(struct vine_manager *q,
 			/* worker's disk is shared even among tasks that are not running,
 			 * thus the proportion is modified by the current overcommit
 			 * multiplier */
-			limits->disk = MAX(1, MAX(limits->disk, floor(w->resources->disk.total * max_proportion / q->resource_submit_multiplier)));
+			limits->disk = MAX(1, MAX(limits->disk, floor((w->resources->disk.total - w->resources->disk.inuse) * max_proportion / q->resource_submit_multiplier)));
 		}
 	}
 

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -97,8 +97,7 @@ int check_worker_have_enough_resources(struct vine_manager *q, struct vine_worke
 	}
 
 	int ok = 1;
-	if (((double)worker_net_resources->disk.inuse) + tr->disk >
-			(double)worker_net_resources->disk.total) { /* No overcommit disk */
+	if (worker_net_resources->disk.inuse + tr->disk > worker_net_resources->disk.total) { /* No overcommit disk */
 		ok = 0;
 	}
 

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -102,12 +102,6 @@ int check_worker_have_enough_resources(struct vine_manager *q, struct vine_worke
 		ok = 0;
 	}
 
-	debug(D_VINE,
-			"comparing worker disk inuse vs task disk request %f : %f",
-			((double)w->resources->disk.inuse),
-			tr->disk);
-	debug(D_VINE, "Worker total disk %ld", w->resources->disk.total);
-
 	if ((tr->cores > worker_net_resources->cores.total) ||
 			(worker_net_resources->cores.inuse + tr->cores > overcommitted_resource_total(q, worker_net_resources->cores.total))) {
 		ok = 0;

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -97,9 +97,16 @@ int check_worker_have_enough_resources(struct vine_manager *q, struct vine_worke
 	}
 
 	int ok = 1;
-	if (worker_net_resources->disk.inuse + tr->disk > worker_net_resources->disk.total) { /* No overcommit disk */
+	if (((double)worker_net_resources->disk.inuse) + tr->disk >
+			(double)worker_net_resources->disk.total) { /* No overcommit disk */
 		ok = 0;
 	}
+
+	debug(D_VINE,
+			"comparing worker disk inuse vs task disk request %f : %f",
+			((double)w->resources->disk.inuse),
+			tr->disk);
+	debug(D_VINE, "Worker total disk %ld", w->resources->disk.total);
 
 	if ((tr->cores > worker_net_resources->cores.total) ||
 			(worker_net_resources->cores.inuse + tr->cores > overcommitted_resource_total(q, worker_net_resources->cores.total))) {


### PR DESCRIPTION
## Proposed Changes

Before we only considered the size of active task data when calculating worker->disk.inuse. 

This additionally sums the cached files currently on the worker. This presents a more accurate picture of worker disk usage.

In combination with the default proportional resource allocation, provided the estimated allocation is large enough, we will not schedule a final task to fill up the disk and make the worker exit.

However if the proportional resource allocation is not large enough we may still overfill the worker and cause it to exit.  



## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
