### PR TITLE
chirp: fix macos-arm64 CI build by removing dead PyInt_Check branch

### DIFF
--- a/chirp/src/chirp.i
+++ b/chirp/src/chirp.i
@@ -35,8 +35,6 @@
 #ifdef SWIGPYTHON
 	if (PyLong_Check($input))
 		$1 = (time_t) PyLong_AsLong($input);
-	else if (PyInt_Check($input))
-		$1 = (time_t) PyInt_AsLong($input);
 	else if (PyFloat_Check($input))
 		$1 = (time_t) PyFloat_AsDouble($input);
 	else {


### PR DESCRIPTION
## Summary
- `chirp.i`'s `time_t` typemap called `PyInt_Check`/`PyInt_AsLong`, Python 2-only C API symbols that don't exist in Python 3 (the project is Python 3-only elsewhere), so the branch was unreachable dead code.
- gcc on Ubuntu/Alma treats the implicit function declaration as a warning and happens to link anyway; clang on the `build-conda-macos-arm64` job treats it as a hard error, breaking the build. See failing run: https://github.com/cooperative-computing-lab/cctools/actions/runs/32149789470/job/95752495324?pr=4444
- `PyLong_Check`/`PyFloat_Check` already cover Python 3's int/float types, so the branch is simply removed.

## Test plan
- [x] CI: `build-conda-macos-arm64` job passes
- [x] CI: Ubuntu/Alma jobs continue to pass (no behavior change on Python 3 int input)

🤖 Generated with [Claude Code](https://claude.com/claude-code)