### PR TITLE
vine: add up peer transfer ids during scheduling 

### DIFF
--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -67,6 +67,7 @@ int vine_file_delete(struct vine_file *f)
 		free(f->source);
 		free(f->cached_name);
 		free(f->data);
+		free(f->transfer_id);
 		free(f);
 	}
 

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -43,6 +43,7 @@ struct vine_file {
 	struct vine_task *recovery_task; // For temp files, a copy of the task that created it.
 	struct vine_worker_info *source_worker; // if this is a substitute file, attach the worker serving it. 
 	int change_message_shown; // True if error message already shown.
+	char *transfer_id;	// Contains the transfer id when file is a remote url/peer transfer.
 	int refcount;       // Number of references from a task object, delete when zero.
 };
 

--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -232,14 +232,11 @@ vine_result_code_t vine_manager_put_url_now(struct vine_manager *q, struct vine_
 	url_encode(source, source_encoded, sizeof(source_encoded));
 	url_encode(f->cached_name, cached_name_encoded, sizeof(cached_name_encoded));
 
-	char *transfer_id = vine_current_transfers_add(q, w, f->source_worker, source);
-
-	vine_manager_send(q, w, "puturl_now %s %s %d %lld 0%o %s\n", source_encoded, cached_name_encoded, f->cache_level, (long long)f->size, mode, transfer_id);
+	vine_manager_send(q, w, "puturl_now %s %s %d %lld 0%o %s\n", source_encoded, cached_name_encoded, f->cache_level, (long long)f->size, mode, f->transfer_id);
 
 	struct vine_file_replica *replica = vine_file_replica_create(f->type, f->cache_level, f->size, f->mtime);
 	vine_file_replica_table_insert(q, w, f->cached_name, replica);
 
-	free(transfer_id);
 	return VINE_SUCCESS;
 }
 
@@ -268,14 +265,11 @@ vine_result_code_t vine_manager_put_url(struct vine_manager *q, struct vine_work
 	url_encode(f->source, source_encoded, sizeof(source_encoded));
 	url_encode(f->cached_name, cached_name_encoded, sizeof(cached_name_encoded));
 
-	char *transfer_id = vine_current_transfers_add(q, w, f->source_worker, f->source);
-
-	vine_manager_send(q, w, "puturl %s %s %d %lld 0%o %s\n", source_encoded, cached_name_encoded, f->cache_level, (long long)f->size, mode, transfer_id);
+	vine_manager_send(q, w, "puturl %s %s %d %lld 0%o %s\n", source_encoded, cached_name_encoded, f->cache_level, (long long)f->size, mode, f->transfer_id);
 
 	struct vine_file_replica *replica = vine_file_replica_create(f->type, f->cache_level, f->size, f->mtime);
 	vine_file_replica_table_insert(q, w, f->cached_name, replica);
 
-	free(transfer_id);
 	return VINE_SUCCESS;
 }
 


### PR DESCRIPTION
## Proposed Changes
Previously we would only add peer transfers to the transfer table in `vine_manager_put_url` after the task had been scheduled.

If a task had many input files, such as temporaries that reside on one worker, we would be happy to assign them all to be retrieved from the same worker in the scheduling stage, greater than the limit for transfers from a single source, since the task has not been sent yet and we were not incrementing the `source_in_use` count. 

In some fashion we need to increment the `source_in_use` count while considering options for peer transfers. It is a bit difficult since there are a few scenarios we give up scheduling so any counting we did in the scheduling attempt needs to get reset. 

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
