### PR TITLE
vine: prune stale files in daskvine

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
@@ -73,7 +73,7 @@ class DaskVineDag:
         # key->value of its computation
         self._result_of = {}
 
-        # child -> pending parents. I.e., parents that have not done
+        # child -> nodes that use the child as an input, and that have not been completed
         self._pending_parents_of = defaultdict(lambda: set())
 
         # key->depth. The shallowest level the key is found

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
@@ -73,6 +73,9 @@ class DaskVineDag:
         # key->value of its computation
         self._result_of = {}
 
+        # child -> pending parents. I.e., parents that have not done
+        self._pending_parents_of = defaultdict(lambda: set())
+
         # key->depth. The shallowest level the key is found
         self._depth_of = defaultdict(lambda: float('inf'))
 
@@ -117,6 +120,7 @@ class DaskVineDag:
 
         for c in self._children_of[key]:
             self._parents_of[c].add(key)
+            self._pending_parents_of[c].add(key)
 
     def get_ready(self):
         """ List of [(key, sexpr),...] ready for computation.
@@ -156,6 +160,10 @@ class DaskVineDag:
                 rs.update(self.set_result(p, sexpr))
             else:
                 rs[p] = (p, sexpr)
+
+        for c in self._children_of[key]:
+            self._pending_parents_of[c].discard(key)
+
         return rs.values()
 
     def _flatten_graph(self):
@@ -211,6 +219,9 @@ class DaskVineDag:
 
     def get_parents(self, key):
         return self._parents_of[key]
+
+    def get_pending_parents(self, key):
+        return self._pending_parents_of[key]
 
     def set_targets(self, keys):
         """ Values of keys that need to be computed. """

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -104,7 +104,7 @@ class DaskVine(Manager):
     #                      fn(*args) at some point during its execution to produce the dask task result.
     #                      Should return a tuple of (wrapper result, dask call result). Use for debugging.
     # @param wrapper_proc  Function to process results from wrapper on completion. (default is print)
-    # @param prune_cluster If True, remove files from the cluster after they are no longer needed.
+    # @param prune_files If True, remove files from the cluster after they are no longer needed.
     def get(self, dsk, keys, *,
             environment=None,
             extra_files=None,
@@ -128,7 +128,7 @@ class DaskVine(Manager):
             progress_label="[green]tasks",
             wrapper=None,
             wrapper_proc=print,
-            prune_cluster=False,
+            prune_files=False,
             import_modules=None,  # Deprecated, use lib_modules
             lazy_transfers=True,  # Deprecated, use worker_tranfers
             ):
@@ -164,7 +164,7 @@ class DaskVine(Manager):
             self.progress_label = progress_label
             self.wrapper = wrapper
             self.wrapper_proc = wrapper_proc
-            self.prune_cluster = prune_cluster
+            self.prune_files = prune_files
 
             if submit_per_cycle is not None and submit_per_cycle < 1:
                 submit_per_cycle = None
@@ -278,8 +278,8 @@ class DaskVine(Manager):
                         if t.key in dsk:
                             bar_update(advance=1)
 
-                        if self.prune_cluster:
-                            self._prune_cluster(dag, t.key)
+                        if self.prune_files:
+                            self._prune_file(dag, t.key)
                     else:
                         retries_left = t.decrement_retry()
                         print(f"task id {t.id} key {t.key} failed: {t.result}. {retries_left} attempts left.\n{t.std_output}")
@@ -394,7 +394,7 @@ class DaskVine(Manager):
         else:
             return raw
 
-    def _prune_cluster(self, dag, key):
+    def _prune_file(self, dag, key):
         children = dag.get_children(key)
         for c in children:
             if len(dag.get_pending_parents(c)) == 0:

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1480,6 +1480,9 @@ class Manager(object):
     def undeclare_file(self, file):
         cvine.vine_undeclare_file(self._taskvine, file._file)
 
+    def prune_file(self, file):
+        cvine.vine_prune_file(self._taskvine, file._file)
+
     # Deprecated, for backwards compatibility.
     def remove_file(self, file):
         self.undeclare_file(file)

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -887,6 +887,14 @@ however this function can be used for earlier cleanup of unneeded file objects.
 */
 void vine_undeclare_file(struct vine_manager *m, struct vine_file *f);
 
+/** Prune a file among the cluster.
+The given file or directory object is deleted from all worker's caches,
+but is still available on the manager's site, and can be recovered by submitting a recovery task.
+@param m A manager object
+@param f Any file object.
+*/
+void vine_prune_file(struct vine_manager *m, struct vine_file *f);
+
 //@}
 
 /** @name Functions - Managers */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5920,6 +5920,18 @@ the UNLINK_WHEN_DONE flag is on, the local state will also be deleted.
 
 void vine_undeclare_file(struct vine_manager *m, struct vine_file *f)
 {
+	if (!f) {
+		return;
+	}
+
+	/*
+	Special case: If the manager has already been gc'ed
+	(e.g. by python exiting), do nothing. Any memory or unlink_when_done files were gc'ed by vine_delete.
+	*/
+	if (!m) {
+		return;
+	}
+
 	/* First prune the file on all workers */
 	vine_prune_file(m, f);
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5876,10 +5876,6 @@ void vine_prune_file(struct vine_manager *m, struct vine_file *f)
 		return;
 	}
 
-	/*
-	Special case: If the manager has already been gc'ed
-	(e.g. by python exiting), do nothing. Any memory or unlink_when_done files were gc'ed by vine_delete.
-	*/
 	if (!m) {
 		return;
 	}

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5872,6 +5872,10 @@ from workers when the file is no longer needed by the manager.
 */
 void vine_prune_file(struct vine_manager *m, struct vine_file *f)
 {
+	if (!f) {
+		return;
+	}
+
 	/*
 	Special case: If the manager has already been gc'ed
 	(e.g. by python exiting), do nothing. Any memory or unlink_when_done files were gc'ed by vine_delete.


### PR DESCRIPTION
## Proposed Changes

The first solution for #3851 

This pr implements the file pruning feature in DaskVine executor. Once the DaskVine executor figures out that an output file is no longer needed in the future, it prunes it right away so that the stale files are not piling up on the workers and the workers have more storage for subsequent tasks. 

I tested the performance before and after the pruning feature is enabled on the following task graph (a compact version of the [skimmer](https://github.com/cmoore24-24/hgg/blob/main/notebooks/skims/skimmer/skimmer.py) application)

![subgraph_1](https://github.com/user-attachments/assets/4d47a05f-c0c7-4588-99c6-161db8f36866)

This is the per-worker disk usage(MB) over time(s) initially
![worker_disk_usage](https://github.com/user-attachments/assets/2e95c3c8-4917-4071-a873-414646fc0c08)
And this is after the pruning is active
![worker_disk_usage (1)](https://github.com/user-attachments/assets/11a0985e-67ff-404e-8e09-d8a13482b3cc)

As the application proceeds, files that are no longer needed will be pruned right away, rather than remaining on the worker until the final task in the dag is completed.

But there is a problem.

If a file is unexpectedly lost due to a worker crash and there is no replica in the cluster, a recovery task is submitted to restore that file. However, the input files for the recovery task might have been pruned, leading to a situation where we need to recover all file dependencies from the bottom up. This process can be time-consuming, especially when there are extremely long tasks in the recovery path.

For example, in this partial graph, where the pink represents recovery tasks, a worker crashes and we lost file `temp-rnd-euugxunbpganuad`, task `1830` is submitted. However, the input file for task 1830 had been pruned and we have to submit task `1831` and `1834` to recover the two files. Likewise, task `1832`, `1833` are submitted to recover the previous input files. 

<img width="715" alt="image" src="https://github.com/user-attachments/assets/40c75ad9-d8ac-40a9-8e21-16c4f4ec1fd7">

Task `1834` is submitted later when the first input file is ready, which is another issue we can improve. Instead, we can submit all the recovery tasks for the input files simultaneously, allowing for more parallel processing. This will be addressed in a separate PR.


## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
