### PR TITLE
dttools: fix scan-build findings in disk_alloc.c and libforce_halt_en…

### DIFF
--- a/dttools/src/disk_alloc.c
+++ b/dttools/src/disk_alloc.c
@@ -186,6 +186,10 @@ int disk_alloc_delete(char *loc)
 	FILE *loop_find;
 	losetup_args = string_format("losetup -j %s", device_loc);
 	loop_find = popen(losetup_args, "r");
+	if (!loop_find) {
+		debug(D_NOTICE, "Failed to run losetup: %s.\n", strerror(errno));
+		goto error;
+	}
 	fscanf(loop_find, "%s %s %s", loop_dev, loop_info, loop_mount);
 	pclose(loop_find);
 	int loop_dev_path_length = strlen(loop_mount);

--- a/dttools/src/libforce_halt_enospc.c
+++ b/dttools/src/libforce_halt_enospc.c
@@ -44,7 +44,7 @@ int open(const char *path, int flags, ...)
 			fprintf(stderr, "OPEN ERROR: device capacity reached.\n");
 			return fd;
 		}
-		err_fd = original_open(filename, O_RDWR | O_CREAT);
+		err_fd = original_open(filename, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
 		if(err_fd < 0) { fprintf(stderr, "OPEN ERROR: could not alert resource management system that loop device is full.\n"); }
 		fprintf(stderr, "OPEN ERROR: device capacity reached.\n");
 		return fd;
@@ -74,7 +74,7 @@ ssize_t write(int fd, const void *buf, size_t count) {
 			original_write(STDERR_FILENO, "WRITE ERROR: device capacity reached.\n", 39);
 			return real_count;
 		}
-		fd = open(filename, O_RDWR | O_CREAT);
+		fd = open(filename, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
 		if(fd < 0) { original_write(STDERR_FILENO, "WRITE ERROR: could not alert resource management system that loop device is full.\n", 77); }	
 		original_write(STDERR_FILENO, "WRITE ERROR: device capacity reached.\n", 39);
 		return real_count;


### PR DESCRIPTION
…ospc.c

disk_alloc.c: disk_alloc_delete() used popen()'s return value unchecked before passing it to fscanf(). If popen() fails (fork/resource failure), this dereferences a NULL FILE*. Add a NULL check that follows the function's existing error convention (debug(D_NOTICE, ...) + goto error
+ return 1).

libforce_halt_enospc.c: open(filename, O_RDWR | O_CREAT) was called without a mode argument in both the open() and write() ENOSPC-simulation wrappers. Without it, the permission bits used when creating the file are undefined (read from whatever is on the stack/in registers at the call site). Pass S_IRUSR | S_IWUSR, matching the mode used for similar flag/marker files elsewhere in dttools (e.g. auth_unix.c).

## Proposed Changes

Give an overall description of the changes, along with the context and motivation.
Mention relevant issues and pull requests as needed.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
