### PR TITLE
vine: check if file exists on worker when access file_replica_table

### DIFF
--- a/taskvine/src/manager/vine_file_replica_table.c
+++ b/taskvine/src/manager/vine_file_replica_table.c
@@ -24,6 +24,10 @@ See the file COPYING for details.
 // add a file to the remote file table.
 int vine_file_replica_table_insert(struct vine_manager *m, struct vine_worker_info *w, const char *cachename, struct vine_file_replica *replica)
 {
+	if (hash_table_lookup(w->current_files, cachename)) {
+		return 0;
+	}
+
 	w->inuse_cache += replica->size;
 	hash_table_insert(w->current_files, cachename, replica);
 
@@ -47,6 +51,10 @@ int vine_file_replica_table_insert(struct vine_manager *m, struct vine_worker_in
 // remove a file from the remote file table.
 struct vine_file_replica *vine_file_replica_table_remove(struct vine_manager *m, struct vine_worker_info *w, const char *cachename)
 {
+	if (!hash_table_lookup(w->current_files, cachename)) {
+		return 0;
+	}
+
 	struct vine_file_replica *replica = hash_table_remove(w->current_files, cachename);
 	if (replica) {
 		w->inuse_cache -= replica->size;


### PR DESCRIPTION
## Proposed Changes

It’s easy to accidentally add a file to a worker twice using `vine_file_replica_table_insert`. 

If the file already exists on the worker, we should avoid incrementing `w->inuse_cache`.

This causes inconsistence between the worker's actual cache inuse and the manager's record.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
