### PR TITLE
vine: count child_count properly in the transfer server process

### DIFF
--- a/taskvine/src/worker/vine_transfer_server.c
+++ b/taskvine/src/worker/vine_transfer_server.c
@@ -68,11 +68,11 @@ static void vine_transfer_process(struct vine_cache *cache)
 	static int child_count = 0;
 
 	/*
-		1. Perform a non-blocking check for any child processes that have exited, this runs very fast.
-		2. If the number of child processes has reached the maximum allowed, perform a blocking wait for a child process to exit.
-		3. Once arrives here, the server is safe to accept a new connection, as the child_count is less than the maximum allowed.
-		4. Upon accepting a connection, fork a new child process to handle it; if timeout, simply continue.
-		5. lnk should be closed in the parent process to prevent file descriptor exhaustion.
+	1. Perform a non-blocking check for any child processes that have exited, this runs very fast.
+	2. If the number of child processes has reached the maximum allowed, perform a blocking wait for a child process to exit.
+	3. Once arrives here, the server is safe to accept a new connection, as the child_count is less than the maximum allowed.
+	4. Upon accepting a connection, fork a new child process to handle it; if timeout, simply continue.
+	5. lnk should be closed in the parent process to prevent file descriptor exhaustion.
 	*/
 	while (1) {
 		/* Do a non-blocking wait for any exited children. */

--- a/taskvine/src/worker/vine_transfer_server.c
+++ b/taskvine/src/worker/vine_transfer_server.c
@@ -100,7 +100,7 @@ static void vine_transfer_process(struct vine_cache *cache)
 				/* Increment the child count when a new child is successfully forked. */
 				child_count++;
 				/* Also close the link in the parent process, otherwise the opened file descriptors will not be closed.
-			     * This caused a problem where incoming transfers were all failing due to the file descriptor limit per process being reached. */
+				 * This caused a problem where incoming transfers were all failing due to the file descriptor limit per process being reached. */
 				link_close(lnk);
 			} else {
 				/* If fork fails, also close the link. */
@@ -109,7 +109,7 @@ static void vine_transfer_process(struct vine_cache *cache)
 		} else {
 			/* If lnk is NULL, it means link_accept failed to accept a connection.
 			 * This could be due to a timeout or other transient issues. */
-			 continue;
+			continue;
 		}
 	}
 }

--- a/taskvine/src/worker/vine_transfer_server.c
+++ b/taskvine/src/worker/vine_transfer_server.c
@@ -68,12 +68,26 @@ static void vine_transfer_process(struct vine_cache *cache)
 	static int child_count = 0;
 
 	/*
-	If link is real, fork. Check if we are at the max
-	child count. If we are over, or link_accept timed out,
-	do a blocking wait on an exited child. If we are under
-	the limit, collect all exited tasks and return to recv
+		1. Perform a non-blocking check for any child processes that have exited, this runs very fast.
+		2. If the number of child processes has reached the maximum allowed, perform a blocking wait for a child process to exit.
+		3. Once arrives here, the server is safe to accept a new connection, as the child_count is less than the maximum allowed.
+		4. Upon accepting a connection, fork a new child process to handle it; if timeout, simply continue.
+		5. lnk should be closed in the parent process to prevent file descriptor exhaustion.
 	*/
 	while (1) {
+		/* Do a non-blocking wait for any exited children. */
+		while (waitpid(-1, NULL, WNOHANG) > 0) {
+			child_count--;
+		}
+		/* If the child count is at the maximum allowed, do a blocking wait for an exited child. */
+		if (child_count >= VINE_TRANSFER_PROC_MAX_CHILD) {
+			debug(D_VINE, "Transfer Server: waiting on exited child. Reached %d", child_count);
+			if (waitpid(-1, NULL, 0) > 0) {
+				child_count--;
+			}
+		}
+
+		/* The server is safe to accept a new connection. */
 		struct link *lnk = link_accept(transfer_link, time(0) + 10);
 
 		if (lnk) {
@@ -88,26 +102,14 @@ static void vine_transfer_process(struct vine_cache *cache)
 				/* Also close the link in the parent process, otherwise the opened file descriptors will not be closed.
 			     * This caused a problem where incoming transfers were all failing due to the file descriptor limit per process being reached. */
 				link_close(lnk);
-				/* If the child count is less than the maximum allowed, wait for any exited children and decrement the child count. */
-				if (child_count < VINE_TRANSFER_PROC_MAX_CHILD) {
-					while (waitpid(-1, NULL, WNOHANG) > 0) {
-						child_count--;
-					}
-					continue;
-				}
 			} else {
-				/* If fork fails, close the link. */
-				debug(D_VINE, "fork failed: %s", strerror(errno));
+				/* If fork fails, also close the link. */
 				link_close(lnk);
 			}
 		} else {
 			/* If lnk is NULL, it means link_accept failed to accept a connection.
 			 * This could be due to a timeout or other transient issues. */
-		}
-
-		debug(D_VINE, "Transfer Server: waiting on exited child. Reached %d", child_count);
-		if (waitpid(-1, NULL, 0) > 0) {
-			child_count--;
+			 continue;
 		}
 	}
 }

--- a/taskvine/src/worker/vine_transfer_server.c
+++ b/taskvine/src/worker/vine_transfer_server.c
@@ -96,7 +96,7 @@ static void vine_transfer_process(struct vine_cache *cache)
 					continue;
 				}
 			} else {
-				/* If fork fails, log the error and close the link. */
+				/* If fork fails, close the link. */
 				debug(D_VINE, "fork failed: %s", strerror(errno));
 				link_close(lnk);
 			}

--- a/taskvine/src/worker/vine_transfer_server.c
+++ b/taskvine/src/worker/vine_transfer_server.c
@@ -80,7 +80,7 @@ static void vine_transfer_process(struct vine_cache *cache)
 			child_count--;
 		}
 		/* If the child count is at the maximum allowed, do a blocking wait for an exited child. */
-		if (child_count >= VINE_TRANSFER_PROC_MAX_CHILD) {
+		while (child_count >= VINE_TRANSFER_PROC_MAX_CHILD) {
 			debug(D_VINE, "Transfer Server: waiting on exited child. Reached %d", child_count);
 			if (waitpid(-1, NULL, 0) > 0) {
 				child_count--;

--- a/taskvine/src/worker/vine_transfer_server.c
+++ b/taskvine/src/worker/vine_transfer_server.c
@@ -79,7 +79,7 @@ static void vine_transfer_process(struct vine_cache *cache)
 		while (waitpid(-1, NULL, WNOHANG) > 0) {
 			child_count--;
 		}
-		/* If the child count is at the maximum allowed, do a blocking wait for an exited child. */
+		/* If the child count is larger than the maximum allowed, do blocking wait until it is safe to accept a new connection. */
 		while (child_count >= VINE_TRANSFER_PROC_MAX_CHILD) {
 			debug(D_VINE, "Transfer Server: waiting on exited child. Reached %d", child_count);
 			if (waitpid(-1, NULL, 0) > 0) {


### PR DESCRIPTION
## Proposed Changes

I found this problamatic while investigating #4076 

In the worker's transfer server process, the time when increasing the `child_count` is before we even check if the `lnk` is valid or if the fork was successful. This leads to inaccurate counting, especially when the connection is `NULL` (timeout) or the fork fails. The result is that the worker could block indefinitely in the `waitpid` call, waiting for a child process that doesn't exist. 

The solution is to only increment the `child_count` after successfully forking a child process, and handle fork failures separately to ensure the count remains accurate, preventing unnecessary blocking.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
