### PR TITLE
vine: skip worker resource check for function calls

### DIFF
--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -81,7 +81,7 @@ int vine_schedule_in_ramp_down(struct vine_manager *q)
 int check_worker_have_enough_resources(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct rmsummary *tr)
 {
 	/* Skip if it is a function task. Resource guarantees for function calls are handled at the end of @check_worker_against_task, which calls
-	 * @vine_schedule_find_library to locate a suitable library for the function call, it directly returns false if no appropriate library is found  */
+	 * @vine_schedule.c:vine_schedule_find_library to locate a suitable library for the function call, it directly returns false if no appropriate library is found  */
 	if (t->needs_library) {
 		return 1;
 	}

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -80,31 +80,21 @@ int vine_schedule_in_ramp_down(struct vine_manager *q)
  * @return 1 if yes, 0 otherwise. */
 int check_worker_have_enough_resources(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t, struct rmsummary *tr)
 {
-	/*
-	This is a temporary hack in order to get Greg's application running.
-	The problem is in line with the problem pointed out in PR #3909 but a special case in the manager's end.
-
-	The problem here is that the manager always allocates the whole disk the the library task,
-	so that libtask->current_resource_box->disk is always equal to worker_net_resources->disk.total.
-	For the first task, the ti->current_resource_box->disk == 0, it is able to run because the expr in line 114 doesn't satisfy.
-	However, if the first task causes any increase in the worker's disk, worker_net_resources->disk.inuse will go above the total,
-	which causes the consistent true of the expr in line 114.
-	*/
+	/* Skip if it is a function task. Resource guarantees for function calls are handled at the end of @check_worker_against_task, which calls
+	 * @vine_schedule_find_library to locate a suitable library for the function call, it directly returns false if no appropriate library is found  */
 	if (t->needs_library) {
 		return 1;
 	}
 
 	struct vine_resources *worker_net_resources = vine_resources_copy(w->resources);
 
-	/* Subtract resources from libraries that have slots unused and don't match the current task. */
-	/* These will be killed anyway as needed in commit_task_to_worker. */
-	/* Matches assumption in vine_manager.c:commit_task_to_worker() */
-
+	/* Subtract resources from libraries that are not running any functions at all.
+	 * This matches the assumption in @vine_manager.c:commit_task_to_worker(), where empty libraries are being killed right before a task is committed. */
 	uint64_t task_id;
 	struct vine_task *ti;
 	ITABLE_ITERATE(w->current_tasks, task_id, ti)
 	{
-		if (ti->provides_library && ti->function_slots_inuse == 0 && (!t->needs_library || strcmp(t->needs_library, ti->provides_library))) {
+		if (ti->provides_library && ti->function_slots_inuse == 0) {
 			worker_net_resources->disk.inuse -= ti->current_resource_box->disk;
 			worker_net_resources->cores.inuse -= ti->current_resource_box->cores;
 			worker_net_resources->memory.inuse -= ti->current_resource_box->memory;


### PR DESCRIPTION
## Proposed Changes

The hack in #3913 that skipped the resource check for function calls was indeed the right way to do it...

And as the check for function calls are skipped, `!t->needs_library` becomes always true, thus the second half part of `if (ti->provides_library && ti->function_slots_inuse == 0 && (!t->needs_library || strcmp(t->needs_library, ti->provides_library)))` can be completely removed.


## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
