### PR TITLE
vine: handling temp files when peer transfers disabled

### DIFF
--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -249,8 +249,11 @@ struct vine_file *vine_file_pseudo_temp()
 {
 	// temp files are always cached at workers until explicitely removed.
 	vine_cache_level_t cache = VINE_CACHE_LEVEL_WORKFLOW;
+	uid_t uid = getuid();
 
-	return vine_file_create("temp", 0, 0, 0, VINE_FILE, 0, cache, 0);
+	char *name = string_format("temp-local-%u", uid);
+	return vine_file_create(name, 0, 0, 0, VINE_FILE, 0, cache, 0);
+	free(name);
 }
 
 struct vine_file *vine_file_buffer(const char *data, size_t size, vine_cache_level_t cache, vine_file_flags_t flags)

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -15,6 +15,7 @@ See the file COPYING for details.
 #include "stringtools.h"
 #include "timestamp.h"
 #include "unlink_recursive.h"
+#include "uuid.h"
 #include "xxmalloc.h"
 
 #include <errno.h>
@@ -249,9 +250,10 @@ struct vine_file *vine_file_temp_no_peers()
 {
 	// temp files are always cached at workers until explicitely removed.
 	vine_cache_level_t cache = VINE_CACHE_LEVEL_WORKFLOW;
-	uid_t uid = getuid();
+	cctools_uuid_t uuid;
+	cctools_uuid_create(&uuid);
 
-	char *name = string_format("temp-local-%u", uid);
+	char *name = string_format("temp-local-%s", uuid.str);
 	return vine_file_create(name, 0, 0, 0, VINE_FILE, 0, cache, VINE_UNLINK_WHEN_DONE);
 	free(name);
 }

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -245,6 +245,14 @@ struct vine_file *vine_file_temp()
 	return vine_file_create("temp", 0, 0, 0, VINE_TEMP, 0, cache, 0);
 }
 
+struct vine_file *vine_file_pseudo_temp()
+{
+	// temp files are always cached at workers until explicitely removed.
+	vine_cache_level_t cache = VINE_CACHE_LEVEL_WORKFLOW;
+
+	return vine_file_create("temp", 0, 0, 0, VINE_FILE, 0, cache, 0);
+}
+
 struct vine_file *vine_file_buffer(const char *data, size_t size, vine_cache_level_t cache, vine_file_flags_t flags)
 {
 	return vine_file_create("buffer", 0, data, size, VINE_BUFFER, 0, cache, flags);

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -245,14 +245,14 @@ struct vine_file *vine_file_temp()
 	return vine_file_create("temp", 0, 0, 0, VINE_TEMP, 0, cache, 0);
 }
 
-struct vine_file *vine_file_pseudo_temp()
+struct vine_file *vine_file_temp_no_peers()
 {
 	// temp files are always cached at workers until explicitely removed.
 	vine_cache_level_t cache = VINE_CACHE_LEVEL_WORKFLOW;
 	uid_t uid = getuid();
 
 	char *name = string_format("temp-local-%u", uid);
-	return vine_file_create(name, 0, 0, 0, VINE_FILE, 0, cache, 0);
+	return vine_file_create(name, 0, 0, 0, VINE_FILE, 0, cache, VINE_UNLINK_WHEN_DONE);
 	free(name);
 }
 

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -62,6 +62,7 @@ char * vine_file_make_file_url( const char * source);
 struct vine_file *vine_file_local( const char *source, vine_cache_level_t cache, vine_file_flags_t flags );
 struct vine_file *vine_file_url( const char *source, vine_cache_level_t cache, vine_file_flags_t flags );
 struct vine_file *vine_file_temp();
+struct vine_file *vine_file_pseudo_temp();
 struct vine_file *vine_file_buffer( const char *buffer, size_t size, vine_cache_level_t cache, vine_file_flags_t flags );
 struct vine_file *vine_file_mini_task( struct vine_task *t, const char *name, vine_cache_level_t cache, vine_file_flags_t flags );
 struct vine_file *vine_file_untar( struct vine_file *f, vine_cache_level_t cache, vine_file_flags_t flags );

--- a/taskvine/src/manager/vine_file.h
+++ b/taskvine/src/manager/vine_file.h
@@ -62,7 +62,7 @@ char * vine_file_make_file_url( const char * source);
 struct vine_file *vine_file_local( const char *source, vine_cache_level_t cache, vine_file_flags_t flags );
 struct vine_file *vine_file_url( const char *source, vine_cache_level_t cache, vine_file_flags_t flags );
 struct vine_file *vine_file_temp();
-struct vine_file *vine_file_pseudo_temp();
+struct vine_file *vine_file_temp_no_peers();
 struct vine_file *vine_file_buffer( const char *buffer, size_t size, vine_cache_level_t cache, vine_file_flags_t flags );
 struct vine_file *vine_file_mini_task( struct vine_task *t, const char *name, vine_cache_level_t cache, vine_file_flags_t flags );
 struct vine_file *vine_file_untar( struct vine_file *f, vine_cache_level_t cache, vine_file_flags_t flags );

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3992,6 +3992,7 @@ int vine_enable_peer_transfers(struct vine_manager *q)
 int vine_disable_peer_transfers(struct vine_manager *q)
 {
 	debug(D_VINE, "Peer Transfers disabled");
+	fprintf(stderr, "warning: Peer Transfers disabled. Using temporary files will force dependent tasks to run on a single worker");
 	q->peer_transfers_enabled = 0;
 	return 1;
 }

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -6181,7 +6181,7 @@ struct vine_file *vine_declare_temp(struct vine_manager *m)
 		struct vine_file *f = vine_file_temp();
 		return vine_manager_declare_file(m, f);
 	} else {
-		struct vine_file *f = vine_file_pseudo_temp();
+		struct vine_file *f = vine_file_temp_no_peers();
 		return vine_manager_declare_file(m, f);
 	}
 }

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3992,7 +3992,7 @@ int vine_enable_peer_transfers(struct vine_manager *q)
 int vine_disable_peer_transfers(struct vine_manager *q)
 {
 	debug(D_VINE, "Peer Transfers disabled");
-	fprintf(stderr, "warning: Peer Transfers disabled. Using temporary files will force dependent tasks to run on a single worker");
+	fprintf(stderr, "warning: Peer Transfers disabled. Temporary files will be returned to the manager upon creation.");
 	q->peer_transfers_enabled = 0;
 	return 1;
 }
@@ -6177,8 +6177,13 @@ struct vine_file *vine_declare_url(struct vine_manager *m, const char *source, v
 
 struct vine_file *vine_declare_temp(struct vine_manager *m)
 {
-	struct vine_file *f = vine_file_temp();
-	return vine_manager_declare_file(m, f);
+	if (m->peer_transfers_enabled) {
+		struct vine_file *f = vine_file_temp();
+		return vine_manager_declare_file(m, f);
+	} else {
+		struct vine_file *f = vine_file_pseudo_temp();
+		return vine_manager_declare_file(m, f);
+	}
 }
 
 struct vine_file *vine_declare_buffer(struct vine_manager *m, const char *buffer, size_t size, vine_cache_level_t cache, vine_file_flags_t flags)


### PR DESCRIPTION
## Proposed Changes

If peer transfers are disabled change temp file behavior so they are returned on creation like normal files. Taskvine will still manage naming and cleanup after the workflow completes.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
