### PR TITLE
Update capitol.jpg URL in makeflow docs

### DIFF
--- a/doc/manuals/makeflow/index.md
+++ b/doc/manuals/makeflow/index.md
@@ -62,7 +62,7 @@ them to run on the controlling machine.
 ```make
 CURL=/usr/bin/curl
 CONVERT=/usr/bin/convert
-URL="http://ccl.cse.nd.edu/images/capitol.jpg"
+URL="https://ccl.cse.nd.edu/images/capitol.jpg"
 
 capitol.anim.gif: capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg
     LOCAL $(CONVERT) -delay 10 -loop 0 capitol.jpg capitol.90.jpg capitol.180.jpg capitol.270.jpg capitol.360.jpg capitol.270.jpg capitol.180.jpg capitol.90.jpg capitol.anim.gif


### PR DESCRIPTION
## Proposed Changes

The simple Makeflow example in the documentation does not work. It calls `curl` to download capitol.jpg using HTTP, which gives a 301 redirect to the HTTPS version. I updated the URL to specify HTTPS as has been done in other sections of the repository.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
