### PR TITLE
vine: properly replicate temp files

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -274,6 +274,8 @@ class DaskVine(Manager):
 
                     if t.successful():
                         result_file = DaskVineFile(t.output_file, t.key, dag, self.task_mode)
+                        print(self.get_file_replica_count(t.output_file))
+
                         rs = dag.set_result(t.key, result_file)
                         self._enqueue_dask_calls(dag, tag, rs, self.retries, enqueued_calls)
 

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -274,7 +274,6 @@ class DaskVine(Manager):
 
                     if t.successful():
                         result_file = DaskVineFile(t.output_file, t.key, dag, self.task_mode)
-
                         rs = dag.set_result(t.key, result_file)
                         self._enqueue_dask_calls(dag, tag, rs, self.retries, enqueued_calls)
 

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/dask_executor.py
@@ -274,7 +274,6 @@ class DaskVine(Manager):
 
                     if t.successful():
                         result_file = DaskVineFile(t.output_file, t.key, dag, self.task_mode)
-                        print(self.get_file_replica_count(t.output_file))
 
                         rs = dag.set_result(t.key, result_file)
                         self._enqueue_dask_calls(dag, tag, rs, self.retries, enqueued_calls)

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -1766,6 +1766,14 @@ class Manager(object):
     def log_debug_app(self, entry):
         cvine.vine_log_debug_app(self._taskvine, entry)
 
+    ##
+    # Gets the number of replicas of a file.
+    #
+    # @param self   The manager to register this file
+    # @param file   The File object
+    def get_file_replica_count(self, file):
+        return cvine.vine_file_replica_count(self._taskvine, file._file)
+
 
 ##
 # @class ndcctools.taskvine.manager.Factory

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -731,6 +731,13 @@ const char *vine_file_source(struct vine_file *f);
 */
 vine_file_type_t vine_file_type(struct vine_file *f);
 
