### PR TITLE
vine: return recovery tasks

### DIFF
--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -487,6 +487,12 @@ int vine_task_set_monitor_output(struct vine_task *t, const char *monitor_output
 
 const char *vine_task_get_state(struct vine_task *t);
 
+/** Return the original task id that a recovery task is restoring.
+@param t A task object.
+@return The source task id for a recovery task, or zero for non-recovery tasks.
+*/
+int vine_task_get_recovery_source_task_id(struct vine_task *t);
+
 /** Get the command line of the task.
 @param t A task object.
 @return The command line set by @ref vine_task_create.
@@ -1118,6 +1124,14 @@ int vine_enable_peer_transfers(struct vine_manager *m);
 
 /** Disable taskvine peer transfers to be scheduled by the manager **/
 int vine_disable_peer_transfers(struct vine_manager *m);
+
+/** Enable recovery tasks to be returned by vine_wait.
+By default, recovery tasks are handled internally by the manager. **/
+int vine_enable_return_recovery_tasks(struct vine_manager *m);
+
+/** Disable recovery tasks from being returned by vine_wait.
+Recovery tasks will be handled internally by the manager. **/
+int vine_disable_return_recovery_tasks(struct vine_manager *m);
 
 /** When enabled, resources to tasks in are assigned in proportion to the size
 of the worker. If a resource is specified (e.g. with @ref vine_task_set_cores),

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -1125,13 +1125,13 @@ int vine_enable_peer_transfers(struct vine_manager *m);
 /** Disable taskvine peer transfers to be scheduled by the manager **/
 int vine_disable_peer_transfers(struct vine_manager *m);
 
-/** Enable recovery tasks to be returned by vine_wait.
+/** Enable external recovery handling by returning recovery tasks from vine_wait.
 By default, recovery tasks are handled internally by the manager. **/
-int vine_enable_recovery_tasks(struct vine_manager *m);
+int vine_enable_external_recovery_handling(struct vine_manager *m);
 
-/** Disable recovery tasks from being returned by vine_wait.
+/** Disable external recovery handling.
 Recovery tasks will be handled internally by the manager. **/
-int vine_disable_recovery_tasks(struct vine_manager *m);
+int vine_disable_external_recovery_handling(struct vine_manager *m);
 
 /** When enabled, resources to tasks in are assigned in proportion to the size
 of the worker. If a resource is specified (e.g. with @ref vine_task_set_cores),

--- a/taskvine/src/manager/taskvine.h
+++ b/taskvine/src/manager/taskvine.h
@@ -1127,11 +1127,11 @@ int vine_disable_peer_transfers(struct vine_manager *m);
 
 /** Enable recovery tasks to be returned by vine_wait.
 By default, recovery tasks are handled internally by the manager. **/
-int vine_enable_return_recovery_tasks(struct vine_manager *m);
+int vine_enable_recovery_tasks(struct vine_manager *m);
 
 /** Disable recovery tasks from being returned by vine_wait.
 Recovery tasks will be handled internally by the manager. **/
-int vine_disable_return_recovery_tasks(struct vine_manager *m);
+int vine_disable_recovery_tasks(struct vine_manager *m);
 
 /** When enabled, resources to tasks in are assigned in proportion to the size
 of the worker. If a resource is specified (e.g. with @ref vine_task_set_cores),

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4315,6 +4315,20 @@ int vine_disable_peer_transfers(struct vine_manager *q)
 	return 1;
 }
 
+int vine_enable_return_recovery_tasks(struct vine_manager *q)
+{
+	debug(D_VINE, "Return recovery tasks enabled");
+	q->return_recovery_tasks = 1;
+	return 1;
+}
+
+int vine_disable_return_recovery_tasks(struct vine_manager *q)
+{
+	debug(D_VINE, "Return recovery tasks disabled");
+	q->return_recovery_tasks = 0;
+	return 1;
+}
+
 int vine_enable_proportional_resources(struct vine_manager *q)
 {
 	debug(D_VINE, "Proportional resources enabled");
@@ -5235,7 +5249,10 @@ struct vine_task *find_task_to_return(struct vine_manager *q, const char *tag, i
 			return t;
 			break;
 		case VINE_TASK_TYPE_RECOVERY:
-			/* do nothing and let vine_manager_consider_recovery_task do its job */
+			if (q->return_recovery_tasks) {
+				return t;
+			}
+			/* Otherwise, do nothing and let vine_manager_consider_recovery_task do its job. */
 			break;
 		case VINE_TASK_TYPE_LIBRARY_INSTANCE:
 			/* silently delete the task, since it was created by the manager.

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4315,17 +4315,17 @@ int vine_disable_peer_transfers(struct vine_manager *q)
 	return 1;
 }
 
-int vine_enable_return_recovery_tasks(struct vine_manager *q)
+int vine_enable_recovery_tasks(struct vine_manager *q)
 {
-	debug(D_VINE, "Return recovery tasks enabled");
-	q->return_recovery_tasks = 1;
+	debug(D_VINE, "Recovery tasks enabled");
+	q->use_recovery_tasks = 1;
 	return 1;
 }
 
-int vine_disable_return_recovery_tasks(struct vine_manager *q)
+int vine_disable_recovery_tasks(struct vine_manager *q)
 {
-	debug(D_VINE, "Return recovery tasks disabled");
-	q->return_recovery_tasks = 0;
+	debug(D_VINE, "Recovery tasks disabled");
+	q->use_recovery_tasks = 0;
 	return 1;
 }
 
@@ -5249,7 +5249,7 @@ struct vine_task *find_task_to_return(struct vine_manager *q, const char *tag, i
 			return t;
 			break;
 		case VINE_TASK_TYPE_RECOVERY:
-			if (q->return_recovery_tasks) {
+			if (q->use_recovery_tasks) {
 				return t;
 			}
 			/* Otherwise, do nothing and let vine_manager_consider_recovery_task do its job. */

--- a/taskvine/src/manager/vine_manager.c
+++ b/taskvine/src/manager/vine_manager.c
@@ -4315,17 +4315,17 @@ int vine_disable_peer_transfers(struct vine_manager *q)
 	return 1;
 }
 
