### PR TITLE
vine: dangling pointer, crashes worker

### DIFF
--- a/dttools/src/copy_stream.c
+++ b/dttools/src/copy_stream.c
@@ -124,7 +124,6 @@ int64_t copy_file_to_buffer(const char *filename, char **buffer, size_t *len)
 	}
 
 	*len = info.st_size;
-	*buffer = NULL;
 	*buffer = malloc(*len + 1);
 	if (*buffer == NULL) {
 		close(fd);

--- a/dttools/src/copy_stream.c
+++ b/dttools/src/copy_stream.c
@@ -124,6 +124,7 @@ int64_t copy_file_to_buffer(const char *filename, char **buffer, size_t *len)
 	}
 
 	*len = info.st_size;
+	*buffer = NULL;
 	*buffer = malloc(*len + 1);
 	if (*buffer == NULL) {
 		close(fd);
@@ -134,6 +135,7 @@ int64_t copy_file_to_buffer(const char *filename, char **buffer, size_t *len)
 	int64_t total = full_read(fd, *buffer, *len);
 	if (total == -1) {
 		free(*buffer);
+		*buffer = NULL;
 	}
 
 	close(fd);

--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -759,10 +759,10 @@ static void vine_cache_check_outputs(struct vine_cache *c, struct vine_cache_fil
 			vine_worker_send_cache_update(manager, cachename, f->original_type, f->cache_level, f->size, f->mode, transfer_time, f->start_time);
 		} else {
 			char *error_path = vine_cache_error_path(c, cachename);
-			char *error_message;
+			char *error_message = NULL;
 			size_t error_length;
 
-			if (copy_file_to_buffer(error_path, &error_message, &error_length)) {
+			if (copy_file_to_buffer(error_path, &error_message, &error_length) > 0 && error_message) {
 				/* got a message string */
 			} else {
 				error_message = strdup("unknown error");


### PR DESCRIPTION
## Proposed Changes

I met a consistent segfault error when running a worker locally which performs frequent temp file staging in/out.

It turned out that there was a bug in the `copy_file_to_buffer` function when handling error cases. The function would free the buffer on read failures but not set it to `NULL`, creating a dangling pointer. Specifically, when `full_read` failed, the function would free `*buffer` without nullifying it, then return `-1`. 

``` C
	int64_t total = full_read(fd, *buffer, *len);
	if (total == -1) {
		printf("copy_file_to_buffer: total == -1\n");
		free(*buffer);
	}
```

The calling code's condition `if (copy_file_to_buffer(...))` was problematic because in C, any non-zero value (including -1) evaluates to true. This meant that with a return value of `-1`, the code would incorrectly enter a branch that assumed a valid buffer, eventually calling `strlen()` on the dangling pointer and later attempting to `free` it again, resulting in the crash.



## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
