### PR TITLE
double reap quick fix

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3039,6 +3039,11 @@ and change the task state.
 
 static void reap_task_from_worker(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, vine_task_state_t new_state)
 {
+	/* hotfix: do not reap the task if it has been reaped before */
+	if (!t->worker) {
+		return;
+	}
+
 	/* Make sure the task and worker agree before changing anything. */
 	assert(t->worker == w);
 


### PR DESCRIPTION
Trying to debug #4000. almalinux* fails on CI but not locally. This pr makes a minimal hot fix change for comparison.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
