### PR TITLE
vine: recover lost temporary files on worker removal

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -157,8 +157,9 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 static void release_all_workers(struct vine_manager *q);
 
 static int vine_manager_check_inputs_available(struct vine_manager *q, struct vine_task *t);
-static void delete_uncacheable_files(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t);
+static void vine_manager_consider_recovery_task(struct vine_manager *q, struct vine_file *lost_file, struct vine_task *rt);
 
+static void delete_uncacheable_files(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t);
 static int delete_worker_file(struct vine_manager *q, struct vine_worker_info *w, const char *filename, vine_cache_level_t cache_level, vine_cache_level_t delete_upto_level);
 
 struct vine_task *send_library_to_worker(struct vine_manager *q, struct vine_worker_info *w, const char *name, vine_result_code_t *result);
@@ -376,8 +377,8 @@ static int handle_cache_update(struct vine_manager *q, struct vine_worker_info *
 			f->state = VINE_FILE_STATE_CREATED;
 			f->size = size;
 
-			/* And if the file is a newly created temporary. replicate it. */
-			if (f->type == VINE_TEMP && *id == 'X') {
+			/* And if the file is a newly created temporary. replicate it as needed. */
+			if (f->type == VINE_TEMP && *id == 'X' && q->temp_replica_count > 0) {
 				hash_table_insert(q->temp_files_to_replicate, f->cached_name, NULL);
 			}
 		}
@@ -931,6 +932,18 @@ static int recover_temp_files(struct vine_manager *q)
 			int curr_file_replication_cnt = vine_file_replica_table_replicate(q, f);
 
 			if (curr_file_replication_cnt < 1) {
+				/* There are two cases that a file can be added into the recovery queue:
+					1. A file is newly created, and the temp_replica_count is tuned to replicate it.
+					2. A worker is lost, and the transfer-temps-recovery is tuned to recover it.
+				Likewise, there might be two cases that the curr_file_replication_cnt can be less than 1:
+					1. A newly created file is pruned before it is about to be replicated.
+					2. A lost file doesn't have any replicas in the cluster.
+				As a file is deleted from the recovery queue when it is pruned (vine_prune_file),
+				so we only need to check the second case here.
+				*/
+				if (q->transfer_temps_recovery) {
+					vine_manager_consider_recovery_task(q, f, f->recovery_task);
+				}
 				hash_table_remove(q->temp_files_to_replicate, cached_name);
 			} else {
 				if (iter_count_var > q->attempt_schedule_depth) {
@@ -5897,6 +5910,12 @@ void vine_prune_file(struct vine_manager *m, struct vine_file *f)
 			}
 		}
 	}
+
+	/*
+	Also, a file can be added into the temp_files_to_replicate
+	list, but not yet replicated. In this case, just remove it.
+	*/
+	hash_table_remove(m->temp_files_to_replicate, f->cached_name);
 }
 
 /*


### PR DESCRIPTION
## Proposed Changes

The third solution for #3851

Currently, with tuning `m.tune("transfer-temps-recovery", 1)`, the manager is able to replicate the lost temp files to reach the threshold, for better failure tolerance. 

The way to replicate temp files on worker removal is to invoke `recall_worker_lost_temp_files`, where every temp file is enqueued into the `temp_files_to_replicate`. Files in this queue will be considered to be replicated to reach the `temp-replica-count` threshold.  

However, there are two problems:

1. If the `temp-replica-count` is not tuned, the default replica count is `0`, a temp file will be recovered when a future task claims it as an input.
2. If the `temp-replica-count` is tuned, and all workers containing a temp file are lost at the same time, as no transfer sources are available, a lost temp file will also not be recovered until a task needs it as an input.

If a lost file can be re-created earlier than when it is actually needed, we may be able to reduce the overall execution time. 

This PR addresses the second problem. I modified the logic for how the manager handles files in the `temp_files_to_replicate` queue. 

Specifically, if there are available sources, then transfer immediately from an appropriate source; if there are no sources in the cluster, we must consider a recovery task. 

A file should not appear in the recovery queue if it has already been pruned because it was deleted from the recovery queue in `vine_prune_file`.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
