### PR TITLE
vine: temporarily remove resource check for function calls

### DIFF
--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -78,6 +78,16 @@ int vine_schedule_in_ramp_down(struct vine_manager *q)
  * @return 1 if yes, 0 otherwise. */
 int check_worker_have_enough_resources(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct rmsummary *tr)
 {
+	/*
+	This is a temporary hack in order to get Greg's application running.
+	The problem is in line with the problem pointed out in PR #3909 but a special case in the manager's end.
+
+	The problem here is that the manager always allocates the whole disk the the library task,
+	so that libtask->current_resource_box->disk is always equal to worker_net_resources->disk.total.
+	For the first task, the ti->current_resource_box->disk == 0, it is able to run because the expr in line 114 doesn't satisfy.
+	However, if the first task causes any increase in the worker's disk, worker_net_resources->disk.total will go above the total,
+	which causes the consistent true of the expr in line 114.
+	*/
 	if (t->needs_library) {
 		return 1;
 	}

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -85,7 +85,7 @@ int check_worker_have_enough_resources(struct vine_manager *q, struct vine_worke
 	The problem here is that the manager always allocates the whole disk the the library task,
 	so that libtask->current_resource_box->disk is always equal to worker_net_resources->disk.total.
 	For the first task, the ti->current_resource_box->disk == 0, it is able to run because the expr in line 114 doesn't satisfy.
-	However, if the first task causes any increase in the worker's disk, worker_net_resources->disk.total will go above the total,
+	However, if the first task causes any increase in the worker's disk, worker_net_resources->disk.inuse will go above the total,
 	which causes the consistent true of the expr in line 114.
 	*/
 	if (t->needs_library) {

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -78,6 +78,10 @@ int vine_schedule_in_ramp_down(struct vine_manager *q)
  * @return 1 if yes, 0 otherwise. */
 int check_worker_have_enough_resources(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct rmsummary *tr)
 {
+	if (t->needs_library) {
+		return 1;
+	}
+
 	struct vine_resources *worker_net_resources = vine_resources_copy(w->resources);
 
 	/* Subtract resources from libraries that have slots unused and don't match the current task. */


### PR DESCRIPTION
## Proposed Changes

The resource allocation problem I pointed out [yesterday](https://github.com/cooperative-computing-lab/cctools/pull/3909#issuecomment-2276165542) is a little bit different from Colin's observation, and PR #3909 doesn't really solve the problem for Greg's application. 

This is a temporary PR to quickly step over the resource check for normal function calls so that they are not hung due to the consistent `in_use + needed > total` statement.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
