### PR TITLE
makeflow: remove deprecated copy_to_spool command

### DIFF
--- a/batch_job/src/batch_queue_condor.c
+++ b/batch_job/src/batch_queue_condor.c
@@ -126,7 +126,6 @@ static batch_queue_id_t batch_queue_condor_submit(struct batch_queue *q, struct 
 	fprintf(file, "should_transfer_files = yes\n");
 	fprintf(file, "when_to_transfer_output = on_exit\n");
 	fprintf(file, "notification = never\n");
-	fprintf(file, "copy_to_spool = true\n");
 	fprintf(file, "transfer_executable = true\n");
 	fprintf(file, "keep_claim_idle = 30\n");
 	fprintf(file, "log = %s\n", q->logfile);


### PR DESCRIPTION
## Proposed Changes

Removes the `copy_to_spool` command from Condor submit script creation. This command is deprecated as of HTCondor version 25.8.2 (https://opensciencegrid.atlassian.net/browse/HTCONDOR-3545).

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
