### PR TITLE
vine: count the available resources for a task on a worker

### DIFF
--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -153,7 +153,7 @@ static struct rmsummary *count_worker_available_resources(struct vine_manager *q
 	worker_available_resources->gpus = overcommitted_resource_total(q, worker_net_resources->gpus.total) - (double)worker_net_resources->gpus.inuse;
 	worker_available_resources->memory = overcommitted_resource_total(q, worker_net_resources->memory.total) - (double)worker_net_resources->memory.inuse;
 	/* No overcommit disk */
-	worker_available_resources->disk = q, worker_net_resources->disk.total - (double)worker_net_resources->disk.inuse;
+	worker_available_resources->disk = worker_net_resources->disk.total - (double)worker_net_resources->disk.inuse;
 
 	vine_resources_delete(worker_net_resources);
 

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -129,10 +129,10 @@ int check_worker_have_enough_disk_with_inputs(struct vine_manager *q, struct vin
 static struct rmsummary *count_worker_available_resources(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
 {
 	/* The "net" resources are those effective or adjusted resources available for computation.
-	 * This requires to subtract resources from libraries that are not running any functions at all. 
+	 * This requires to subtract resources from libraries that are not running any functions at all.
 	 * This matches the assumption in @vine_manager.c:commit_task_to_worker(), where empty libraries are being killed right before a task is committed. */
 	struct vine_resources *worker_net_resources = vine_resources_copy(w->resources);
-	
+
 	uint64_t task_id;
 	struct vine_task *ti;
 	ITABLE_ITERATE(w->current_tasks, task_id, ti)

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -145,10 +145,10 @@ static struct rmsummary *count_worker_net_resources(struct vine_manager *q, stru
 	ITABLE_ITERATE(w->current_tasks, task_id, ti)
 	{
 		if (ti->provides_library && ti->function_slots_inuse == 0) {
-			worker_net_resources->cores += ti->resources_provided->cores;
-			worker_net_resources->memory += ti->resources_provided->memory;
-			worker_net_resources->gpus += ti->resources_provided->gpus;
-			worker_net_resources->disk += ti->resources_provided->disk;
+			worker_net_resources->cores += ti->current_resource_box->cores;
+			worker_net_resources->memory += ti->current_resource_box->memory;
+			worker_net_resources->gpus += ti->current_resource_box->gpus;
+			worker_net_resources->disk += ti->current_resource_box->disk;
 		}
 	}
 

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -126,7 +126,7 @@ int check_worker_have_enough_disk_with_inputs(struct vine_manager *q, struct vin
  * @param t The task structure.
  * @return The available resources of the worker for the task.
  */
-static struct rmsummary *count_worker_available_resources(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
+static struct rmsummary *count_worker_net_resources(struct vine_manager *q, struct vine_worker_info *w, struct vine_task *t)
 {
 	/* The "net" resources are those effective or adjusted resources available for computation. */
 	struct rmsummary *worker_net_resources = rmsummary_create(-1);
@@ -214,7 +214,7 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 	}
 
 	/* Count the available resources on the worker for the task. */
-	struct rmsummary *worker_net_resources = count_worker_available_resources(q, w, t);
+	struct rmsummary *worker_net_resources = count_worker_net_resources(q, w, t);
 
 	/* Check if the worker has some idle resources to use. */
 	if (!check_worker_have_idle_resources(t, worker_net_resources)) {

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -130,6 +130,8 @@ int check_worker_have_enough_resources(struct vine_manager *q, struct vine_worke
 		return 0;
 	}
 
+	rmsummary_delete(worker_net_resources);
+
 	return 1;
 }
 

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -130,7 +130,7 @@ static struct rmsummary *count_worker_available_resources(struct vine_manager *q
 {
 	/* The "net" resources are those effective or adjusted resources available for computation. */
 	struct rmsummary *worker_net_resources = rmsummary_create(-1);
-	
+
 	/* Overcommit resources if needed */
 	worker_net_resources->cores = overcommitted_resource_total(q, w->resources->cores.total) - (double)w->resources->cores.inuse;
 	worker_net_resources->memory = overcommitted_resource_total(q, w->resources->memory.total) - (double)w->resources->memory.inuse;

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -149,7 +149,7 @@ static struct rmsummary *count_worker_available_resources(struct vine_manager *q
 		}
 	}
 
-	/* The worker's available resources are the net resources minus the resources in use. */
+	/* The worker's available resources are the net minus those in use. */
 	struct rmsummary *worker_available_resources = rmsummary_create(-1);
 
 	/* Overcommit resources if needed */

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -124,15 +124,17 @@ int check_worker_have_enough_resources(struct vine_manager *q, struct vine_worke
 	/* Count the available resources on the worker for the task. */
 	struct rmsummary *worker_net_resources = count_worker_net_resources(q, w, t);
 
+	int ok = 1;
+
 	/* check if the allocated resources are enough for the task */
 	if (tr->cores > worker_net_resources->cores || tr->gpus > worker_net_resources->gpus ||
 			tr->memory > worker_net_resources->memory || tr->disk > worker_net_resources->disk) {
-		return 0;
+		ok = 0;
 	}
 
 	rmsummary_delete(worker_net_resources);
 
-	return 1;
+	return ok;
 }
 
 /* t->disk only specifies the size of output and ephemeral files. Here we check if the task would fit together with all its input files

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -85,7 +85,7 @@ static struct rmsummary *count_worker_net_resources(struct vine_manager *q, stru
 	worker_net_resources->memory = overcommitted_resource_total(q, w->resources->memory.total) - (double)w->resources->memory.inuse;
 	worker_net_resources->gpus = overcommitted_resource_total(q, w->resources->gpus.total) - (double)w->resources->gpus.inuse;
 	/* No overcommit disk */
-	worker_net_resources->disk = w->resources->disk.total - (double)w->resources->disk.inuse;
+	worker_net_resources->disk = w->resources->disk.total - w->resources->disk.inuse;
 
 	/* Add resources from empty libraries that are not running any functions at all.
 	 * This matches the assumption in @vine_manager.c:commit_task_to_worker(), where empty libraries are being killed right before a task is committed. */

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -164,7 +164,7 @@ static struct rmsummary *count_worker_available_resources(struct vine_manager *q
 }
 
 /* Check if the worker is fully occupied by other tasks, or the disk is full. */
-static int check_worker_have_available_resources(struct vine_task *t, struct rmsummary *worker_available_resources)
+static int check_worker_have_idle_resources(struct vine_task *t, struct rmsummary *worker_available_resources)
 {
 	/* Skip if it is a function task. Resource guarantees for function calls are handled at the end of @check_worker_against_task, which calls
 	 * @vine_schedule_find_library to locate a suitable library for the function call, it directly returns false if no appropriate library is found  */
@@ -221,11 +221,11 @@ int check_worker_against_task(struct vine_manager *q, struct vine_worker_info *w
 		return 0;
 	}
 
-	/* Count the available resources of the worker for the task. */
+	/* Count the available resources on the worker for the task. */
 	struct rmsummary *worker_available_resources = count_worker_available_resources(q, w, t);
 
-	/* Check if the worker has some usable resources for the task. */
-	if (!check_worker_have_available_resources(t, worker_available_resources)) {
+	/* Check if the worker has some idle resources to use. */
+	if (!check_worker_have_idle_resources(t, worker_available_resources)) {
 		rmsummary_delete(worker_available_resources);
 		return 0;
 	}


### PR DESCRIPTION
## Proposed Changes

Calculate the usable resources for a task on a worker and check it earlier. The avoids resource allocations if the worker doesn't have usable resources for a task at all.

This speeds up my workflows slightly, for about 1.5% 

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
