### PR TITLE
Set sched constants

### DIFF
--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -484,7 +484,8 @@ class Manager(object):
     #                   task to a worker. See @ref vine_schedule_t for
     #                   possible values.
     def set_scheduler(self, scheduler):
-        return cvine.vine_set_scheduler(self._taskvine, scheduler)
+        sched = get_c_constant(f"vine_schedule_{scheduler}")
+        return cvine.vine_set_scheduler(self._taskvine, sched)
 
     ##
     # Change the project name for the given manager.

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/manager.py
@@ -480,9 +480,13 @@ class Manager(object):
     # Set the worker selection scheduler for manager.
     #
     # @param self       Reference to the current manager object.
-    # @param scheduler  One of the following schedulers to use in assigning a
-    #                   task to a worker. See @ref vine_schedule_t for
-    #                   possible values.
+    # @param scheduler  One of the following schedulers set preference when assigning a
+    #                   task to a worker:
+    #                     - "files"         Prefer the available worker that has the most data required for the task.
+    #                     - "time"          Prefer the available worker that has completed previous tasks the fastest.
+    #                     - "rand"          Select a random available worker.
+    #                     - "worst"         Select a worker with the most unused resources (tie breakers: cores, memory, disk).
+    #                     - "disk"          Select a worker with the most unused disk.
     def set_scheduler(self, scheduler):
         sched = get_c_constant(f"vine_schedule_{scheduler}")
         return cvine.vine_set_scheduler(self._taskvine, sched)

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -294,9 +294,14 @@ class Task(object):
     # Set the worker selection scheduler for task.
     #
     # @param self       Reference to the current task object.
-    # @param scheduler  One of the following schedulers to use in assigning a
-    #                   task to a worker. See @ref vine_schedule_t for
-    #                   possible values.
+    # @param scheduler  One of the following schedulers set preference when assigning a
+    #                   task to a worker:
+    #                     - "files"         Prefer the available worker that has the most data required for the task.
+    #                     - "time"          Prefer the available worker that has completed previous tasks the fastest.
+    #                     - "rand"          Select a random available worker.
+    #                     - "worst"         Select a worker with the most unused resources (tie breakers: cores, memory, disk).
+    #                     - "disk"          Select a worker with the most unused disk.
+    #                   If not set for the task, defaults to the one set for the manager.
     def set_scheduler(self, scheduler):
         sched = get_c_constant(f"vine_schedule_{scheduler}")
         return cvine.vine_task_set_scheduler(self._task, sched)

--- a/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
+++ b/taskvine/src/bindings/python3/ndcctools/taskvine/task.py
@@ -11,6 +11,8 @@
 from . import cvine
 from .file import File
 
+from .utils import get_c_constant
+
 import copy
 import os
 import sys
@@ -296,7 +298,8 @@ class Task(object):
     #                   task to a worker. See @ref vine_schedule_t for
     #                   possible values.
     def set_scheduler(self, scheduler):
-        return cvine.vine_task_set_scheduler(self._task, scheduler)
+        sched = get_c_constant(f"vine_schedule_{scheduler}")
+        return cvine.vine_task_set_scheduler(self._task, sched)
 
     ##
     # Attach a user defined logical name to the task.

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -77,7 +77,8 @@ typedef enum {
 	VINE_SCHEDULE_FILES,     /**< Select worker that has the most data required by the task. (default) */
 	VINE_SCHEDULE_TIME,      /**< Select worker that has the fastest execution time on previous tasks. */
 	VINE_SCHEDULE_RAND,      /**< Select a random worker. */
-	VINE_SCHEDULE_WORST      /**< Select the worst fit worker (the worker with more unused resources). */
+	VINE_SCHEDULE_WORST,     /**< Select the worst fit worker (the worker with more unused resources). */
+	VINE_SCHEDULE_DISK       /**< Select the worker with the largest free disk space. */
 } vine_schedule_t;
 
 /** Possible outcomes for a task, returned by @ref vine_task_get_result.

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -73,7 +73,7 @@ typedef enum {
 /** Select overall scheduling algorithm for matching tasks to workers. */
 typedef enum {
 	VINE_SCHEDULE_UNSET = 0, /**< Internal use only. */
-	VINE_SCHEDULE_FCFS,      /**< Select worker on a first-come-first-serve basis. */
+	VINE_SCHEDULE_FCFS,      /**< Select worker on a first-come-first-serve basis. (deprecated, same as random) */
 	VINE_SCHEDULE_FILES,     /**< Select worker that has the most data required by the task. (default) */
 	VINE_SCHEDULE_TIME,      /**< Select worker that has the fastest execution time on previous tasks. */
 	VINE_SCHEDULE_RAND,      /**< Select a random worker. */

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -418,26 +418,6 @@ static struct vine_worker_info *find_worker_by_files(struct vine_manager *q, str
 }
 
 /*
-Find the first available worker in first-come, first-served order.
-Since the order of workers in the hashtable is somewhat arbitrary,
-this amounts to simply "find the first available worker".
-*/
-
-static struct vine_worker_info *find_worker_by_fcfs(struct vine_manager *q, struct vine_task *t)
-{
-	char *key;
-	struct vine_worker_info *w;
-	HASH_TABLE_ITERATE(q->worker_table, key, w)
-	{
-		/* Careful: If check_worker_against task fails, then w may no longer be valid. */
-		if (check_worker_against_task(q, w, t)) {
-			return w;
-		}
-	}
-	return NULL;
-}
-
-/*
 Select an available worker at random.
 This works by finding all compatible workers,
 putting them in a list, and then choosing from the list at random.
@@ -531,7 +511,7 @@ static struct vine_worker_info *find_worker_by_time(struct vine_manager *q, stru
 	} else if (vine_schedule_in_ramp_down(q)) {
 		return find_worker_by_worst_fit(q, t);
 	} else {
-		return find_worker_by_fcfs(q, t);
+		return find_worker_by_random(q, t);
 	}
 }
 
@@ -555,7 +535,6 @@ struct vine_worker_info *vine_schedule_task_to_worker(struct vine_manager *q, st
 	case VINE_SCHEDULE_WORST:
 		return find_worker_by_worst_fit(q, t);
 	case VINE_SCHEDULE_FCFS:
-		return find_worker_by_fcfs(q, t);
 	case VINE_SCHEDULE_RAND:
 	default:
 		return find_worker_by_random(q, t);

--- a/taskvine/src/manager/vine_schedule.c
+++ b/taskvine/src/manager/vine_schedule.c
@@ -533,6 +533,7 @@ struct vine_worker_info *vine_schedule_task_to_worker(struct vine_manager *q, st
 	case VINE_SCHEDULE_TIME:
 		return find_worker_by_time(q, t);
 	case VINE_SCHEDULE_WORST:
+	case VINE_SCHEDULE_DISK:
 		return find_worker_by_worst_fit(q, t);
 	case VINE_SCHEDULE_FCFS:
 	case VINE_SCHEDULE_RAND:


### PR DESCRIPTION
Sets scheduler constants with strings from python API.
Removes fcfs (makes it the same as random) as it is a leftover from when workers were kept in a list.
Adds a stub for DISK scheduling. (@JinZhou5042, let's keep worst and keep separate. If priorities are to get with WORST, let's make WORST only about cores.)



## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
