### PR TITLE
Vine: Add documentation for taskvine caching feature

### DIFF
--- a/doc/manuals/taskvine/index.md
+++ b/doc/manuals/taskvine/index.md
@@ -1246,6 +1246,17 @@ warranted:
     }
     ```
 
+### Task Result Caching
+
+For workflows where the same task is submitted multiple times with identical arguments (such as during iterative development or notebook re-execution), TaskVine can cache task outputs and return them without dispatching to a worker. Enable caching by calling `enable_tasks_cache` on the manager:
+
+```python
+m = vine.Manager(port=9123)
+m.enable_tasks_cache(cache_dir="vine-cache-outputs", log_file="vine-cache.txlog")
+```
+
+When a task completes, its output is stored in `cache_dir` and indexed by a fingerprint of the function and its arguments. On subsequent submissions of an identical task, the result is returned directly from cache. The cache persists across manager restarts via the transaction log, so results from a previous run are available immediately in a new session. Tasks that do not match any cached result are executed normally on a worker.
+
 ### Automatic Garbage Collection on Disk
 
 For workflows that generate partial results that are not needed once a final


### PR DESCRIPTION
## Proposed Changes

Add documentation for taskvine caching feature implemented here https://github.com/cooperative-computing-lab/cctools/pull/4376

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
