### PR TITLE
vine: do not override user resource specifications

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2663,6 +2663,16 @@ struct rmsummary *vine_manager_choose_resources_for_task(struct vine_manager *q,
 	/* never go below specified min resources. */
 	rmsummary_merge_max(limits, min);
 
+	/* If the user specified resources, override proportional calculation */
+	if (t->resources_requested->cores > 0)
+		limits->cores = t->resources_requested->cores;
+	if (t->resources_requested->memory > 0)
+		limits->memory = t->resources_requested->memory;
+	if (t->resources_requested->disk > 0)
+		limits->disk = t->resources_requested->disk;
+	if (t->resources_requested->gpus > 0)
+		limits->gpus = t->resources_requested->gpus;
+
 	return limits;
 }
 


### PR DESCRIPTION
## Proposed Changes

We have observed in a few different scenarios where our proportional resource calculation and other default values are not effective in running some applications, sometimes even detrimental to their function. 

If a user specifies resources for a task we should give them exactly what they asked for. Some may find it confusing to see tasks are receiving more resources than were specified. This will also give the user the control to get their application running in the event our calculation is causing some issue. 

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Update the manual to reflect user-visible changes.
- [x] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
