### PR TITLE
vine: remove a line from debug file

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -993,7 +993,7 @@ static int consider_tempfile_replications(struct vine_manager *q)
 			continue;
 		}
 
-		debug(D_VINE, "Found %d workers holding %s, %d replicas needed", nsources, f->cached_name, to_find);
+		// debug(D_VINE, "Found %d workers holding %s, %d replicas needed", nsources, f->cached_name, to_find);
 
 		int round_replication_request_sent = vine_file_replica_table_replicate(q, f, sources, to_find);
 		total_replication_request_sent += round_replication_request_sent;


### PR DESCRIPTION
## Proposed Changes

This line of log constitues most of the debug file when the replication threshold is large.

It's very easy to generate a 5 GB debug file when dealing with 9K tasks and each temp file is replicated for 6 times, wheras once removed it the debug file is less than 100 MB.




## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
