### PR TITLE
Fix discrepancies between C and Python TaskVine examples (Solves #3937)

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -734,7 +734,7 @@ that are specific to one task, and one task only.
 should be retained as long as the workflow runs, and then deleted at the end.
 - A cache value of **worker** indicates that the file should be retained
 by the worker until the worker's end-of-life.
-- A cache value of **always** indicates that the file should be retained
+- A cache value of **forever** indicates that the file should be retained
 by the worker, even across workflows.  This is appropriate for widely used
 software packages and reference datasets. This level of cache leaves files on
 the execution sites even when workers terminate, thus use with care.

--- a/taskvine/src/examples/vine_example_blast.py
+++ b/taskvine/src/examples/vine_example_blast.py
@@ -105,15 +105,15 @@ with all the same tasks on the worker.""",
     print("Declaring files...")
     blast_url = m.declare_url(
         "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.13.0/ncbi-blast-2.13.0+-x64-linux.tar.gz",
-        cache="always",  # with "always", workers keep this file until they are terminated
+        cache="forever",  # with "forever", workers keep this file even after they are terminated
     )
-    blast = m.declare_untar(blast_url, cache="always")
+    blast = m.declare_untar(blast_url, cache="forever")
 
     landmark_url = m.declare_url(
         "https://ftp.ncbi.nlm.nih.gov/blast/db/landmark.tar.gz",
-        cache="always",
+        cache="forever",
     )
-    landmark = m.declare_untar(landmark_url)
+    landmark = m.declare_untar(landmark_url, cache="forever")
 
     print("Declaring tasks...")
     for i in range(args.task_count):

--- a/taskvine/src/examples/vine_example_gutenberg.py
+++ b/taskvine/src/examples/vine_example_gutenberg.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
         m.disable_peer_transfers()
 
     # declare all urls in the manager:
-    urls = map(lambda u: m.declare_url(u, cache=True), urls_sources)
+    urls = map(lambda u: m.declare_url(u, cache="forever"), urls_sources)
 
     # script to process the files
     my_script = m.declare_buffer(compare_script, cache=True)

--- a/taskvine/src/examples/vine_example_watch.py
+++ b/taskvine/src/examples/vine_example_watch.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
 
         t.add_input(script, "trickle.sh")
 
-        output = m.declare_file(f"output.{i}")
+        output = m.declare_file(f"output.{i}", cache=True)
         t.add_output(output, "output", watch=True)
 
         t.set_cores(1)


### PR DESCRIPTION
## Proposed Changes

Solves #3937 by fixing discrepancies between the C and Python TaskVine examples. Also fixes stale reference to cache of "always" in docs.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Update the manual to reflect user-visible changes.
- [x] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
