### PR TITLE
vine: Fix waiting retrieval

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3570,20 +3570,6 @@ static int send_one_task(struct vine_manager *q)
 }
 
 /*
-get available results from a worker. This is typically used for signaling watched files.
-*/
-int get_results_from_worker(struct vine_manager *q, struct vine_worker_info *w)
-{
-	/* get available results from the worker, bail out if that also fails. */
-	vine_result_code_t r = get_available_results(q, w);
-	if (r != VINE_SUCCESS) {
-		handle_worker_failure(q, w);
-		return 0;
-	}
-	return 1;
-}
-
-/*
 Finding a worker that has tasks waiting to be retrieved, then fetch the outputs
 of those tasks. Returns the number of tasks received.
 */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -508,20 +508,6 @@ static int handle_transfer_hostport(struct vine_manager *q, struct vine_worker_i
 	return VINE_MSG_PROCESSED;
 }
 
-static void register_waiting_retrieval(struct vine_manager *q, struct vine_worker_info *w)
-{
-	/* Here we increment the counter of tasks ready to be retrieved at the worker.
-	 * In case no other task at the worker was ready to be retrieved, we add it
-	 * to the list for the manager to eventually process in the wait loop.
-	 * The counter is decremented as tasks are retrieved. */
-
-	w->tasks_waiting_retrieval += 1;
-	if (w->tasks_waiting_retrieval == 1) {
-		/* if this is the first task waiting retrieval, then tell manager about it. */
-		list_push_tail(q->workers_with_complete_tasks, xxstrdup(w->hashkey));
-	}
-}
-
 static vine_result_code_t get_completion_result(struct vine_manager *q, struct vine_worker_info *w, const char *line)
 {
 	if (!q || !w || !line)
@@ -637,7 +623,7 @@ static vine_result_code_t get_completion_result(struct vine_manager *q, struct v
 			c->min_vine_sandbox = sandbox_used;
 		}
 
-		register_waiting_retrieval(q, w);
+		hash_table_insert(q->workers_with_complete_tasks, w->hashkey, w);
 	}
 
 	/* Finally update data structures to reflect the completion. */
