### PR TITLE
WQ: port skip_list to maintain priority order in ready list. 

### DIFF
--- a/work_queue/src/work_queue.c
+++ b/work_queue/src/work_queue.c
@@ -4735,8 +4735,6 @@ static int receive_one_task( struct work_queue *q )
 		trim_factory(q, w);
 	}
 
-	skip_list_seek(q->ready_list_cursor, 0);
-
 	return 1;
 }
 
@@ -6939,10 +6937,6 @@ static int connect_new_workers(struct work_queue *q, int stoptime, int max_new_w
 		} while(link_usleep(q->manager_link, 0, 1, 0) && (stoptime >= time(0) && (max_new_workers > new_workers)));
 	}
 
-	if(new_workers){
-		skip_list_seek(q->ready_list_cursor, 0);
-	}
-
 	return new_workers;
 }
 
@@ -7044,6 +7038,7 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 			// retrieved at least one task
 			events++;
 			compute_manager_load(q, 1);
+			skip_list_seek(q->ready_list_cursor, 0); // reset ready list cursor on receive event
 			continue;
 		}
 
@@ -7092,6 +7087,7 @@ struct work_queue_task *work_queue_wait_internal(struct work_queue *q, int timeo
 		if(result) {
 			// accepted at least one worker
 			events++;
+			skip_list_seek(q->ready_list_cursor, 0); // reset ready list cursor on new worker event
 			continue;
 		}
 


### PR DESCRIPTION
## Proposed Changes
Addresses #4276 

We cannot partially iterate the ready list and leave it out of order if we wish to maintain priority scheduling. 

The skip list offers partial but eventually complete iteration while maintaining order in the ready task list.  

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update:     Update the manual to reflect user-visible changes.
- [x] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM:            Mark your PR as ready to merge.
