### PR TITLE
vine: stage out pythontask input properly

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -992,8 +992,8 @@ class PythonTask(Task):
         name = os.path.join(manager.staging_directory, "arguments", self._id)
         with open(name, "wb") as wf:
             cloudpickle.dump([args, kwargs], wf)
-        f = manager.declare_file(name, unlink_when_done=True)
-        self.add_input(f, f"a_{self._id}")
+        self._input_file = manager.declare_file(name, unlink_when_done=True)
+        self.add_input(self._input_file, f"a_{self._id}")
 
         if self._tmp_output_enabled:
             self._output_file = self.manager.declare_temp()


### PR DESCRIPTION
## Proposed Changes

In PythonTask and FunctionCall, we do the garbage collection for input files in `__del__`, which undeclares the `self._input_file` to remove those files both in the cluster and the manager. The way FunctionCall declares input files is correct, but PythonTask uses local variables to declare input files, this prevents us from unsuccessfully undeclaring them in `__del__`.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
