### PR TITLE
wq static link openssl

### DIFF
--- a/work_queue/src/bindings/python3/Makefile
+++ b/work_queue/src/bindings/python3/Makefile
@@ -5,9 +5,8 @@ include $(CCTOOLS_HOME)/rules.mk
 CCTOOLS_DYNAMIC_SUFFIX = so
 # SWIG produces code that causes a lot of warnings, so use -w to turn those off.
 LOCAL_CCFLAGS = -w -fPIC -DNDEBUG $(CCTOOLS_PYTHON3_CCFLAGS)
-LOCAL_LINKAGE = $(CCTOOLS_PYTHON3_LDFLAGS) -lz $(CCTOOLS_OPENSSL_LDFLAGS)
+LOCAL_LINKAGE = $(CCTOOLS_PYTHON3_LDFLAGS) -lz $(CCTOOLS_OPENSSL_LDFLAGS) $(CCTOOLS_HOME)/work_queue/src/libwork_queue.a $(CCTOOLS_HOME)/dttools/src/libdttools.a
 
-EXTERNAL_DEPENDENCIES = $(CCTOOLS_HOME)/work_queue/src/libwork_queue.a $(CCTOOLS_HOME)/dttools/src/libdttools.a
 WQPYTHONSO = ndcctools/_cwork_queue.$(CCTOOLS_DYNAMIC_SUFFIX)
 LIBRARIES = $(WQPYTHONSO)
 OBJECTS = work_queue_wrap.o
@@ -19,7 +18,7 @@ work_queue_wrap.c: work_queue.i
 	@echo "SWIG work_queue.i (python)"
 	@$(CCTOOLS_SWIG) -o work_queue_wrap.c -outdir ndcctools -python -I$(CCTOOLS_HOME)/dttools/src -I$(CCTOOLS_HOME)/work_queue/src work_queue.i
 
-$(WQPYTHONSO): work_queue_wrap.o $(EXTERNAL_DEPENDENCIES)
+$(WQPYTHONSO): work_queue_wrap.o
 
 test:
 


### PR DESCRIPTION
Fix wq linking so that most symbols in libdttools.a are resolved statically.

## Merge Checklist

The following items must be completed before PRs can be merged.
Check these off to verify you have completed all steps.

- [ ] `make test`       Run local tests prior to pushing.
- [ ] `make format`     Format source code to comply with lint policies. Note that some lint errors can only be resolved manually (e.g., Python)
- [ ] `make lint`       Run lint on source code prior to pushing.
- [ ] Manual Update:     Update the manual to reflect user-visible changes.
- [ ] Type Labels:       Select a github label for the type: bugfix, enhancement, etc.
- [ ] Product Labels:    Select a github label for the product: TaskVine, Makeflow, etc.
- [ ] PR RTM:            Mark your PR as ready to merge.
