### PR TITLE
Vine: Specific error cases for vine_fetch_file

### DIFF
--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -908,6 +908,8 @@ whose contents are not returned to the manager by default.
 @param m A manager object
 @param f A file object.
 @return A pointer to the contents of the file.  This will be freed with the file object.
+On error, returns NULL with errno set to: ENOENT if the file was not yet created,
+EAGAIN is the fetch failed but can be tried again, EIO if some unexpected I/O error occured.
 */
 
 const char *vine_fetch_file(struct vine_manager *m, struct vine_file *f);

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -6593,7 +6593,7 @@ EIO    - something more serious went wrong.
 const char *vine_fetch_file(struct vine_manager *m, struct vine_file *f)
 {
 	/* If the file should not exist yet, bail out quickly. */
-	if(f->state==VINE_FILE_STATE_PENDING) {
+	if (f->state == VINE_FILE_STATE_PENDING) {
 		errno = ENOENT;
 		return 0;
 	}
@@ -6631,7 +6631,7 @@ const char *vine_fetch_file(struct vine_manager *m, struct vine_file *f)
 			struct vine_worker_info *w = vine_file_replica_table_find_worker(m, f->cached_name);
 			if (w) {
 				vine_manager_get_single_file(m, w, f);
-				if(f->data) {
+				if (f->data) {
 					return f->data;
 				} else {
 					/* Something went wrong in fetching a good replica. */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -6582,38 +6582,67 @@ struct vine_file *vine_declare_chirp(
 	return vine_manager_declare_file(m, t);
 }
 
+/*
+Return the contents of a vine_file as a memory buffer.
+If the content is not available, set errno in one of three ways:
+ENOENT - file has not been created yet
+EAGAIN - file has been created, but not currently available, try again.
+EIO    - something more serious went wrong.
+*/
+
 const char *vine_fetch_file(struct vine_manager *m, struct vine_file *f)
 {
+	/* If the file should not exist yet, bail out quickly. */
+	if(f->state==VINE_FILE_STATE_PENDING) {
+		errno = ENOENT;
+		return 0;
+	}
+
 	/* If the data has already been loaded, just return it. */
-	if (f->data)
+	if (f->data) {
 		return f->data;
+	}
+
+	/* Now consider the various ways to get the file content. */
 
 	switch (f->type) {
 	case VINE_FILE:
-		/* If it is on the local filesystem, load it. */
+		/* It should already be on the local filesystem */
 		{
 			size_t length;
 			if (copy_file_to_buffer(f->source, &f->data, &length)) {
 				return f->data;
 			} else {
+				/* something went wrong in loading the file. */
+				errno = EIO;
 				return 0;
 			}
 		}
 		break;
 	case VINE_BUFFER:
-		/* Buffer files will already have their contents in memory, if available. */
-		return f->data;
-		break;
+		/* We shouldn't get here: f->data should be filled when file created. */
+		errno = EIO;
+		return 0;
 	case VINE_TEMP:
 	case VINE_URL:
 	case VINE_MINI_TASK:
 		/* If the file has been materialized remotely, go get it from a worker. */
 		{
 			struct vine_worker_info *w = vine_file_replica_table_find_worker(m, f->cached_name);
-			if (w)
+			if (w) {
 				vine_manager_get_single_file(m, w, f);
-			/* If that succeeded, then f->data is now set, null otherwise. */
-			return f->data;
+				if(f->data) {
+					return f->data;
+				} else {
+					/* Something went wrong in fetching a good replica. */
+					errno = EIO;
+					return 0;
+				}
+			} else {
+				/* No replicas were currently available, but you can try again later. */
+				errno = EAGAIN;
+				return 0;
+			}
 		}
 		break;
 	}


### PR DESCRIPTION
## Proposed Changes

Modify vine_fetch_file to set errno according to various cases:
- `ENOENT` - file has not yet been created, no context expected.
- `EAGAIN` - file has been created, but no replica currently available, try again
- `EIO` - some other unexpected failure mode, data no longer available

Fixes #3750

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update:     Update the manual to reflect user-visible changes.
- [x] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM:            Mark your PR as ready to merge.
