### PR TITLE
vine: default worker disk to half avaialble

### DIFF
--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -406,6 +406,11 @@ static void measure_worker_resources()
 	if (options->disk_total > 0) {
 		r->disk.total = MIN(r->disk.total, options->disk_total);
 	} else if (!disk_set) {
+		/* XXX If no disk is specified we will allocate half of the worker disk available
+		   at startup. We will not update the allocation since it should remain static.
+		   If something else is consuming disk on the machine it would cause issues with tasks which
+		   request the whole available worker disk. Leaving half of the disk to other processes
+		   should leave the worker free to use the other half without the need to re measure. */
 		r->disk.total = ceil(r->disk.total * options->disk_percent / 100) + r->disk.inuse;
 		disk_set = 1;
 	}

--- a/taskvine/src/worker/vine_worker_options.c
+++ b/taskvine/src/worker/vine_worker_options.c
@@ -47,7 +47,7 @@ struct vine_worker_options *vine_worker_options_create()
 	self->arch_name = xxstrdup(uname_data.machine);
 
 	self->catalog_hosts = xxstrdup(CATALOG_HOST);
-	self->disk_percent = 90;
+	self->disk_percent = 50;
 
 	self->initial_ppid = 0;
 


### PR DESCRIPTION
## Proposed Changes

When other processes alongside the worker are consuming disk space on the machine, tasks which request the whole worker disk will be forsaken periodically because the worker is offering the entire available disk space, and the manager does not know about the unrelated disk consumption. 

This can be mitigated by either assigning a disk value to a task, or starting the worker with a finite disk value. If the user does none of these things the problem will persist. This will set a default worker disk value of half the available disk at the time the worker starts.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Update the manual to reflect user-visible changes.
- [x] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
