### PR TITLE
Chirp-FUSE: Single Server Mode

### DIFF
--- a/doc/man/m4/chirp_fuse.m4
+++ b/doc/man/m4/chirp_fuse.m4
@@ -33,6 +33,7 @@ OPTION_ARG(b,block-size,bytes)Block size for network I/O. (default is 65536s)
 OPTION_ARG(d,debug,flag)Enable debugging for this subsystem.
 OPTION_FLAG(D,no-optimize)Disable small file optimizations such as recursive delete.
 OPTION_FLAG(f,foreground)Run in foreground for debugging.
+OPTION_ARG(s,single-server,hostport)Connect only to the named host:port and hide the global namespace.
 OPTION_ARG(i,tickets,files)Comma-delimited list of tickets to use for authentication.
 OPTION_ARG(m,mount-option,option)Pass mount option to FUSE. Can be specified multiple times.
 OPTION_ARG(o,debug-file,file)Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.

--- a/doc/man/md/chirp_fuse.md
+++ b/doc/man/md/chirp_fuse.md
@@ -55,6 +55,7 @@ For complete details with examples, see the
 - **-d**,**--debug=_&lt;flag&gt;_**<br />Enable debugging for this subsystem.
 - **-D**,**--no-optimize**<br />Disable small file optimizations such as recursive delete.
 - **-f**,**--foreground**<br />Run in foreground for debugging.
+- **-s**,**--single-server=_&lt;hostport&gt;_**<br />Connect only to the named host:port and hide the global namespace.
 - **-i**,**--tickets=_&lt;files&gt;_**<br />Comma-delimited list of tickets to use for authentication.
 - **-m**,**--mount-option=_&lt;option&gt;_**<br />Pass mount option to FUSE. Can be specified multiple times.
 - **-o**,**--debug-file=_&lt;file&gt;_**<br />Write debugging output to this file. By default, debugging is sent to stderr (":stderr"). You may specify logs to be sent to stdout (":stdout") instead.


### PR DESCRIPTION
## Proposed Changes

Add `--single-server` option to `chirp_fuse` that connects the mount to a single fixed server, rather than the global namespace.  May be helpful for Angel's use-case at Argonne.

## Merge Checklist

The following items must be completed before PRs can be merge.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update     Update the manual to reflect user-visible changes.
- [ ] Type Labels       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM            Mark your PR as ready to merge.
