### PR TITLE
vine: use stat consistently for file modifications

### DIFF
--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -194,7 +194,7 @@ int vine_file_has_changed(struct vine_file *f)
 
 		struct stat info;
 
-		int result = lstat(f->source, &info);
+		int result = stat(f->source, &info);
 		if (result != 0) {
 			debug(D_NOTICE | D_VINE, "input file %s couldn't be accessed: %s", f->source, strerror(errno));
 			return 1;


### PR DESCRIPTION
We were comparing lstat and stat, which would produce different results when input files were specified with symlinks.

Fix for #4068 

## Proposed Changes

Give an overall description of the changes, along with the context and motivation.
Mention relevant issues and pull requests as needed.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
