### PR TITLE
Vine: Function Calls Should Fail on Missing Library

### DIFF
--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -106,7 +106,8 @@ typedef enum {
 							 location input file requirements. */
 	VINE_RESULT_CANCELLED = 11 << 3,	      /**< The task was cancelled by the caller. */
 	VINE_RESULT_LIBRARY_EXIT = 12 << 3,	      /**< Task is a library that has terminated. **/
-	VINE_RESULT_SANDBOX_EXHAUSTION = 13 << 3	      /**< The task used more disk than the allowed sandbox. **/
+	VINE_RESULT_SANDBOX_EXHAUSTION = 13 << 3,     /**< The task used more disk than the allowed sandbox. **/
+	VINE_RESULT_MISSING_LIBRARY = 14 << 3         /**< The task is a function requiring a library that does not exist. */
 } vine_result_t;
 
 /** Select how to allocate resources for similar tasks with @ref vine_set_category_mode */

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -1436,6 +1436,7 @@ a times series, if this feature is enabled. See @ref vine_enable_monitoring.
  - "large_task_check_interval" How frequently to check for tasks that do not fit any worker. (default=180000000)
  - "option_blocklist_slow_workers_timeout" Timeout for slow workers to come back to the pool. (default=900)
  - "watch-library-logfiles" If 1, watch the output files produced by each of the library processes running on the remote workers, take them back the current logging directory. (default=0)
+ - "max-library-retries" The number of times a library task can fail and be retried before it is permanently removed.
 @param value The value to set the parameter to.
 @return 0 on succes, -1 on failure.
 */

