### PR TITLE
vine: set output missing if file not found

### DIFF
--- a/taskvine/src/manager/vine_manager_get.c
+++ b/taskvine/src/manager/vine_manager_get.c
@@ -427,6 +427,7 @@ vine_result_code_t vine_manager_get_output_files(struct vine_manager *q, struct 
 				// if temp, check that we got a cache update message.
 				struct vine_file *f = hash_table_lookup(q->file_table, m->file->cached_name);
 				if (!f || f->state != VINE_FILE_STATE_CREATED) {
+					vine_task_set_result(t, VINE_RESULT_OUTPUT_MISSING);
 					result_single_file = VINE_APP_FAILURE;
 				}
 			} else {

--- a/taskvine/src/manager/vine_manager_get.c
+++ b/taskvine/src/manager/vine_manager_get.c
@@ -427,7 +427,6 @@ vine_result_code_t vine_manager_get_output_files(struct vine_manager *q, struct 
 				// if temp, check that we got a cache update message.
 				struct vine_file *f = hash_table_lookup(q->file_table, m->file->cached_name);
 				if (!f || f->state != VINE_FILE_STATE_CREATED) {
-					vine_task_set_result(t, VINE_RESULT_OUTPUT_MISSING);
 					result_single_file = VINE_APP_FAILURE;
 				}
 			} else {


### PR DESCRIPTION
## Proposed Changes

In `vine_manager_get_output_files`, if the manager does not find a created `TEMP` output file of a task, the result of that task should be set to `VINE_RESULT_OUTPUT_MISSING`.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
