### PR TITLE
Futures executor working done and running

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1648,7 +1648,7 @@ a Future object. The result of the task can retrieved by calling `future.result(
     a = m.submit(my_sum, 3, 4)
     b = m.submit(my_sum, 5, 2)
     c = m.submit(my_sum, a, b)  # note that the futures a and b are
-                                # a passed as any other argument.
+                                # passed as any other argument.
 
     print(c.result())
     ```
@@ -1674,6 +1674,26 @@ can be tailored as any other task:
 
     print(f.result())
     ```
+
+Additionally, the executor the Vine Factory to submit TaskVine workers.
+Specifications for the workers can be provided via the `opts` keyword argument when creating to executor.
+
+=== "Python"
+    ```python
+    import ndcctools.taskvine as vine
+
+    def my_sum(x, y):
+        return x + y
+
+    opts = {"memory": 8000, "disk":8000, "cores":8, "min-workers": 5}
+    m = vine.FuturesExecutor(manager_name='my_manager', batch_type="condor", opts=opts)
+
+    t = m.future_task(my_sum, 3, 4)
+    t.set_cores(1)
+
+    f = m.submit(t)
+
+    print(f.result())
 
 Instead of tasks, the futures may also executed using [function calls](#serverless-computing) with the `future_funcall` method:
 

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/futures.py
@@ -248,15 +248,15 @@ class VineFuture(Future):
             return False
 
     def running(self):
-        state = self._task._module_manager.task_state(self._task.id)
-        if state == cvine.VINE_TASK_RUNNING:
+        state = self._task.state
+        if state == "RUNNING":
             return True
         else:
             return False
 
     def done(self):
-        state = self._task._module_manager.task_state(self._task.id)
-        if state == cvine.VINE_TASK_DONE:
+        state = self._task.state
+        if state == "DONE" or state == "RETRIEVED":
             return True
         else:
             return False

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -575,6 +575,15 @@ class Task(object):
         return cvine.vine_task_get_command(self._task)
 
     ##
+    # Get the state of the task.
+    # @code
+    # >>> print(t.command)
+    # @endcode
+    @property
+    def state(self):
+        return cvine.vine_task_get_state(self._task)
+
+    ##
     # Get the standard output of the task. Must be called only after the task
     # completes execution.
     # @code

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -468,6 +468,13 @@ also written to that directory.
 
 int vine_task_set_monitor_output(struct vine_task *t, const char *monitor_output);
 
+/** Get the state line of the task.
+@param t A task object.
+@return a string of the task's state.
+*/
+
+const char *vine_task_get_state(struct vine_task *t);
+
 /** Get the command line of the task.
 @param t A task object.
 @return The command line set by @ref vine_task_create.

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -799,7 +799,6 @@ const char *vine_task_get_state(struct vine_task *t)
 	return vine_task_state_to_string(t->state);
 }
 
-
 #define METRIC(x) \
 	if (!strcmp(name, #x)) \
 		return t->x;

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -794,6 +794,12 @@ const char *vine_task_get_hostname(struct vine_task *t)
 	return t->hostname;
 }
 
+const char *vine_task_get_state(struct vine_task *t)
+{
+	return vine_task_state_to_string(t->state);
+}
+
+
 #define METRIC(x) \
 	if (!strcmp(name, #x)) \
 		return t->x;


### PR DESCRIPTION
## Proposed Changes

For part of  #3920. Calling `future.done()` or `future.running()` on a future would fail as `cvine.vine_task_state(self._taskvine, task_id)` was removed. This adds bindings to check a task's state. NOTE: there is no cancelled state for a task so this still has to be fixed. 

Give an overall description of the changes, along with the context and motivation.
Mention relevant issues and pull requests as needed.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Update the manual to reflect user-visible changes.
- [x] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
