### PR TITLE
dttools: mark fatal() analyzer_noreturn to silence downstream scan-bu…

### DIFF
--- a/dttools/src/debug.h
+++ b/dttools/src/debug.h
@@ -42,6 +42,25 @@ unless it has the flags D_NOTICE or D_FATAL.  For example, a main program might 
 #include <stdarg.h>
 #include <stdio.h>
 
+/*
+Tells the clang static analyzer (scan-build) specifically that a function
+never returns, on top of (and independently of) the standard noreturn
+attribute below. The analyzer's path-sensitive checkers do not always
+trust a custom noreturn function to end a path, which otherwise produces
+a false-positive null-deref/uninitialized-value/etc finding at every call
+site guarded by fatal() -- one that would need a fresh suppression-file
+entry each time someone adds another fatal() call. See CCTOOLS_ANALYZER_NORETURN
+below on fatal() itself.
+*/
+#if defined(__has_attribute)
+#if __has_attribute(analyzer_noreturn)
+#define CCTOOLS_ANALYZER_NORETURN __attribute__((analyzer_noreturn))
+#endif
+#endif
+#ifndef CCTOOLS_ANALYZER_NORETURN
+#define CCTOOLS_ANALYZER_NORETURN
+#endif
+
 /* priority */
 #define D_INFO     (0LL)     /**< Indicates a message that is of general interest to the user. (the default) */
 #define D_FATAL    (1LL<<0)  /**< Indicates a message that is fatal. */
@@ -172,6 +191,7 @@ Displays a printf-style message, and then forcibly exits the program.
 void fatal(const char *fmt, ...)
 #ifndef SWIG
 __attribute__ ((noreturn))
+CCTOOLS_ANALYZER_NORETURN
 #endif
 ;
 


### PR DESCRIPTION
…ild noise

fatal() is already __attribute__((noreturn)), but the clang static analyzer's path-sensitive checkers don't always trust a custom noreturn function to end a path there. That produces a false-positive finding (null-deref, nonnull-passed-null, uninitialized-value, etc.) at every call site guarded by a fatal() check -- e.g. `x = malloc(...); if (!x) fatal(...); use(x);` -- which otherwise needs a new suppression-file entry every time someone adds another fatal() call anywhere in the tree.

Add __attribute__((analyzer_noreturn)) (guarded by __has_attribute, so it's a no-op on compilers that don't support it) alongside the existing noreturn attribute. This is the standard fix clang recommends for custom abort/die-style functions and should retroactively suppress a chunk of the existing baseline too, once regenerated.

## Proposed Changes

Give an overall description of the changes, along with the context and motivation.
Mention relevant issues and pull requests as needed.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
