### PR TITLE
Vine: Protect Pid in Process

### DIFF
--- a/taskvine/src/worker/vine_process.c
+++ b/taskvine/src/worker/vine_process.c
@@ -89,7 +89,7 @@ struct vine_process *vine_process_create(struct vine_task *task, vine_process_ty
 
 	/* Invalid pid indicating that this process has not yet started. */
 	p->pid = 0;
-	
+
 	const char *dirtype = vine_process_sandbox_code(p->type);
 
 	p->sandbox = string_format("%s/%s.%d", workspace->workspace_dir, dirtype, p->task->task_id);
@@ -427,10 +427,10 @@ int vine_process_is_complete(struct vine_process *p)
 	}
 
 	/* Invalid pid means the process was never started. */
-	if (p->pid==0) {
+	if (p->pid == 0) {
 		return 0;
 	}
-	
+
 	/* But any other type of process is done when the Unix process completes. */
 	int status;
 	int result = wait4(p->pid, &status, WNOHANG, &p->rusage);
@@ -455,10 +455,10 @@ int vine_process_wait(struct vine_process *p)
 	}
 
 	/* Invalid pid means the process was never started. */
-	if (p->pid==0) {
+	if (p->pid == 0) {
 		return 0;
 	}
-	
+
 	while (1) {
 		int status;
 		pid_t pid = waitpid(p->pid, &status, 0);
@@ -538,11 +538,11 @@ void vine_process_kill(struct vine_process *p)
 	}
 
 	/* If vine_process_executed was never called, p->pid will be invalid. */
-	if (p->pid==0) {
+	if (p->pid == 0) {
 		debug(D_VINE, "task %d was never started", p->task->task_id);
 		return;
 	}
-	
+
 	// make sure a few seconds have passed since child process was created to avoid sending a signal
 	// before it has been fully initialized. Else, the signal sent to that process gets lost.
 	timestamp_t elapsed_time_execution_start = timestamp_get() - p->execution_start;


### PR DESCRIPTION
## Proposed Changes

Protect `p->pid` in `vine_process` so that we do not accidentally kill/wait on invalid pids.  This can occur when a `vine_process` is created but never started due to some failure in sandbox setup, or remote cancellation by the manager.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
