### PR TITLE
Fallback resources: allocated to measured

### DIFF
--- a/dttools/src/rmsummary.c
+++ b/dttools/src/rmsummary.c
@@ -742,6 +742,21 @@ void rmsummary_merge_override_basic(struct rmsummary *dest, const struct rmsumma
 	RM_BIN_OP_BASIC(dest, src, override_field);
 }
 
+/* Copy the value for all the fields in src to dest when dest < 0 */
+static inline double default_field(double d, double s)
+{
+	return (d > -1) ? d : s;
+}
+
+void rmsummary_merge_default(struct rmsummary *dest, const struct rmsummary *src)
+{
+	if (!src) {
+		return;
+	}
+
+	RM_BIN_OP(dest, src, default_field);
+}
+
 struct rmsummary *rmsummary_copy(const struct rmsummary *src, int deep_copy)
 {
 	struct rmsummary *dest = rmsummary_create(-1);

--- a/dttools/src/rmsummary.h
+++ b/dttools/src/rmsummary.h
@@ -111,6 +111,7 @@ void rmsummary_merge_max_w_time(struct rmsummary *dest, const struct rmsummary *
 struct rmsummary *rmsummary_copy(const struct rmsummary *src, int deep_copy);
 void rmsummary_merge_override(struct rmsummary *dest, const struct rmsummary *src);
 void rmsummary_merge_override_basic(struct rmsummary *dest, const struct rmsummary *src);
+void rmsummary_merge_default(struct rmsummary *dest, const struct rmsummary *src);
 void rmsummary_merge_max(struct rmsummary *dest, const struct rmsummary *src);
 void rmsummary_merge_min(struct rmsummary *dest, const struct rmsummary *src);
 void rmsummary_add(struct rmsummary *dest, const struct rmsummary *src);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -571,7 +571,11 @@ static vine_result_code_t get_completion_result(struct vine_manager *q, struct v
 		t->result = task_status;
 		t->exit_code = exit_status;
 
-		t->resources_measured->wall_time = execution_time;
+		/* fill resources measured with whatever vine reported/committed, as a fallback when task ran without monitoring enabled */
+		t->resources_measured->start = ((double)start_time) / ONE_SECOND;
+		t->resources_measured->end = ((double)end_time) / ONE_SECOND;
+		t->resources_measured->wall_time = ((double)t->time_workers_execute_last) / ONE_SECOND;
+		rmsummary_merge_override_basic(t->resources_measured, t->resources_allocated);
 
 		/* If output is less than 1KB stdout is sent along with completion msg. retrieve it from the link. */
 		if (bytes_sent) {


### PR DESCRIPTION
Fills up measured resources with allocated as a fallback when monitoring is not enabled.
Also fixes a bug where the fallback for wall_time was filled with microseconds rather than seconds.

@JinZhou5042 this is related to a recent pr you submitted for the priority based on execution time.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
