### PR TITLE
vine: include functions and classes in hoisting_modules

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1556,7 +1556,7 @@ You can certainly embed `import` statements within the function and install any 
     libtask = m.create_library_from_functions("my_library", divide)
     ```
 
-If the overhead of importing modules per function is noticeable, modules can be optionally imported as a common preamble to the function executions. Common modules can be specified with the `import_modules` argument to `create_library_from_functions`. This reduces the overhead by eliminating redundant imports:
+If the overhead of importing modules per function is noticeable, modules can be optionally imported as a common preamble to the function executions. Common modules can be specified with the `hoisting_modules` argument to `create_library_from_functions`. This reduces the overhead by eliminating redundant imports:
 
 
 === Python
@@ -1564,10 +1564,10 @@ If the overhead of importing modules per function is noticeable, modules can be 
     import numpy
     import math
 
-    import_modules = [numpy, math]
+    hoisting_modules = [numpy, math]
     ```
 
-`import_modules` only accepts modules as arguments (e.g. it can't be used to import functions, or select particular names with `from ... import ...` statements. Such statements should be made inside functions after specifying the modules with `import_modules`.
+`hoisting_modules` only accepts modules as arguments (e.g. it can't be used to import functions, or select particular names with `from ... import ...` statements. Such statements should be made inside functions after specifying the modules with `hoisting_modules`.
 
 === Python
     ```python

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -129,8 +129,9 @@ class DaskVine(Manager):
             wrapper=None,
             wrapper_proc=print,
             prune_files=False,
-            import_modules=None,  # Deprecated, use lib_modules
-            lazy_transfers=True,  # Deprecated, use worker_tranfers
+            hoisting_modules=None,  # Deprecated, use lib_modules
+            import_modules=None,    # Deprecated, use lib_modules
+            lazy_transfers=True,    # Deprecated, use worker_tranfers
             ):
         try:
             self.set_property("framework", "dask")
@@ -157,7 +158,7 @@ class DaskVine(Manager):
             if lib_modules:
                 self.lib_modules = lib_modules
             else:
-                self.lib_modules = import_modules  # Deprecated
+                self.lib_modules = hoisting_modules if hoisting_modules else import_modules  # Deprecated
             self.task_mode = task_mode
             self.env_per_task = env_per_task
             self.progress_disable = progress_disable
@@ -212,7 +213,7 @@ class DaskVine(Manager):
                                                          poncho_env="dummy-value",
                                                          add_env=False,
                                                          init_command=self.lib_command,
-                                                         import_modules=self.lib_modules)
+                                                         hoisting_modules=self.lib_modules)
 
             if self.environment:
                 libtask.add_environment(self.environment)

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -195,8 +195,8 @@ class FuturesExecutor(Executor):
     def future_task(self, fn, *args, **kwargs):
         return FuturePythonTask(self.manager, fn, *args, **kwargs)
 
-    def create_library_from_functions(self, name, *function_list, poncho_env=None, init_command=None, add_env=True, import_modules=None):
-        return self.manager.create_library_from_functions(name, *function_list, retrieve_output, poncho_env=poncho_env, init_command=init_command, add_env=add_env, import_modules=import_modules)
+    def create_library_from_functions(self, name, *function_list, poncho_env=None, init_command=None, add_env=True, hoisting_modules=None):
+        return self.manager.create_library_from_functions(name, *function_list, retrieve_output, poncho_env=poncho_env, init_command=init_command, add_env=add_env, hoisting_modules=hoisting_modules)
 
     def install_library(self, libtask):
         self.manager.install_library(libtask)

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -930,8 +930,8 @@ class Manager(object):
     # @param init_command    A string describing a shell command to execute before the library task is run
     # @param add_env         Whether to automatically create and/or add environment to the library
     # @returns               A task to be used with @ref ndcctools.taskvine.manager.Manager.install_library.
-    # @param import_modules  A list of modules to be imported at the preamble of library
-    def create_library_from_functions(self, library_name, *function_list, poncho_env=None, init_command=None, add_env=True, import_modules=None):
+    # @param hoisting_modules  A list of modules imported at the preamble of library, including packages, functions and classes.
+    def create_library_from_functions(self, library_name, *function_list, poncho_env=None, init_command=None, add_env=True, hoisting_modules=None):
         # Delay loading of poncho until here, to avoid bringing in poncho dependencies unless needed.
         # Ensure poncho python library is available.
         try:
@@ -941,7 +941,7 @@ class Manager(object):
 
         # Positional arguments are the list of functions to include in the library.
         # Create a unique hash of a combination of function names and bodies.
-        functions_hash = package_serverize.generate_functions_hash(function_list, import_modules)
+        functions_hash = package_serverize.generate_functions_hash(function_list, hoisting_modules)
 
         # Create path for caching library code and environment based on function hash.
         library_cache_path = f"{self.cache_directory}/vine-library-cache/{functions_hash}"
@@ -966,7 +966,7 @@ class Manager(object):
                 need_pack = False
 
             # create library code and environment, if appropriate
-            package_serverize.serverize_library_from_code(library_cache_path, function_list, library_name, need_pack=need_pack, import_modules=import_modules)
+            package_serverize.serverize_library_from_code(library_cache_path, function_list, library_name, need_pack=need_pack, hoisting_modules=hoisting_modules)
 
             # enable correct permissions for library code
             os.chmod(library_code_path, 0o775)

--- a/taskvine/src/examples/vine_example_function_call.py
+++ b/taskvine/src/examples/vine_example_function_call.py
@@ -58,8 +58,8 @@ def main():
     print("Creating library from packages and functions...")
 
     # This format shows how tocd create package import statements for the library
-    import_modules = [math]
-    libtask = q.create_library_from_functions('test-library', divide, double, cube, import_modules=import_modules, add_env=False)
+    hoisting_modules = [math]
+    libtask = q.create_library_from_functions('test-library', divide, double, cube, hoisting_modules=hoisting_modules, add_env=False)
 
     q.install_library(libtask)
 

--- a/taskvine/test/vine_python_future_funcall.py
+++ b/taskvine/test/vine_python_future_funcall.py
@@ -33,7 +33,7 @@ def main():
     # Create library task
     print("creating library from functions...")
     libtask = executor.create_library_from_functions(
-        "test-library", my_sum, import_modules=None, add_env=False
+        "test-library", my_sum, hoisting_modules=None, add_env=False
     )
 
     # Install library on executor.manager

--- a/taskvine/test/vine_python_serverless.py
+++ b/taskvine/test/vine_python_serverless.py
@@ -38,6 +38,7 @@ def main():
     args = parser.parse_args()
 
     q = vine.Manager(port=0)
+    q.tune("watch-library-logfiles", 1)
 
     print(f"TaskVine manager listening on port {q.port}")
 
@@ -48,8 +49,8 @@ def main():
     print("Creating library from packages and functions...")
 
     # This format shows how to create package import statements for the library
-    import_modules = [math]
-    libtask = q.create_library_from_functions('test-library', divide, double, cube, import_modules=import_modules, add_env=False)
+    hoisting_modules = [math]
+    libtask = q.create_library_from_functions('test-library', divide, double, cube, hoisting_modules=hoisting_modules, add_env=False)
     
     libtask.set_cores(1)
     libtask.set_memory(1000)


### PR DESCRIPTION
## Proposed Changes

This PR is in part to support #3892 to run on a serverless mode. It essentially does two things:

1. Rename the `import_modules` to `hoisting_modules` to expand it's definition, so as to accept not only python packages, but also classes and functions

2. Accept class and function declarations and hoist in the library code. For example:

``` Python
import uuid
import random

class test_class():
    def __init__(self):
        print("test")

def test_func():
    return 100

libtask = engine.executor.create_library_from_functions(
    "test-library", noop_task, hoisting_modules=[uuid, random, test_class, test_func], add_env=False
)
```

This will hoist the declarations of `test_class` and `test_func` so that function calls can invoke directly.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
