### PR TITLE
Recommend Miniforge instead of Miniconda and remove Python 3.9 note in install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ at the [University of Notre Dame](https://www.nd.edu),
 led by [Prof. Douglas Thain](https://dthain.github.io).
 The file [CREDITS](CREDITS) lists the many people that have contributed to the software over the years.
 
-## Quick Install Via Miniconda
+## Quick Install Via Miniforge
 
-The easiest way to install the binaries is via [Miniconda](https://docs.conda.io/en/latest/miniconda.html)
+The easiest way to install the binaries is via [Miniforge](https://github.com/conda-forge/miniforge#install), a light version of Anaconda
 ```
 conda install -y -c conda-forge ndcctools
 ```

--- a/doc/manuals/install/index.md
+++ b/doc/manuals/install/index.md
@@ -19,9 +19,8 @@ You may already have Conda installed.  To check:
 $ conda -V
 ```
 
-This displays the version of conda currently installed. If it fails, then you should install [Miniconda](https://docs.conda.io/projects/conda/en/latest/user-guide/install).
-Miniconda is a __light__ version of Anaconda, and we recommend it as it is much faster to install.
-We also recommend installing the version for `Python 3.9`
+This displays the version of conda currently installed. If it fails, then you should install [Miniforge](https://github.com/conda-forge/miniforge#install).
+Miniforge is a __light__ version of Anaconda that uses the conda-forge channel by default, and we recommend it as it is much faster to install.
 
 Once Conda is installed, then install **CCTools** with:
 
@@ -69,7 +68,6 @@ This can run slowly, so, for a potential speedup, try running:
 ```sh
 unset PYTHONPATH
 conda env create -y -f environment.yml --experimental-solver=libmamba
-
 ```
 
 Now that you are inside the `cctools-dev` environment, you can check out

--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -71,7 +71,7 @@ and machine learning.
 ## Quick Start
 
 Installing via `conda` is the easiest method for most users.
-First, [Install Miniconda](https://docs.conda.io/en/latest/miniconda.html) if you haven't done so before.
+First, [Install Miniforge](https://github.com/conda-forge/miniforge#install) if you don't already have `conda` installed.
 Then, open a terminal and install `ndcctools` like this:
 
 ```

--- a/doc/manuals/work_queue/index.md
+++ b/doc/manuals/work_queue/index.md
@@ -31,7 +31,7 @@ There are a variety of ways to install Work Queue, depending on your local envir
 In most cases, installing via `conda` is the easiest method.
 Please see our [full installation instructions](../install/index.md) for other options.
 
-First, [Install Miniconda](https://docs.conda.io/en/latest/miniconda.html) if you haven't done so before.
+First, [Install Miniforge](https://github.com/conda-forge/miniforge#install) if you don't already have `conda` installed.
 Then, open a terminal and install `ndcctools` like this:
 
 ```

--- a/packaging/build-conda/setup.sh
+++ b/packaging/build-conda/setup.sh
@@ -6,11 +6,11 @@ if [ $OSNAME = Darwin ]
 then
     # On macos, conda is not installed in the environment by default.
     # So we deploy it here, and then are force to source bash_profile in every step.
-    mkdir -p ~/miniconda3
-    curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o ~/miniconda3/miniconda.sh
-    bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
+    mkdir -p ~/miniforge3
+    curl -L "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -o ~/miniforge3/miniforge.sh
+    bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
     # This adds the conda configuration to bash_profile, which is executed once at login.
-    ~/miniconda3/bin/conda init bash
+    ~/miniforge3/bin/conda init bash
     # Now we pull in the configuration.
     source ~/.bash_profile
     # Install mamba for faster solves.


### PR DESCRIPTION
## Proposed Changes

This PR updates the documentation to recommend the Miniforge distribution instead of Miniconda, since Miniforge defaults to the permissively licensed `conda-forge` channel (where `ndcctools` lives) rather than the default channel. This also removes the outdated note recommending Python 3.9, since this no longer applies.

I left the `-c conda-forge` flag in the conda usage examples to preserve compatibility with existing Miniconda installations.

~~The only remaining meaningful reference to Miniconda in the repo is the `packaging/build-conda/setup.sh` script, as I did not want to touch any CI infrastructure.~~ The script now uses Miniforge. 

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