--- a/taskvine/src/manager/vine_file_replica.c
+++ b/taskvine/src/manager/vine_file_replica.c
@@ -24,6 +24,8 @@ struct vine_file_replica *vine_file_replica_create(vine_file_type_t type, vine_c
 
 void vine_file_replica_delete(struct vine_file_replica *r)
 {
+	if (!r)
+		return;
 	free(r);
 	vine_counters.replica.deleted++;
 }

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5673,6 +5673,9 @@ int vine_tune(struct vine_manager *q, const char *name, double value)
 	} else if (!strcmp(name, "sandbox-grow-factor")) {
 		q->sandbox_grow_factor = MAX(1.1, value);
 
+	} else if (!strcmp(name, "max-library-retries")) {
+		q->max_library_retries = MIN(1, value);
+
 	} else {
 		debug(D_NOTICE | D_VINE, "Warning: tuning parameter \"%s\" not recognized\n", name);
 		return -1;

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -1138,7 +1138,9 @@ static int delete_worker_file(struct vine_manager *q, struct vine_worker_info *w
 		vine_manager_send(q, w, "unlink %s\n", filename);
 		struct vine_file_replica *replica;
 		replica = vine_file_replica_table_remove(q, w, filename);
-		vine_file_replica_delete(replica);
+		if (replica) {
+			vine_file_replica_delete(replica);
+		}
 		return 1;
 	}
 

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -499,10 +499,16 @@ int vine_process_library_get_result(struct vine_process *p, uint64_t *done_task_
 
 	/* null terminate the buffer before treating it as a string. */
 	buffer_data[ok] = 0;
-	sscanf(buffer_data, "%" SCNu64 " %d", done_task_id, done_exit_code);
-	debug(D_VINE, "Received result for function %" PRIu64 ", exit code %d", *done_task_id, *done_exit_code);
 
-	return ok;
+	/* is the received message properly formatted as two integers? */
+	ok = sscanf(buffer_data, "%" SCNu64 " %d", done_task_id, done_exit_code);
+	if(ok!=2) {
+		debug(D_VINE,"Invalid message received from library: %s",buffer_data);
+		return 0;
+	}
+
+	debug(D_VINE, "Received result for function %" PRIu64 ", exit code %d", *done_task_id, *done_exit_code);
+	return 1;
 }
 
 /*

--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -502,8 +502,8 @@ int vine_process_library_get_result(struct vine_process *p, uint64_t *done_task_
 
 	/* is the received message properly formatted as two integers? */
 	ok = sscanf(buffer_data, "%" SCNu64 " %d", done_task_id, done_exit_code);
-	if(ok!=2) {
-		debug(D_VINE,"Invalid message received from library: %s",buffer_data);
+	if (ok != 2) {
+		debug(D_VINE, "Invalid message received from library: %s", buffer_data);
 		return 0;
 	}
 

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1426,20 +1426,25 @@ Return true if this process can run eventually, supposing that other processes w
 
 static int process_can_run_eventually(struct vine_process *p, struct vine_cache *cache, struct link *manager)
 {
-	if (!task_resources_fit_eventually(p->task))
+	if (!task_resources_fit_eventually(p->task)) {
+		debug(D_VINE, "task %d does not fit the total resources", p->task->task_id);
 		return 0;
+	}
 
 	if (p->task->needs_library) {
 		/* Note that we check for *some* library but do not bind to it. */
 		struct vine_process *p_future = find_future_library_for_function(p->task->needs_library);
-		if (!p || p_future->result == VINE_RESULT_LIBRARY_EXIT)
+		if (!p || p_future->result == VINE_RESULT_LIBRARY_EXIT) {
+			debug(D_VINE, "task %d does not match any library \"%s\"", p->task->task_id, p->task->needs_library);
 			return 0;
+		}
 	}
 
 	vine_cache_status_t status = vine_sandbox_ensure(p, cache, manager);
 	switch (status) {
 	case VINE_CACHE_STATUS_FAILED:
 	case VINE_CACHE_STATUS_UNKNOWN:
+		debug(D_VINE, "task %d requires failed input cache transfers", p->task->task_id);
 		return 0;
 	default:
 		break;
@@ -1738,7 +1743,6 @@ static void vine_worker_serve_manager(struct link *manager)
 				} else if (process_can_run_eventually(p, cache_manager, manager)) {
 					list_push_tail(procs_waiting, p);
 				} else {
-					debug(D_VINE, "task does not have necessary resources to run %d", p->task->task_id);
 					forsake_waiting_process(manager, p);
 					task_event++;
 				}

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -742,7 +742,9 @@ static void handle_failed_library_process(struct vine_process *p, struct link *m
 	ITABLE_ITERATE(procs_running, task_id, p_running)
 	{
 		if (p_running->library_process == p) {
+			debug(D_VINE,"killing function task %d running on library task %d",(int)task_id,p->task->task_id);
 			finish_running_task(p_running, VINE_RESULT_FORSAKEN);
+			reap_process(p_running,manager);
 		}
 	}
 }

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -742,9 +742,9 @@ static void handle_failed_library_process(struct vine_process *p, struct link *m
 	ITABLE_ITERATE(procs_running, task_id, p_running)
 	{
 		if (p_running->library_process == p) {
-			debug(D_VINE,"killing function task %d running on library task %d",(int)task_id,p->task->task_id);
+			debug(D_VINE, "killing function task %d running on library task %d", (int)task_id, p->task->task_id);
 			finish_running_task(p_running, VINE_RESULT_FORSAKEN);
-			reap_process(p_running,manager);
+			reap_process(p_running, manager);
 		}
 	}
 }

--- a/taskvine/test/TR_vine_python_serverless_failure.sh
+++ b/taskvine/test/TR_vine_python_serverless_failure.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+
+set -e
+
+. ../../dttools/test/test_runner_common.sh
+
+import_config_val CCTOOLS_PYTHON_TEST_EXEC
+import_config_val CCTOOLS_PYTHON_TEST_DIR
+
+export PYTHONPATH=$(pwd)/../../test_support/python_modules/${CCTOOLS_PYTHON_TEST_DIR}:$PYTHONPATH
+
+STATUS_FILE=vine.status
+PORT_FILE=vine.port
+PYTHON_SCRIPT=vine_python_serverless_failure.py
+
+check_needed()
+{
+	[ -n "${CCTOOLS_PYTHON_TEST_EXEC}" ] || return 1
+
+	# Poncho currently requires ast.unparse to serialize the function,
+	# which only became available in Python 3.9.  Some older platforms
+	# (e.g. almalinux8) will not have this natively.
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "from ast import unparse" || return 1
+
+	# In some limited build circumstances (e.g. macos build on github),
+	# poncho doesn't work due to lack of conda-pack or cloudpickle
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import conda_pack" || return 1
+	"${CCTOOLS_PYTHON_TEST_EXEC}" -c "import cloudpickle" || return 1
+
+        return 0
+}
+
+prepare()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+	return 0
+}
+
+run()
+{
+	( ${CCTOOLS_PYTHON_TEST_EXEC} ${PYTHON_SCRIPT} $PORT_FILE; echo $? > $STATUS_FILE ) &
+
+	# wait at most 15 seconds for vine to find a port.
+	wait_for_file_creation $PORT_FILE 15
+
+	# run the worker in the foreground
+	run_taskvine_worker $PORT_FILE worker.log
+
+	# wait for vine to exit.
+	wait_for_file_creation $STATUS_FILE 30
+
+	# retrieve exit status
+	status=$(cat $STATUS_FILE)
+	if [ $status -ne 0 ]
+	then
+		# display log files in case of failure.
+		logfile=$(latest_vine_debug_log)
+		if [ -f ${logfile}  ]
+		then
+			echo "master log:"
+			cat ${logfile}
+		fi
+
+		if [ -f worker.log  ]
+		then
+			echo "worker log:"
+			cat worker.log
+		fi
+
+		exit 1
+	fi
+
+	exit 0
+}
+
+clean()
+{
+	rm -f $STATUS_FILE
+	rm -f $PORT_FILE
+	rm -rf vine-run-info
+        rm worker.log
+	exit 0
+}
+
+
+dispatch "$@"

--- a/taskvine/test/vine_python_serverless_failure.py
+++ b/taskvine/test/vine_python_serverless_failure.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# This test exercises the (rather complex) coupled failure mode
+# of libraries and tasks together.  If a user submits a library
+# with a bunch of function calls, but the library keeps crashing,
+# then the following should eventually occur:
+
+# 1 - The library template will be removed, and no more library
+#     instances will be deployed.
+# 2 - The function calls depending on that library should return
+#     to the user with error LIBRARY_MISSING.
+
+import ndcctools.taskvine as vine
+import argparse
+import os
+import sys
+
+def func( x ) :
+    sys.exit(127)
+    return x*x
+
+def main():
+    parser = argparse.ArgumentParser("Test for taskvine python serverless failure.")
+    parser.add_argument("port_file", help="File to write the port the queue is using.")
+
+    args = parser.parse_args()
+
+    q = vine.Manager(port=0)
+    q.tune("watch-library-logfiles", 1)  # get logs back from failed libraries
+    q.tune("transient-error-interval",2) # retry failed libraries quickly
+    q.tune("max-library-retries", 2)     # retry failed libraries only twice
+    print(f"TaskVine manager listening on port {q.port}")
+
+    with open(args.port_file, "w") as f:
+        print("Writing port {port} to file {file}".format(port=q.port, file=args.port_file))
+        f.write(str(q.port))
+
+    print("Creating library from packages and functions...")
+    libtask = q.create_library_from_functions("bad-library",func,add_env=False,exec_mode="direct")
+    q.install_library(libtask)
+
+    print("Submitting function call tasks...")
+    for n in range(0,10):
+        task = vine.FunctionCall("bad-library","func",n)
+        q.submit(task)
+
+    while not q.empty():
+        t = q.wait(5)
+        if t:
+            print(f"task {t.id} completed with result {t.result} output {t.output}")
+
+if __name__ == '__main__':
+    main()
+
+
+# vim: set sts=4 sw=4 ts=4 expandtab ft=python:


### PR DESCRIPTION
## Proposed Changes

Add check for missing library into expire_tasks_waiting. Causes function call tasks that cannot possibly match a library to be returned to the called with error `MISSING_LIBRARY`.   Now, if the user submits a library that fails (and is removed), the corresponding function calls will also return and fail, so that we end up with a concrete failure instead of an endless application hang.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update:     Update the manual to reflect user-visible changes.
- [x] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM:            Mark your PR as ready to merge.
