### PR TITLE
vine: remove disk check for library task

### DIFF
--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1328,7 +1328,7 @@ static int task_resources_fit_now(struct vine_task *t)
 	return (cores_allocated + t->resources_requested->cores <= total_resources->cores.total) &&
 	       (memory_allocated + t->resources_requested->memory <= total_resources->memory.total) &&
 	       ((t->needs_library || disk_allocated + t->resources_requested->disk <= total_resources->disk.total)) && (gpus_allocated + t->resources_requested->gpus <= total_resources->gpus.total);
-		// XXX Disk is constantly shrinking, and library disk requests are currently static. Once we generate some files things will hang. 
+	// XXX Disk is constantly shrinking, and library disk requests are currently static. Once we generate some files things will hang.
 }
 
 /*

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1327,7 +1327,8 @@ static int task_resources_fit_now(struct vine_task *t)
 {
 	return (cores_allocated + t->resources_requested->cores <= total_resources->cores.total) &&
 	       (memory_allocated + t->resources_requested->memory <= total_resources->memory.total) &&
-	       (disk_allocated + t->resources_requested->disk <= total_resources->disk.total) && (gpus_allocated + t->resources_requested->gpus <= total_resources->gpus.total);
+	       ((t->needs_library || disk_allocated + t->resources_requested->disk <= total_resources->disk.total)) && (gpus_allocated + t->resources_requested->gpus <= total_resources->gpus.total);
+		// XXX Disk is constantly shrinking, and library disk requests are currently static. Once we generate some files things will hang. 
 }
 
 /*


### PR DESCRIPTION
## Proposed Changes

In a local setting (and perhaps remote) the total worker disk will grow smaller as files are generated and will quickly go below the library task allocation if it is has been given the whole disk.

Currently the resources given to a library task by the manager are fixed, where ideally we would adjust the allocation at runtime based on available remaining disk in the same way we schedule normal tasks. However the process of doing that is somewhat of a question. 



## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Update the manual to reflect user-visible changes.
- [x] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
