### PR TITLE
vine: submit all potential recovery tasks for one task in one go

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3145,7 +3145,7 @@ and should consider re-creating it via a recovery task.
 static int vine_manager_check_inputs_available(struct vine_manager *q, struct vine_task *t)
 {
 	struct vine_mount *m;
-	// check if all input files are available, if not, consider recovery tasks for them at once
+	/* all input files are available, if not, consider recovery tasks for them at once */
 	int all_available = 1;
 	LIST_ITERATE(t->input_mounts, m)
 	{

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3145,17 +3145,19 @@ and should consider re-creating it via a recovery task.
 static int vine_manager_check_inputs_available(struct vine_manager *q, struct vine_task *t)
 {
 	struct vine_mount *m;
+	// check if all input files are available, if not, consider recovery tasks for them at once
+	int all_available = 1;
 	LIST_ITERATE(t->input_mounts, m)
 	{
 		struct vine_file *f = m->file;
 		if (f->type == VINE_TEMP && f->state == VINE_FILE_STATE_CREATED) {
 			if (!vine_file_replica_table_exists_somewhere(q, f->cached_name)) {
 				vine_manager_consider_recovery_task(q, f, f->recovery_task);
-				return 0;
+				all_available = 0;
 			}
 		}
 	}
-	return 1;
+	return all_available;
 }
 
 /*


### PR DESCRIPTION
## Proposed Changes

The second solution for #3851 

While checking for available inputs, we return 0 as soon as an input file is missing and submit a relevant recovery task. For Connor's application, there are a large number of parallel tasks in the final stages, and most of them are lengthy. The final task can only run when all inputs are available. However, when considering the first several inputs' availability, some at the end may be missing and are not properly accounted for. Given that some tasks are extremely long, this increases the likelihood of losing other files during recovery. Recovering them one by one results in an endless loop.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
