### PR TITLE
Vine: Fix Crash After Idle Disconnect

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -2519,8 +2519,9 @@ static vine_result_code_t handle_worker(struct vine_manager *q, struct link *l)
 	free(key);
 
 	/* This should not happen, but just in case: */
-	if(!w) return VINE_WORKER_FAILURE;
-		       
+	if (!w)
+		return VINE_WORKER_FAILURE;
+
 	vine_msg_code_t mcode;
 	mcode = vine_manager_recv_no_retry(q, w, line, sizeof(line));
 

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -269,30 +269,41 @@ static vine_msg_code_t handle_name(struct vine_manager *q, struct vine_worker_in
 }
 
 /*
-Handle a timeout request from a worker. Check if the worker has any important data before letting it go.
+Handle a request from a worker to shutdown because it has been idle for a while.
+However, do not accept the request if the manager has some further information
+indicating that the worker should be kept around.
 */
 
-static void handle_worker_timeout(struct vine_manager *q, struct vine_worker_info *w)
+static void handle_idle_disconnect_request(struct vine_manager *q, struct vine_worker_info *w)
 {
-	// Look at the files and check if any are endangered temps.
 	char *cachename;
 	struct vine_file_replica *replica;
-	// debug(D_VINE, "Handling timeout request");
+
+	/* First check to see if this worker has any unique files that should not be lost. */
+
 	HASH_TABLE_ITERATE(w->current_files, cachename, replica)
 	{
 		if (replica->type == VINE_TEMP) {
 			int c = vine_file_replica_table_count_replicas(q, cachename, VINE_FILE_REPLICA_STATE_READY);
 			if (c == 1) {
-				debug(D_VINE, "Rejecting timeout request from worker %s (%s). Has unique file %s", w->hostname, w->addrport, cachename);
+				debug(D_VINE, "Rejecting disconnect request from worker %s (%s). Has unique file %s", w->hostname, w->addrport, cachename);
 				return;
 			}
 		}
 	}
 
+	/*
+	Then, if it is not running any tasks, tell it to exit and shut down cleanly.
+	We do not disconnect just yet because there may be more messages pending,
+	or other information the worker wants to send as it shuts down.
+	The worker will disconnect on its own.
+	Also, we don't want to invalidate the worker object w in an unexpected location.
+	*/
+
 	if (itable_size(w->current_tasks) == 0) {
-		debug(D_VINE, "Accepting timeout request from worker %s (%s).", w->hostname, w->addrport);
+		debug(D_VINE, "Accepting disconnect request from worker %s (%s).", w->hostname, w->addrport);
 		q->stats->workers_idled_out++;
-		vine_manager_shut_down_worker(q, w);
+		vine_manager_send(q, w, "exit\n");
 	}
 
 	return;
@@ -313,7 +324,7 @@ static vine_msg_code_t handle_info(struct vine_manager *q, struct vine_worker_in
 	if (string_prefix_is(field, "tasks_running")) {
 		w->dynamic_tasks_running = atoi(value);
 	} else if (string_prefix_is(field, "idle-disconnect-request")) {
-		handle_worker_timeout(q, w);
+		handle_idle_disconnect_request(q, w);
 	} else if (string_prefix_is(field, "worker-id")) {
 		free(w->workerid);
 		w->workerid = xxstrdup(value);
@@ -2507,6 +2518,9 @@ static vine_result_code_t handle_worker(struct vine_manager *q, struct link *l)
 	w = hash_table_lookup(q->worker_table, key);
 	free(key);
 
+	/* This should not happen, but just in case: */
+	if(!w) return VINE_WORKER_FAILURE;
+		       
 	vine_msg_code_t mcode;
 	mcode = vine_manager_recv_no_retry(q, w, line, sizeof(line));
 
@@ -4961,7 +4975,12 @@ struct vine_task *vine_wait_for_task_id(struct vine_manager *q, int task_id, int
 	return vine_wait_internal(q, timeout, NULL, task_id);
 }
 
-/* return number of workers that failed */
+/*
+Consider all of the connected workers, and act open each connection
+that has pending input data, until the input buffer is empty.
+Return the number of workers that *failed* and disconnected.
+*/
+
 static int poll_active_workers(struct vine_manager *q, int stoptime)
 {
 	BEGIN_ACCUM_TIME(q, time_polling);
@@ -4993,9 +5012,14 @@ static int poll_active_workers(struct vine_manager *q, int stoptime)
 
 	int i;
 	int workers_failed = 0;
-	// Then consider all existing active workers
+
+	/* Consider all active connections of any kind. */
 	for (i = 1; i < n; i++) {
+
+		/* If there is pending input data on that connection. */
 		if (q->poll_table[i].revents) {
+
+			/* Act on the next input message, until there is no more buffered data. */
 			do {
 				if (handle_worker(q, q->poll_table[i].link) == VINE_WORKER_FAILURE) {
 					workers_failed++;


### PR DESCRIPTION
## Proposed Changes

@btovar observed a problem in which the manager crashes after processing an `idle-disconnect` message and disconnecting the worker.  The problem is that this invalidates the `vine_worker_info` object and the `link` object in the middle of `handle_worker`.  If the `idle-disconnect` is followed by any other asynchronous message (which is likely) then the manager ends up seeing messages from a worker that no longer exists.

The solution here is to eliminate the special case: `handle_idle_disconnect` now sends an `exit` message to a worker, but does not disconnect it immediately.   This allows the manager to process any following asynchronous messages, and the worker can perform whatever cleanup and communication it needs to do before disconnecting.  And then the disconnect will be handled in the single (normal) place when the connection is dropped.

@colinthomas-z80 the crash was occurring in the recently-modified location of `link_poll_active_workers` but really the problem was deeper in that we shouldn't be invalidating the worker object in multiple places.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
