### PR TITLE
vine: scale task priority multiplicatively

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4668,14 +4668,13 @@ static void push_task_to_ready_tasks(struct vine_manager *q, struct vine_task *t
 {
 	if (t->result == VINE_RESULT_RESOURCE_EXHAUSTION) {
 		/* when a task is resubmitted given resource exhaustion, we
-		 * increment its priority by 1, so it gets to run as soon
+		 * increment its priority a bit, so it gets to run as soon
 		 * as possible among those with the same priority. This avoids
 		 * the issue in which all 'big' tasks fail because the first
 		 * allocation is too small. */
-		priority_queue_push(q->ready_tasks, t, t->priority + 1);
-	} else {
-		priority_queue_push(q->ready_tasks, t, t->priority);
+		t->priority *= 1.05;
 	}
+	priority_queue_push(q->ready_tasks, t, t->priority);
 
 	/* If the task has been used before, clear out accumulated state. */
 	vine_task_clean(t);


### PR DESCRIPTION
## Proposed Changes

Task priorities can differ by several orders of magnitude, so increasing them by a fixed number internally would be meaningless. Instead, we should scale the priorities multiplicatively to preserve their relative magnitude.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
