### PR TITLE
vine: reset waiting retrieval like running task (fall through)

### DIFF
--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -3909,6 +3909,10 @@ static void reset_task_to_state(struct vine_manager *q, struct vine_task *t, vin
 		change_task_state(q, t, new_state);
 		break;
 
+	case VINE_TASK_WAITING_RETRIEVAL:
+		/* do the same for run vs waiting retrieval, only difference is waiting_retrieval_list */
+		list_remove(q->waiting_retrieval_list, t);
+		/* fall through */
 	case VINE_TASK_RUNNING:
 		/* t->worker must be set if in RUNNING state */
 		assert(w);
@@ -3922,11 +3926,6 @@ static void reset_task_to_state(struct vine_manager *q, struct vine_task *t, vin
 
 		/* change_task_state() happened inside reap_task_from_worker */
 
-		break;
-
-	case VINE_TASK_WAITING_RETRIEVAL:
-		list_remove(q->waiting_retrieval_list, t);
-		change_task_state(q, t, new_state);
 		break;
 
 	case VINE_TASK_RETRIEVED:


### PR DESCRIPTION
Needed when task is marked as waiting retrieval but it is cancelled.


## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
