### PR TITLE
vine: remove file from need to replicate if no replicas

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -952,6 +952,14 @@ static void cleanup_worker_files(struct vine_manager *q, struct vine_worker_info
 		if (removed_replica) {
 			vine_file_replica_delete(removed_replica);
 		}
+		/* If a VINE_TEMP file now has 0 replicas because the worker with the last replica was lost,
+		 * remove it from temp_files_to_replicate since there's nothing to replicate. */
+		if (f && f->type == VINE_TEMP) {
+			int replica_count = vine_file_replica_count(q, f);
+			if (replica_count == 0) {
+				hash_table_remove(q->temp_files_to_replicate, cachename);
+			}
+		}
 		/* consider if this replica needs recovery because of worker removal */
 		if (q->immediate_recovery && f->type == VINE_TEMP && !vine_temp_exists_somewhere(q, f)) {
 			vine_manager_consider_recovery_task(q, f, f->recovery_task);


### PR DESCRIPTION
If the replica count of a temp file is 0 because of workers disconnecting, we now remove the file from the "needs to replicate" table. This removes a warning when we try to reinstert the file into the table when the cache-update of the recovery task is received, and should make iterating the table a little more efficient.

## Proposed Changes

Give an overall description of the changes, along with the context and motivation.
Mention relevant issues and pull requests as needed.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
