### PR TITLE
Mini task fail on input missing

### DIFF
--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -700,7 +700,7 @@ vine_cache_status_t vine_cache_ensure(struct vine_cache *c, const char *cachenam
 			LIST_ITERATE(f->mini_task->input_mounts, m)
 			{
 				result = vine_cache_ensure(c, m->file->cached_name);
-				if (result == VINE_CACHE_STATUS_FAILED) {
+				if (result == VINE_CACHE_STATUS_FAILED || result == VINE_CACHE_STATUS_UNKNOWN) {
 					/* an input file for the mini task failed to transfer,
 					 * thus the mini task is marked also as failed */
 					mini_task_inputs_permanent_failure = 1;

--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -159,7 +159,9 @@ static void vine_cache_kill(struct vine_cache *c, struct vine_cache_file *f, con
 	while (f->status == VINE_CACHE_STATUS_PROCESSING) {
 		debug(D_VINE, "cache: killing pending transfer process %d...", f->pid);
 		kill(f->pid, SIGKILL);
-		vine_cache_wait_for_file(c, f, cachename, manager);
+		if (manager) {
+			vine_cache_wait_for_file(c, f, cachename, manager);
+		}
 		if (f->status == VINE_CACHE_STATUS_PROCESSING) {
 			debug(D_VINE, "cache:still not killed, trying again!");
 			sleep(1);
@@ -407,9 +409,8 @@ int vine_cache_remove(struct vine_cache *c, const char *cachename, struct link *
 		return 0;
 
 	/* Ensure that any child process associated with the entry is stopped. */
-	if (manager) {
-		vine_cache_kill(c, f, cachename, manager);
-	}
+
+	vine_cache_kill(c, f, cachename, manager);
 
 	hash_table_remove(c->pending_transfers, cachename);
 	hash_table_remove(c->processing_transfers, cachename);

--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -320,8 +320,19 @@ int vine_cache_add_transfer(struct vine_cache *c, const char *cachename, const c
 	/* Has this transfer already been queued? */
 	struct vine_cache_file *f = hash_table_lookup(c->table, cachename);
 	if (f) {
-		/* The transfer is already queued up. */
-		return 1;
+		switch (f->status) {
+		case VINE_CACHE_STATUS_PROCESSING:
+		case VINE_CACHE_STATUS_TRANSFERRED:
+		case VINE_CACHE_STATUS_READY:
+		case VINE_CACHE_STATUS_PENDING:
+			/* The transfer is already queued up. */
+			return 1;
+			break;
+		case VINE_CACHE_STATUS_FAILED:
+		case VINE_CACHE_STATUS_UNKNOWN:
+			vine_cache_remove(c, cachename, NULL);
+			break;
+		}
 	}
 
 	/* Create the object and fill in the metadata. */
@@ -341,33 +352,7 @@ int vine_cache_add_transfer(struct vine_cache *c, const char *cachename, const c
 	f->mtime = 0;
 	f->transfer_time = 0;
 
-	int status = hash_table_insert(c->table, cachename, f);
-	if (!status) {
-		int bad_cache = 0;
-		struct vine_cache_file *previous = hash_table_remove(c->table, cachename);
-		if (!previous) {
-			bad_cache = 1;
-		} else {
-			switch (previous->status) {
-			case VINE_CACHE_STATUS_PROCESSING:
-			case VINE_CACHE_STATUS_TRANSFERRED:
-			case VINE_CACHE_STATUS_READY:
-			case VINE_CACHE_STATUS_PENDING:
-				bad_cache = 1;
-				break;
-			case VINE_CACHE_STATUS_FAILED:
-			case VINE_CACHE_STATUS_UNKNOWN:
-				break;
-			}
-			vine_cache_file_delete(previous);
-			hash_table_insert(c->table, cachename, f);
-		}
-
-		if (bad_cache) {
-			fatal("Manager sent conflicting cache information.");
-		}
-	}
-
+	hash_table_insert(c->table, cachename, f);
 	hash_table_insert(c->pending_transfers, cachename, NULL);
 
 	/* Note metadata is not saved here but when transfer is completed. */
@@ -422,7 +407,9 @@ int vine_cache_remove(struct vine_cache *c, const char *cachename, struct link *
 		return 0;
 
 	/* Ensure that any child process associated with the entry is stopped. */
-	vine_cache_kill(c, f, cachename, manager);
+	if (manager) {
+		vine_cache_kill(c, f, cachename, manager);
+	}
 
 	hash_table_remove(c->pending_transfers, cachename);
 	hash_table_remove(c->processing_transfers, cachename);
@@ -703,6 +690,7 @@ vine_cache_status_t vine_cache_ensure(struct vine_cache *c, const char *cachenam
 		break;
 	}
 
+	int mini_task_inputs_permanent_failure = 0;
 	/* For a mini-task, we must also insure the inputs to the task exist. */
 	if (f->cache_type == VINE_CACHE_MINI_TASK) {
 		if (f->mini_task->input_mounts) {
@@ -711,8 +699,14 @@ vine_cache_status_t vine_cache_ensure(struct vine_cache *c, const char *cachenam
 			LIST_ITERATE(f->mini_task->input_mounts, m)
 			{
 				result = vine_cache_ensure(c, m->file->cached_name);
-				if (result != VINE_CACHE_STATUS_READY)
+				if (result == VINE_CACHE_STATUS_FAILED) {
+					/* an input file for the mini task failed to transfer,
+					 * thus the mini task is marked also as failed */
+					mini_task_inputs_permanent_failure = 1;
+					break;
+				} else if (result != VINE_CACHE_STATUS_READY) {
 					return result;
+				}
 			}
 		}
 	}
@@ -725,10 +719,9 @@ vine_cache_status_t vine_cache_ensure(struct vine_cache *c, const char *cachenam
 		struct vine_process *p = vine_process_create(f->mini_task, VINE_PROCESS_TYPE_MINI_TASK);
 		if (!vine_sandbox_stagein(p, c)) {
 			debug(D_VINE, "cache: can't stage input files for task %d.", p->task->task_id);
-			p->task = 0;
-			vine_process_delete(p);
-			f->status = VINE_CACHE_STATUS_FAILED;
-			return f->status;
+			/* we know mini task will fail because of lack of inputs, here we set the flag
+			   to terminate the transfer child process immediately. */
+			mini_task_inputs_permanent_failure = 1;
 		}
 		f->process = p;
 	}
@@ -760,7 +753,9 @@ vine_cache_status_t vine_cache_ensure(struct vine_cache *c, const char *cachenam
 		}
 		return f->status;
 	} else {
-		vine_cache_worker_process(f, c, cachename);
+		if (!mini_task_inputs_permanent_failure) {
+			vine_cache_worker_process(f, c, cachename);
+		}
 		_exit(1);
 	}
 }

--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -159,9 +159,7 @@ static void vine_cache_kill(struct vine_cache *c, struct vine_cache_file *f, con
 	while (f->status == VINE_CACHE_STATUS_PROCESSING) {
 		debug(D_VINE, "cache: killing pending transfer process %d...", f->pid);
 		kill(f->pid, SIGKILL);
-		if (manager) {
-			vine_cache_wait_for_file(c, f, cachename, manager);
-		}
+		vine_cache_wait_for_file(c, f, cachename, manager);
 		if (f->status == VINE_CACHE_STATUS_PROCESSING) {
 			debug(D_VINE, "cache:still not killed, trying again!");
 			sleep(1);
@@ -863,7 +861,7 @@ static void vine_cache_check_outputs(struct vine_cache *c, struct vine_cache_fil
 Evaluate the exit status of a transfer process to determine if it succeeded.
 */
 
-static void vine_cache_handle_exit_status(struct vine_cache *c, struct vine_cache_file *f, const char *cachename, int status, struct link *manager)
+static void vine_cache_handle_exit_status(struct vine_cache *c, struct vine_cache_file *f, const char *cachename, int status)
 {
 	f->stop_time = timestamp_get();
 
@@ -902,7 +900,7 @@ static void vine_cache_wait_for_file(struct vine_cache *c, struct vine_cache_fil
 			debug(D_VINE, "cache: wait4 on pid %d returned an error: %s", (int)f->pid, strerror(errno));
 		} else if (result > 0) {
 			hash_table_remove(c->processing_transfers, cachename);
-			vine_cache_handle_exit_status(c, f, cachename, status, manager);
+			vine_cache_handle_exit_status(c, f, cachename, status);
 			vine_cache_check_outputs(c, f, cachename, manager);
 		}
 	}

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -74,8 +74,7 @@ vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cach
 				processing++;
 				break;
 			}
-		}
-		break;
+		} break;
 		case VINE_CACHE_STATUS_FAILED:
 			debug(D_VINE, "unavailable in cache for task sandbox: %s", m->file->cached_name);
 			return VINE_CACHE_STATUS_FAILED;

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -75,8 +75,10 @@ vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cach
 				break;
 			}
 		}
+			debug(D_VINE, "unavailable in cache for task sandbox: %s", m->file->cached_name);
 			return VINE_CACHE_STATUS_FAILED;
 		case VINE_CACHE_STATUS_FAILED:
+			debug(D_VINE, "unavailable in cache for task sandbox: %s", m->file->cached_name);
 			return VINE_CACHE_STATUS_FAILED;
 		}
 	}

--- a/taskvine/src/worker/vine_sandbox.c
+++ b/taskvine/src/worker/vine_sandbox.c
@@ -75,8 +75,7 @@ vine_cache_status_t vine_sandbox_ensure(struct vine_process *p, struct vine_cach
 				break;
 			}
 		}
-			debug(D_VINE, "unavailable in cache for task sandbox: %s", m->file->cached_name);
-			return VINE_CACHE_STATUS_FAILED;
+		break;
 		case VINE_CACHE_STATUS_FAILED:
 			debug(D_VINE, "unavailable in cache for task sandbox: %s", m->file->cached_name);
 			return VINE_CACHE_STATUS_FAILED;


### PR DESCRIPTION
Now mini tasks are allowed to fork if their sandbox cannot be staged. In this way the output file of the mini task can generate the corresponding cache-invalid message.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
