### PR TITLE
vine: delay registering file_replica_table

### DIFF
--- a/taskvine/src/manager/vine_manager_put.c
+++ b/taskvine/src/manager/vine_manager_put.c
@@ -245,8 +245,8 @@ vine_result_code_t vine_manager_put_url_now(struct vine_manager *q, struct vine_
 
 	vine_manager_send(q, w, "puturl_now %s %s %d %lld 0%o %s\n", source_encoded, cached_name_encoded, f->cache_level, (long long)f->size, mode, transfer_id);
 
-	struct vine_file_replica *replica = vine_file_replica_create(f->type, f->cache_level, f->size, f->mtime);
-	vine_file_replica_table_insert(q, w, f->cached_name, replica);
+	// struct vine_file_replica *replica = vine_file_replica_create(f->type, f->cache_level, f->size, f->mtime);
+	// vine_file_replica_table_insert(q, w, f->cached_name, replica);
 
 	free(transfer_id);
 	return VINE_SUCCESS;


### PR DESCRIPTION
## Proposed Changes

This is a tentative fix for #4038

Do not put a replica into the `file_replica_table` when sending the `put_url` message

Instead, `handle_cache_update` will properly register it into the `file_replica_table` when a file is physically existing in a worker's cache

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
