### PR TITLE
Link: Fix failed listen after bind

### DIFF
--- a/dttools/src/link.c
+++ b/dttools/src/link.c
@@ -459,6 +459,7 @@ struct link *link_serve_address(const char *addr, int port)
 	SOCKLEN_T address_length;
 	int success;
 	int value;
+	int save_errno;
 
 	if (!address_to_sockaddr(addr, /* port to be set */ 0, &address, &address_length)) {
 		goto failure;
@@ -501,7 +502,7 @@ struct link *link_serve_address(const char *addr, int port)
 	return link;
 
 failure:
-	int save_errno = errno;
+	save_errno = errno;
 
 	if (link)
 		link_close(link);

--- a/dttools/src/link.c
+++ b/dttools/src/link.c
@@ -452,7 +452,7 @@ A null address indicates all local addresses.
 A zero port indicates any available port.
 */
 
-struct link *link_serve_address(const char *addr, int port )
+struct link *link_serve_address(const char *addr, int port)
 {
 	struct link *link = 0;
 	struct sockaddr_storage address;
@@ -487,7 +487,7 @@ struct link *link_serve_address(const char *addr, int port )
 	sockaddr_set_port(&address, port);
 
 	success = bind(link->fd, (struct sockaddr *)&address, address_length);
-	if(success<0)
+	if (success < 0)
 		goto failure;
 
 	success = listen(link->fd, 5);
@@ -545,18 +545,18 @@ struct link *link_serve_address_range(const char *addr, int low, int high)
 		fatal("high port %d is less than low port %d in range", high, low);
 	}
 
-	if(high==low) {
-		return link_serve_address(addr,low);
+	if (high == low) {
+		return link_serve_address(addr, low);
 	}
 
 	int port;
-	
+
 	for (port = low; port <= high; port++) {
-		struct link *link = link_serve_address(addr,port);
-		if(link) {
+		struct link *link = link_serve_address(addr, port);
+		if (link) {
 			return link;
 		} else {
-			if(errno==EADDRINUSE) {
+			if (errno == EADDRINUSE) {
 				/* keep looking for a free port */
 				continue;
 			} else {
@@ -566,7 +566,7 @@ struct link *link_serve_address_range(const char *addr, int low, int high)
 		}
 	}
 
-	debug(D_TCP, "unable to listen on any port between %d and %d: %s",low,high,strerror(errno));
+	debug(D_TCP, "unable to listen on any port between %d and %d: %s", low, high, strerror(errno));
 	return 0;
 }
 

--- a/dttools/src/link.c
+++ b/dttools/src/link.c
@@ -379,16 +379,6 @@ void sockaddr_set_port(struct sockaddr_storage *addr, int port)
 	}
 }
 
-struct link *link_serve_range(int low, int high)
-{
-	return link_serve_address_range(0, low, high);
-}
-
-struct link *link_serve(int port)
-{
-	return link_serve_address(0, port);
-}
-
 #ifdef HAS_OPENSSL
 static int _ssl_errors_cb(const char *str, size_t len, void *use_warn)
 {
@@ -456,12 +446,13 @@ static void _set_ssl_keys(SSL_CTX *ctx, const char *ssl_key, const char *ssl_cer
 }
 #endif
 
-struct link *link_serve_address(const char *addr, int port)
-{
-	return link_serve_address_range(addr, port, port);
-}
+/*
+Attempt to create a link listening on a specific address and port.
+A null address indicates all local addresses.
+A zero port indicates any available port.
+*/
 
-struct link *link_serve_address_range(const char *addr, int low, int high)
+struct link *link_serve_address(const char *addr, int port )
 {
 	struct link *link = 0;
 	struct sockaddr_storage address;
@@ -493,6 +484,45 @@ struct link *link_serve_address_range(const char *addr, int low, int high)
 
 	link_window_configure(link);
 
+	sockaddr_set_port(&address, port);
+
+	success = bind(link->fd, (struct sockaddr *)&address, address_length);
+	if(success<0)
+		goto failure;
+
+	success = listen(link->fd, 5);
+	if (success < 0)
+		goto failure;
+
+	if (!link_nonblocking(link, 1))
+		goto failure;
+
+	debug(D_TCP, "listening on port %d", port);
+	return link;
+
+failure:
+	int save_errno = errno;
+
+	if (link)
+		link_close(link);
+
+	errno = save_errno;
+	return 0;
+}
+
+/*
+Attempt to listen on any available port between low and high,
+by attempting to create a link on all the ports in that range.
+If low or high are not specified, get ranges from the environment
+or the static configuration.
+
+We do this the "expensive" way by creating a new link object for every port attempt.
+This is because listen() can fail with EADDRINUSE even after a successful bind(),
+at which point you have to start over from scratch instead of rebinding.
+*/
+
+struct link *link_serve_address_range(const char *addr, int low, int high)
+{
 	if (low < 1) {
 		const char *lowstr = getenv("TCP_LOW_PORT");
 		if (lowstr) {
@@ -515,39 +545,39 @@ struct link *link_serve_address_range(const char *addr, int low, int high)
 		fatal("high port %d is less than low port %d in range", high, low);
 	}
 
-	int port;
-	for (port = low; port <= high; port++) {
-		sockaddr_set_port(&address, port);
-		success = bind(link->fd, (struct sockaddr *)&address, address_length);
-		if (success == -1) {
-			if (errno == EADDRINUSE) {
-				// If a port is specified, fail!
-				if (low == high) {
-					goto failure;
-				} else {
-					continue;
-				}
-			} else {
-				goto failure;
-			}
-		}
-		break;
+	if(high==low) {
+		return link_serve_address(addr,low);
 	}
 
-	success = listen(link->fd, 5);
-	if (success < 0)
-		goto failure;
+	int port;
+	
+	for (port = low; port <= high; port++) {
+		struct link *link = link_serve_address(addr,port);
+		if(link) {
+			return link;
+		} else {
+			if(errno==EADDRINUSE) {
+				/* keep looking for a free port */
+				continue;
+			} else {
+				/* some other problem means we shouldn't retry */
+				break;
+			}
+		}
+	}
 
-	if (!link_nonblocking(link, 1))
-		goto failure;
-
-	debug(D_TCP, "listening on port %d", port);
-	return link;
-
-failure:
-	if (link)
-		link_close(link);
+	debug(D_TCP, "unable to listen on any port between %d and %d: %s",low,high,strerror(errno));
 	return 0;
+}
+
+struct link *link_serve_range(int low, int high)
+{
+	return link_serve_address_range(0, low, high);
+}
+
+struct link *link_serve(int port)
+{
+	return link_serve_address(0, port);
 }
 
 int link_ssl_wrap_accept(struct link *link, const char *key, const char *cert)

--- a/dttools/src/list.c
+++ b/dttools/src/list.c
@@ -590,7 +590,7 @@ void *list_find(struct list *l, list_op_t comparator, const void *arg)
 	return out;
 }
 
-int list_iterate(struct list *l, list_op_t operator, const void *arg)
+int list_iterate(struct list *l, list_op_t operator, const void * arg)
 {
 	void *item;
 	int alltheway = 1;
@@ -607,7 +607,7 @@ int list_iterate(struct list *l, list_op_t operator, const void *arg)
 	return alltheway;
 }
 
-int list_iterate_reverse(struct list *l, list_op_t operator, const void *arg)
+int list_iterate_reverse(struct list *l, list_op_t operator, const void * arg)
 {
 	void *item;
 	int alltheway = 1;

--- a/dttools/src/list.c
+++ b/dttools/src/list.c
@@ -590,7 +590,7 @@ void *list_find(struct list *l, list_op_t comparator, const void *arg)
 	return out;
 }
 
-int list_iterate(struct list *l, list_op_t operator, const void * arg)
+int list_iterate(struct list *l, list_op_t operator, const void *arg)
 {
 	void *item;
 	int alltheway = 1;
@@ -607,7 +607,7 @@ int list_iterate(struct list *l, list_op_t operator, const void * arg)
 	return alltheway;
 }
 
-int list_iterate_reverse(struct list *l, list_op_t operator, const void * arg)
+int list_iterate_reverse(struct list *l, list_op_t operator, const void *arg)
 {
 	void *item;
 	int alltheway = 1;


### PR DESCRIPTION
## Proposed Changes

#4074 describes a (rare) problem where `listen` can fail after a `bind`.  Our current range-listening code cannot handle this well, because one cannot attempt to rebind after one has succeeded.  This PR simplifies and reworks the link listening code to do range-listening by calling `link_serve_address` repeatedly, so that we can recover from a failed `listen.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update:     Update the manual to reflect user-visible changes.
- [x] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM:            Mark your PR as ready to merge.
