### PR TITLE
vine: stage out input files in PythonTask properly

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_dag.py
@@ -73,6 +73,9 @@ class DaskVineDag:
         # key->value of its computation
         self._result_of = {}
 
+        # child -> pending parents. I.e., parents that have not done
+        self._pending_parents_of = defaultdict(lambda: set())
+
         # key->depth. The shallowest level the key is found
         self._depth_of = defaultdict(lambda: float('inf'))
 
@@ -117,6 +120,7 @@ class DaskVineDag:
 
         for c in self._children_of[key]:
             self._parents_of[c].add(key)
+            self._pending_parents_of[c].add(key)
 
     def get_ready(self):
         """ List of [(key, sexpr),...] ready for computation.
@@ -156,6 +160,10 @@ class DaskVineDag:
                 rs.update(self.set_result(p, sexpr))
             else:
                 rs[p] = (p, sexpr)
+
+        for c in self._children_of[key]:
+            self._pending_parents_of[c].discard(key)
+
         return rs.values()
 
     def _flatten_graph(self):
@@ -211,6 +219,9 @@ class DaskVineDag:
 
     def get_parents(self, key):
         return self._parents_of[key]
+
+    def get_pending_parents(self, key):
+        return self._pending_parents_of[key]
 
     def set_targets(self, keys):
         """ Values of keys that need to be computed. """

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1480,6 +1480,9 @@ class Manager(object):
     def undeclare_file(self, file):
         cvine.vine_undeclare_file(self._taskvine, file._file)
 
+    def prune_file(self, file):
+        cvine.vine_prune_file(self._taskvine, file._file)
+
     # Deprecated, for backwards compatibility.
     def remove_file(self, file):
         self.undeclare_file(file)

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -992,8 +992,8 @@ class PythonTask(Task):
         name = os.path.join(manager.staging_directory, "arguments", self._id)
         with open(name, "wb") as wf:
             cloudpickle.dump([args, kwargs], wf)
-        f = manager.declare_file(name, unlink_when_done=True)
-        self.add_input(f, f"a_{self._id}")
+        self._input_file = manager.declare_file(name, unlink_when_done=True)
+        self.add_input(self._input_file, f"a_{self._id}")
 
         if self._tmp_output_enabled:
             self._output_file = self.manager.declare_temp()

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -887,6 +887,14 @@ however this function can be used for earlier cleanup of unneeded file objects.
 */
 void vine_undeclare_file(struct vine_manager *m, struct vine_file *f);
 
+/** Prune a file among the cluster.
+The given file or directory object is deleted from all worker's caches,
+but is still available on the manager's site, and can be recovered by submitting a recovery task.
+@param m A manager object
+@param f Any file object.
+*/
+void vine_prune_file(struct vine_manager *m, struct vine_file *f);
+
 //@}
 
 /** @name Functions - Managers */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5927,9 +5927,9 @@ void vine_undeclare_file(struct vine_manager *m, struct vine_file *f)
 }
 
 /*
-This function shares a similar purpose with vine_undeclare_file in 
-managing file replicas across remote workers, but it differs in execution. 
-While vine_undeclare_file removes the file from the manager’s table and 
+This function shares a similar purpose with vine_undeclare_file in
+managing file replicas across remote workers, but it differs in execution.
+While vine_undeclare_file removes the file from the manager’s table and
 all the remote workers, vine_prune_file solely focuses on removing replicas
 from worker nodes.
 
@@ -5938,20 +5938,20 @@ needed by the manager.
 */
 void vine_prune_file(struct vine_manager *m, struct vine_file *f)
 {
-       if (!f || !m) {
-               return;
-       }
-       const char *filename = f->cached_name;
-       if (f->cache_level < VINE_CACHE_LEVEL_FOREVER) {
-               char *key;
-               struct vine_worker_info *w;
-               HASH_TABLE_ITERATE(m->worker_table, key, w)
-               {
-                       if (vine_file_replica_table_lookup(w, filename)) {
-                               delete_worker_file(m, w, filename, 0, 0);
-                       }
-               }
-       }
+	if (!f || !m) {
+		return;
+	}
+	const char *filename = f->cached_name;
+	if (f->cache_level < VINE_CACHE_LEVEL_FOREVER) {
+		char *key;
+		struct vine_worker_info *w;
+		HASH_TABLE_ITERATE(m->worker_table, key, w)
+		{
+			if (vine_file_replica_table_lookup(w, filename)) {
+				delete_worker_file(m, w, filename, 0, 0);
+			}
+		}
+	}
 }
 
 struct vine_file *vine_manager_lookup_file(struct vine_manager *m, const char *cached_name)


### PR DESCRIPTION
## Proposed Changes

In PythonTask and FunctionCall, we do the garbage collection for input files in `__del__`, which undeclares the `self._input_file` to remove those files both in the cluster and the manager. The way FunctionCall declares input files is correct, but PythonTask uses local variables to declare input files, this prevents us from unsuccessfully undeclaring them in `__del__`.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
