### PR TITLE
Futures stream output

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/file.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/file.py
@@ -67,6 +67,8 @@ class File(object):
             with open(self.source(), "rb") as f:
                 return unserializer(f)
         else:
+            with io.BytesIO(cvine.vine_file_contents_as_bytes(self._file)) as f:
+                return unserializer(f)
             raise ValueError("File does not have local contents", self.type())
 
     ##

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/file.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/file.py
@@ -66,9 +66,13 @@ class File(object):
         elif ftype == cvine.VINE_FILE:
             with open(self.source(), "rb") as f:
                 return unserializer(f)
+        elif ftype == cvine.VINE_TEMP:
+            try:
+                with io.BytesIO(cvine.vine_file_contents_as_bytes(self._file)) as f:
+                    return unserializer(f)
+            except Exception as e:
+                raise e("Temp file does not have local contents, The file much be fetched beforehand", self.type())
         else:
-            with io.BytesIO(cvine.vine_file_contents_as_bytes(self._file)) as f:
-                return unserializer(f)
             raise ValueError("File does not have local contents", self.type())
 
     ##

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -412,6 +412,7 @@ class FuturePythonTask(PythonTask):
         if not self._output_loaded and self._has_retrieved:
             if self.successful():
                 try:
+                    self._module_manager.fetch_file(self._output_file)
                     self._output = cloudpickle.loads(self._output_file.contents())
                 except Exception as e:
                     self._output = e

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -234,6 +234,7 @@ class VineFuture(Future):
         self._callback_fns = []
         self._result = None
         self._is_submitted = False
+        self._ran_functions = False
 
     def cancel(self):
         self._task._module_manager.cancel_by_task_id(self._task.id)
@@ -269,6 +270,10 @@ class VineFuture(Future):
         else:
             self._result = result
             self._state = FINISHED
+            if self._callback_fns and not self._ran_functions:
+                self._ran_functions = True
+                for fn in self._callback_fns:
+                    fn(self)
             return result
 
     def add_done_callback(self, fn):
@@ -291,64 +296,37 @@ class FutureFunctionCall(FunctionCall):
         self._envs = []
 
         self._future = VineFuture(self)
-        self._is_retriever = is_retriever
         self._has_retrieved = False
-        self._retriever = None
-        self._ran_functions = False
-
-    # Set a retriever for this task, it has to disable temp_output b/c
-    # it aims to bring the remote output back to the manager
-    def set_retriever(self):
-        self._retriever = FutureFunctionCall(self.manager, True, self.library_name, 'retrieve_output', self._future)
-        self._retriever.disable_temp_output()
-        self.manager.submit(self._retriever)
 
     # Given that every designated task stores its outcome in a temp file,
-    # this function is invoked through `VineFuture.result()` to trigger its retriever
+    # we must first fetch the file before retruning the result.
     # to bring that output back to the manager.
     def output(self, timeout="wait_forever"):
 
-        # when output() is called, set a retriever task to bring back the on-worker output
-        if not self._is_retriever and not self._retriever:
-            self.set_retriever()
-
-        # for retrievee task: wait for retriever to get result
-        if not self._is_retriever:
-            if self._saved_output:
-                return self._saved_output
-            result = self._retriever.output(timeout=timeout)
-            if result is RESULT_PENDING:
+        if not self._has_retrieved:
+            result = self._module_manager.wait_for_task_id(self.id, timeout=timeout)
+            if result:
+                self._has_retrieved = True
+            else:
                 return RESULT_PENDING
-            self._saved_output = result
-            if not self._ran_functions:
-                self._ran_functions = True
-                for fn in self._future._callback_fns:
-                    fn(self._future)
-            return self._saved_output
 
-        # for retriever task: fetch the result of its retrievee on completion
-        if self._is_retriever:
-            if not self._has_retrieved:
-                result = self._manager.wait_for_task_id(self.id, timeout=timeout)
-                if result:
-                    self._has_retrieved = True
-                else:
-                    return RESULT_PENDING
-            if not self._saved_output and self._has_retrieved:
-                if self.successful():
-                    try:
-                        output = cloudpickle.loads(self._output_file.contents())
-                        if output['Success']:
-                            self._saved_output = output['Result']
-                        else:
-                            self._saved_output = output['Reason']
+        if not self._saved_output and self._has_retrieved:
+            if self.successful():
+                try:
+                    self._module_manager.fetch_file(self._output_file)
+                    output = cloudpickle.loads(self._output_file.contents())
+                    if output['Success']:
+                        self._saved_output = output['Result']
+                    else:
+                        self._saved_output = output['Reason']
 
-                    except Exception as e:
-                        self._saved_output = e
-                        raise e
-                else:
-                    self._saved_output = FunctionCallNoResult()
-            return self._saved_output
+                except Exception as e:
+                    self._saved_output = e
+                    raise e
+            else:
+                self._saved_output = FunctionCallNoResult()
+            self._output_loaded = True
+        return self._saved_output
 
     # gather results from preceding tasks to use as inputs for this specific task
     def submit_finalize(self):
@@ -390,18 +368,17 @@ class FuturePythonTask(PythonTask):
     # @param func
     # @param args
     # @param kwargs
