### PR TITLE
Vine: Fix installation of plot tools.

### DIFF
--- a/taskvine/src/tools/Makefile
+++ b/taskvine/src/tools/Makefile
@@ -5,9 +5,12 @@ LOCAL_LINKAGE+=${CCTOOLS_HOME}/taskvine/src/manager/libtaskvine.a ${CCTOOLS_HOME
 LOCAL_CCFLAGS+=-I ${CCTOOLS_HOME}/taskvine/src/manager
 
 PROGRAMS = vine_status vine_benchmark
-SCRIPTS = vine_plot_performance vine_plot_taskgraph vine_plot_workers vine_plot_txn_log vine_profile_dispatch vine_submit_workers vine_transfer_plot_animate vine_plot_compose
+SCRIPTS = vine_plot_performance vine_plot_taskgraph vine_plot_workers vine_plot_txn_log vine_submit_workers vine_plot_compose
 TEST_PROGRAMS = vine_test
 TARGETS = $(PROGRAMS) $(TEST_PROGRAMS)
+
+# These are useful development tools but not meant for end user consumption.
+DEVEL_SCRIPTS = vine_profile_dispatch vine_transfer_plot_animate
 
 all: $(TARGETS)
 


### PR DESCRIPTION
## Proposed Changes

The prior PR updating the name/docs for the plotting tools left out the install rule, whoops!
This fixes the installation so that tools with the right name are installed.
Undocumented development tools are built but not installed.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [x] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
