### PR TITLE
vine: dask arg worker_transfers

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -145,7 +145,7 @@ class DaskVine(Manager):
 
             self.extra_files = extra_files
             # if one of both is False, then worker_transfers is False, otherwise True
-            if not self.worker_transfers or not worker_transfers:
+            if not self.worker_transfers or not lazy_transfers:
                 self.worker_transfers = False
             else:
                 self.worker_transfers = True

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -145,7 +145,7 @@ class DaskVine(Manager):
 
             self.extra_files = extra_files
             # if one of both is False, then worker_transfers is False, otherwise True
-            if not self.worker_transfers or not lazy_transfers:
+            if not worker_transfers or not lazy_transfers:
                 self.worker_transfers = False
             else:
                 self.worker_transfers = True

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -144,7 +144,11 @@ class DaskVine(Manager):
                 self.environment = environment
 
             self.extra_files = extra_files
-            self.worker_transfers = worker_transfers or lazy_transfers
+            # if one of both is False, then worker_transfers is False, otherwise True
+            if not self.worker_transfers or not worker_transfers:
+                self.worker_transfers = False
+            else:
+                self.worker_transfers = True
             self.env_vars = env_vars
             self.low_memory_mode = low_memory_mode
             self.checkpoint_fn = checkpoint_fn


### PR DESCRIPTION
## Proposed Changes

While calling DaskVine get API, we have two arguments for the same purpose, `worker_transfers` and `lazy_transfers`, the later one is marked as deprecated.

The default value for both is `True`. If the users want to activate it, they may pass 
- worker_transfers=True
- lazy_transfers=True
- worker_transfers=True, lazy_transfers=True

This works well. However, if they want to deactivate it, they may pass
- worker_transfers=False
- lazy_transfers=False
- worker_transfers=False, lazy_transfers=False

Only the last works, because `worker_transfers or lazy_transfers` is always True if only one argument is explicitly passed by the users.

This PR changes the logic to - if one of the two arguments is False, then `self.worker_transfers` is False, otherwise True.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
