### PR TITLE
Use raw string for Python regular expression

### DIFF
--- a/taskvine/src/tools/vine_graph_log
+++ b/taskvine/src/tools/vine_graph_log
@@ -271,7 +271,7 @@ def check_gnuplot_version(gnuplot_cmd):
     try:
         version = check_output([gnuplot_cmd, '--version'])
         version = version.decode("utf-8")
-        result = re.match('gnuplot\s+(\d+\.\d+)\D', version)
+        result = re.match(r'gnuplot\s+(\d+\.\d+)\D', version)
 
         if not result:
             sys.stderr.write("Could not determine gnuplot version.")


### PR DESCRIPTION
## Proposed Changes

The `vine_graph_log` tool uses a Python regular expression to extract the version of `gnuplot`. The regex string contains multiple regex escape sequences (e.g., `\s` and `\d`) that are not properly escaped. In Python <3.12, this raises a `DeprecationWarning`. In Python >=3.12, this raises a `SyntaxWarning`. In future versions of Python, this warning will become a `SyntaxError`.

When writing _complex_ regular expressions in Python, we should use raw strings. This prevents backslash characters from special treatment so they are properly passed to the regex engine.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
