### PR TITLE
WIP Vine Shared Filesystem Mode

### DIFF
--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -145,6 +145,7 @@ typedef enum {
 	VINE_TEMP,                  /**< A temporary file created as an output of a task. */
 	VINE_BUFFER,                /**< A file obtained from data in the manager's memory space. */
 	VINE_MINI_TASK,             /**< A file obtained by executing a Unix command line. */
+	VINE_SHAREDFS,              /**< A file in a shared filesystem at both manager and worker. */
 } vine_file_type_t;
 
 

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -225,6 +225,11 @@ struct vine_file *vine_file_local(const char *source, vine_cache_level_t cache, 
 	return vine_file_create(source, 0, 0, 0, VINE_FILE, 0, cache, flags);
 }
 
+struct vine_file *vine_file_sharedfs(const char *source, vine_file_flags_t flags )
+{
+	return vine_file_create(source, 0, 0, 0, VINE_SHAREDFS, 0, VINE_CACHE_LEVEL_TASK, flags);
+}
+
 struct vine_file *vine_file_url(const char *source, vine_cache_level_t cache, vine_file_flags_t flags)
 {
 	return vine_file_create(source, 0, 0, 0, VINE_URL, 0, cache, flags);

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -225,7 +225,7 @@ struct vine_file *vine_file_local(const char *source, vine_cache_level_t cache, 
 	return vine_file_create(source, 0, 0, 0, VINE_FILE, 0, cache, flags);
 }
 
-struct vine_file *vine_file_sharedfs(const char *source, vine_file_flags_t flags )
+struct vine_file *vine_file_sharedfs(const char *source, vine_file_flags_t flags)
 {
 	return vine_file_create(source, 0, 0, 0, VINE_SHAREDFS, 0, VINE_CACHE_LEVEL_TASK, flags);
 }

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -64,6 +64,8 @@ struct vine_file *vine_file_url( const char *source, vine_cache_level_t cache, v
 struct vine_file *vine_file_temp();
 struct vine_file *vine_file_buffer( const char *buffer, size_t size, vine_cache_level_t cache, vine_file_flags_t flags );
 struct vine_file *vine_file_mini_task( struct vine_task *t, const char *name, vine_cache_level_t cache, vine_file_flags_t flags );
+struct vine_file *vine_file_sharedfs( const char *source, vine_file_flags_t flags );
+
 struct vine_file *vine_file_untar( struct vine_file *f, vine_cache_level_t cache, vine_file_flags_t flags );
 struct vine_file *vine_file_poncho( struct vine_file *f, vine_cache_level_t cache, vine_file_flags_t flags );
 struct vine_file *vine_file_starch( struct vine_file *f, vine_cache_level_t cache, vine_file_flags_t flags );

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -6160,9 +6160,9 @@ struct vine_file *vine_declare_file(struct vine_manager *m, const char *source, 
 {
 	struct vine_file *f;
 
-	if(m->shared_filesystem_link_mode) {
+	if (m->shared_filesystem_link_mode) {
 		/* XXX need to get absolute path here. */
-		f = vine_file_sharedfs(source,flags);
+		f = vine_file_sharedfs(source, flags);
 	} else if (m->shared_filesystem_cache_mode) {
 		char *file_url = vine_file_make_file_url(source);
 		f = vine_file_url(file_url, cache, flags);

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -176,6 +176,10 @@ struct vine_manager {
 	int file_source_max_transfers;
 	int worker_source_max_transfers;
 
+	/* Shared Filesystem Configuration */
+	int shared_filesystem_cache_mode; /* Worker loads input files from shared filesystem into cache. */
+	int shared_filesystem_link_mode;  /* Worker links directly to files in shared filesystem. */
+
 	/* Various performance knobs that can be tuned. */
 	int short_timeout;            /* Timeout in seconds to send/recv a brief message from worker */
 	int long_timeout;             /* Timeout if in the middle of an incomplete message. */
@@ -193,7 +197,6 @@ struct vine_manager {
                                      than 1, prefer to receive all completed tasks before submitting new tasks. */
 	int worker_retrievals;        /* retrieve all completed tasks from a worker as opposed to recieving one of any completed task*/
 	int prefer_dispatch;          /* try to dispatch tasks even if there are retrieved tasks ready to return  */
-	int load_from_shared_fs_enabled;/* Allow worker to load file from shared filesytem instead of through manager */
 
 	int fetch_factory;            /* If true, manager queries catalog for factory configuration. */
 	int proportional_resources;   /* If true, tasks divide worker resources proportionally. */

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -334,6 +334,11 @@ static vine_result_code_t vine_manager_put_input_file(struct vine_manager *q, st
 		debug(D_VINE, "%s (%s) will use temp file %s", w->hostname, w->addrport, f->source);
 		// Do nothing.  Temporary files are created and used in place.
 		break;
+
+	case VINE_SHAREDFS:
+		debug(D_VINE, "%s (%s) will use shared file %s", w->hostname, w->addrport, f->source);
+		// Do nothing.  Shared FS files are used in place.
+		break;
 	}
 
 	if (result == VINE_SUCCESS) {
@@ -438,6 +443,7 @@ static vine_result_code_t vine_manager_put_input_file_if_needed(struct vine_mana
 		case VINE_FILE:
 		case VINE_MINI_TASK:
 		case VINE_BUFFER:
+		case VINE_SHAREDFS: // XXX I'm not sure this makes sense
 			/* For these types, we sent the data, so we know it exists. */
 			replica->state = VINE_FILE_REPLICA_STATE_READY;
 			f->state = VINE_FILE_STATE_CREATED;

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -543,6 +543,7 @@ int vine_task_add_output(struct vine_task *t, struct vine_file *f, const char *r
 	case VINE_FILE:
 	case VINE_BUFFER:
 	case VINE_TEMP:
+	case VINE_SHAREDFS:
 		/* keep going */
 		break;
 	case VINE_URL:

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -43,8 +43,9 @@ vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cach
 	LIST_ITERATE(p->task->input_mounts, m)
 	{
 		// no need to check files stored in the shared filesystem
-		if(m->file->type==VINE_SHAREDFS) continue;
-		
+		if (m->file->type == VINE_SHAREDFS)
+			continue;
+
 		vine_cache_status_t cache_status = vine_cache_ensure(cache, m->file->cached_name);
 
 		switch (cache_status) {
@@ -133,7 +134,7 @@ static int vine_sandbox_symlink_to_sharedfs(struct vine_process *p, struct vine_
 {
 	char *sandbox_path = vine_sandbox_full_path(p, m->remote_name);
 
-	int result = symlink(m->file->source,sandbox_path);
+	int result = symlink(m->file->source, sandbox_path);
 	if (result != 0) {
 		debug(D_VINE, "sandbox: couldn't symlink %s -> %s : %s", sandbox_path, m->file->source, strerror(errno));
 	}
@@ -158,26 +159,28 @@ int vine_sandbox_stagein(struct vine_process *p, struct vine_cache *cache)
 
 	LIST_ITERATE(t->input_mounts, m)
 	{
-		if(m->file->type==VINE_SHAREDFS) {
+		if (m->file->type == VINE_SHAREDFS) {
 			result = vine_sandbox_symlink_to_sharedfs(p, m);
 		} else {
 			result = stage_input_file(p, m, m->file, cache);
 		}
-		if (!result) break;
+		if (!result)
+			break;
 	}
 
 	/* Certain output file types must also be created in the sandbox */
 
 	LIST_ITERATE(t->output_mounts, m)
 	{
-		if(m->file->type==VINE_SHAREDFS) {
+		if (m->file->type == VINE_SHAREDFS) {
 			result = vine_sandbox_symlink_to_sharedfs(p, m);
 		} else if (m->flags & VINE_MOUNT_MKDIR) {
 			result = vine_sandbox_create_empty_output_dir(p, m);
 		} else {
 			result = 1;
 		}
-		if (!result) break;
+		if (!result)
+			break;
 	}
 
 	return result;


### PR DESCRIPTION
## Proposed Changes

Added new access mode enabled by vine_tune() to compare TaskVine caching behavior to direct use of shared filesystem.

- Add VINE_SHAREDFS file type which causes worker to link from sandbo…x to shared filesystem.
- Added shared_filesystem_link_mode to replace VINE_FILE with VINE_SHAREDFS.
- Rename load_from_shared_fs to shared_filesystem_cache_mode, which replaces VINE_FILE with VINE_URL.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
