### PR TITLE
work_queue: fix memory leak on duplicate cache_file insert

### DIFF
--- a/work_queue/src/work_queue_cache.c
+++ b/work_queue/src/work_queue_cache.c
@@ -91,7 +91,7 @@ Add a file to the cache manager (already created in the proper place) and note i
 int work_queue_cache_addfile( struct work_queue_cache *c, int64_t size, const char *cachename )
 {
 	struct cache_file *f = cache_file_create(WORK_QUEUE_CACHE_FILE,"manager",size,size,0777,1);
-	hash_table_insert(c->table,cachename,f);
+	if(!hash_table_insert(c->table,cachename,f)) cache_file_delete(f);
 	return 1;
 }
 
@@ -103,7 +103,7 @@ This entry will be materialized later in work_queue_cache_ensure.
 int work_queue_cache_queue( struct work_queue_cache *c, work_queue_cache_type_t type, const char *source, const char *cachename, int64_t size, int mode )
 {
 	struct cache_file *f = cache_file_create(type,source,size,0,mode,0);
-	hash_table_insert(c->table,cachename,f);
+	if(!hash_table_insert(c->table,cachename,f)) cache_file_delete(f);
 	return 1;
 }
 


### PR DESCRIPTION
hash_table_insert() returns 0 without freeing or overwriting anything when the key already exists. work_queue_cache_addfile() and work_queue_cache_queue() both allocated a cache_file via cache_file_create() and ignored this return value, so a duplicate cachename orphaned the newly-allocated struct. Free it with the existing cache_file_delete() destructor when insertion fails.

Flagged by scan-build at work_queue_cache.c:95 and :107.

## Proposed Changes

Give an overall description of the changes, along with the context and motivation.
Mention relevant issues and pull requests as needed.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
