### PR TITLE
Vine: Fix cache removal error in worker.

### DIFF
--- a/taskvine/src/worker/vine_cache.h
+++ b/taskvine/src/worker/vine_cache.h
@@ -62,7 +62,8 @@ int vine_cache_add_mini_task( struct vine_cache *c, const char *cachename, const
 vine_cache_status_t vine_cache_ensure( struct vine_cache *c, const char *cachename);
 int vine_cache_remove( struct vine_cache *c, const char *cachename, struct link *manager );
 int vine_cache_contains( struct vine_cache *c, const char *cachename );
-int vine_cache_wait( struct vine_cache *c, struct link *manager );
-int vine_cache_process_pending_transfers(struct vine_cache *c);
+
+int vine_cache_check_files( struct vine_cache *c, struct link *manager );
+int vine_cache_start_transfers(struct vine_cache *c);
 
 #endif

--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1713,7 +1713,7 @@ static void vine_worker_serve_manager(struct link *manager)
 		expire_procs_running();
 
 		ok &= handle_completed_tasks(manager);
-		ok &= vine_cache_wait(cache_manager, manager);
+		ok &= vine_cache_check_files(cache_manager, manager);
 
 		measure_worker_resources();
 
@@ -1737,8 +1737,8 @@ static void vine_worker_serve_manager(struct link *manager)
 			break;
 		}
 
-		/* Periodically process pending transfers. */
-		vine_cache_process_pending_transfers(cache_manager);
+		/* Periodically start some pending transfers. */
+		vine_cache_start_transfers(cache_manager);
 
 		/* Check all known libraries if they are ready to execute functions. */
 		check_libraries_ready(manager);


### PR DESCRIPTION
## Proposed Changes

Fix removal sequence to avoid some rare memory errors:
- Rename vine_cache_wait -> vine_cache_check_files for clarity.  (It doesn't block!)
- vine_cache_check_file should *not* remove the object, because some callers expect it to be valid.
- vine_cache_check_files *should* remove because it has no further use for the object.

Fixes #4205

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
