### PR TITLE
vine: fix useless recovery tasks submission

### DIFF
--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -112,7 +112,7 @@ struct vine_worker_info *vine_file_replica_table_find_worker(struct vine_manager
 // trigger replications of file to satisfy temp_replica_count
 int vine_file_replica_table_replicate(struct vine_manager *m, struct vine_file *f)
 {
-	/* the number of replicas in this round */
+	/* the number of replicated copies in this round */
 	int round_replication_count = 0;
 
 	if (vine_current_transfers_get_table_size(m) >= hash_table_size(m->worker_table) * m->worker_source_max_transfers) {

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -929,12 +929,12 @@ static int recover_temp_files(struct vine_manager *q)
 		struct vine_file *f = hash_table_lookup(q->file_table, cached_name);
 
 		if (f) {
-			int curr_file_replication_cnt = vine_file_replica_table_replicate(q, f);
+			int round_replication_count = vine_file_replica_table_replicate(q, f);
 
 			/* Worker busy or no replicas found */
-			if (curr_file_replication_cnt < 1) {
+			if (round_replication_count < 1) {
 				/*
-				If no replicas are found, it indicates that the file is pruned or lost.
+				If no replicas are found, it indicates that the file doesn't exist, either pruned or lost.
 				Because a pruned file is removed from the recovery queue, so it definitely indicates that the file is lost.
 				*/
 				if (!vine_file_replica_table_exists_somewhere(q, f->cached_name) && q->transfer_temps_recovery) {
@@ -949,7 +949,7 @@ static int recover_temp_files(struct vine_manager *q)
 				}
 			}
 
-			total_replication_count += curr_file_replication_cnt;
+			total_replication_count += round_replication_count;
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

Fix #3890 

I previously misunderstood the meaning of `curr_file_replication_cnt`, which should be *the count of replicated files in the current round*, rather than *the total count of replicas for the current file*. 

The `curr_file_replication_cnt` can be `0` because the only worker holding it is busy replicating or the manager reaches the transfer limit. But that doesn't mean the file was lost.

It should be working now.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