+/** Get the number of replicas of a file.
+@param m A manager object
+@param f A file object.
+@return The number of replicas of the file.
+*/
+int vine_file_replica_count(struct vine_manager *m, struct vine_file *f);
+
 /** Declare a file object from a local file
 @param m A manager object
 @param source The path of the file on the local filesystem

--- a/taskvine/src/manager/vine_current_transfers.h
+++ b/taskvine/src/manager/vine_current_transfers.h
@@ -24,7 +24,6 @@ int vine_current_transfers_url_in_use(struct vine_manager *q, const char *source
 
 int vine_current_transfers_dest_in_use(struct vine_manager *q,struct vine_worker_info *w);
 
-
 int vine_current_transfers_wipe_worker(struct vine_manager *q, struct vine_worker_info *w);
 
 void vine_current_transfers_print_table(struct vine_manager *q);

--- a/taskvine/src/manager/vine_current_transfers.h
+++ b/taskvine/src/manager/vine_current_transfers.h
@@ -8,7 +8,7 @@ See the file COPYING for details.
 #include "uuid.h"
 
 #define VINE_FILE_SOURCE_MAX_TRANSFERS 1
-#define VINE_WORKER_SOURCE_MAX_TRANSFERS 10 // static 10 until if/when multiple transfer ports are opened up on worker transfer server
+#define VINE_WORKER_SOURCE_MAX_TRANSFERS 10
 
 char *vine_current_transfers_add(struct vine_manager *q, struct vine_worker_info *to, struct vine_worker_info *source_worker, const char *source_url);
 

--- a/taskvine/src/manager/vine_current_transfers.h
+++ b/taskvine/src/manager/vine_current_transfers.h
@@ -8,7 +8,7 @@ See the file COPYING for details.
 #include "uuid.h"
 
 #define VINE_FILE_SOURCE_MAX_TRANSFERS 1
-#define VINE_WORKER_SOURCE_MAX_TRANSFERS 3 // static 1 until if/when multiple transfer ports are opened up on worker transfer server
+#define VINE_WORKER_SOURCE_MAX_TRANSFERS 10 // static 10 until if/when multiple transfer ports are opened up on worker transfer server
 
 char *vine_current_transfers_add(struct vine_manager *q, struct vine_worker_info *to, struct vine_worker_info *source_worker, const char *source_url);
 

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -77,6 +77,12 @@ struct vine_file_replica *vine_file_replica_table_lookup(struct vine_worker_info
 	return hash_table_lookup(w->current_files, cachename);
 }
 
+// count the number of in-cluster replicas of a file
+int vine_file_replica_count(struct vine_manager *m, struct vine_file *f)
+{
+    return set_size(hash_table_lookup(m->file_worker_table, f->cached_name));
+}
+
 // find a worker (randomly) in posession of a specific file, and is ready to transfer it.
 struct vine_worker_info *vine_file_replica_table_find_worker(struct vine_manager *q, const char *cachename)
 {

--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -139,11 +139,12 @@ int vine_file_replica_table_replicate(struct vine_manager *m, struct vine_file *
 	struct vine_worker_info **sources_frozen = (struct vine_worker_info **)set_values(sources);
 	struct vine_worker_info *source;
 
-	int i = 0;
-	for (source = sources_frozen[i]; i < nsources; i++) {
+	for (int i = 0; i < nsources; i++) {
 
+		source = sources_frozen[i];
 		int dest_found = 0;
 
+		// skip if the file on the source is not ready to transfer
 		struct vine_file_replica *replica = hash_table_lookup(source->current_files, f->cached_name);
 		if (!replica || replica->state != VINE_FILE_REPLICA_STATE_READY) {
 			continue;
@@ -152,13 +153,18 @@ int vine_file_replica_table_replicate(struct vine_manager *m, struct vine_file *
 		char *source_addr = string_format("%s/%s", source->transfer_url, f->cached_name);
 		int source_in_use = vine_current_transfers_source_in_use(m, source);
 
+		// skip if the source is busy with other transfers
+		if (source_in_use >= m->worker_source_max_transfers) {
+			continue;
+		}
+
 		char *id;
 		struct vine_worker_info *dest;
 		int offset_bookkeep;
 
 		HASH_TABLE_ITERATE_RANDOM_START(m->worker_table, offset_bookkeep, id, dest)
 		{
-			// skip if the source is the same as the destination
+			// skip if the source and destination are on the same host
 			if (set_lookup(sources, dest) || strcmp(source->hostname, dest->hostname) == 0) {
 				continue;
 			}
@@ -177,27 +183,25 @@ int vine_file_replica_table_replicate(struct vine_manager *m, struct vine_file *
 
 			vine_manager_put_url_now(m, dest, source_addr, f);
 
-			// break if the source has paired with enough destinations for this file
+			round_replication_request_sent++;
+
+			// break if we have found enough destinations for this source
 			if (++dest_found >= MIN(m->file_source_max_transfers, to_find)) {
 				break;
 			}
 
-			// break if the source is busy with multiple transfers
+			// break if the source becomes busy with transfers
 			if (++source_in_use >= m->worker_source_max_transfers) {
 				break;
 			}
-
-			// break if we have found enough destinations
-			if (++round_replication_request_sent >= to_find) {
-				break;
-			}
-		}
-
-		if (round_replication_request_sent >= to_find) {
-			break;
 		}
 
 		free(source_addr);
+
+		// break if we have sent enough replication requests for this file
+		if (round_replication_request_sent >= to_find) {
+			break;
+		}
 	}
 
 	free(sources_frozen);

--- a/taskvine/src/manager/vine_file_replica_table.h
+++ b/taskvine/src/manager/vine_file_replica_table.h
@@ -14,6 +14,7 @@ See the file COPYING for details.
 #define VINE_FILE_REPLICA_TABLE_H
 
 #include "taskvine.h"
+#include "set.h"
 #include "vine_file_replica.h"
 #include "vine_worker_info.h"
 
@@ -27,7 +28,7 @@ struct vine_file_replica *vine_file_replica_table_lookup(struct vine_worker_info
 
 struct vine_worker_info *vine_file_replica_table_find_worker(struct vine_manager *q, const char *cachename);
 
-int vine_file_replica_table_replicate(struct vine_manager *q, struct vine_file *f);
+int vine_file_replica_table_replicate(struct vine_manager *q, struct vine_file *f, struct set *sources, int to_find);
 
 int vine_file_replica_table_exists_somewhere( struct vine_manager *q, const char *cachename );
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -989,7 +989,6 @@ static int recover_temp_files(struct vine_manager *q)
 		total_replication_request_sent += round_replication_request_sent;
 	}
 
-
 	return total_replication_request_sent;
 }
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -941,9 +941,7 @@ static int recover_temp_files(struct vine_manager *q)
 	int iter_count_var;
 
 	// ^^^
-	q->transfer_replica_per_cycle = 100;
 	q->file_source_max_transfers = 1;
-	q->worker_source_max_transfers = 10;
 
 	HASH_TABLE_ITERATE_FROM_KEY(q->temp_files_to_replicate, iter_control, iter_count_var, key_start, cached_name, empty_val)
 	{

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -948,7 +948,7 @@ static int recover_temp_files(struct vine_manager *q)
 			continue;
 		}
 
-		/* Are there any available sources? */
+		/* are there any available sources? */
 		struct set *sources = hash_table_lookup(q->file_worker_table, f->cached_name);
 		if (!sources) {
 			/* If no sources found, it indicates that the file doesn't exist, either pruned or lost.
@@ -960,7 +960,7 @@ static int recover_temp_files(struct vine_manager *q)
 			continue;
 		}
 
-		/* At least one source is able to transfer? */
+		/* at least one source is able to transfer? */
 		int has_valid_source = 0;
 		struct vine_worker_info *s;
 		SET_ITERATE(sources, s)
@@ -974,7 +974,7 @@ static int recover_temp_files(struct vine_manager *q)
 			continue;
 		}
 
