### PR TITLE
Chirp: Fix FUSE configure flags

### DIFF
--- a/configure
+++ b/configure
@@ -702,11 +702,12 @@ then
 	fuse_path=${fuse_path:-${base_root}}
 	if library_search fuse ${fuse_path} || library_search fuse /
 	then
+		fuse_ccflags="-DHAS_FUSE"
 		if [ "${fuse_path}" != / -a "${fuse_path}" != ${base_root} ]
 		then
-			fuse_ccflags="-I${fuse_path}/include"
+			fuse_ccflags="${fuse_ccflags} -I${fuse_path}/include"
 		fi
-		fuse_ldflags="-DHAS_FUSE ${library_search_result}"
+		fuse_ldflags="${library_search_result}"
 	else
 		fuse_avail=no
 	fi


### PR DESCRIPTION
## Proposed Changes

Fix configure flags so that HAS_FUSE goes in ccflags not ldflags.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Update the manual to reflect user-visible changes.
- [x] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
