### PR TITLE
vine: resolve shutdown_workers to workers_shutdown

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -156,7 +156,7 @@ class Manager(object):
         try:
             if self._taskvine:
                 if self._shutdown:
-                    self.shutdown_workers(0)
+                    self.workers_shutdown(0)
                 self._update_status_display(force=True)
                 cvine.vine_delete(self._taskvine)
                 self._taskvine = None


### PR DESCRIPTION
## Proposed Changes

Update internal call to `shutdown_workers` to `workers_shutdown`. Resolves issue #4062 

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
