### PR TITLE
Vine: Function Slots Default to Number of Cores

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1583,7 +1583,7 @@ If the overhead of importing modules per function is noticeable, modules can be 
     ```
 
 
-After installing the packages and functions, you can optionally specify the number of functions the library can run concurrently by setting the number of function slots (default to 1):
+After installing the packages and functions, you can optionally specify the number of functions the library can run concurrently by setting the number of function slots.  (If unset, TaskVine will assume the library can run one function per core available.)
 
 === "Python"
     ```python

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -306,6 +306,7 @@ void vine_task_set_library_provided(struct vine_task *t, const char *name);
 const char *vine_task_get_library_provided(struct vine_task *t);
 
 /** Set the number of concurrent functions a library can run.
+If unset, the library will runs as many functions as it has cores available.
 @param t A task object.
 @param nslots The maximum number of concurrent functions this library can run.
 */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2677,6 +2677,19 @@ static vine_result_code_t start_one_task(struct vine_manager *q, struct vine_wor
 {
 	struct rmsummary *limits = vine_manager_choose_resources_for_task(q, w, t);
 
+	/*
+	If this is a library task, then choose the number of slots to either
+	match the explicit request, or set it to the number of cores.
+	*/
+
+	if (t->provides_library) {
+		if (t->function_slots_requested <= 0) {
+			t->function_slots_total = limits->cores;
+		} else {
+			t->function_slots_total = t->function_slots_requested;
+		}
+	}
+
 	char *command_line;
 
 	if (q->monitor_mode && !t->needs_library) {

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -508,7 +508,7 @@ vine_result_code_t vine_manager_put_task(
 
 	if (t->provides_library) {
 		vine_manager_send(q, w, "provides_library %s\n", t->provides_library);
-		vine_manager_send(q, w, "function_slots %d\n", t->function_slots);
+		vine_manager_send(q, w, "function_slots %d\n", t->function_slots_total);
 	}
 
 	vine_manager_send(q, w, "category %s\n", t->category);

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -237,7 +237,7 @@ struct vine_task *vine_schedule_find_library(struct vine_manager *q, struct vine
 	ITABLE_ITERATE(w->current_tasks, task_id, task)
 	{
 		if (task->type == VINE_TASK_TYPE_LIBRARY_INSTANCE && task->provides_library && !strcmp(task->provides_library, library_name) &&
-				(task->function_slots_inuse < task->function_slots)) {
+				(task->function_slots_inuse < task->function_slots_total)) {
 			return task;
 		}
 	}

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -56,7 +56,8 @@ struct vine_task *vine_task_create(const char *command_line)
 	t->worker_selection_algorithm = VINE_SCHEDULE_UNSET;
 
 	t->state = VINE_TASK_INITIAL;
-	t->function_slots = 1;
+	t->function_slots_requested = -1;
+	t->function_slots_total = 0;
 	t->function_slots_inuse = 0;
 
 	t->result = VINE_RESULT_UNKNOWN;
@@ -96,6 +97,7 @@ void vine_task_clean(struct vine_task *t)
 	t->bytes_transferred = 0;
 
 	t->library_task = 0;
+	t->function_slots_total = 0;
 	t->function_slots_inuse = 0;
 
 	free(t->output);
@@ -225,7 +227,7 @@ struct vine_task *vine_task_copy(const struct vine_task *task)
 	vine_task_mount_list_copy(new->output_mounts, task->output_mounts);
 	vine_task_string_list_copy(new->env_list, task->env_list);
 	vine_task_string_list_copy(new->feature_list, task->feature_list);
-	new->function_slots = task->function_slots;
+	new->function_slots_requested = task->function_slots_requested;
 
 	/* Scheduling features of task are copied. */
 	new->resource_request = task->resource_request;
@@ -308,7 +310,7 @@ const char *vine_task_get_library_provided(struct vine_task *t)
 
 void vine_task_set_function_slots(struct vine_task *t, int nslots)
 {
-	t->function_slots = nslots;
+	t->function_slots_requested = nslots;
 }
 
 void vine_task_set_env_var(struct vine_task *t, const char *name, const char *value)

--- a/taskvine/src/manager/vine_task.h
+++ b/taskvine/src/manager/vine_task.h
@@ -51,7 +51,7 @@ struct vine_task {
 
 	char *needs_library;         /**< If this is a FunctionTask, the name of the library used */
 	char *provides_library;      /**< If this is a LibraryTask, the name of the library provided. */
-	int   function_slots;        /**< If this is a LibraryTask, the max concurrent functions. */
+	int   function_slots_requested; /**< If this is a LibraryTask, the number of function slots requested by the user. -1 causes the number of slots to match the number of cores. */
 	
 	struct list *input_mounts;    /**< The mounted files expected as inputs. */
 	struct list *output_mounts;   /**< The mounted files expected as outputs. */
@@ -77,6 +77,7 @@ struct vine_task {
 	int exhausted_attempts;     /**< Number of times the task failed given exhausted resources. */
 	int forsaken_attempts;      /**< Number of times the task was submitted to a worker but failed to start execution. */
 	int workers_slow;           /**< Number of times this task has been terminated for running too long. */
+	int function_slots_total;   /**< If a library, the total number of function slots usable. */
 	int function_slots_inuse;   /**< If a library, the number of functions currently running. */
 		
 	/***** Results of task once it has reached completion. *****/

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -397,7 +397,7 @@ int vine_process_execute(struct vine_process *p)
 					out_pipe_fd,
 					p->task->task_id,
 					(int)p->task->resources_requested->cores,
-					p->task->function_slots,
+					p->task->function_slots_total,
 					getppid());
 			execl("/bin/sh", "sh", "-c", final_command, (char *)0);
 		}

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -858,7 +858,10 @@ static struct vine_task *do_task_body(struct link *manager, int task_id, time_t 
 		} else if (sscanf(line, "provides_library %s", library_name) == 1) {
 			vine_task_set_library_provided(task, library_name);
 		} else if (sscanf(line, "function_slots %" PRId64, &n) == 1) {
-			vine_task_set_function_slots(task, n);
+			/* Set the number of slots requested by the user. */
+			task->function_slots_requested = n;
+			/* Also set the total number determined by the manager. */
+			task->function_slots_total = n;
 		} else if (sscanf(line, "infile %s %s %d", localname, taskname_encoded, &flags)) {
 			url_decode(taskname_encoded, taskname, VINE_LINE_MAX);
 			vine_hack_do_not_compute_cached_name = 1;
@@ -1356,7 +1359,7 @@ static struct vine_process *find_running_library_for_function(const char *librar
 	ITABLE_ITERATE(procs_running, task_id, p)
 	{
 		if (p->task->provides_library && !strcmp(p->task->provides_library, library_name)) {
-			if (p->library_ready && p->functions_running < p->task->function_slots) {
+			if (p->library_ready && p->functions_running < p->task->function_slots_total) {
 				return p;
 			}
 		}

--- a/taskvine/test/TR_vine_python_serverless.sh
+++ b/taskvine/test/TR_vine_python_serverless.sh
@@ -43,7 +43,8 @@ run()
 	# wait at most 15 seconds for vine to find a port.
 	wait_for_file_creation $PORT_FILE 15
 
-	run_taskvine_worker $PORT_FILE worker.log --cores 2 --memory 2000 --disk 2000
+	# run an artificially large worker in order to test high concurreny for serverless
+	run_taskvine_worker $PORT_FILE worker.log --cores 8 --memory 1000 --disk 1000
 
 	# wait for vine to exit.
 	wait_for_file_creation $STATUS_FILE 15

--- a/taskvine/test/vine_python_serverless.py
+++ b/taskvine/test/vine_python_serverless.py
@@ -50,10 +50,9 @@ def main():
     # This format shows how to create package import statements for the library
     import_modules = [math]
     libtask = q.create_library_from_functions('test-library', divide, double, cube, import_modules=import_modules, add_env=False)
-    
-    libtask.set_cores(1)
-    libtask.set_memory(1000)
-    libtask.set_disk(1000)
+   
+    # Just take default resources for the library, this will cause it to fill the whole worker. 
+    # And the number of functions slots will match the number of cores available.
 
     q.install_library(libtask)
 


### PR DESCRIPTION
## Proposed Changes

If the number of function slots is unspecified, it will now be set to the number of cores allocated to the LibraryTask.   (And, it was already the case that an unlabeled task uses all the cores on a worker.). This makes it easier for a user to get the expected result by just taking the defaults all the way through.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Update the manual to reflect user-visible changes.
- [x] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
