### PR TITLE
Skip list dead

### DIFF
--- a/dttools/src/debug.h
+++ b/dttools/src/debug.h
@@ -270,7 +270,8 @@ void debug_close(void);
 
 /* Use offset info (+0x...) with addr2line -f -e [exe or .so] */
 #define debug_backtrace \
-	{ debug(D_ERROR, "%s:%s:%d[%s]", __func__, __FILE__, __LINE__, CCTOOLS_SOURCE); \
+	{ \
+		debug(D_ERROR, "%s:%s:%d", __func__, __FILE__, __LINE__); \
 		void *buffer[DEBUG_BT_SIZE]; \
 		size_t nptrs = backtrace(buffer, DEBUG_BT_SIZE); \
 		char **strings = backtrace_symbols(buffer, nptrs); \
@@ -284,11 +285,11 @@ void debug_close(void);
 		free(strings); \
 	} // generate a core if possible
 
-
-#define debug_assert(cond)\
-  if (!(cond)) {\
-    debug(D_ERROR, "Assertion failed: %s", #cond);\
-    debug_backtrace;\
-    abort(); }
+#define debug_assert(cond) \
+	if (!(cond)) { \
+		debug(D_ERROR, "Assertion failed: %s:%s:%d", __func__, __FILE__, __LINE__); \
+		debug_backtrace; \
+		abort(); \
+	}
 
 #endif

--- a/dttools/src/skip_list.c
+++ b/dttools/src/skip_list.c
@@ -685,7 +685,8 @@ void skip_list_insert_arr(struct skip_list *sl, void *item, double *priority)
 	/* For each level, find the insertion point */
 	for (int i = sl->level; i >= 0; i--) {
 		while (x->forward[i] != sl->tail &&
-				compare_priority(x->forward[i]->priority, priority, sl->priority_size) > 0) {
+				(x->forward[i]->dead ||
+						compare_priority(x->forward[i]->priority, priority, sl->priority_size) > 0)) {
 			x = x->forward[i];
 		}
 		update[i] = x;

--- a/dttools/src/skip_list.c
+++ b/dttools/src/skip_list.c
@@ -345,14 +345,14 @@ bool seek_forward(struct skip_list_cursor *cur, int index)
 			return false;
 		}
 
-		// Skip dead nodes without counting them
-		// and try to delete them if their refcount is 0
-		if (cur->target->dead) {
-			// Save next pointer before delete_node potentially frees the node
+		/* Skip dead nodes without counting them */
+		while (cur->target->dead) {
 			struct skip_list_node *next = cur->target->forward[0];
 			delete_node(cur->target, sl);
 			cur->target = next;
-			continue;
+			if (cur->target == sl->tail) {
+				return false;
+			}
 		}
 
 		index--;
@@ -381,14 +381,14 @@ bool seek_backward(struct skip_list_cursor *cur, int index)
 			return false;
 		}
 
-		// Skip dead nodes without counting them
-		// and try to delete them if their refcount is 0
-		if (cur->target->dead) {
-			// Save previous pointer before delete_node potentially frees the node
+		/* Skip dead nodes without counting them */
+		while (cur->target->dead) {
 			struct skip_list_node *prev = cur->target->backward[0];
 			delete_node(cur->target, sl);
 			cur->target = prev;
-			continue;
+			if (cur->target == sl->head) {
+				return false;
+			}
 		}
 
 		index++;
@@ -538,10 +538,11 @@ bool skip_list_get(struct skip_list_cursor *cur, void **item)
 	if (cur->target->dead)
 		return false;
 	if (item) {
-		// if item is not given, then we are simply checking if the cursor is
-		// at a valid position
 		*item = cur->target->data;
 	}
+
+	// if item is not given, then we are simply checking if the cursor is
+	// at a valid position
 	return true;
 }
 


### PR DESCRIPTION
Fixes a couple of bugs with skip list dealing with dead nodes. 
I don't think that these bugs are related to #4415 as they involve operations beside iterating the list, but maybe?

bug1: popping head and peek said that the list was empty. wq and vine 'corrected' this by looking again in the next cycle with a new iteration.
bug2: with dead nodes a new task may have been inserted at the incorrect priority.

@RHartung-ND @dthain 

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