-int vine_enable_recovery_tasks(struct vine_manager *q)
+int vine_enable_external_recovery_handling(struct vine_manager *q)
 {
-	debug(D_VINE, "Recovery tasks enabled");
-	q->use_recovery_tasks = 1;
+	debug(D_VINE, "External recovery handling enabled");
+	q->external_recovery_handling = 1;
 	return 1;
 }
 
-int vine_disable_recovery_tasks(struct vine_manager *q)
+int vine_disable_external_recovery_handling(struct vine_manager *q)
 {
-	debug(D_VINE, "Recovery tasks disabled");
-	q->use_recovery_tasks = 0;
+	debug(D_VINE, "External recovery handling disabled");
+	q->external_recovery_handling = 0;
 	return 1;
 }
 
@@ -5249,7 +5249,7 @@ struct vine_task *find_task_to_return(struct vine_manager *q, const char *tag, i
 			return t;
 			break;
 		case VINE_TASK_TYPE_RECOVERY:
-			if (q->use_recovery_tasks) {
+			if (q->external_recovery_handling) {
 				return t;
 			}
 			/* Otherwise, do nothing and let vine_manager_consider_recovery_task do its job. */

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -222,6 +222,7 @@ struct vine_manager {
 	int temp_replica_count;       /* Number of replicas per temp file */
 	int clean_redundant_replicas; /* If true, remove redundant replicas of temp files to save disk space. */
 	int shift_disk_load;          /* If true, shift storage burden to more available workers to minimize disk usage peaks. */
+	int return_recovery_tasks;    /* If true, recovery tasks are returned by vine_wait to the user. */
 
 	double resource_submit_multiplier; /* Factor to permit overcommitment of resources at each worker.  */
 	double bandwidth_limit;            /* Artificial limit on bandwidth of manager<->worker transfers. */

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -222,7 +222,7 @@ struct vine_manager {
 	int temp_replica_count;       /* Number of replicas per temp file */
 	int clean_redundant_replicas; /* If true, remove redundant replicas of temp files to save disk space. */
 	int shift_disk_load;          /* If true, shift storage burden to more available workers to minimize disk usage peaks. */
-	int return_recovery_tasks;    /* If true, recovery tasks are returned by vine_wait to the user. */
+	int use_recovery_tasks;       /* If true, recovery tasks are returned by vine_wait to the user. */
 
 	double resource_submit_multiplier; /* Factor to permit overcommitment of resources at each worker.  */
 	double bandwidth_limit;            /* Artificial limit on bandwidth of manager<->worker transfers. */

--- a/taskvine/src/manager/vine_manager.h
+++ b/taskvine/src/manager/vine_manager.h
@@ -222,7 +222,7 @@ struct vine_manager {
 	int temp_replica_count;       /* Number of replicas per temp file */
 	int clean_redundant_replicas; /* If true, remove redundant replicas of temp files to save disk space. */
 	int shift_disk_load;          /* If true, shift storage burden to more available workers to minimize disk usage peaks. */
-	int use_recovery_tasks;       /* If true, recovery tasks are returned by vine_wait to the user. */
+	int external_recovery_handling; /* If true, recovery tasks are returned by vine_wait to the user. */
 
 	double resource_submit_multiplier; /* Factor to permit overcommitment of resources at each worker.  */
 	double bandwidth_limit;            /* Artificial limit on bandwidth of manager<->worker transfers. */

--- a/taskvine/src/manager/vine_task.c
+++ b/taskvine/src/manager/vine_task.c
@@ -829,6 +829,27 @@ const char *vine_task_get_state(struct vine_task *t)
 	return vine_task_state_to_string(t->state);
 }
 
+int vine_task_get_recovery_source_task_id(struct vine_task *t)
+{
+	if (!t || t->type != VINE_TASK_TYPE_RECOVERY) {
+		return 0;
+	}
+
+	/*
+	Recovery tasks are copies of original tasks and keep the same output file objects.
+	The file records the original producer so the task does not need duplicate state.
+	*/
+	struct vine_mount *m;
+	LIST_ITERATE(t->output_mounts, m)
+	{
+		if (m && m->file && m->file->original_producer_task_id > 0) {
+			return m->file->original_producer_task_id;
+		}
+	}
+
+	return 0;
+}
+
 #define METRIC(x) \
 	if (!strcmp(name, #x)) \
 		return t->x;


### PR DESCRIPTION
## Proposed Changes

Goals:
- The executor wants the manager to return recovery tasks on completion so that it knows pruned files are present again, and then it can prune recovered files when their consumers finish.
- When taskvine returns a recovery task to the executor, it wants to know what the original task is so that it can target which node it belongs to. This is because each original task corresponds to a node in the graph, which recovery tasks can be dynamic.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