-    def __init__(self, manager, rf, func, *args, **kwargs):
+    def __init__(self, manager, func, *args, **kwargs):
         super(FuturePythonTask, self).__init__(func, *args, **kwargs)
         self.enable_temp_output()
         self._module_manager = manager
         self._future = VineFuture(self)
         self._envs = []
         self._has_retrieved = False
-        self._ran_functions = False
-        self._is_retriever = rf
-        self._retriever = None
 
     def output(self, timeout="wait_forever"):
+
+        # wait for task to complete if it has not been completed
         if not self._has_retrieved:
             result = self._module_manager.wait_for_task_id(self.id, timeout=timeout)
             if result:
@@ -409,6 +386,7 @@ class FuturePythonTask(PythonTask):
             else:
                 return RESULT_PENDING
 
+        # fetch output file and load output
         if not self._output_loaded and self._has_retrieved:
             if self.successful():
                 try:
@@ -420,6 +398,7 @@ class FuturePythonTask(PythonTask):
             else:
                 self._output = PythonTaskNoResult()
             self._output_loaded = True
+
         return self._output
 
     def submit_finalize(self):

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -288,7 +288,7 @@ class VineFuture(Future):
 # This class is a sublcass of FunctionCall that is specialized for future execution
 
 class FutureFunctionCall(FunctionCall):
-    def __init__(self, manager, is_retriever, library_name, fn, *args, **kwargs):
+    def __init__(self, manager, library_name, fn, *args, **kwargs):
         super().__init__(library_name, fn, *args, **kwargs)
         self.enable_temp_output()
         self.manager = manager

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -304,7 +304,7 @@ class FutureFunctionCall(FunctionCall):
     def output(self, timeout="wait_forever"):
 
         if not self._has_retrieved:
-            result = self._module_manager.wait_for_task_id(self.id, timeout=timeout)
+            result = self.manager.wait_for_task_id(self.id, timeout=timeout)
             if result:
                 self._has_retrieved = True
             else:
@@ -313,7 +313,7 @@ class FutureFunctionCall(FunctionCall):
         if not self._saved_output and self._has_retrieved:
             if self.successful():
                 try:
-                    self._module_manager.fetch_file(self._output_file)
+                    self.manager.fetch_file(self._output_file)
                     output = cloudpickle.loads(self._output_file.contents())
                     if output['Success']:
                         self._saved_output = output['Result']

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -193,7 +193,7 @@ class FuturesExecutor(Executor):
         return future_task._future
 
     def future_task(self, fn, *args, **kwargs):
-        return FuturePythonTask(self.manager, False, fn, *args, **kwargs)
+        return FuturePythonTask(self.manager, fn, *args, **kwargs)
 
     def create_library_from_functions(self, name, *function_list, poncho_env=None, init_command=None, add_env=True, import_modules=None):
         return self.manager.create_library_from_functions(name, *function_list, retrieve_output, poncho_env=poncho_env, init_command=init_command, add_env=add_env, import_modules=import_modules)
@@ -202,7 +202,7 @@ class FuturesExecutor(Executor):
         self.manager.install_library(libtask)
 
     def future_funcall(self, library_name, fn, *args, **kwargs):
-        return FutureFunctionCall(self.manager, False, library_name, fn, *args, **kwargs)
+        return FutureFunctionCall(self.manager, library_name, fn, *args, **kwargs)
 
     def set(self, name, value):
         if self.factory:


### PR DESCRIPTION
## Proposed Changes

This changes the method in which results for TaskVine futures a retrieved. Previously, a retriever task would be spawned to read the TEMP file output of a future task and return the result. Instead, this PR directs the manager to fetch the file once a result is called.

This is to address #3892 in which exposes a weakness to the previous approach. For a DAG with N leaf nodes in which results are retrieved, 2N tasks will be spawned. Using the example @gpauloski provided, the latency should now be more comparable to the base example using PythonTasks.

```python
import time
import sys
import ndcctools.taskvine as vine


def noop():
    pass

tasks = 50

if sys.argv[1] ==  'executor':
    with vine.FuturesExecutor(manager_name='manager', opts={'min_workers': 1}, batch_type='local') as e:
        start = time.perf_counter()
        for n in range(tasks):
            f = e.submit(noop)
            f.result()
        total = time.perf_counter() - start
        print(f'{tasks/total} tasks/s')


elif sys.argv[1] == 'basic':
    manager = vine.Manager(9123)
    factory = vine.Factory(manager=manager)
    factory.min_workers = 1
    factory.start()

    start = time.perf_counter()
    for i in range(tasks):
        task = vine.PythonTask(noop)
        manager.submit(task)

        while not manager.empty():
            result = manager.wait(5)
            if result:
                if isinstance(result.output, vine.PythonTaskNoResult):
                    print(f'Task {result.id} failed.')
    total = time.perf_counter() - start
    print(f'{tasks/total} tasks/s')
~                                   
``` 

```
(base-env) bash-4.4$ python latency_test.py basic
14.941598823072217 tasks/s
(base-env) bash-4.4$ python latency_test.py executor
16.75609707900016 tasks/s

```

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Update the manual to reflect user-visible changes.
- [x] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
