### PR TITLE
TaskVine: Set file size in meta cachename 

### DIFF
--- a/taskvine/src/manager/vine_cached_name.c
+++ b/taskvine/src/manager/vine_cached_name.c
@@ -289,6 +289,7 @@ char *vine_meta_name(const struct vine_file *f, ssize_t *totalsize)
 	char *meta = string_format("%s-%" PRIu64 "-%s", f->source, info.st_size, mtime);
 	char *metahash = md5_of_string(meta);
 	char *name = string_format("file-meta-%s", metahash);
+	*totalsize = info.st_size;
 
 	free(metahash);
 	free(meta);
@@ -300,7 +301,7 @@ Generates a random cached name of a file object.
 Returns a string that must be freed with free().
 */
 
-char *vine_random_name(const struct vine_file *f, ssize_t *totalsize)
+char *vine_random_name(const struct vine_file *f)
 {
 	char *name;
 	char random[17];
@@ -349,7 +350,7 @@ char *vine_cached_name(const struct vine_file *f, ssize_t *totalsize)
 			free(hash);
 		} else {
 			/* A pending file gets a random name. */
-			name = vine_random_name(f, totalsize);
+			name = vine_random_name(f);
 		}
 		break;
 	case VINE_MINI_TASK:
@@ -367,7 +368,7 @@ char *vine_cached_name(const struct vine_file *f, ssize_t *totalsize)
 	case VINE_TEMP:
 		/* An empty temporary file gets a random name. */
 		/* Until we later have a better name for it.*/
-		name = vine_random_name(f, totalsize);
+		name = vine_random_name(f);
 		break;
 	case VINE_BUFFER:
 		if (f->data) {
@@ -378,7 +379,7 @@ char *vine_cached_name(const struct vine_file *f, ssize_t *totalsize)
 		} else {
 			/* If the buffer doesn't exist yet, then give a random name. */
 			/* Until we later have a better name for it.*/
-			name = vine_random_name(f, totalsize);
+			name = vine_random_name(f);
 		}
 		break;
 	default:

--- a/taskvine/src/manager/vine_cached_name.h
+++ b/taskvine/src/manager/vine_cached_name.h
@@ -12,6 +12,6 @@ See the file COPYING for details.
 
 char *vine_cached_name( const struct vine_file *f, ssize_t *totalsize );
 char *vine_meta_name( const struct vine_file *f, ssize_t *totalsize );
-char *vine_random_name( const struct vine_file *f, ssize_t *totalsize );
+char *vine_random_name( const struct vine_file *f );
 
 #endif

--- a/taskvine/src/manager/vine_file.c
+++ b/taskvine/src/manager/vine_file.c
@@ -119,10 +119,10 @@ struct vine_file *vine_file_create(const char *source, const char *cached_name, 
 				f->cached_name = vine_meta_name(f, &totalsize);
 				/* if this is a pending file give it a random name */
 				if (!f->cached_name) {
-					f->cached_name = vine_random_name(f, &totalsize);
+					f->cached_name = vine_random_name(f);
 				}
 			} else {
-				f->cached_name = vine_random_name(f, &totalsize);
+				f->cached_name = vine_random_name(f);
 			}
 		}
 		if (size == 0) {


### PR DESCRIPTION
## Proposed Changes

As in the worker/forever cachename generation, get the file size when we make the meta-cachename. 

Also remove reference to unused "totalsize" from random name generation so it is not mistaken for assigning that value. 

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [x] `make test`       Run local tests prior to pushing.
- [x] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [x] `make lint`       Run lint on source code prior to pushing.
- [x] Manual Update:     Update the manual to reflect user-visible changes.
- [x] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [x] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [x] PR RTM:            Mark your PR as ready to merge.
