### PR TITLE
Vine: Improve how errors are propagated with `FuturesExecutor`

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -333,11 +333,10 @@ class FutureFunctionCall(FunctionCall):
                     if output['Success']:
                         self._saved_output = output['Result']
                     else:
-                        self._saved_output = output['Reason']
+                        self._saved_output = FunctionCallNoResult(output['Reason'])
 
                 except Exception as e:
                     self._saved_output = e
-                    raise e
             else:
                 self._saved_output = FunctionCallNoResult()
             self._output_loaded = True

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -266,7 +266,7 @@ class VineFuture(Future):
             timeout = "wait_forever"
         result = self._task.output(timeout=timeout)
         if result == RESULT_PENDING:
-            return RESULT_PENDING
+            raise TimeoutError()
 
         if isinstance(result, Exception):
             self._exception = result

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -1,6 +1,7 @@
 
 from . import cvine
 import hashlib
+from collections import deque
 from concurrent.futures import Executor
 from concurrent.futures import Future
 from concurrent.futures import FIRST_COMPLETED
@@ -100,48 +101,45 @@ def wait(fs, timeout=None, return_when=ALL_COMPLETED):
 
 
 def as_completed(fs, timeout=None):
+    fs = deque(fs)
 
-    results = set()
-
-    # submit tasks if they have not been subitted
+    # submit tasks if they have not been submitted
     for f in fs:
         if not f._is_submitted:
             f.module_manager.submit(f._task)
 
-    time_init = time.time()
-    if timeout is None:
-        time_check = float('inf')
-    else:
-        time_check = timeout
+    start = time.perf_counter()
+    result_timeout = min(timeout, 5) if timeout is not None else 5
 
-    done = False
-    while time.time() - time_init < time_check and not done:
-        for f in fs:
-            done = True
-            # skip if future is complete
-            if f in results:
-                continue
+    def _iterator():
+        # iterate of queue of futures, yeilding completed futures and
+        # requeuing non-completed futures until all futures are yielded or
+        # the timeout is reached.
+        while fs:
+            f = fs.popleft()
 
-            # check for completion
-            result = f.result(timeout=5)
-
-            # add to set of finished tasks
-            if result != RESULT_PENDING:
-                results.add(f)
-
-            # set done to false to finish loop.
+            try:
+                result = f.result(timeout=result_timeout)
+            except TimeoutError:
+                # TimeoutError's are expected since we are polling the
+                # future's status. If a timeout happens, add the future to
+                # the back of the queue.
+                fs.append(f)
+            except Exception:
+                # Future.result() raises the task's exception but that is
+                # not relevant here---just if the task has finished.
+                yield f
             else:
-                done = False
+                assert result != RESULT_PENDING
+                yield f
 
-            # check form timeout
-            if timeout is not None:
-                if time.time() - time_init > timeout:
-                    break
-    for f in fs:
-        if f not in results:
-            results.add(TimeoutError)
+            if (
+                fs and timeout is not None
+                and time.perf_counter() - start > timeout
+            ):
+                raise TimeoutError()
 
-    return iter(results)
+    return _iterator()
 
 
 ##

--- a/taskvine/test/vine_python_future_module.py
+++ b/taskvine/test/vine_python_future_module.py
@@ -22,6 +22,11 @@ def my_sum(x, y, negate=False):
     return s
 
 
+def my_timeout():
+    import time
+    time.sleep(60)
+
+
 def main():
     executor = vine.FuturesExecutor(
         port=[9123, 9129], manager_name="vine_matrtix_build_test", factory=False
@@ -69,6 +74,19 @@ def main():
     print("waiting for result...")
     results = vine.futures.as_completed([a, b, c])
     print(f"results = {results}")
+
+    # Test timeouts
+    t1 = executor.future_task(my_timeout)
+    t1.set_cores(1)
+    future = executor.submit(t1)
+
+    try:
+        future.result(timeout=1)
+    except TimeoutError:
+        print("timeout raised correctly")
+    else:
+        raise RuntimeError("TimeoutError was not raised correctly.")
+
 
 if __name__ == "__main__":
     main()

--- a/taskvine/test/vine_python_future_module.py
+++ b/taskvine/test/vine_python_future_module.py
@@ -5,6 +5,7 @@ import ndcctools.taskvine as vine
 from concurrent.futures import FIRST_COMPLETED
 from concurrent.futures import FIRST_EXCEPTION
 from concurrent.futures import ALL_COMPLETED
+from concurrent.futures import TimeoutError
 
 port_file = None
 try:

--- a/taskvine/test/vine_python_future_pythontask.py
+++ b/taskvine/test/vine_python_future_pythontask.py
@@ -22,6 +22,10 @@ def my_sum(x, y, negate=False):
     return s
 
 
+def failure():
+    raise Exception('Expected failure.')
+
+
 def main():
     executor = vine.FuturesExecutor(
         port=[9123, 9129], manager_name="vine_matrtix_build_test", factory=False
@@ -49,11 +53,24 @@ def main():
 
     res = t3.output()
     print(f"t3 output = {c.result()}")
+    assert c.exception() is None
 
     a = 7 + 4
     b = a + a
     c = a + b
     assert res == c
+
+    f1 = executor.future_task(failure)
+    f1.set_cores(1)
+    future = executor.submit(f1)
+
+    try:
+        future.result()
+    except Exception as e:
+        assert str(e) == "Expected failure."
+        assert future.exception() == e
+    else:
+        raise RuntimeError("Future did not raise exception.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed Changes

Improves how task errors and timeouts are propagated in `Future`, `wait()`, and `as_completed()` when using the `FuturesExecutor` (see #3920). The commits are in chronological order, each addressing a single class/function, if you prefer to review it that way.

A couple notes:
- In addition to fixing how `TimeoutErrors` are raised in `as_completed`, I changed it to return a generator which will reduce latency on the consumer side compared to waiting to construct an iterator from a fully constructed list of futures.
- `FutureFunctionCall.output()`/`FuturePythonTask.output()` were inconsistent in when they raised vs returned task exceptions. I changed those methods to always return task exceptions, and then left the responsibility of raising exceptions to the `Future.result()`.
- `FutureFunctionCall.output()` seems to only have access to the string representation of the exception (not the pickled exception like in `FuturePythonTask`). I construct a `FunctionCallNoResult` to return containing the string representation of the task's exception. This has the downside of not letting the user catch specific types of task exceptions (e.g., exceptions they might expect to occur), but they will at least see the true exception message and not just an empty `FunctionCallNoResult`.

**Warning:** This PR only fixes four of the five items in #3920. I didn't immediately see how to fix `Future.done()`. It calls `Manager.task_state()` which then calls `cvine.vine_task_state` but this function was removed in c1f1cd7beeb4cad8a29b3025067d67daa04ff136. Could `Future.done()` be implemented by calling `Future.result(timeout=0)`? It's probably not very efficient to do it that way---maybe there's an alternative to the remove `cvine.vine_task_state`?

Please feel free to push to my branch if you want to alter anything yourself.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