@@ -1076,6 +1062,7 @@ void vine_manager_remove_worker(struct vine_manager *q, struct vine_worker_info 
 
 	hash_table_remove(q->worker_table, w->hashkey);
 	hash_table_remove(q->workers_with_watched_file_updates, w->hashkey);
+	hash_table_remove(q->workers_with_complete_tasks, w->hashkey);
 
 	if (q->transfer_temps_recovery) {
 		recall_worker_lost_temp_files(q, w);
@@ -3586,6 +3573,20 @@ static int send_one_task(struct vine_manager *q)
 }
 
 /*
+get available results from a worker. This is typically used for signaling watched files.
+*/
+int get_results_from_worker(struct vine_manager *q, struct vine_worker_info *w)
+{
+	/* get available results from the worker, bail out if that also fails. */
+	vine_result_code_t r = get_available_results(q, w);
+	if (r != VINE_SUCCESS) {
+		handle_worker_failure(q, w);
+		return 0;
+	}
+	return 1;
+}
+
+/*
 Finding a worker that has tasks waiting to be retrieved, then fetch the outputs
 of those tasks. Returns the number of tasks received.
 */
@@ -3604,25 +3605,23 @@ static int receive_tasks_from_worker(struct vine_manager *q, struct vine_worker_
 		max_to_receive = itable_size(w->current_tasks);
 	}
 
+	/* Reset the available results table now that the worker is removed */
+	hash_table_remove(q->workers_with_complete_tasks, w->hashkey);
+	hash_table_firstkey(q->workers_with_complete_tasks);
+
 	/* Now consider all tasks assigned to that worker .*/
 	ITABLE_ITERATE(w->current_tasks, task_id, t)
 	{
 		/* If the task is waiting to be retrieved... */
 		if (t->state == VINE_TASK_WAITING_RETRIEVAL) {
-			if (tasks_received >= max_to_receive) {
-				/* but we are over the max_to_receive, then re-add worker to list to be processed later. */
-				list_push_head(q->workers_with_complete_tasks, xxstrdup(w->hashkey));
-				break;
-			}
-
 			/* Attempt to fetch it. */
 			if (fetch_outputs_from_worker(q, w, task_id)) {
 				/* If it was fetched, update stats and keep going. */
 				tasks_received++;
 
-				/* Pair the increment of register_waiting_retrieval with
-				 * a decrement as the tasks has been retrieved. */
-				w->tasks_waiting_retrieval--;
+				if (tasks_received >= max_to_receive) {
+					break;
+				}
 			} else {
 				/* But if the fetch failed, the worker is no longer vaild, bail out. */
 				return tasks_received;
@@ -4068,7 +4067,7 @@ struct vine_manager *vine_ssl_create(int port, const char *key, const char *cert
 	q->stats_measure = calloc(1, sizeof(struct vine_stats));
 
 	q->workers_with_watched_file_updates = hash_table_create(0, 0);
-	q->workers_with_complete_tasks = list_create();
+	q->workers_with_complete_tasks = hash_table_create(0, 0);
 
 	// The poll table is initially null, and will be created
 	// (and resized) as needed by build_poll_table.
@@ -4421,8 +4420,7 @@ void vine_delete(struct vine_manager *q)
 	list_delete(q->waiting_retrieval_list);
 	list_delete(q->retrieved_list);
 	hash_table_delete(q->workers_with_watched_file_updates);
-	list_clear(q->workers_with_complete_tasks, free);
-	list_delete(q->workers_with_complete_tasks);
+	hash_table_delete(q->workers_with_complete_tasks);
 
 	list_clear(q->task_info_list, (void *)vine_task_info_delete);
 	list_delete(q->task_info_list);
@@ -5258,27 +5256,13 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 		int retrieved_this_cycle = 0;
 		BEGIN_ACCUM_TIME(q, time_receive);
 		do {
-			char *key = NULL;
-			struct vine_worker_info *w = NULL;
+			char *key;
+			struct vine_worker_info *w;
 
 			// consider one worker at a time
-			while (list_size(q->workers_with_complete_tasks) > 0) {
-				key = list_pop_head(q->workers_with_complete_tasks);
-				w = hash_table_lookup(q->worker_table, key);
-				free(key);
 
-				if (w) {
-					// found a worker that is still connected.
-					break;
-				} else {
-					// if the worker is not in the worker_table anymore,
-					// this means that it disconnected before we got to it
-					// in the workers_with_complete_tasks list. Elements
-					// of that list are only removed in the pop above.
-				}
-			}
-
-			if (w) {
+			hash_table_firstkey(q->workers_with_complete_tasks);
+			if (hash_table_nextkey(q->workers_with_complete_tasks, &key, (void **)&w)) {
 				int retrieved_from_worker = receive_tasks_from_worker(q, w, retrieved_this_cycle);
 				retrieved_this_cycle += retrieved_from_worker;
 				events += retrieved_from_worker;

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -116,7 +116,6 @@ struct vine_manager {
 	struct hash_table *worker_blocklist; /* Maps hostname -> vine_blocklist_info */
 	struct hash_table *factory_table;    /* Maps factory_name -> vine_factory_info */
 	struct hash_table *workers_with_watched_file_updates;  /* Maps link -> vine_worker_info */
-	struct hash_table *workers_with_complete_tasks;  /* Maps link -> vine_worker_info */
 	struct hash_table *current_transfer_table; 	/* Maps uuid -> struct transfer_pair */
 	struct itable     *task_group_table; 	/* Maps group id -> list vine_task */
 

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -116,11 +116,7 @@ struct vine_manager {
 	struct hash_table *worker_blocklist; /* Maps hostname -> vine_blocklist_info */
 	struct hash_table *factory_table;    /* Maps factory_name -> vine_factory_info */
 	struct hash_table *workers_with_watched_file_updates;  /* Maps link -> vine_worker_info */
-	struct list       *workers_with_complete_tasks;  /* List of worker->hashkey. The hashkeys correspond to
-																											workers that have at least one task to be retrieve.
-																											We add only hashkeys and not vine_worker_info because the worker
-																											may have disconnected before the tasks are retrieved, which would
-																											invalidate the vine_worker_info structure.*/
+	struct hash_table *workers_with_complete_tasks;  /* Maps link -> vine_worker_info */
 	struct hash_table *current_transfer_table; 	/* Maps uuid -> struct transfer_pair */
 	struct itable     *task_group_table; 	/* Maps group id -> list vine_task */
 

--- a/taskvine/src/manager/vine_worker_info.c
+++ b/taskvine/src/manager/vine_worker_info.c
@@ -43,8 +43,6 @@ struct vine_worker_info *vine_worker_create(struct link *lnk)
 	w->last_transfer_failure = 0;
 	w->last_failure_time = 0;
 
-	w->tasks_waiting_retrieval = 0;
-
 	vine_counters.worker.created++;
 
 	w->incoming_xfer_counter = 0;

--- a/taskvine/src/manager/vine_worker_info.h
+++ b/taskvine/src/manager/vine_worker_info.h
@@ -73,7 +73,6 @@ struct vine_worker_info {
 	int64_t     total_bytes_transferred;
 	int         forsaken_tasks;
 	int64_t     inuse_cache;
-	int         tasks_waiting_retrieval;
 
 	timestamp_t total_task_time;
 	timestamp_t total_transfer_time;


### PR DESCRIPTION
When retrieving tasks results, we want to do one worker at a time. The previous mechanism would maintain two data structures: one hash table with workers that have results, and a list of tasks with results ready to be retrieved. Looking at workers one at a time in the table, tasks would be retrieved and deleted from the list. Keeping the hash table was inefficient, and as @JinZhou5042 observed, the implementation lead to O(n^2) iterations.

This pr uses only the list of tasks to be retrieved and removes the hash table. Now we look at one task in the list, see which worker has it, and get all the tasks from that worker. Note that the first task we looked at may not be actually retrieved if there are more tasks to be retrieved in that worker, and the retrieval limit has been reached.

I like this approach better as we only need to maintain one data structure. Further this pr simplifies the code, as when not all the tasks of a worker were retrieved, the worker would be deleted from the retrieval table anyway. Later, tasks would be retrieved using the list. With this change, all task are retrieved per worker.