### PR TITLE
fix nothing_happened_this_cycle with prefer dispatch

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -5532,7 +5532,7 @@ static struct vine_task *vine_wait_internal(struct vine_manager *q, int timeout,
 		// if we got here, no events were triggered this time around.
 		// we set the nothing_happened_last_wait_cycle flag so that link_poll waits for some time
 		// the next time around, or return retrieved tasks if there some available.
-		if (tasks_ready_left_to_consider < 1) {
+		if (tasks_ready_left_to_consider < 1 && retrieved_this_cycle < 1) {
 			q->nothing_happened_last_wait_cycle = 1;
 			tasks_ready_left_to_consider = priority_queue_size(q->ready_tasks);
 		}


### PR DESCRIPTION
With prefer_dispatch enabled, nothing_happened_this_cycle was being set incorrectly. This cause the wait loop to poll when there were tasks waiting to be retrieved.

## Proposed Changes

Give an overall description of the changes, along with the context and motivation.
Mention relevant issues and pull requests as needed.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
