### PR TITLE
DaskVine: add dask init_command

### DIFF
--- a/poncho/src/poncho/library_network_code.py
+++ b/poncho/src/poncho/library_network_code.py
@@ -124,7 +124,6 @@ def start_function(in_pipe_fd, thread_limit=1):
         exit(1)
 
     with threadpool_limits(limits=thread_limit):
-        global exec_method
         if exec_method == "direct":
             library_sandbox = os.getcwd()
             try:

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/compat/dask_executor.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/compat/dask_executor.py
@@ -128,6 +128,7 @@ class DaskVine(Manager):
             task_mode='tasks',
             scheduling_mode='FIFO',
             env_per_task=False,
+            init_command=None,
             progress_disable=False,
             progress_label="[green]tasks",
             wrapper=None,
@@ -170,6 +171,7 @@ class DaskVine(Manager):
             self.task_mode = task_mode
             self.scheduling_mode = scheduling_mode
             self.env_per_task = env_per_task
+            self.init_command = init_command
             self.progress_disable = progress_disable
             self.progress_label = progress_label
             self.wrapper = wrapper
@@ -411,6 +413,9 @@ class DaskVine(Manager):
                     t.set_command(
                         f"mkdir envdir && tar -xf {self._environment_name} -C envdir && envdir/bin/run_in_env {t._command}")
                     t.add_input(self.environment_file, self.environment_name)
+
+                if self.init_command:
+                    t.set_command(f"{self.init_command} {t.command}")
 
                 t.set_tag(tag)  # tag that identifies this dag
                 enqueued_calls.append(t)

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5355,8 +5355,8 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 
 			if (done) {
 				if (retrieved_this_cycle > 0) {
-					continue; // we only get here with prefer-dispatch, continue to find a task to
-						  // return
+					continue;	// we only get here with prefer-dispatch, continue to find a task to
+							// return
 				} else {
 					break;
 				}

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5355,8 +5355,8 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 
 			if (done) {
 				if (retrieved_this_cycle > 0) {
-					continue;	// we only get here with prefer-dispatch, continue to find a task to
-							// return
+					continue; // we only get here with prefer-dispatch, continue to find a task to
+						  // return
 				} else {
 					break;
 				}


### PR DESCRIPTION
## Proposed Changes

Add an init_command to daskvine tasks, common in other workflow systems eg. parsl. I am using it for filetrace.

Also do a "make format" to fix the general linting issue

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
