### PR TITLE
vine: apply BYTES_TO_MEGABYTES when calculate inuse_cache

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -371,7 +371,7 @@ static int handle_cache_update(struct vine_manager *q, struct vine_worker_info *
 
 		vine_txn_log_write_cache_update(q, w, size, transfer_time, start_time, cachename);
 
-		w->resources->disk.inuse += size / 1e6;
+		w->resources->disk.inuse += BYTES_TO_MEGABYTES(size);
 
 		/* If the replica corresponds to a declared file. */
 
@@ -2874,8 +2874,8 @@ static void update_max_worker(struct vine_manager *q, struct vine_worker_info *w
 		q->current_max_worker->memory = w->resources->memory.total;
 	}
 
-	if (q->current_max_worker->disk < (w->resources->disk.total - w->inuse_cache)) {
-		q->current_max_worker->disk = w->resources->disk.total - w->inuse_cache;
+	if (q->current_max_worker->disk < (w->resources->disk.total - BYTES_TO_MEGABYTES(w->inuse_cache))) {
+		q->current_max_worker->disk = w->resources->disk.total - BYTES_TO_MEGABYTES(w->inuse_cache);
 	}
 
 	if (q->current_max_worker->gpus < w->resources->gpus.total) {
@@ -5869,7 +5869,7 @@ static void aggregate_workers_resources(
 	}
 
 	// vine_stats wants MB
-	*inuse_cache = (int64_t)ceil(*inuse_cache / (1.0 * MEGA));
+	*inuse_cache = (int64_t)ceil(BYTES_TO_MEGABYTES(*inuse_cache));
 }
 
 /* This simple wrapper function allows us to hide the debug.h interface from the end user. */


### PR DESCRIPTION
## Proposed Changes

- Apply `BYTES_TO_MEGABYTES` when converting bytes data into megabytes, instead of doing math.

- There is a bug in doing `w->resources->disk.total - w->inuse_cache`, where the left side is in MB while the right side is in Bytes

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
