### PR TITLE
CCtools: Add instruction to add Copilot as a code reviewer to all PRs to CCtools

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,10 +8,11 @@ Mention relevant issues and pull requests as needed.
 The following items must be completed before PRs can be merged.
 Check these off to verify you have completed all steps.
 
-- [ ] `make test`       Run local tests prior to pushing.
-- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
-- [ ] `make lint`       Run lint on source code prior to pushing.
-- [ ] Manual Update:     Update the manual to reflect user-visible changes.
-- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
-- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
-- [ ] PR RTM:            Mark your PR as ready to merge.
+- [ ] `make test`                           Run local tests prior to pushing.
+- [ ] `make format`                         Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
+- [ ] `make lint`                           Run lint on source code prior to pushing.
+- [ ] Manual Update:                        Update the manual to reflect user-visible changes.
+- [ ] Type Labels:                          Select a github label for the type: bugfix, enhancement, etc.
+- [ ] Product Labels:                       Select a github label for the product: TaskVine, Makeflow, etc.
+- [ ] [Optional] Request Copilot's review:  Request a code review from Copilot (or ask @tphung to request one for you).
+- [ ] PR RTM:                               Mark your PR as ready to merge.


### PR DESCRIPTION
## Proposed Changes

This PR proposes adding Copilot as an automatic code reviewer to *all PRs* in CCTools. An example of how Copilot works is in this PR https://github.com/cooperative-computing-lab/cctools/pull/4236. This is expected to help improve the productivity, catch errors, and maintain the health of CCtools' codebase via Copilot.

Per enabling Copilot to review code, there's 3 structural ways of doing it, per PR, per repository, or per organization (see https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/configure-automatic-review). The example PR above uses the per PR approach. Considerations are needed however to whether use Copilot as a code reviewer, and if so on which level should we enable Copilot. Costwise it's pretty reasonable ($10/month for 1 person), and it's currently free for verified students and teachers (see https://docs.github.com/en/copilot/how-tos/manage-your-account/get-free-access-to-copilot-pro) for 2 years (from what I observed).

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
