### PR TITLE
vine: worker unlinks file if invalid cache

### DIFF
--- a/taskvine/src/worker/vine_cache.c
+++ b/taskvine/src/worker/vine_cache.c
@@ -909,6 +909,13 @@ static void vine_cache_wait_for_file(struct vine_cache *c, struct vine_cache_fil
 			hash_table_remove(c->processing_transfers, cachename);
 			vine_cache_handle_exit_status(c, f, cachename, status);
 			vine_cache_check_outputs(c, f, cachename, manager);
+
+			if (f->status == VINE_CACHE_STATUS_FAILED) {
+				/* if transfer failed, then we delete all of our records of the file. The manager
+				 * assumes that the file is not at the worker after the manager receives
+				 * the cache invalid message sent from vine_cache_check_outputs. */
+				vine_cache_remove(c, cachename, manager);
+			}
 		}
 	}
 }


### PR DESCRIPTION
When the worker sends an invalid cache message to the manager, it now also removes the file from its cache as if the manager had sent an unlink message. This cleans up the state of the replicas at the worker so that further puturl request succeed.

This fixes a bug where puturls are ignored because of previous failures to transfer, which caused tasks to be forsaken forever.

## Proposed Changes

Give an overall description of the changes, along with the context and motivation.
Mention relevant issues and pull requests as needed.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