-		/* Has this file been fully replicated? */
+		/* has this file been fully replicated? */
 		int nsources = set_size(sources);
 		int to_find = MIN(q->temp_replica_count - nsources, q->transfer_replica_per_cycle);
 		if (to_find <= 0) {
@@ -985,8 +985,11 @@ static int recover_temp_files(struct vine_manager *q)
 		debug(D_VINE, "Found %d workers holding %s, %d replicas needed", nsources, f->cached_name, to_find);
 
 		int round_replication_request_sent = vine_file_replica_table_replicate(q, f, sources, to_find);
-
 		total_replication_request_sent += round_replication_request_sent;
+
+		if (total_replication_request_sent >= q->attempt_schedule_depth) {
+			break;
+		}
 	}
 
 	return total_replication_request_sent;

--- a/taskvine/src/worker/vine_worker_options.c
+++ b/taskvine/src/worker/vine_worker_options.c
@@ -56,7 +56,7 @@ struct vine_worker_options *vine_worker_options_create()
 	self->transfer_port_min = 0;
 	self->transfer_port_max = 0;
 
-	self->max_transfer_procs = 5;
+	self->max_transfer_procs = 10;
 
 	self->reported_transfer_host = 0;
 


### PR DESCRIPTION
## Proposed Changes


Fix #3996

- Update the default values for a set of arguments regarding temp file replication:
    - `q->worker_source_max_transfers` from 3 to 10
    - `max_transfer_procs` from 5 to 10
    - I keep `q->transfer_replica_per_cycle` as is (which is 10), as it limits the number of replications to request per temp file per iteration, and we are not likely to replicate each temp file more than 10 times.

- Improve the logic in the replication process, which helps the manager replicate more efficiently, add more comments
- Provide an API for Python to query the replica count for a file



## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update:     Update the manual to reflect user-visible changes.
- [x] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM:            Mark your PR as ready to merge.
