### PR TITLE
Vine: Fix cache directory property of manager in Python bindings

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -257,7 +257,7 @@ class Manager(object):
     # Get the caching directory of the manager
     @property
     def cache_directory(self):
-        return cvine.vine_get_path_staging(self._taskvine, None)
+        return cvine.vine_get_path_cache(self._taskvine, None)
 
     ##
     # Get manager statistics.


### PR DESCRIPTION
## Proposed Changes
The cache directory of the TaskVine manager is incorrectly assigned to each workflow's staging directory. The property now correctly points to the global cache of TaskVine which is workflow-agnostic.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
