### PR TITLE
vine: remove a printing message from the debug log

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3437,7 +3437,6 @@ int vine_manager_transfer_capacity_available(struct vine_manager *q, struct vine
 		}
 	}
 
-	debug(D_VINE, "task %lld has a ready transfer source for all files", (long long)t->task_id);
 	return 1;
 }
 


### PR DESCRIPTION
## Proposed Changes

Removing this line can greatly reduce the size of the debug log for some workflows

<img width="719" height="200" alt="image" src="https://github.com/user-attachments/assets/10160179-e508-44ae-9685-21b1d2676b32" />

<img width="719" height="78" alt="image" src="https://github.com/user-attachments/assets/eaff739c-0622-4a2e-88be-9d1ad1d558cc" />


## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
