### PR TITLE
vine: assume file created on declaration until specified as output

### DIFF
--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -87,7 +87,7 @@ struct vine_file *vine_file_create(const char *source, const char *cached_name, 
 	f->size = size;
 	f->mini_task = mini_task;
 	f->recovery_task = 0;
-	f->state = VINE_FILE_STATE_PENDING;
+	f->state = VINE_FILE_STATE_CREATED; /* Assume state created until told otherwise */
 	f->cache_level = cache_level;
 	f->flags = flags;
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3249,10 +3249,9 @@ static int vine_manager_check_inputs_available(struct vine_manager *q, struct vi
 	LIST_ITERATE(t->input_mounts, m)
 	{
 		struct vine_file *f = m->file;
-		if (f->type == VINE_FILE && f->state != VINE_FILE_STATE_CREATED) {
+		if (f->type == VINE_FILE && f->state == VINE_FILE_STATE_PENDING) {
 			all_available = 0;
-		}
-		if (f->type == VINE_TEMP && f->state == VINE_FILE_STATE_CREATED) {
+		} else if (f->type == VINE_TEMP && f->state == VINE_FILE_STATE_CREATED) {
 			if (!vine_file_replica_table_exists_somewhere(q, f->cached_name)) {
 				vine_manager_consider_recovery_task(q, f, f->recovery_task);
 				all_available = 0;
@@ -6152,12 +6151,6 @@ struct vine_file *vine_manager_declare_file(struct vine_manager *m, struct vine_
 	} else {
 		/* Otherwise add it to the table. */
 		hash_table_insert(m->file_table, f->cached_name, f);
-	}
-
-	struct stat info;
-	int result = lstat(f->source, &info);
-	if (result == 0) {
-		f->state = VINE_FILE_STATE_CREATED;
 	}
 
 	vine_taskgraph_log_write_file(m, f);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -6154,6 +6154,12 @@ struct vine_file *vine_manager_declare_file(struct vine_manager *m, struct vine_
 		hash_table_insert(m->file_table, f->cached_name, f);
 	}
 
+	struct stat info;
+	int result = lstat(f->source, &info);
+	if (result == 0) {
+		f->state = VINE_FILE_STATE_CREATED;
+	}
+
 	vine_taskgraph_log_write_file(m, f);
 
 	return f;

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3249,6 +3249,9 @@ static int vine_manager_check_inputs_available(struct vine_manager *q, struct vi
 	LIST_ITERATE(t->input_mounts, m)
 	{
 		struct vine_file *f = m->file;
+		if (f->type == VINE_FILE && f->state != VINE_FILE_STATE_CREATED) {
+			all_available = 0;
+		}
 		if (f->type == VINE_TEMP && f->state == VINE_FILE_STATE_CREATED) {
 			if (!vine_file_replica_table_exists_somewhere(q, f->cached_name)) {
 				vine_manager_consider_recovery_task(q, f, f->recovery_task);

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -573,6 +573,8 @@ int vine_task_add_output(struct vine_task *t, struct vine_file *f, const char *r
 		return 0;
 	}
 
+	f->state = VINE_FILE_STATE_PENDING;
+
 	struct vine_mount *m = vine_mount_create(f, remote_name, flags, 0);
 
 	list_push_tail(t->output_mounts, m);


### PR DESCRIPTION
## Proposed Changes

Assuming a declared file is created until it is specified as an output allows us to do two things:
- Fail a task if its input file is missing and no source for the input file has been given
- Use regular files as intermediate data without failing in the same way, since we specify the file as an input and revert it to the pending state

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update     Update the manual to reflect user-visible changes.
- [x] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM            Mark your PR as ready to merge.
