### PR TITLE
Vine: Make tests use ports consistently.

### DIFF
--- a/taskvine/test/vine_python_future_funcall.py
+++ b/taskvine/test/vine_python_future_funcall.py
@@ -27,9 +27,8 @@ def failure():
 
 
 def main():
-    executor = vine.FuturesExecutor(
-        port=[9123, 9129], manager_name="test-executor", factory=False
-    )
+    executor = vine.FuturesExecutor(port=0,factory=False)
+    
     print("listening on port {}".format(executor.port))
     with open(port_file, "w") as f:
         f.write(str(executor.port))

--- a/taskvine/test/vine_python_future_hof.py
+++ b/taskvine/test/vine_python_future_hof.py
@@ -11,9 +11,7 @@ except IndexError:
     raise
 
 def main():
-    executor = vine.FuturesExecutor(
-        port=[9123, 9129], manager_name="vine_hof_test", factory=False
-    )
+    executor = vine.FuturesExecutor(port=0,factory=False)
 
     print("listening on port {}".format(executor.manager.port))
     with open(port_file, "w") as f:

--- a/taskvine/test/vine_python_future_module.py
+++ b/taskvine/test/vine_python_future_module.py
@@ -36,9 +36,8 @@ def my_timeout():
 
 
 def main():
-    executor = vine.FuturesExecutor(
-        port=[9123, 9129], manager_name="vine_matrtix_build_test", factory=False
-    )
+    executor = vine.FuturesExecutor(port=0,factory=False)
+
     print("listening on port {}".format(executor.manager.port))
     with open(port_file, "w") as f:
         f.write(str(executor.manager.port))

--- a/taskvine/test/vine_python_future_pythontask.py
+++ b/taskvine/test/vine_python_future_pythontask.py
@@ -27,9 +27,8 @@ def failure():
 
 
 def main():
-    executor = vine.FuturesExecutor(
-        port=[9123, 9129], manager_name="vine_matrtix_build_test", factory=False
-    )
+    executor = vine.FuturesExecutor(port=0,factory=False)
+
     print("listening on port {}".format(executor.manager.port))
     with open(port_file, "w") as f:
         f.write(str(executor.manager.port))

--- a/taskvine/test/vine_python_no_serialization.py
+++ b/taskvine/test/vine_python_no_serialization.py
@@ -18,7 +18,7 @@ def my_fun():
 
 
 # Create a new m
-m = vine.Manager(port=[9123, 9130])
+m = vine.Manager(port=0)
 print("listening on port {}".format(m.port))
 with open(port_file, "w") as f:
     f.write(str(m.port))

--- a/taskvine/test/vine_python_task.py
+++ b/taskvine/test/vine_python_task.py
@@ -23,7 +23,7 @@ def my_sum(x, y, negate=False):
 
 
 # Create a new queue
-queue = vine.Manager(port=[9123, 9130])
+queue = vine.Manager(port=0)
 print("listening on port {}".format(queue.port))
 with open(port_file, "w") as f:
     f.write(str(queue.port))

--- a/taskvine/test/vine_python_temp_files.py
+++ b/taskvine/test/vine_python_temp_files.py
@@ -24,7 +24,7 @@ def fun_b(remote_data):
 
 
 # Create a new m
-m = vine.Manager(port=[9123, 9130])
+m = vine.Manager(port=0)
 print("listening on port {}".format(m.port))
 with open(port_file, "w") as f:
     f.write(str(m.port))

--- a/taskvine/test/vine_python_unlink_when_done.py
+++ b/taskvine/test/vine_python_unlink_when_done.py
@@ -11,7 +11,7 @@ def create_file():
         f.write("hello")
 
 
-m = vine.DaskVine(port=[9123, 9129])
+m = vine.DaskVine(port=0)
 
 print("testing without submitting task")
 create_file()


### PR DESCRIPTION
Fixed vine tests to all use any available port (port=0) and skip the use of manager reporting, so that we don't have `vine_status` polluted with a lot of test jobs.

## Proposed Changes

Give an overall description of the changes, along with the context and motivation.
Mention relevant issues and pull requests as needed.
- Remove manager name reporting from automated tests.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [X] `make test`       Run local tests prior to pushing.
- [X] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [X] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [X] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [X] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM:            Mark your PR as ready to merge.
