### PR TITLE
deltadb: stop silently dropping 'U' records with legacy plain-string values

### DIFF
--- a/deltadb/src/deltadb_stream.c
+++ b/deltadb/src/deltadb_stream.c
@@ -94,7 +94,6 @@ int deltadb_process_stream( struct deltadb_query *query, struct deltadb_event_ha
 			if(!jvalue) {
 				/* backwards compatibility with old format */
 				jvalue = jx_string(value);
-				continue;
 			}
 
 			if(!handlers->deltadb_update_event(query,key,name,jvalue)) break;


### PR DESCRIPTION
The 'U' (update) record handler had a stray `continue` in its backwards-compatibility fallback (jx_parse_string() failing on a legacy plain-string value), which skipped calling
handlers->deltadb_update_event() entirely -- silently dropping the update instead of delivering it, unlike the working 'C' (create) handler's identical fallback just above it in the same file.

## Proposed Changes

Give an overall description of the changes, along with the context and motivation.
Mention relevant issues and pull requests as needed.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
