### PR TITLE
taskvine: fix NULL deref in interfaces_to_list on missing 'address'

### DIFF
--- a/taskvine/src/worker/vine_worker.c
+++ b/taskvine/src/worker/vine_worker.c
@@ -1999,7 +1999,12 @@ static struct list *interfaces_to_list(const char *canonical_host_or_addr, int p
 		for (void *i = NULL; (host_alias = jx_iterate_array(host_aliases, &i));) {
 			const char *address = jx_lookup_string(host_alias, "address");
 
-			if (address && strcmp(canonical_host_or_addr, address) == 0) {
+			if (!address) {
+				warn(D_NOTICE, "Skipping interface entry with missing or invalid 'address' field.");
+				continue;
+			}
+
+			if (strcmp(canonical_host_or_addr, address) == 0) {
 				found_canonical = 1;
 			}
 


### PR DESCRIPTION
jx_lookup_string(host_alias, "address") can return NULL if a host alias entry in the interfaces config is missing the "address" key or has a non-string value. The existing NULL check only guarded the strcmp() used to detect the canonical address, but the following strncpy(m->host, address, ...) used the same pointer unconditionally, crashing the worker on a malformed/missing "address" field.

Skip the malformed entry (with a D_NOTICE warning), matching how the rest of interfaces_to_list() already tolerates a missing canonical address.

## Proposed Changes

Give an overall description of the changes, along with the context and motivation.
Mention relevant issues and pull requests as needed.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
