### PR TITLE
Poncho pinned

### DIFF
--- a/poncho/src/poncho/package_create.py
+++ b/poncho/src/poncho/package_create.py
@@ -179,6 +179,15 @@ def dict_to_env(
     return output
 
 
+def _write_pinned_files(poncho_spec, env_dir):
+    if "pinned" in poncho_spec:
+        if "conda" in poncho_spec:
+            with open(os.path.join(env_dir, "env", "conda-meta", "pinned"), "w") as f:
+                for p, v in poncho_spec["pinned"]["conda"].items():
+                    assert isinstance(v, str)
+                    f.write(f"{p}={v}\n")
+
+
 def pack_env_from_dict(
     spec,
     output,
@@ -210,11 +219,21 @@ def pack_env_from_dict(
         http_data(spec, env_dir)
 
         # create conda environment in temp directory
+        logger.info("creating environment directory...")
+        _run_conda_command(
+            env_dir,
+            needs_confirmation,
+            "create",
+        )
+
+        _write_pinned_files(spec, env_dir)
+
+        # update conda environment in temp directory from spec
         logger.info("populating environment...")
         _run_conda_command(
             env_dir,
             needs_confirmation,
-            "env create",
+            "env update",
             "--file",
             env_dir + "/conda_spec.yml",
         )

--- a/poncho/src/poncho/package_create.py
+++ b/poncho/src/poncho/package_create.py
@@ -265,15 +265,15 @@ def pack_env(
 
     # else if spec is a file or from stdin
     elif os.path.isfile(spec) or spec == "-":
-        f = open(spec, "r")
-        poncho_spec = json.load(f)
-        pack_env_from_dict(
-            poncho_spec,
-            output,
-            conda_executable,
-            download_micromamba,
-            ignore_editable_packages,
-        )
+        with open(spec, "r") as f:
+            poncho_spec = json.load(f)
+            pack_env_from_dict(
+                poncho_spec,
+                output,
+                conda_executable,
+                download_micromamba,
+                ignore_editable_packages,
+            )
 
     # else pack from a conda environment name
     # this thus assumes conda executable is in the current shell executable path

--- a/poncho/src/poncho_package_create
+++ b/poncho/src/poncho_package_create
@@ -5,7 +5,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Create a packed environment from a spec, a conda environment name, or a conda directory.')
     parser.add_argument('spec', help='Read in a spec file, a conda environment name, a conda directory, or - for stdin.')
     parser.add_argument('output', help='Write output from conda-pack to the given file.')
-    parser.add_argument('--conda-executable', action='store_true', help='Path to conda executable to use. Default are, in this order: mamba, $CONDA_EXE, conda')
+    parser.add_argument('--conda-executable', action='store', help='Path to conda executable to use. Default are, in this order: mamba, $CONDA_EXE, conda')
 
     parser.add_argument('--no-micromamba', action='store_true', help='Do not try no download micromamba if a conda executable is not found.')
     parser.add_argument('--ignore-editable-packages', action='store_true', help='Skip checks for editable packages.')


### PR DESCRIPTION
## Proposed Changes

This pr adds “pinned” to the poncho spec. The target use case is something like topcoffea, where we want to create an environment compatible with another environment. For example, we want numpy in the former, which means it should be the same version of numpy in the latter. The “pinned” spec allows specifying versions of packages that should be used in case they need to be installed as a dependency.

As an example: 
```json
{
    "conda": {
        "channels": ["conda-forge"],
        "packages": [
            "ndcctools",
        ]
    },
    "pinned": {
      "conda": {
        "python": "3.8.20=h4a871b0_2_cpython"
      }
    }
}
````

The above will try to install `ndcctools`, which depends on python. Python is pinned to version `3.8.20` and thus the version installed for `ndcctools` is `7.12.0`, the last version that exists with python 3.8 support.

Currently this only works for conda packages. I'm thinking how to do this easily for pip.

If this looks good, I can update the docs.




## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
