### PR TITLE
Revert "user resource specifications are absolute (#3914)"

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2663,16 +2663,6 @@ struct rmsummary *vine_manager_choose_resources_for_task(struct vine_manager *q,
 	/* never go below specified min resources. */
 	rmsummary_merge_max(limits, min);
 
-	/* If the user specified resources, override proportional calculation */
-	if (t->resources_requested->cores > 0)
-		limits->cores = t->resources_requested->cores;
-	if (t->resources_requested->memory > 0)
-		limits->memory = t->resources_requested->memory;
-	if (t->resources_requested->disk > 0)
-		limits->disk = t->resources_requested->disk;
-	if (t->resources_requested->gpus > 0)
-		limits->gpus = t->resources_requested->gpus;
-
 	return limits;
 }
 


### PR DESCRIPTION
This reverts commit c4da6557541c06ee48245d6361451b1d11fb1538.

If an override is needed, use:

m.tune("proportional-resources", 0)
m.tune("proportional-whole-tasks", 0)

(See taskvine manual for more info.)

## Proposed Changes

Give an overall description of the changes, along with the context and motivation.
Mention relevant issues and pull requests as needed.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
