### PR TITLE
chirp_distribute: check getenv("HOME") result before sprintf

### DIFF
--- a/chirp/src/chirp_distribute.c
+++ b/chirp/src/chirp_distribute.c
@@ -305,7 +305,10 @@ int main(int argc, char *argv[])
 	struct chirp_stat buf;
 
 	char home_dir[50];
-	sprintf(home_dir, "%s/.chirp", getenv("HOME"));
+	const char *home = getenv("HOME");
+	if(!home)
+		fatal("HOME environment variable is not set");
+	sprintf(home_dir, "%s/.chirp", home);
 	mkdir(home_dir, 0777);
 
 	result = chirp_reli_stat(sourcehost, sourcepath, &buf, time(0) + 20);


### PR DESCRIPTION
home_dir was built with sprintf(home_dir, "%s/.chirp", getenv("HOME")) with no NULL check. If HOME is unset (minimal containers, cron/service contexts, sandboxes), getenv() returns NULL and passing it as a %s argument is undefined behavior -- it crashes on most libc implementations. home_dir is also required later in main() (outRe and clusterFile paths under home_dir), so silently skipping it is not an option; fail fast with fatal(), matching the existing fatal() usage a few lines above in the same function for other unrecoverable startup errors.

The equivalent sprintf(host_file, "%s/.chirp/hosts", getenv("HOME")) in chirp_matrix.c already guards this with `if(getenv("HOME"))` (see a487ff88e); chirp_distribute.c was the one remaining unguarded call site of this pattern under chirp/src.

Found while triaging packaging/lint/scan-build-suppressions.txt.

## Proposed Changes

Give an overall description of the changes, along with the context and motivation.
Mention relevant issues and pull requests as needed.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
